### PR TITLE
feat(apig): add new data source for query instance metric data

### DIFF
--- a/docs/data-sources/apig_instance_metric_data.md
+++ b/docs/data-sources/apig_instance_metric_data.md
@@ -1,0 +1,105 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_instance_metric_data"
+description: |-
+  Use this data source to query the metric data of the dedicated instance within HuaweiCloud.
+---
+
+# huaweicloud_apig_instance_metric_data
+
+Use this data source to query the metric data of the dedicated instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "from_unix_timestamp" {}
+variable "to_unix_timestamp" {}
+
+data "huaweicloud_apig_instance_metric_data" "test" {
+  instance_id = var.instance_id
+  dim         = "inbound_eip"
+  metric_name = "upstream_bandwidth"
+  from        = var.from_unix_timestamp
+  to          = var.to_unix_timestamp
+  period      = 300
+  filter      = "average"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the dedicated instance is located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance.
+
+* `dim` - (Required, String) Specifies the dimension of the metric data.  
+  The valid values are as follows:
+  + **inbound_eip**: The inbound public network bandwidth, only supported by ELB type instances.
+  + **outbound_eip**: The outbound public network bandwidth.
+
+* `metric_name` - (Required, String) Specifies name of the metric data.  
+  The valid values are as follows:
+  + **upstream_bandwidth**: The outbound bandwidth.
+  + **downstream_bandwidth**: The inbound bandwidth.
+  + **upstream_bandwidth_usage**: The outbound bandwidth usage rate.
+  + **downstream_bandwidth_usage**: The inbound bandwidth usage rate.
+  + **up_stream**: The outbound traffic.
+  + **down_stream**: The inbound traffic.
+
+* `from` - (Required, String) Specifies the start time of the metric data, UNIX timestamp in milliseconds.
+
+* `to` - (Required, String) Specifies the end time of the metric data, UNIX timestamp in milliseconds.  
+  The value of `from` must be less than the value of `to`.
+
+* `period` - (Required, Int) Specifies the granularity of the metric data.  
+  The valid values are as follows:
+  + **1**: Real-time data.
+  + **300**: `5` minutes granularity.
+  + **1,200**: `20` minutes granularity.
+  + **3,600**: `1` hour granularity.
+  + **14,400**: `4` hours granularity.
+  + **86,400**: `1` day granularity.
+
+* `filter` - (Required, String) Specifies the data aggregation method of the metric data.  
+  The valid values are as follows:
+  + **average**: The average value of the metric data within the aggregation period.
+  + **max**: The maximum value of the metric data within the aggregation period.
+  + **min**: The minimum value of the metric data within the aggregation period.
+  + **sum**: The sum value of the metric data within the aggregation period.
+  + **variance**: The variance value of the metric data within the aggregation period.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `datapoints` - The list of the metric data points that matched the filter parameters.  
+  The [datapoints](#apig_metric_data_datapoints_attr) structure is documented below.
+
+<a name="apig_metric_data_datapoints_attr"></a>
+The `datapoints` block supports:
+
+* `average` - The average value of the metric data within the aggregation period.  
+  Required if the `filter` parameter is set to `average`, this field is available.
+
+* `max` - The maximum value of the metric data within the aggregation period.  
+  Required if the `filter` parameter is set to `max`, this field is available.
+
+* `min` - The minimum value of the metric data within the aggregation period.  
+  Required if the `filter` parameter is set to `min`, this field is available.
+
+* `sum` - The sum value of the metric data within the aggregation period.  
+  Required if the `filter` parameter is set to `sum`, this field is available.
+
+* `variance` - The variance value of the metric data within the aggregation period.  
+  Required if the `filter` parameter is set to `variance`, this field is available.
+
+* `timestamp` - The collection time of the metric data, UNIX timestamp in milliseconds.
+
+* `unit` - The unit of the metric.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -596,6 +596,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_instance_features":                   apig.DataSourceInstanceFeatures(),
 			"huaweicloud_apig_instance_ingress_associated_domains": apig.DataSourceInstanceIngressAssociatedDomains(),
 			"huaweicloud_apig_instance_ingress_ports":              apig.DataSourceInstanceIngressPorts(),
+			"huaweicloud_apig_instance_metric_data":                apig.DataSourceInstanceMetricData(),
 			"huaweicloud_apig_instance_quotas":                     apig.DataSourceInstanceQuotas(),
 			"huaweicloud_apig_instance_supported_features":         apig.DataSourceInstanceSupportedFeatures(),
 			"huaweicloud_apig_instance_tags":                       apig.DataSourceInstanceTags(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instance_metric_data_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instance_metric_data_test.go
@@ -1,0 +1,57 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataInstanceMetricData_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_apig_instance_metric_data.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataInstanceMetricData_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dcName, "datapoints.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(dcName, "datapoints.0.timestamp"),
+					resource.TestCheckResourceAttrSet(dcName, "datapoints.0.unit"),
+					resource.TestCheckResourceAttrSet(dcName, "datapoints.0.average"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataInstanceMetricData_basic() string {
+	now := time.Now()
+	to := now.UnixMilli()
+	from := now.Add(-24 * time.Hour).UnixMilli()
+
+	return fmt.Sprintf(`
+data "huaweicloud_apig_instance_metric_data" "test" {
+  instance_id = "%[1]s"
+  dim         = "inbound_eip"
+  metric_name = "upstream_bandwidth"
+  from        = "%[2]d"
+  to          = "%[3]d"
+  period      = 300
+  filter      = "average"
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, from, to)
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_metric_data.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_metric_data.go
@@ -1,0 +1,203 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/metric-data
+func DataSourceInstanceMetricData() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceMetricDataRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the dedicated instance is located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance.`,
+			},
+			"dim": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The dimension of the metric data.`,
+			},
+			"metric_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the metric data.`,
+			},
+			"from": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The start time of the metric data, UNIX timestamp in milliseconds.`,
+			},
+			"to": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The end time of the metric data, UNIX timestamp in milliseconds.`,
+			},
+			"period": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The granularity of the metric data.`,
+			},
+			"filter": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The data aggregation method of the metric data.`,
+			},
+
+			// Attributes.
+			"datapoints": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the metric data points that matched the filter parameters.`,
+				Elem:        dataPointsSchema(),
+			},
+		},
+	}
+}
+
+func dataPointsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"average": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The average value of the metric data within the aggregation period.`,
+			},
+			"max": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The maximum value of the metric data within the aggregation period.`,
+			},
+			"min": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The minimum value of the metric data within the aggregation period.`,
+			},
+			"sum": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The sum value of the metric data within the aggregation period.`,
+			},
+			"variance": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The variance value of the metric data within the aggregation period.`,
+			},
+			"timestamp": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The collection time of the metric data, UNIX timestamp in milliseconds.`,
+			},
+			"unit": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The unit of the metric data.`,
+			},
+		},
+	}
+}
+
+func flattenInstanceMetricDatapoints(datapoints []interface{}) []interface{} {
+	if len(datapoints) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(datapoints))
+	for _, datapoint := range datapoints {
+		result = append(result, map[string]interface{}{
+			"average":   utils.PathSearch("average", datapoint, nil),
+			"max":       utils.PathSearch("max", datapoint, nil),
+			"min":       utils.PathSearch("min", datapoint, nil),
+			"sum":       utils.PathSearch("sum", datapoint, nil),
+			"variance":  utils.PathSearch("variance", datapoint, nil),
+			"timestamp": utils.PathSearch("timestamp", datapoint, nil),
+			"unit":      utils.PathSearch("unit", datapoint, nil),
+		})
+	}
+
+	return result
+}
+
+func buildInstanceMetricDataQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	res = fmt.Sprintf("%s&dim=%v", res, d.Get("dim"))
+	res = fmt.Sprintf("%s&metric_name=%v", res, d.Get("metric_name"))
+	res = fmt.Sprintf("%s&from=%v", res, d.Get("from"))
+	res = fmt.Sprintf("%s&to=%v", res, d.Get("to"))
+	res = fmt.Sprintf("%s&period=%v", res, d.Get("period"))
+	res = fmt.Sprintf("%s&filter=%v", res, d.Get("filter"))
+
+	return "?" + res[1:]
+}
+
+func dataSourceInstanceMetricDataRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/metric-data"
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath += buildInstanceMetricDataQueryParams(d)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return diag.Errorf("error querying instance metric data: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("datapoints", flattenInstanceMetricDatapoints(
+			utils.PathSearch("datapoints", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
feat(apig): add new data source for query instance metric data

**Special notes for your reviewer**:
nothing

**Release note**:
nothing

```release-note
1. add provider implement.
2. add test case.
3. add document.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccDataInstanceMetricData_basic -timeout 360m -parallel 10
=== RUN   TestAccDataInstanceMetricData_basic
=== PAUSE TestAccDataInstanceMetricData_basic
=== CONT  TestAccDataInstanceMetricData_basic
--- PASS: TestAccDataInstanceMetricData_basic (21.89s)
PASS
coverage: 2.0% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      22.032s coverage: 2.0% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.