### PR TITLE
feat(hss): add new data source to get list of static WTP events

### DIFF
--- a/docs/data-sources/hss_webtamper_static_protect_history.md
+++ b/docs/data-sources/hss_webtamper_static_protect_history.md
@@ -1,0 +1,88 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_webtamper_static_protect_history"
+description: |-
+  Use this data source to get the list of static WTP events.
+---
+
+# huaweicloud_hss_webtamper_static_protect_history
+
+Use this data source to get the list of static WTP events.
+
+## Example Usage
+
+```hcl
+variable "start_time" {}
+variable "end_time" {}
+
+data "huaweicloud_hss_webtamper_static_protect_history" "test" {
+  start_time = var.start_time
+  end_time   = var.end_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `start_time` - (Required, Int) Specifies the query start time, in milliseconds.
+  The start time cannot be earlier than `30` days ago. If an earlier time is specified,
+  the query range is still the past `30` days.
+
+* `end_time` - (Required, Int) Specifies the query end time, in milliseconds.
+  The end time cannot be earlier than the start time. The difference between the end time and start time
+  cannot exceed `30` days. If it exceeds `30` days, the end time is set to one day later than the start time.
+
+* `host_id` - (Optional, String) Specifies the server ID.
+
+* `host_name` - (Optional, String) Specifies the server name.
+
+* `host_ip` - (Optional, String) Specifies the server EIP.
+
+* `file_path` - (Optional, String) Specifies the protection file path.
+
+* `file_operation` - (Optional, String) Specifies the file operation.
+  The valid values are as follows:
+  + **add**
+  + **delete**
+  + **modify**
+  + **attribute**
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the hosts belong.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data_list` - The list of static WTP events.
+  The [data_list](#static_data_list) structure is documented below.
+
+<a name="static_data_list"></a>
+The `data_list` block supports:
+
+* `host_name` - The server name.
+
+* `occur_time` - The detection time, in milliseconds.
+
+* `file_path` - The protection file path.
+
+* `file_operation` - The file operation.
+
+* `host_ip` - The server EIP.
+
+* `process_id` - The process ID.
+
+* `process_name` - The process name.
+
+* `process_cmd` - The process command line.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1448,6 +1448,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_webtamper_host_management_hosts":            hss.DataSourceWebTamperHostManagementHosts(),
 			"huaweicloud_hss_webtamper_rasp_path":                        hss.DataSourceWebtamperRaspPath(),
 			"huaweicloud_hss_webtamper_rasp_protect_history":             hss.DataSourceWebtamperRaspProtectHistory(),
+			"huaweicloud_hss_webtamper_static_protect_history":           hss.DataSourceWebtamperStaticProtectHistory(),
 			"huaweicloud_hss_webtamper_policy":                           hss.DataSourceWebTamperPolicy(),
 			"huaweicloud_hss_antivirus_custom_scan_policies":             hss.DataSourceAntivirusCustomScanPolicies(),
 			"huaweicloud_hss_antivirus_available_hosts":                  hss.DataSourceAntivirusAvailableHosts(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_static_protect_history_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_static_protect_history_test.go
@@ -1,0 +1,49 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceWebtamperStaticProtectHistory_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_webtamper_static_protect_history.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		startTime  = time.Now().Add(-24*time.Hour).UnixNano() / int64(time.Millisecond)
+		endTime    = time.Now().UnixNano() / int64(time.Millisecond)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Because there is no available data for testing, the test case is only
+			// used to verify that the API can be invoked.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceWebtamperStaticProtectHistory_basic(startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceWebtamperStaticProtectHistory_basic(startTime, endTime int64) string {
+	return fmt.Sprintf(`
+data "huaweicloud_hss_webtamper_static_protect_history" "test" {
+  start_time            = %[1]d
+  end_time              = %[2]d
+  enterprise_project_id = "0"
+}
+`, startTime, endTime)
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_webtamper_static_protect_history.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_webtamper_static_protect_history.go
@@ -1,0 +1,210 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/webtamper/static/protect-history
+func DataSourceWebtamperStaticProtectHistory() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWebtamperStaticProtectHistoryRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"start_time": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"end_time": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"file_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"file_operation": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"occur_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"file_path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"file_operation": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"process_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"process_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"process_cmd": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildWebtamperStaticProtectHistoryQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := fmt.Sprintf("?start_time=%v&end_time=%v&limit=200", d.Get("start_time"), d.Get("start_time"))
+
+	if v, ok := d.GetOk("host_id"); ok {
+		queryParams = fmt.Sprintf("%s&host_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("host_name"); ok {
+		queryParams = fmt.Sprintf("%s&host_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("host_ip"); ok {
+		queryParams = fmt.Sprintf("%s&host_ip=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("file_path"); ok {
+		queryParams = fmt.Sprintf("%s&file_path=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("file_operation"); ok {
+		queryParams = fmt.Sprintf("%s&file_operation=%v", queryParams, v)
+	}
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	return queryParams
+}
+
+func dataSourceWebtamperStaticProtectHistoryRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/webtamper/static/protect-history"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildWebtamperStaticProtectHistoryQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", currentPath, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving static WTP events: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataResp := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataResp) == 0 {
+			break
+		}
+
+		result = append(result, dataResp...)
+		offset += len(dataResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenWebtamperStaticProtectHistory(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenWebtamperStaticProtectHistory(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"host_name":      utils.PathSearch("host_name", v, nil),
+			"occur_time":     utils.PathSearch("occur_time", v, nil),
+			"file_path":      utils.PathSearch("file_path", v, nil),
+			"file_operation": utils.PathSearch("file_operation", v, nil),
+			"host_ip":        utils.PathSearch("host_ip", v, nil),
+			"process_id":     utils.PathSearch("process_id", v, nil),
+			"process_name":   utils.PathSearch("process_name", v, nil),
+			"process_cmd":    utils.PathSearch("process_cmd", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add new data source to get list of static WTP events.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceWebtamperStaticProtectHistory_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceWebtamperStaticProtectHistory_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWebtamperStaticProtectHistory_basic
=== PAUSE TestAccDataSourceWebtamperStaticProtectHistory_basic
=== CONT  TestAccDataSourceWebtamperStaticProtectHistory_basic
--- PASS: TestAccDataSourceWebtamperStaticProtectHistory_basic (17.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       17.444s
```
<img width="1208" height="20" alt="image" src="https://github.com/user-attachments/assets/5f16b656-6283-4207-8e89-5f3a4006f50f" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
