### PR TITLE
feat(workspace): add new one-time action resource to authorize applications

### DIFF
--- a/docs/resources/workspace_application_batch_authorize.md
+++ b/docs/resources/workspace_application_batch_authorize.md
@@ -1,0 +1,119 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_application_batch_authorize"
+description: |-
+  Use this resource to batch authorize applications within HuaweiCloud.
+---
+
+# huaweicloud_workspace_application_batch_authorize
+
+Use this resource to batch authorize applications within HuaweiCloud.
+
+-> This resource is a one-time action resource for batch authorizing applications. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+### Batch authorize applications with assigned users
+
+```hcl
+variable "application_ids" {
+  type = list(string)
+}
+variable "user_names_to_be_authorized" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_application_batch_authorize" "test" {
+  app_ids            = var.application_ids
+  authorization_type = "ASSIGN_USER"
+
+  dynamic "users" {
+    for_each = var.user_names_to_be_authorized
+
+    content {
+      account      = users.value.name
+      account_type = "SIMPLE"
+    }
+  }
+}
+```
+
+### Batch authorize applications for all users
+
+```hcl
+resource "huaweicloud_workspace_application_batch_authorize" "test" {
+  app_ids            = ["app_id_1", "app_id_2"]
+  authorization_type = "ALL_USER"
+}
+```
+
+### Batch authorize applications with user cancellation
+
+```hcl
+variable "application_ids" {
+  type = list(string)
+}
+variable "authorized_user_names" {}
+
+resource "huaweicloud_workspace_application_batch_authorize" "test" {
+  app_ids            = var.application_ids
+  authorization_type = "ASSIGN_USER"
+
+  dynamic "del_users" {
+    for_each = var.authorized_user_names
+
+    content {
+      account      = del_users.value.name
+      account_type = "SIMPLE"
+    }
+  }
+
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the application batch authorization is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `app_ids` - (Required, List) Specifies the list of application IDs to be authorized or unauthorized.
+
+* `authorization_type` - (Required, String, NonUpdatable) Specifies the authorization type.  
+  Valid values are:
+  + **ALL_USER** - All users can access the applications.
+  + **ASSIGN_USER** - Only assigned users can access the applications.
+
+* `users` - (Optional, List, NonUpdatable) Specifies the list of users to be authorized.  
+  The maximum number is `100`.  
+  The [users](#application_batch_authorize_user) structure is documented below.
+
+* `del_users` - (Optional, List, NonUpdatable) Specifies the list of users to be unauthorized.  
+  The maximum number is `100`.  
+  The [del_users](#application_batch_authorize_user) structure is documented below.
+
+<a name="application_batch_authorize_user"></a>
+The `users` and `del_users` block supports:
+
+* `account` - (Required, String) Specifies the account name.
+
+* `account_type` - (Required, String) Specifies the account type.  
+  The valid values are as follows:
+  + **SIMPLE** - Simple user.
+  + **USER_GROUP** - User group.
+
+* `domain` - (Optional, String) Specifies the domain name. Required for user groups.
+
+* `platform_type` - (Optional, String) Specifies the platform type.  
+  The valid values are as follows:
+  + **AD** - AD domain.
+  + **LOCAL** - LiteAs.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3706,6 +3706,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_user_group":                           workspace.ResourceUserGroup(),
 			"huaweicloud_workspace_access_policy":                        workspace.ResourceAccessPolicy(),
 			"huaweicloud_workspace_application":                          workspace.ResourceApplication(),
+			"huaweicloud_workspace_application_batch_authorize":          workspace.ResourceApplicationBatchAuthorize(),
 			"huaweicloud_workspace_application_rule":                     workspace.ResourceApplicationRule(),
 			"huaweicloud_workspace_application_rule_restriction":         workspace.ResourceApplicationRuleRestriction(),
 			"huaweicloud_workspace_application_rule_restriction_setting": workspace.ResourceApplicationRuleRestrictionSetting(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_application_batch_authorize_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_application_batch_authorize_test.go
@@ -1,0 +1,163 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApplicationBatchAuthorize_basic(t *testing.T) {
+	var (
+		name         = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_workspace_application_batch_authorize.test"
+		baseConfig   = testAccApplicationBatchAuthorize_base(name)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationBatchAuthorize_basic_step1(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", "ASSIGN_USER"),
+					resource.TestCheckResourceAttr(resourceName, "app_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "users.#", "2"),
+				),
+			},
+			{
+				Config: testAccApplicationBatchAuthorize_basic_step2(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", "ASSIGN_USER"),
+					resource.TestCheckResourceAttr(resourceName, "app_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "del_users.#", "1"),
+				),
+			},
+			{
+				Config: testAccApplicationBatchAuthorize_basic_step3(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", "ALL_USER"),
+					resource.TestCheckResourceAttr(resourceName, "app_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccApplicationBatchAuthorize_base(name string) string {
+	randomPhoneNum := acctest.RandIntRange(1000000000, 1999999999)
+
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_application_catalogs" "test" {}
+
+resource "huaweicloud_workspace_application" "test" {
+  count = 2
+
+  name               = format("%%s_%%d", "%[1]s", count.index)
+  version            = "1.0.0"
+  authorization_type = "ALL_USER"
+  install_type       = "QUIET_INSTALL"
+  support_os         = "Windows"
+  catalog_id         = try(data.huaweicloud_workspace_application_catalogs.test.catalogs[0].id, "NOT_FOUND")
+  install_command    = "terraform test install"
+  description        = "Created by terraform script"
+
+  application_file_store {
+    store_type = "LINK"
+    file_link  = "https://www.huaweicloud.com/TerraformTest.msi"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      authorization_type
+    ]
+  }
+}
+
+resource "huaweicloud_workspace_user" "test" {
+  count = 3
+
+  name  = format("%[1]s_%%d", count.index)
+  email = format("test%%d@example.com", count.index)
+  phone = format("+%[2]d%%d", count.index)
+}
+`, name, randomPhoneNum)
+}
+
+func testAccApplicationBatchAuthorize_basic_step1(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_application_batch_authorize" "test" {
+  depends_on = [
+    huaweicloud_workspace_user.test
+  ]
+
+  app_ids            = huaweicloud_workspace_application.test[*].id
+  authorization_type = "ASSIGN_USER"
+
+  dynamic "users" {
+    for_each = slice(huaweicloud_workspace_user.test, 0, 2)
+
+    content {
+      account      = users.value.name
+      account_type = "SIMPLE"
+    }
+  }
+
+  enable_force_new = "true"
+}
+`, baseConfig)
+}
+
+func testAccApplicationBatchAuthorize_basic_step2(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_application_batch_authorize" "test" {
+  depends_on = [
+    huaweicloud_workspace_user.test
+  ]
+
+  app_ids            = huaweicloud_workspace_application.test[*].id
+  authorization_type = "ASSIGN_USER"
+
+  dynamic "del_users" {
+    for_each = slice(huaweicloud_workspace_user.test, 0, 1)
+
+    content {
+      account      = del_users.value.name
+      account_type = "SIMPLE"
+    }
+  }
+
+  enable_force_new = "true"
+}
+`, baseConfig)
+}
+
+func testAccApplicationBatchAuthorize_basic_step3(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_application_batch_authorize" "test" {
+  depends_on = [
+    huaweicloud_workspace_user.test
+  ]
+
+  app_ids            = slice(huaweicloud_workspace_application.test[*].id, 0, 1)
+  authorization_type = "ALL_USER"
+
+  enable_force_new = "true"
+}
+`, baseConfig)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_application_batch_authorize.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_application_batch_authorize.go
@@ -1,0 +1,199 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var applicationBatchAuthorizeNonUpdatableParams = []string{
+	"app_ids",
+	"authorization_type",
+	"users",
+	"del_users",
+}
+
+// @API Workspace POST /v1/{project_id}/app-center/apps/actions/batch-assign-authorization
+func ResourceApplicationBatchAuthorize() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceApplicationBatchAuthorizeCreate,
+		ReadContext:   resourceApplicationBatchAuthorizeRead,
+		UpdateContext: resourceApplicationBatchAuthorizeUpdate,
+		DeleteContext: resourceApplicationBatchAuthorizeDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(applicationBatchAuthorizeNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the application batch authorization is located.`,
+			},
+
+			// Required parameters.
+			"app_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of application IDs to be authorized or unauthorized.`,
+			},
+			"authorization_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The authorization type.`,
+			},
+
+			// Optional parameters.
+			"users": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    100,
+				Elem:        applicationBatchAuthorizeUserSchema(),
+				Description: `The list of users to be authorized.`,
+			},
+			"del_users": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    100,
+				Elem:        applicationBatchAuthorizeUserSchema(),
+				Description: `The list of users to be unauthorized.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func applicationBatchAuthorizeUserSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"account": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The account name.`,
+			},
+			"account_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The account type. Valid values are "SIMPLE" and "USER_GROUP".`,
+			},
+			"domain": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The domain name. Required for user groups.`,
+			},
+			"platform_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The platform type. Valid values are "AD" and "LOCAL".`,
+			},
+		},
+	}
+}
+
+func buildApplicationBatchAuthorizeUsersBodyParams(users []interface{}) []interface{} {
+	if len(users) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(users))
+	for _, user := range users {
+		result = append(result, utils.RemoveNil(map[string]interface{}{
+			"account":       utils.PathSearch("account", user, ""),
+			"account_type":  utils.PathSearch("account_type", user, ""),
+			"domain":        utils.ValueIgnoreEmpty(utils.PathSearch("domain", user, "")),
+			"platform_type": utils.ValueIgnoreEmpty(utils.PathSearch("platform_type", user, "")),
+		}))
+	}
+
+	return result
+}
+
+func buildApplicationBatchAuthorizeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	body := map[string]interface{}{
+		"app_ids":            d.Get("app_ids").([]interface{}),
+		"authorization_type": d.Get("authorization_type"),
+	}
+
+	if v, ok := d.GetOk("users"); ok {
+		body["users"] = buildApplicationBatchAuthorizeUsersBodyParams(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("del_users"); ok {
+		body["del_users"] = buildApplicationBatchAuthorizeUsersBodyParams(v.([]interface{}))
+	}
+
+	return body
+}
+
+func resourceApplicationBatchAuthorizeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/app-center/apps/actions/batch-assign-authorization"
+	)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildApplicationBatchAuthorizeBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating application batch authorization: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceApplicationBatchAuthorizeRead(ctx, d, meta)
+}
+
+func resourceApplicationBatchAuthorizeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceApplicationBatchAuthorizeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceApplicationBatchAuthorizeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource for batch authorizing applications. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new one-time action resource that used to authorize Workspace applications

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1144" height="452" alt="image" src="https://github.com/user-attachments/assets/1e0caa9d-c693-4f45-b513-fbaaaff8d07d" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new one-time action resource to authorize applications
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccApplicationBatchAuthorize_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccApplicationBatchAuthorize_basic -timeout 360m -parallel 10
=== RUN   TestAccApplicationBatchAuthorize_basic
=== PAUSE TestAccApplicationBatchAuthorize_basic
=== CONT  TestAccApplicationBatchAuthorize_basic
--- PASS: TestAccApplicationBatchAuthorize_basic (48.53s)
PASS
coverage: 2.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 48.742s coverage: 2.9% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
