### PR TITLE
feat(cdn): add new resource to manage rule engine rule in CDN service

### DIFF
--- a/docs/resources/cdn_rule_engine_rule.md
+++ b/docs/resources/cdn_rule_engine_rule.md
@@ -1,0 +1,509 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_rule_engine_rule"
+description: |-
+  Manages a rule engine rule resource within HuaweiCloud.
+---
+
+# huaweicloud_cdn_rule_engine_rule
+
+Manages a rule engine rule resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "domain_name" {}
+variable "rule_name" {}
+
+resource "huaweicloud_cdn_rule_engine_rule" "test" {
+  domain_name = var.domain_name
+  name        = var.rule_name
+  status      = "on"
+  priority    = 2
+
+  conditions = jsonencode({
+    "match": {
+      "logic": "and",
+      "criteria": [
+        {
+          "match_target_type": "extension",
+          "match_type": "contains",
+          "match_pattern": [".txt", ".png"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "scheme",
+          "match_type": "contains",
+          "match_pattern": ["HTTPS"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "method",
+          "match_type": "contains",
+          "match_pattern": ["PATCH"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "path",
+          "match_type": "contains",
+          "match_pattern": ["/test"],
+          "negate": false,
+          "case_sensitive": true
+        },
+        {
+          "match_target_type": "arg",
+          "match_target_name": "test",
+          "match_type": "contains",
+          "match_pattern": ["123"],
+          "negate": false,
+          "case_sensitive": true
+        },
+        {
+          "match_target_type": "filename",
+          "match_type": "contains",
+          "match_pattern": ["test", "123"],
+          "negate": false,
+          "case_sensitive": true
+        },
+        {
+          "match_target_type": "header",
+          "match_target_name": "test",
+          "match_type": "contains",
+          "match_pattern": ["123"],
+          "negate": false,
+          "case_sensitive": true
+        },
+        {
+          "match_target_type": "clientip",
+          "match_target_name": "connect",
+          "match_type": "contains",
+          "match_pattern": ["1.1.1.1"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "clientip_version",
+          "match_target_name": "connect",
+          "match_type": "contains",
+          "match_pattern": ["IPv4"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "ua",
+          "match_type": "contains",
+          "match_pattern": ["test"],
+          "negate": false,
+          "case_sensitive": true
+        }
+      ]
+    }
+  })
+
+  actions {
+    cache_rule {
+      ttl           = 10
+      ttl_unit      = "m"
+      follow_origin = "min_ttl"
+      force_cache   = "off"
+    }
+  }
+
+  actions {
+    access_control {
+      type = "block"
+    }
+  }
+
+  actions {
+    http_response_header {
+      name   = "Access-Control-Deny-Origin"
+      value  = "*"
+      action = "delete"
+    }
+  }
+
+  actions {
+    browser_cache_rule {
+      cache_type = "follow_origin"
+    }
+  }
+
+  actions {
+    request_url_rewrite {
+      execution_mode = "break"
+      redirect_url   = "/path/$1"
+    }
+  }
+
+  actions {
+    flexible_origin {
+      sources_type      = "ipaddr"
+      ip_or_domain      = "1.1.1.1"
+      http_port         = 80
+      https_port        = 443
+      origin_protocol  = "follow"
+      host_name         = "1.1.1.1"
+      priority          = 2
+      weight            = 10
+    }
+    flexible_origin {
+      sources_type      = "third_bucket"
+      ip_or_domain      = "test.third-bucket.com"
+      bucket_access_key = "test-ak"
+      bucket_secret_key = "test-sk"
+      bucket_region     = "cn-north-4"
+      bucket_name       = "test-third-bucket-name"
+      http_port         = 80
+      https_port        = 443
+      origin_protocol   = "follow"
+      host_name         = "1.1.1.1"
+      priority          = 1
+      weight            = 2
+    }
+  }
+
+  actions {
+    origin_request_header {
+      action = "delete"
+      name   = "test"
+      value  = "123"
+    }
+  }
+
+  actions {
+    origin_request_url_rewrite {
+      rewrite_type = "simple"
+      target_url   = "/test"
+    }
+  }
+
+  actions {
+    origin_range {
+      status = "on"
+    }
+  }
+
+  actions {
+    request_limit_rule {
+      limit_rate_after = 2
+      limit_rate_value = 3
+    }
+  }
+
+  actions {
+    error_code_cache {
+      code = 403
+      ttl  = 123
+    }
+
+    error_code_cache {
+      code = 404
+      ttl  = 123
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the rule engine rule is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `domain_name` - (Required, String, NonUpdatable) Specifies the accelerated domain name to which the rule engine rule
+  belongs.  
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the rule engine rule.  
+  The valid length is limit from `1` to `50`.
+
+* `status` - (Required, String) Whether to enable the rule engine rule.  
+  The valid values are as follows:
+  + **on**
+  + **off**
+
+* `priority` - (Required, Int) Specifies the priority of the rule engine rule.
+  The valid value is range from `1` to `100`.
+
+* `conditions` - (Optional, String) Specifies the trigger conditions of the rule engine rule, in JSON format.
+
+* `actions` - (Required, List) Specifies the list of actions to be performed when the rule engine rule is met.
+  The [actions](#cdn_rule_engine_rule_actions) structure is documented below.
+
+<a name="cdn_rule_engine_rule_actions"></a>
+The `actions` block supports:
+
+* `flexible_origin` - (Optional, List) Specifies the list of flexible origin configurations.  
+  The [flexible_origin](#cdn_rule_engine_rule_actions_flexible_origin) structure is documented below.
+
+* `origin_request_header` - (Optional, List) Specifies the list of origin request header configurations.  
+  The [origin_request_header](#cdn_rule_engine_rule_actions_origin_request_header) structure is documented below.
+
+* `http_response_header` - (Optional, List) Specifies the list of HTTP response header configurations.  
+  The [http_response_header](#cdn_rule_engine_rule_actions_http_response_header) structure is documented below.
+
+* `access_control` - (Optional, List) Specifies the access control configuration.  
+  The [access_control](#cdn_rule_engine_rule_actions_access_control) structure is documented below.
+
+* `request_limit_rule` - (Optional, List) Specifies the request rate limit configuration.  
+  The [request_limit_rule](#cdn_rule_engine_rule_actions_request_limit_rule) structure is documented below.
+
+* `origin_request_url_rewrite` - (Optional, List) Specifies the origin request URL rewrite configuration.  
+  The [origin_request_url_rewrite](#cdn_rule_engine_rule_actions_origin_request_url_rewrite) structure is documented
+  below.
+
+* `cache_rule` - (Optional, List) Specifies the cache rule configuration.  
+  The [cache_rule](#cdn_rule_engine_rule_actions_cache_rule) structure is documented below.
+
+* `request_url_rewrite` - (Optional, List) Specifies the access URL rewrite configuration.  
+  The [request_url_rewrite](#cdn_rule_engine_rule_actions_request_url_rewrite) structure is documented below.
+
+* `browser_cache_rule` - (Optional, List) Specifies the browser cache rule configuration.  
+  The [browser_cache_rule](#cdn_rule_engine_rule_actions_browser_cache_rule) structure is documented below.
+
+* `error_code_cache` - (Optional, List) Specifies the list of error code cache configurations.  
+  The [error_code_cache](#cdn_rule_engine_rule_actions_error_code_cache) structure is documented below.
+
+* `origin_range` - (Optional, List) Specifies the origin range configuration.  
+  The [error_code_cache](#cdn_rule_engine_rule_actions_origin_range) structure is documented below.
+
+-> Each of the above configuration items must be declared in a separate actions structure.
+
+<a name="cdn_rule_engine_rule_actions_flexible_origin"></a>
+The `flexible_origin` block supports:
+
+* `sources_type` - (Required, String) Specifies the source type.  
+  The valid values are as follows:
+  + **ipaddr**
+  + **domain**
+  + **obs_bucket**
+  + **third_bucket**
+
+* `ip_or_domain` - (Required, String) Specifies the origin IP or domain name.
+
+* `priority` - (Required, Int) Specifies the origin priority.  
+  The valid value is range from `1` to `100`.
+
+* `weight` - (Required, Int) Specifies the origin weight.  
+  The valid value is range from `1` to `100`.
+
+* `obs_bucket_type` - (Optional, String) Specifies the OBS bucket type.  
+  The valid values are as follows:
+  + **private**
+  + **public**
+
+* `bucket_access_key` - (Optional, String) Specifies the third-party object storage access key.
+
+* `bucket_secret_key` - (Optional, String) Specifies the third-party object storage secret key.
+
+* `bucket_region` - (Optional, String) Specifies the third-party object storage region.
+
+* `bucket_name` - (Optional, String) Specifies the third-party object storage name.
+
+* `host_name` - (Optional, String) Specifies the origin host name.
+
+* `origin_protocol` - (Optional, String) Specifies the origin protocol.  
+  The valid values are as follows:
+  + **follow**
+  + **http**
+  + **https**
+
+* `http_port` - (Optional, Int) Specifies the HTTP port number.  
+  The valid value is range from `1` to `65,535`.
+
+* `https_port` - (Optional, Int) Specifies the HTTPS port number.  
+  The valid value is range from `1` to `65,535`.
+
+<a name="cdn_rule_engine_rule_actions_origin_request_header"></a>
+The `origin_request_header` block supports:
+
+* `name` - (Required, String) Specifies the back-to-origin request header parameter name.
+
+* `action` - (Required, String) Specifies the back-to-origin request header setting type.  
+  The valid values are as follows:
+  + **delete**
+  + **set**
+
+* `value` - (Optional, String) Specifies the back-to-origin request header parameter value.
+
+<a name="cdn_rule_engine_rule_actions_http_response_header"></a>
+The `http_response_header` block supports:
+
+* `name` - (Required, String) Specifies the HTTP response header parameter name.
+
+* `action` - (Required, String) Specifies the operation type of setting HTTP response header.  
+  The valid values are as follows:
+  + **set**
+  + **delete**
+
+* `value` - (Optional, String) Specifies the HTTP response header parameter value.
+
+<a name="cdn_rule_engine_rule_actions_access_control"></a>
+The `access_control` block supports:
+
+* `type` - (Required, String) Specifies the access control type.  
+  The valid values are as follows:
+  + **block**
+  + **trust**
+
+<a name="cdn_rule_engine_rule_actions_request_limit_rule"></a>
+The `request_limit_rule` block supports:
+
+* `limit_rate_after` - (Required, Int) Specifies the rate limit condition.
+
+* `limit_rate_value` - (Required, Int) Specifies the rate limit value.
+
+<a name="cdn_rule_engine_rule_actions_origin_request_url_rewrite"></a>
+The `origin_request_url_rewrite` block supports:
+
+* `rewrite_type` - (Required, String) Specifies the rewrite type.  
+  The valid values are as follows:
+  + **simple**
+  + **wildcard**
+  + **regex**
+
+* `target_url` - (Required, String) Specifies the target URL.
+
+* `source_url` - (Optional, String) Specifies the source URL to be rewritten.
+
+  -> This parameter is required if the value of parameter `rewrite_type` is **wildcard**.
+
+<a name="cdn_rule_engine_rule_actions_cache_rule"></a>
+The `cache_rule` block supports:
+
+* `ttl` - (Required, Int) Specifies the cache expiration time.
+
+* `ttl_unit` - (Required, String) Specifies the cache expiration time unit.  
+  The valid values are as follows:
+  + **s**
+  + **m**
+  + **h**
+  + **d**
+
+* `follow_origin` - (Required, String) Specifies the cache expiration time source.  
+  The valid values are as follows:
+  + **off**
+  + **on**
+  + **min_ttl**
+
+* `force_cache` - (Optional, String) Whether to enable forced caching.  
+  The valid values are as follows:
+  + **on**
+  + **off**
+
+<a name="cdn_rule_engine_rule_actions_request_url_rewrite"></a>
+The `request_url_rewrite` block supports:
+
+* `execution_mode` - (Required, String) Specifies the execution mode.  
+  The valid values are as follows:
+  + **redirect**
+  + **break**
+
+* `redirect_url` - (Required, String) Specifies the redirect URL.
+
+* `redirect_status_code` - (Optional, Int) Specifies the redirect status code.  
+  The valid values are as follows:
+  + `301`
+  + `302`
+  + `303`
+  + `307`
+
+* `redirect_host` - (Optional, String) Specifies the redirect host.
+
+-> Parameter `redirect_status_code` and `redirect_host` can only be configured when the value of `cache_type` is
+   **redirect**.
+
+<a name="cdn_rule_engine_rule_actions_browser_cache_rule"></a>
+The `browser_cache_rule` block supports:
+
+* `cache_type` - (Required, String) Specifies the cache effective type.  
+  The valid values are as follows:
+  + **follow_origin**
+  + **ttl**
+  + **never**
+
+* `ttl` - (Optional, Int) Specifies the cache expiration time.
+
+* `ttl_unit` - (Optional, String) Specifies the cache expiration time unit.  
+  The valid values are as follows:
+  + **s**
+  + **m**
+  + **h**
+  + **d**
+
+-> Parameter `ttl` and `ttl_unit` can only be configured when the value of `cache_type` is **ttl**.
+
+<a name="cdn_rule_engine_rule_actions_error_code_cache"></a>
+The `error_code_cache` block supports:
+
+* `code` - (Required, Int) Specifies the error code to be cached.  
+  The valid values are as follows:
+  + `301`
+  + `302`
+  + `400`
+  + `401`
+  + `403`
+  + `404`
+  + `405`
+  + `407`
+  + `414`
+  + `451`
+  + `500`
+  + `501`
+  + `502`
+  + `503`
+  + `504`
+  + `509`
+  + `514`
+
+* `ttl` - (Required, Int) Specifies the error code cache time.
+
+<a name="cdn_rule_engine_rule_actions_origin_range"></a>
+The `origin_range` block supports:
+
+* `status` - (Required, String) Specifies the origin range status.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The rule engine rule can be imported using the format `<domain_name>/<id>` or `<domain_name>/<name>`, e.g.
+
+```bash
+$ terraform import huaweicloud_cdn_rule_engine_rule.test <domain_name>/<id>
+```
+
+or
+
+```bash
+$ terraform import huaweicloud_cdn_rule_engine_rule.test <domain_name>/<name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `actions.*.flexible_origin.*.bucket_secret_key`.
+It is generally recommended running `terraform plan` after importing rule engine rule.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_cdn_rule_engine_rule" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      actions.5.flexible_origin.1.bucket_secret_key,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2583,14 +2583,15 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdm_job":            cdm.ResourceCdmJob(),
 			"huaweicloud_cdm_link":           cdm.ResourceCdmLink(),
 
-			"huaweicloud_cdn_domain":                        cdn.ResourceDomain(),
-			"huaweicloud_cdn_domain_rule":                   cdn.ResourceDomainRule(),
 			"huaweicloud_cdn_billing_option":                cdn.ResourceBillingOption(),
 			"huaweicloud_cdn_cache_preheat":                 cdn.ResourceCachePreheat(),
 			"huaweicloud_cdn_cache_refresh":                 cdn.ResourceCacheRefresh(),
 			"huaweicloud_cdn_certificate_associate_domains": cdn.ResourceCertificateAssociateDomains(),
+			"huaweicloud_cdn_domain":                        cdn.ResourceDomain(),
 			"huaweicloud_cdn_domain_batch_copy":             cdn.ResourceDomainBatchCopy(),
 			"huaweicloud_cdn_domain_owner_verify":           cdn.ResourceDomainOwnerVerify(),
+			"huaweicloud_cdn_domain_rule":                   cdn.ResourceDomainRule(),
+			"huaweicloud_cdn_rule_engine_rule":              cdn.ResourceRuleEngineRule(),
 
 			"huaweicloud_ces_alarmrule":                                     ces.ResourceAlarmRule(),
 			"huaweicloud_ces_alarm_template":                                ces.ResourceCesAlarmTemplate(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -3372,9 +3372,9 @@ func TestAccPreCheckCCISecretDockerconfigjson(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckCDN(t *testing.T) {
+func TestAccPreCheckCdnDomainName(t *testing.T) {
 	if HW_CDN_DOMAIN_NAME == "" {
-		t.Skip("This environment does not support CDN tests")
+		t.Skip("HW_CDN_DOMAIN_NAME must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_certificate_deploy_test.go
+++ b/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_certificate_deploy_test.go
@@ -20,7 +20,7 @@ func TestAccResourceCertificateDeploy_cdn(t *testing.T) {
 			// Configure the international certificate. The SM2 certificate does not support deployment operations.
 			acceptance.TestAccPreCheckCCMSSLCertificateId(t)
 			// Make sure the domain name match the certificate.
-			acceptance.TestAccPreCheckCDN(t)
+			acceptance.TestAccPreCheckCdnDomainName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_analytics_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_analytics_test.go
@@ -21,7 +21,7 @@ func TestAccDataAnalytics_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCDN(t)
+			acceptance.TestAccPreCheckCdnDomainName(t)
 			acceptance.TestAccPrecheckCDNAnalytics(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domain_statistics_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domain_statistics_test.go
@@ -16,7 +16,7 @@ func TestAccDataStatistics_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCDN(t)
+			acceptance.TestAccPreCheckCdnDomainName(t)
 			acceptance.TestAccPrecheckCDNAnalytics(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_logs_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_logs_test.go
@@ -27,7 +27,7 @@ func TestAccDataLogs_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCDN(t)
+			acceptance.TestAccPreCheckCdnDomainName(t)
 			acceptance.TestAccPrecheckTimeStamp(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_top_referrer_statistics_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_top_referrer_statistics_test.go
@@ -24,7 +24,7 @@ func TestAccDataTopReferrerStatistics_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCDN(t)
+			acceptance.TestAccPreCheckCdnDomainName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_top_url_statistics_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_top_url_statistics_test.go
@@ -24,7 +24,7 @@ func TestAccDataTopUrlStatistics_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCDN(t)
+			acceptance.TestAccPreCheckCdnDomainName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_owner_verify_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_owner_verify_test.go
@@ -15,7 +15,7 @@ func TestAccDomainOwnerVerify_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCDN(t)
+			acceptance.TestAccPreCheckCdnDomainName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_rule_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_rule_test.go
@@ -38,7 +38,7 @@ func TestAccDomainRule_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCDN(t)
+			acceptance.TestAccPreCheckCdnDomainName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_rule_engine_rule_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_rule_engine_rule_test.go
@@ -1,0 +1,611 @@
+package cdn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cdn"
+)
+
+func getRuleEngineRuleFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	domainName := state.Primary.Attributes["domain_name"]
+	ruleId := state.Primary.ID
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return nil, fmt.Errorf("error creating CDN client: %s", err)
+	}
+
+	return cdn.GetRuleEngineRuleById(client, domainName, ruleId)
+}
+
+func TestAccRuleEngineRule_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_cdn_rule_engine_rule.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getRuleEngineRuleFunc)
+
+		name       = acceptance.RandomAccResourceNameWithDash()
+		updateName = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCdnDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleEngineRule_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", acceptance.HW_CDN_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "conditions"),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "11"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_rule.0.ttl", "10"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_rule.0.ttl_unit", "m"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_rule.0.follow_origin", "min_ttl"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_rule.0.force_cache", "off"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.access_control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.access_control.0.type", "block"),
+					resource.TestCheckResourceAttr(resourceName, "actions.2.http_response_header.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.2.http_response_header.0.name", "Access-Control-Deny-Origin"),
+					resource.TestCheckResourceAttr(resourceName, "actions.2.http_response_header.0.value", "*"),
+					resource.TestCheckResourceAttr(resourceName, "actions.2.http_response_header.0.action", "delete"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3.browser_cache_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3.browser_cache_rule.0.cache_type", "follow_origin"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4.request_url_rewrite.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4.request_url_rewrite.0.redirect_url", "/path/$1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4.request_url_rewrite.0.execution_mode", "break"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.0.sources_type", "ipaddr"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.0.ip_or_domain", "1.1.1.1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.0.http_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.0.https_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.0.origin_protocol", "follow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.0.host_name", "1.1.1.1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.0.priority", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.0.weight", "10"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.1.sources_type", "third_bucket"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.1.ip_or_domain", "test.third-bucket.com"),
+					resource.TestCheckResourceAttr(resourceName, "actions.6.origin_request_header.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.6.origin_request_header.0.action", "delete"),
+					resource.TestCheckResourceAttr(resourceName, "actions.6.origin_request_header.0.name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "actions.6.origin_request_header.0.value", "123"),
+					resource.TestCheckResourceAttr(resourceName, "actions.7.origin_request_url_rewrite.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.7.origin_request_url_rewrite.0.rewrite_type", "simple"),
+					resource.TestCheckResourceAttr(resourceName, "actions.7.origin_request_url_rewrite.0.target_url", "/test"),
+					resource.TestCheckResourceAttr(resourceName, "actions.8.origin_range.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.8.origin_range.0.status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "actions.9.request_limit_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.9.request_limit_rule.0.limit_rate_after", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.9.request_limit_rule.0.limit_rate_value", "3"),
+					resource.TestCheckResourceAttr(resourceName, "actions.10.error_code_cache.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.10.error_code_cache.0.code", "403"),
+					resource.TestCheckResourceAttr(resourceName, "actions.10.error_code_cache.0.ttl", "123"),
+					resource.TestCheckResourceAttr(resourceName, "actions.10.error_code_cache.1.code", "404"),
+					resource.TestCheckResourceAttr(resourceName, "actions.10.error_code_cache.1.ttl", "123"),
+				),
+			},
+			{
+				Config: testAccRuleEngineRule_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", acceptance.HW_CDN_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "status", "off"),
+					resource.TestCheckResourceAttr(resourceName, "priority", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "conditions"),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "11"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_rule.0.ttl", "360"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_rule.0.ttl_unit", "s"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_rule.0.follow_origin", "off"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.cache_rule.0.force_cache", "on"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.access_control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.access_control.0.type", "trust"),
+					resource.TestCheckResourceAttr(resourceName, "actions.2.http_response_header.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.2.http_response_header.0.name", "Access-Control-Allow-Origin"),
+					resource.TestCheckResourceAttr(resourceName, "actions.2.http_response_header.0.value", "*"),
+					resource.TestCheckResourceAttr(resourceName, "actions.2.http_response_header.0.action", "set"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3.browser_cache_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3.browser_cache_rule.0.cache_type", "ttl"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3.browser_cache_rule.0.ttl", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "actions.3.browser_cache_rule.0.ttl_unit", "s"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4.request_url_rewrite.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4.request_url_rewrite.0.redirect_status_code", "301"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4.request_url_rewrite.0.redirect_url", "/new-path/$1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.4.request_url_rewrite.0.execution_mode", "redirect"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.0.sources_type", "ipaddr"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.0.ip_or_domain", "1.1.1.1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.0.priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.0.weight", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.1.sources_type", "third_bucket"),
+					resource.TestCheckResourceAttr(resourceName, "actions.5.flexible_origin.1.ip_or_domain", "test.third-bucket.com"),
+					resource.TestCheckResourceAttr(resourceName, "actions.6.origin_request_header.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.6.origin_request_header.0.action", "set"),
+					resource.TestCheckResourceAttr(resourceName, "actions.6.origin_request_header.0.name", "new-test"),
+					resource.TestCheckResourceAttr(resourceName, "actions.6.origin_request_header.0.value", "456"),
+					resource.TestCheckResourceAttr(resourceName, "actions.7.origin_request_url_rewrite.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.7.origin_request_url_rewrite.0.rewrite_type", "wildcard"),
+					resource.TestCheckResourceAttr(resourceName, "actions.7.origin_request_url_rewrite.0.source_url", "/test"),
+					resource.TestCheckResourceAttr(resourceName, "actions.7.origin_request_url_rewrite.0.target_url", "/test/new"),
+					resource.TestCheckResourceAttr(resourceName, "actions.8.origin_range.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.8.origin_range.0.status", "off"),
+					resource.TestCheckResourceAttr(resourceName, "actions.9.request_limit_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.9.request_limit_rule.0.limit_rate_after", "20"),
+					resource.TestCheckResourceAttr(resourceName, "actions.9.request_limit_rule.0.limit_rate_value", "30"),
+					resource.TestCheckResourceAttr(resourceName, "actions.10.error_code_cache.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.10.error_code_cache.0.code", "405"),
+					resource.TestCheckResourceAttr(resourceName, "actions.10.error_code_cache.0.ttl", "456"),
+					resource.TestCheckResourceAttr(resourceName, "actions.10.error_code_cache.1.code", "407"),
+					resource.TestCheckResourceAttr(resourceName, "actions.10.error_code_cache.1.ttl", "456"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testRuleEngineRuleImportStateWithId(resourceName),
+				ImportStateVerifyIgnore: []string{
+					"actions.5.flexible_origin.1.bucket_secret_key",
+					"conditions_origin",
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testRuleEngineRuleImportStateWithName(resourceName),
+				ImportStateVerifyIgnore: []string{
+					"actions.5.flexible_origin.1.bucket_secret_key",
+					"conditions_origin",
+				},
+			},
+		},
+	})
+}
+
+func testRuleEngineRuleImportStateWithId(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		domainName := rs.Primary.Attributes["domain_name"]
+		ruleId := rs.Primary.ID
+		if domainName == "" || ruleId == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<domain_name>/<id>', but got '%s/%s'", domainName, ruleId)
+		}
+		return fmt.Sprintf("%s/%s", domainName, ruleId), nil
+	}
+}
+
+func testRuleEngineRuleImportStateWithName(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		domainName := rs.Primary.Attributes["domain_name"]
+		ruleName := rs.Primary.Attributes["name"]
+		if domainName == "" || ruleName == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<domain_name>/<name>', but got '%s/%s'", domainName, ruleName)
+		}
+		return fmt.Sprintf("%s/%s", domainName, ruleName), nil
+	}
+}
+
+func testAccRuleEngineRule_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_rule_engine_rule" "test" {
+  domain_name = "%[1]s"
+  name        = "%[2]s"
+  status      = "on"
+  priority    = 1
+
+  conditions = jsonencode({
+    "match": {
+      "logic": "and",
+      "criteria": [
+        {
+          "match_target_type": "extension",
+          "match_type": "contains",
+          "match_pattern": [".txt", ".png"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "scheme",
+          "match_type": "contains",
+          "match_pattern": ["HTTPS"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "method",
+          "match_type": "contains",
+          "match_pattern": ["PATCH"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "path",
+          "match_type": "contains",
+          "match_pattern": ["/test"],
+          "negate": false,
+          "case_sensitive": true
+        },
+        {
+          "match_target_type": "arg",
+          "match_target_name": "test",
+          "match_type": "contains",
+          "match_pattern": ["123"],
+          "negate": false,
+          "case_sensitive": true
+        },
+        {
+          "match_target_type": "filename",
+          "match_type": "contains",
+          "match_pattern": ["test", "123"],
+          "negate": false,
+          "case_sensitive": true
+        },
+        {
+          "match_target_type": "header",
+          "match_target_name": "test",
+          "match_type": "contains",
+          "match_pattern": ["123"],
+          "negate": false,
+          "case_sensitive": true
+        },
+        {
+          "match_target_type": "clientip",
+          "match_target_name": "connect",
+          "match_type": "contains",
+          "match_pattern": ["1.1.1.1"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "clientip_version",
+          "match_target_name": "connect",
+          "match_type": "contains",
+          "match_pattern": ["IPv4"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "ua",
+          "match_type": "contains",
+          "match_pattern": ["test"],
+          "negate": false,
+          "case_sensitive": true
+        }
+      ]
+    }
+  })
+
+  actions {
+    cache_rule {
+      ttl           = 10
+      ttl_unit      = "m"
+      follow_origin = "min_ttl"
+      force_cache   = "off"
+    }
+  }
+
+  actions {
+    access_control {
+      type = "block"
+    }
+  }
+
+  actions {
+    http_response_header {
+      name   = "Access-Control-Deny-Origin"
+      value  = "*"
+      action = "delete"
+    }
+  }
+
+  actions {
+    browser_cache_rule {
+      cache_type = "follow_origin"
+    }
+  }
+
+  actions {
+    request_url_rewrite {
+      execution_mode = "break"
+      redirect_url   = "/path/$1"
+    }
+  }
+
+  actions {
+    flexible_origin {
+      sources_type      = "ipaddr"
+      ip_or_domain      = "1.1.1.1"
+      http_port         = 80
+      https_port        = 443
+      origin_protocol  = "follow"
+      host_name         = "1.1.1.1"
+      priority          = 2
+      weight            = 10
+    }
+    flexible_origin {
+      sources_type      = "third_bucket"
+      ip_or_domain      = "test.third-bucket.com"
+      bucket_access_key = "test-ak"
+      bucket_secret_key = "test-sk"
+      bucket_region     = "cn-north-4"
+      bucket_name       = "test-third-bucket-name"
+      http_port         = 80
+      https_port        = 443
+      origin_protocol   = "follow"
+      host_name         = "1.1.1.1"
+      priority          = 1
+      weight            = 2
+    }
+  }
+
+  actions {
+    origin_request_header {
+      action = "delete"
+      name   = "test"
+      value  = "123"
+    }
+  }
+
+  actions {
+    origin_request_url_rewrite {
+      rewrite_type = "simple"
+      target_url   = "/test"
+    }
+  }
+
+  actions {
+    origin_range {
+      status = "on"
+    }
+  }
+
+  actions {
+    request_limit_rule {
+      limit_rate_after = 2
+      limit_rate_value = 3
+    }
+  }
+
+  actions {
+    error_code_cache {
+      code = 403
+      ttl  = 123
+    }
+
+    error_code_cache {
+      code = 404
+      ttl  = 123
+    }
+  }
+}
+`, acceptance.HW_CDN_DOMAIN_NAME, name)
+}
+
+func testAccRuleEngineRule_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_rule_engine_rule" "test" {
+  domain_name = "%[1]s"
+  name        = "%[2]s"
+  status      = "off"
+  priority    = 2
+
+  conditions = jsonencode({
+    "match": {
+      "logic": "and",
+      "criteria": [
+        {
+          "match_target_type": "extension",
+          "match_type": "contains",
+          "match_pattern": [".txt", ".png", ".gif"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "scheme",
+          "match_type": "contains",
+          "match_pattern": ["HTTP"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "method",
+          "match_type": "contains",
+          "match_pattern": ["GET"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "path",
+          "match_type": "contains",
+          "match_pattern": ["/test/new"],
+          "negate": false,
+          "case_sensitive": true
+        },
+        {
+          "match_target_type": "arg",
+          "match_target_name": "test",
+          "match_type": "contains",
+          "match_pattern": ["123"],
+          "negate": false,
+          "case_sensitive": true
+        },
+        {
+          "match_target_type": "filename",
+          "match_type": "contains",
+          "match_pattern": ["test", "123"],
+          "negate": false,
+          "case_sensitive": true
+        },
+        {
+          "match_target_type": "header",
+          "match_target_name": "test",
+          "match_type": "contains",
+          "match_pattern": ["123"],
+          "negate": false,
+          "case_sensitive": true
+        },
+        {
+          "match_target_type": "clientip",
+          "match_target_name": "connect",
+          "match_type": "contains",
+          "match_pattern": ["1.1.1.1"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "clientip_version",
+          "match_target_name": "connect",
+          "match_type": "contains",
+          "match_pattern": ["IPv4"],
+          "negate": false,
+          "case_sensitive": false
+        },
+        {
+          "match_target_type": "ua",
+          "match_type": "contains",
+          "match_pattern": ["test"],
+          "negate": false,
+          "case_sensitive": true
+        }
+      ]
+    }
+  })
+
+  actions {
+    cache_rule {
+      ttl          = 360
+      ttl_unit     = "s"
+      follow_origin = "off"
+      force_cache   = "on"
+    }
+  }
+
+  actions {
+    access_control {
+      type = "trust"
+    }
+  }
+
+  actions {
+    http_response_header {
+      name   = "Access-Control-Allow-Origin"
+      value  = "*"
+      action = "set"
+    }
+  }
+
+  actions {
+    browser_cache_rule {
+      cache_type = "ttl"
+      ttl        = 86400
+      ttl_unit   = "s"
+    }
+  }
+
+  actions {
+    request_url_rewrite {
+      redirect_status_code = 301
+      redirect_url         = "/new-path/$1"
+      execution_mode       = "redirect"
+    }
+  }
+
+  actions {
+    flexible_origin {
+      sources_type      = "ipaddr"
+      ip_or_domain      = "1.1.1.1"
+      bucket_access_key = ""
+      bucket_secret_key = ""
+      bucket_region     = ""
+      bucket_name       = ""
+      http_port         = 80
+      https_port        = 443
+      origin_protocol  = "follow"
+      host_name         = "1.1.1.1"
+      priority          = 1
+      weight            = 2
+    }
+    flexible_origin {
+      sources_type      = "third_bucket"
+      ip_or_domain      = "test.third-bucket.com"
+      bucket_access_key = "test-ak"
+      bucket_secret_key = "test-sk"
+      bucket_region     = "cn-north-4"
+      bucket_name       = "test-third-bucket-name"
+      http_port         = 80
+      https_port        = 443
+      origin_protocol   = "follow"
+      host_name         = "1.1.1.1"
+      priority          = 1
+      weight            = 2
+    }
+  }
+
+  actions {
+    origin_request_header {
+      action = "set"
+      name   = "new-test"
+      value  = "456"
+    }
+  }
+
+  actions {
+    origin_request_url_rewrite {
+      rewrite_type = "wildcard"
+	  source_url   = "/test"
+      target_url   = "/test/new"
+    }
+  }
+
+  actions {
+    origin_range {
+      status = "off"
+    }
+  }
+
+  actions {
+    request_limit_rule {
+      limit_rate_after = 20
+      limit_rate_value = 30
+    }
+  }
+
+  actions {
+    error_code_cache {
+      code = 405
+      ttl  = 456
+    }
+
+    error_code_cache {
+      code = 407
+      ttl  = 456
+    }
+  }
+}
+`, acceptance.HW_CDN_DOMAIN_NAME, name)
+}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_rule_engine_rule.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_rule_engine_rule.go
@@ -1,0 +1,1151 @@
+package cdn
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var ruleEngineRuleNonUpdatableParams = []string{"domain_name"}
+
+// @API CDN POST /v1.0/cdn/configuration/domains/{domain_name}/rules
+// @API CDN GET /v1.0/cdn/configuration/domains/{domain_name}/rules
+// @API CDN PUT /v1.0/cdn/configuration/domains/{domain_name}/rules/{rule_id}
+// @API CDN DELETE /v1.0/cdn/configuration/domains/{domain_name}/rules/{rule_id}
+func ResourceRuleEngineRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRuleEngineRuleCreate,
+		ReadContext:   resourceRuleEngineRuleRead,
+		UpdateContext: resourceRuleEngineRuleUpdate,
+		DeleteContext: resourceRuleEngineRuleDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(ruleEngineRuleNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceRuleEngineRuleImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the rule engine rule is located.`,
+			},
+
+			// Required parameters.
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The accelerated domain name to which the rule engine rule belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the rule engine rule.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Whether to enable the rule engine rule.`,
+			},
+			"priority": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The priority of the rule engine rule.`,
+			},
+
+			// Optional parameters.
+			"conditions": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Description:  `The trigger conditions of the rule engine rule, in JSON format.`,
+			},
+			"actions": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"flexible_origin": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							Description: `The list of flexible origin configurations.`,
+							Elem:        ruleEngineRuleActionsFlexibleOriginSchema(),
+						},
+						"origin_request_header": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							Description: `The list of origin request header configurations.`,
+							Elem:        ruleEngineRuleActionsOriginRequestHeaderSchema(),
+						},
+						"http_response_header": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							Description: `The list of HTTP response header configurations.`,
+							Elem:        ruleEngineRuleActionsHttpResponseHeaderSchema(),
+						},
+						"access_control": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Description: `The access control configuration.`,
+							Elem:        ruleEngineRuleActionsAccessControlSchema(),
+						},
+						"request_limit_rule": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Description: `The request rate limit configuration.`,
+							Elem:        ruleEngineRuleActionsRequestLimitRuleSchema(),
+						},
+						"origin_request_url_rewrite": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Description: `The origin request URL rewrite configuration.`,
+							Elem:        ruleEngineRuleActionsOriginRequestUrlRewriteSchema(),
+						},
+						"cache_rule": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Description: `The cache rule configuration.`,
+							Elem:        ruleEngineRuleActionsCacheRuleSchema(),
+						},
+						"request_url_rewrite": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Description: `The access URL rewrite configuration.`,
+							Elem:        ruleEngineRuleActionsRequestUrlRewriteSchema(),
+						},
+						"browser_cache_rule": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Description: `The browser cache rule configuration.`,
+							Elem:        ruleEngineRuleActionsBrowserCacheRuleSchema(),
+						},
+						"error_code_cache": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							Description: `The list of error code cache configurations.`,
+							Elem:        ruleEngineRuleActionsErrorCodeCacheSchema(),
+						},
+						"origin_range": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Description: `The origin range configuration.`,
+							Elem:        ruleEngineRuleActionsOriginRangeSchema(),
+						},
+					},
+				},
+				Description: `The list of actions to be performed when the rule engine rule is met.`,
+			},
+
+			// Internal parameter.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+
+			// Internal attribute.
+			"conditions_origin": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: utils.SuppressDiffAll,
+				Description: utils.SchemaDesc(
+					`The script configuration value of this change is also the original value used for comparison with
+ the new value next time the change is made. The corresponding parameter name is 'conditions'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func ruleEngineRuleActionsFlexibleOriginSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"sources_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The source type.`,
+			},
+			"ip_or_domain": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The origin IP or domain name.`,
+			},
+			"priority": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The origin priority.`,
+			},
+			"weight": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The origin weight.`,
+			},
+
+			// Optional parameters.
+			"obs_bucket_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The OBS bucket type.`,
+			},
+			"bucket_access_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The third-party object storage access key.`,
+			},
+			"bucket_secret_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The third-party object storage secret key.`,
+			},
+			"bucket_region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The third-party object storage region.`,
+			},
+			"bucket_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The third-party object storage name.`,
+			},
+			"host_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The origin host name.`,
+			},
+			"origin_protocol": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The origin protocol.`,
+			},
+			"http_port": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The HTTP port number.`,
+			},
+			"https_port": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The HTTPS port number.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRuleActionsOriginRequestHeaderSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The back-to-origin request header parameter name.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The back-to-origin request header setting type.`,
+			},
+
+			// Optional parameters.
+			"value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The back-to-origin request header parameter value.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRuleActionsHttpResponseHeaderSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The HTTP response header parameter name.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The operation type of setting HTTP response header.`,
+			},
+
+			// Optional parameters.
+			"value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The HTTP response header parameter value.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRuleActionsAccessControlSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The access control type.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRuleActionsRequestLimitRuleSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"limit_rate_after": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The rate limit condition.`,
+			},
+			"limit_rate_value": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The rate limit value.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRuleActionsOriginRequestUrlRewriteSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"rewrite_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The rewrite type.`,
+			},
+			"target_url": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The target URL.`,
+			},
+
+			// Optional parameters.
+			"source_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The source URL to be rewritten.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRuleActionsCacheRuleSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"ttl": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The cache expiration time.`,
+			},
+			"ttl_unit": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The cache expiration time unit.`,
+			},
+			"follow_origin": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The cache expiration time source.`,
+			},
+
+			// Optional parameters.
+			"force_cache": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to enable forced caching.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRuleActionsRequestUrlRewriteSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"redirect_url": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The redirect URL.`,
+			},
+			"execution_mode": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The execution mode.`,
+			},
+
+			// Optional parameters.
+			"redirect_status_code": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The redirect status code.`,
+			},
+			"redirect_host": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The redirect host.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRuleActionsBrowserCacheRuleSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"cache_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The cache effective type.`,
+			},
+
+			// Optional parameters.
+			"ttl": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The cache expiration time.`,
+			},
+			"ttl_unit": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The cache expiration time unit.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRuleActionsErrorCodeCacheSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"code": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The error code to be cached.`,
+			},
+			"ttl": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The error code cache time.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRuleActionsOriginRangeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"status": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The origin range status.`,
+			},
+		},
+	}
+}
+
+func buildRuleEngineRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":       d.Get("name").(string),
+		"status":     d.Get("status").(string),
+		"priority":   d.Get("priority").(int),
+		"conditions": utils.StringToJson(d.Get("conditions").(string)),
+		"actions":    buildRuleEngineRuleActionsBodyParams(d.Get("actions").([]interface{})),
+	}
+}
+
+func buildRuleEngineRuleActionsBodyParams(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, utils.RemoveNil(map[string]interface{}{
+			"flexible_origin": utils.ValueIgnoreEmpty(buildRuleEngineRuleActionsFlexibleOriginBodyParams(
+				utils.PathSearch("flexible_origin", item, make([]interface{}, 0)).([]interface{}))),
+			"origin_request_header": utils.ValueIgnoreEmpty(buildRuleEngineRuleActionsOriginRequestHeaderBodyParams(
+				utils.PathSearch("origin_request_header", item, make([]interface{}, 0)).([]interface{}))),
+			"http_response_header": utils.ValueIgnoreEmpty(buildRuleEngineRuleActionsHttpResponseHeaderBodyParams(
+				utils.PathSearch("http_response_header", item, make([]interface{}, 0)).([]interface{}))),
+			"access_control": utils.ValueIgnoreEmpty(buildRuleEngineRuleActionsAccessControlBodyParams(
+				utils.PathSearch("access_control", item, make([]interface{}, 0)).([]interface{}))),
+			"request_limit_rule": utils.ValueIgnoreEmpty(buildRuleEngineRuleActionsRequestLimitRuleBodyParams(
+				utils.PathSearch("request_limit_rule", item, make([]interface{}, 0)).([]interface{}))),
+			"origin_request_url_rewrite": utils.ValueIgnoreEmpty(buildRuleEngineRuleActionsOriginRequestUrlRewriteBodyParams(
+				utils.PathSearch("origin_request_url_rewrite", item, make([]interface{}, 0)).([]interface{}))),
+			"cache_rule": utils.ValueIgnoreEmpty(buildRuleEngineRuleActionsCacheRuleBodyParams(
+				utils.PathSearch("cache_rule", item, make([]interface{}, 0)).([]interface{}))),
+			"request_url_rewrite": utils.ValueIgnoreEmpty(buildRuleEngineRuleActionsRequestUrlRewriteBodyParams(
+				utils.PathSearch("request_url_rewrite", item, make([]interface{}, 0)).([]interface{}))),
+			"browser_cache_rule": utils.ValueIgnoreEmpty(buildRuleEngineRuleActionsBrowserCacheRuleBodyParams(
+				utils.PathSearch("browser_cache_rule", item, make([]interface{}, 0)).([]interface{}))),
+			"error_code_cache": utils.ValueIgnoreEmpty(buildRuleEngineRuleActionsErrorCodeCacheBodyParams(
+				utils.PathSearch("error_code_cache", item, make([]interface{}, 0)).([]interface{}))),
+			"origin_range": utils.ValueIgnoreEmpty(buildRuleEngineRuleActionsOriginRangeBodyParams(
+				utils.PathSearch("origin_range", item, make([]interface{}, 0)).([]interface{}))),
+		}))
+	}
+
+	return result
+}
+
+func buildRuleEngineRuleActionsFlexibleOriginBodyParams(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, utils.RemoveNil(map[string]interface{}{
+			"sources_type":      utils.ValueIgnoreEmpty(utils.PathSearch("sources_type", item, nil)),
+			"ip_or_domain":      utils.ValueIgnoreEmpty(utils.PathSearch("ip_or_domain", item, nil)),
+			"priority":          utils.ValueIgnoreEmpty(utils.PathSearch("priority", item, nil)),
+			"weight":            utils.ValueIgnoreEmpty(utils.PathSearch("weight", item, nil)),
+			"obs_bucket_type":   utils.ValueIgnoreEmpty(utils.PathSearch("obs_bucket_type", item, nil)),
+			"bucket_access_key": utils.ValueIgnoreEmpty(utils.PathSearch("bucket_access_key", item, nil)),
+			"bucket_secret_key": utils.ValueIgnoreEmpty(utils.PathSearch("bucket_secret_key", item, nil)),
+			"bucket_region":     utils.ValueIgnoreEmpty(utils.PathSearch("bucket_region", item, nil)),
+			"bucket_name":       utils.ValueIgnoreEmpty(utils.PathSearch("bucket_name", item, nil)),
+			"host_name":         utils.ValueIgnoreEmpty(utils.PathSearch("host_name", item, nil)),
+			"origin_protocol":   utils.ValueIgnoreEmpty(utils.PathSearch("origin_protocol", item, nil)),
+			"http_port":         utils.ValueIgnoreEmpty(utils.PathSearch("http_port", item, nil)),
+			"https_port":        utils.ValueIgnoreEmpty(utils.PathSearch("https_port", item, nil)),
+		}))
+	}
+
+	return result
+}
+
+func buildRuleEngineRuleActionsOriginRequestHeaderBodyParams(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, utils.RemoveNil(map[string]interface{}{
+			"action": utils.ValueIgnoreEmpty(utils.PathSearch("action", item, nil)),
+			"name":   utils.ValueIgnoreEmpty(utils.PathSearch("name", item, nil)),
+			"value":  utils.ValueIgnoreEmpty(utils.PathSearch("value", item, nil)),
+		}))
+	}
+
+	return result
+}
+
+func buildRuleEngineRuleActionsHttpResponseHeaderBodyParams(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, utils.RemoveNil(map[string]interface{}{
+			"action": utils.ValueIgnoreEmpty(utils.PathSearch("action", item, nil)),
+			"name":   utils.ValueIgnoreEmpty(utils.PathSearch("name", item, nil)),
+			"value":  utils.ValueIgnoreEmpty(utils.PathSearch("value", item, nil)),
+		}))
+	}
+
+	return result
+}
+
+func buildRuleEngineRuleActionsAccessControlBodyParams(items []interface{}) map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	return utils.RemoveNil(map[string]interface{}{
+		"type": utils.ValueIgnoreEmpty(utils.PathSearch("type", items[0], nil)),
+	})
+}
+
+func buildRuleEngineRuleActionsRequestLimitRuleBodyParams(items []interface{}) map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	return utils.RemoveNil(map[string]interface{}{
+		"limit_rate_after": utils.ValueIgnoreEmpty(utils.PathSearch("limit_rate_after", items[0], nil)),
+		"limit_rate_value": utils.ValueIgnoreEmpty(utils.PathSearch("limit_rate_value", items[0], nil)),
+	})
+}
+
+func buildRuleEngineRuleActionsOriginRequestUrlRewriteBodyParams(items []interface{}) map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	return utils.RemoveNil(map[string]interface{}{
+		"rewrite_type": utils.ValueIgnoreEmpty(utils.PathSearch("rewrite_type", items[0], nil)),
+		"target_url":   utils.ValueIgnoreEmpty(utils.PathSearch("target_url", items[0], nil)),
+		"source_url":   utils.ValueIgnoreEmpty(utils.PathSearch("source_url", items[0], nil)),
+	})
+}
+
+func buildRuleEngineRuleActionsCacheRuleBodyParams(items []interface{}) map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	return utils.RemoveNil(map[string]interface{}{
+		"ttl":           utils.ValueIgnoreEmpty(utils.PathSearch("ttl", items[0], nil)),
+		"ttl_unit":      utils.ValueIgnoreEmpty(utils.PathSearch("ttl_unit", items[0], nil)),
+		"follow_origin": utils.ValueIgnoreEmpty(utils.PathSearch("follow_origin", items[0], nil)),
+		"force_cache":   utils.ValueIgnoreEmpty(utils.PathSearch("force_cache", items[0], nil)),
+	})
+}
+
+func buildRuleEngineRuleActionsRequestUrlRewriteBodyParams(items []interface{}) map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"redirect_url":         utils.ValueIgnoreEmpty(utils.PathSearch("redirect_url", items[0], nil)),
+		"execution_mode":       utils.ValueIgnoreEmpty(utils.PathSearch("execution_mode", items[0], nil)),
+		"redirect_status_code": utils.ValueIgnoreEmpty(utils.PathSearch("redirect_status_code", items[0], nil)),
+		"redirect_host":        utils.ValueIgnoreEmpty(utils.PathSearch("redirect_host", items[0], nil)),
+	}
+}
+
+func buildRuleEngineRuleActionsBrowserCacheRuleBodyParams(items []interface{}) map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	return utils.RemoveNil(map[string]interface{}{
+		"cache_type": utils.ValueIgnoreEmpty(utils.PathSearch("cache_type", items[0], nil)),
+		"ttl":        utils.ValueIgnoreEmpty(utils.PathSearch("ttl", items[0], nil)),
+		"ttl_unit":   utils.ValueIgnoreEmpty(utils.PathSearch("ttl_unit", items[0], nil)),
+	})
+}
+
+func buildRuleEngineRuleActionsErrorCodeCacheBodyParams(items []interface{}) []interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"code": utils.ValueIgnoreEmpty(utils.PathSearch("code", item, nil)),
+			"ttl":  utils.ValueIgnoreEmpty(utils.PathSearch("ttl", item, nil)),
+		})
+	}
+
+	return result
+}
+
+func buildRuleEngineRuleActionsOriginRangeBodyParams(items []interface{}) map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	return utils.RemoveNil(map[string]interface{}{
+		"status": utils.ValueIgnoreEmpty(utils.PathSearch("status", items[0], nil)),
+	})
+}
+
+func createRuleEngineRule(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1.0/cdn/configuration/domains/{domain_name}/rules"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{domain_name}", d.Get("domain_name").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildRuleEngineRuleBodyParams(d)),
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	return err
+}
+
+func listRuleEngineRules(client *golangsdk.ServiceClient, domainName string) ([]interface{}, error) {
+	httpUrl := "v1.0/cdn/configuration/domains/{domain_name}/rules"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{domain_name}", domainName)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	rules := utils.PathSearch("rules", respBody, make([]interface{}, 0)).([]interface{})
+	return rules, nil
+}
+
+func GetRuleEngineRuleByName(client *golangsdk.ServiceClient, domainName string, ruleName string) (interface{}, error) {
+	rules, err := listRuleEngineRules(client, domainName)
+	if err != nil {
+		return nil, err
+	}
+
+	rule := utils.PathSearch(fmt.Sprintf("[?name =='%s']|[0]", ruleName), rules, nil)
+	if rule == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1.0/cdn/configuration/domains/{domain_name}/rules",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the rule with name '%s' has been removed", ruleName)),
+			},
+		}
+	}
+	return rule, nil
+}
+
+func resourceRuleEngineRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		domainName = d.Get("domain_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	if err := createRuleEngineRule(client, d); err != nil {
+		return diag.Errorf("error creating CDN rule engine rule: %s", err)
+	}
+
+	ruleName := d.Get("name").(string)
+	rule, err := GetRuleEngineRuleByName(client, domainName, ruleName)
+	if err != nil {
+		return diag.Errorf("unable to find the created rule with name '%s': %s", ruleName, err)
+	}
+
+	ruleId := utils.PathSearch("rule_id", rule, "").(string)
+	if ruleId == "" {
+		return diag.Errorf("unable to find the rule ID from the API response")
+	}
+
+	d.SetId(ruleId)
+
+	// If the request is successful, obtain the values ​​of all JSON parameters first and save them to the
+	// corresponding '_origin' attributes for subsequent determination and construction of the request body during
+	// next updates.
+	err = utils.RefreshObjectParamOriginValues(d, []string{"conditions"})
+	if err != nil {
+		return diag.Errorf("unable to refresh the origin values: %s", err)
+	}
+
+	return resourceRuleEngineRuleRead(ctx, d, meta)
+}
+
+func flattenRuleEngineRuleActionsFlexibleOrigin(items, originItems []interface{}) []interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(items))
+	for i, item := range items {
+		result = append(result, map[string]interface{}{
+			"priority":          utils.PathSearch("priority", item, nil),
+			"weight":            utils.PathSearch("weight", item, nil),
+			"sources_type":      utils.PathSearch("sources_type", item, nil),
+			"ip_or_domain":      utils.PathSearch("ip_or_domain", item, nil),
+			"obs_bucket_type":   utils.PathSearch("obs_bucket_type", item, nil),
+			"bucket_access_key": utils.PathSearch("bucket_access_key", item, nil),
+			"bucket_secret_key": utils.PathSearch(fmt.Sprintf("[%d].bucket_secret_key", i), originItems, nil),
+			"bucket_region":     utils.PathSearch("bucket_region", item, nil),
+			"bucket_name":       utils.PathSearch("bucket_name", item, nil),
+			"host_name":         utils.PathSearch("host_name", item, nil),
+			"origin_protocol":   utils.PathSearch("origin_protocol", item, nil),
+			"http_port":         utils.PathSearch("http_port", item, nil),
+			"https_port":        utils.PathSearch("https_port", item, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenRuleEngineRuleActionsOriginRequestHeader(items []interface{}) []interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"action": utils.PathSearch("action", item, nil),
+			"name":   utils.PathSearch("name", item, nil),
+			"value":  utils.PathSearch("value", item, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenRuleEngineRuleActionsHttpResponseHeader(items []interface{}) []interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"action": utils.PathSearch("action", item, nil),
+			"name":   utils.PathSearch("name", item, nil),
+			"value":  utils.PathSearch("value", item, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenRuleEngineRuleActionsAccessControl(item map[string]interface{}) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"type": utils.PathSearch("type", item, nil),
+		},
+	}
+}
+
+func flattenRuleEngineRuleActionsRequestLimitRule(item map[string]interface{}) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"limit_rate_after": utils.PathSearch("limit_rate_after", item, nil),
+			"limit_rate_value": utils.PathSearch("limit_rate_value", item, nil),
+		},
+	}
+}
+
+func flattenRuleEngineRuleActionsOriginRequestUrlRewrite(item map[string]interface{}) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"rewrite_type": utils.PathSearch("rewrite_type", item, nil),
+			"source_url":   utils.PathSearch("source_url", item, nil),
+			"target_url":   utils.PathSearch("target_url", item, nil),
+		},
+	}
+}
+
+func flattenRuleEngineRuleActionsCacheRule(item map[string]interface{}) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"ttl":           utils.PathSearch("ttl", item, nil),
+			"ttl_unit":      utils.PathSearch("ttl_unit", item, nil),
+			"follow_origin": utils.PathSearch("follow_origin", item, nil),
+			"force_cache":   utils.PathSearch("force_cache", item, nil),
+		},
+	}
+}
+
+func flattenRuleEngineRuleActionsRequestUrlRewrite(item map[string]interface{}) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"redirect_url":         utils.PathSearch("redirect_url", item, nil),
+			"execution_mode":       utils.PathSearch("execution_mode", item, nil),
+			"redirect_status_code": utils.PathSearch("redirect_status_code", item, nil),
+			"redirect_host":        utils.PathSearch("redirect_host", item, nil),
+		},
+	}
+}
+
+func flattenRuleEngineRuleActionsBrowserCacheRule(item map[string]interface{}) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"cache_type": utils.PathSearch("cache_type", item, nil),
+			"ttl":        utils.PathSearch("ttl", item, nil),
+			"ttl_unit":   utils.PathSearch("ttl_unit", item, nil),
+		},
+	}
+}
+
+func flattenRuleEngineRuleActionsErrorCodeCache(items []interface{}) []interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"code": utils.PathSearch("code", item, nil),
+			"ttl":  utils.PathSearch("ttl", item, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenRuleEngineRuleActionsOriginRange(item map[string]interface{}) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"status": utils.PathSearch("status", item, nil),
+		},
+	}
+}
+
+func flattenRuleEngineRuleActionsAttribute(rawArray, actionsOriginValue []interface{}) []interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(rawArray))
+	for i, item := range rawArray {
+		result = append(result, map[string]interface{}{
+			"flexible_origin": flattenRuleEngineRuleActionsFlexibleOrigin(utils.PathSearch("flexible_origin",
+				item, make([]interface{}, 0)).([]interface{}), utils.PathSearch(fmt.Sprintf("[%d].flexible_origin", i),
+				actionsOriginValue, make([]interface{}, 0)).([]interface{})),
+			"origin_request_header": flattenRuleEngineRuleActionsOriginRequestHeader(utils.PathSearch("origin_request_header",
+				item, make([]interface{}, 0)).([]interface{})),
+			"http_response_header": flattenRuleEngineRuleActionsHttpResponseHeader(utils.PathSearch("http_response_header",
+				item, make([]interface{}, 0)).([]interface{})),
+			"access_control": flattenRuleEngineRuleActionsAccessControl(utils.PathSearch("access_control",
+				item, make(map[string]interface{})).(map[string]interface{})),
+			"request_limit_rule": flattenRuleEngineRuleActionsRequestLimitRule(utils.PathSearch("request_limit_rule",
+				item, make(map[string]interface{})).(map[string]interface{})),
+			"origin_request_url_rewrite": flattenRuleEngineRuleActionsOriginRequestUrlRewrite(utils.PathSearch("origin_request_url_rewrite",
+				item, make(map[string]interface{})).(map[string]interface{})),
+			"cache_rule": flattenRuleEngineRuleActionsCacheRule(utils.PathSearch("cache_rule",
+				item, make(map[string]interface{})).(map[string]interface{})),
+			"request_url_rewrite": flattenRuleEngineRuleActionsRequestUrlRewrite(utils.PathSearch("request_url_rewrite",
+				item, make(map[string]interface{})).(map[string]interface{})),
+			"browser_cache_rule": flattenRuleEngineRuleActionsBrowserCacheRule(utils.PathSearch("browser_cache_rule",
+				item, make(map[string]interface{})).(map[string]interface{})),
+			"error_code_cache": flattenRuleEngineRuleActionsErrorCodeCache(utils.PathSearch("error_code_cache",
+				item, make([]interface{}, 0)).([]interface{})),
+			"origin_range": flattenRuleEngineRuleActionsOriginRange(utils.PathSearch("origin_range",
+				item, make(map[string]interface{})).(map[string]interface{})),
+		})
+	}
+
+	return result
+}
+
+func GetRuleEngineRuleById(client *golangsdk.ServiceClient, domainName string, ruleId string) (interface{}, error) {
+	rules, err := listRuleEngineRules(client, domainName)
+	if err != nil {
+		return nil, err
+	}
+
+	rule := utils.PathSearch(fmt.Sprintf("[?rule_id =='%s']|[0]", ruleId), rules, nil)
+	if rule == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1.0/cdn/configuration/domains/{domain_name}/rules",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the rule with ID '%s' has been removed", ruleId)),
+			},
+		}
+	}
+	return rule, nil
+}
+
+func resourceRuleEngineRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		domainName = d.Get("domain_name").(string)
+		ruleId     = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	rule, err := GetRuleEngineRuleById(client, domainName, ruleId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CDN rule engine rules")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", cfg.GetRegion(d)),
+		d.Set("domain_name", domainName),
+		d.Set("name", utils.PathSearch("name", rule, nil)),
+		d.Set("status", utils.PathSearch("status", rule, nil)),
+		d.Set("priority", utils.PathSearch("priority", rule, nil)),
+		d.Set("conditions", utils.JsonToString(utils.PathSearch("conditions", rule, nil))),
+		d.Set("actions", flattenRuleEngineRuleActionsAttribute(utils.PathSearch("actions", rule, make([]interface{}, 0)).([]interface{}),
+			d.Get("actions").([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func updateFullRuleEngineRules(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1.0/cdn/configuration/domains/{domain_name}/rules/{rule_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{domain_name}", d.Get("domain_name").(string))
+	updatePath = strings.ReplaceAll(updatePath, "{rule_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildRuleEngineRuleBodyParams(d)),
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func resourceRuleEngineRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg = meta.(*config.Config)
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	err = updateFullRuleEngineRules(client, d)
+	if err != nil {
+		return diag.Errorf("error updating CDN rule engine rule: %s", err)
+	}
+
+	// If the request is successful, obtain the values ​​of all JSON parameters first and save them to the
+	// corresponding '_origin' attributes for subsequent determination and construction of the request body during
+	// next updates.
+	err = utils.RefreshObjectParamOriginValues(d, []string{"conditions"})
+	if err != nil {
+		return diag.Errorf("unable to refresh the origin values: %s", err)
+	}
+
+	return resourceRuleEngineRuleRead(ctx, d, meta)
+}
+
+func deleteRuleEngineRule(client *golangsdk.ServiceClient, domainName, ruleId string) error {
+	httpUrl := "v1.0/cdn/configuration/domains/{domain_name}/rules/{rule_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{domain_name}", domainName)
+	deletePath = strings.ReplaceAll(deletePath, "{rule_id}", ruleId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceRuleEngineRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		domainName = d.Get("domain_name").(string)
+		ruleId     = d.Id()
+		// The error code of the rule engine rule not found is 'CDN.0001'.
+		ruleEngineRuleNotFoundCodes = []string{"CDN.0001"}
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	err = deleteRuleEngineRule(client, domainName, ruleId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error.error_code", ruleEngineRuleNotFoundCodes...),
+			fmt.Sprintf("error deleting CDN rule engine rule (%s)", ruleId))
+	}
+
+	return nil
+}
+
+func resourceRuleEngineRuleImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	importId := d.Id()
+	parts := strings.SplitN(importId, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<domain_name>/<id>' or '<domain_name>/<name>', but got '%s'", importId)
+	}
+
+	// If the ID is a UUID, set the ID and domain name
+	if utils.IsUUID(parts[1]) {
+		d.SetId(parts[1])
+		return []*schema.ResourceData{d}, d.Set("domain_name", parts[0])
+	}
+	// If the ID is not a UUID, get the rule by name and set the ID and domain name
+	var (
+		cfg        = meta.(*config.Config)
+		domainName = parts[0]
+		ruleName   = parts[1]
+	)
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return nil, fmt.Errorf("error creating CDN client: %s", err)
+	}
+	rule, err := GetRuleEngineRuleByName(client, domainName, ruleName)
+	if err != nil {
+		return nil, err
+	}
+	d.SetId(utils.PathSearch("rule_id", rule, "").(string))
+
+	return []*schema.ResourceData{d}, d.Set("domain_name", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource to manage rule engine rule in CDN service.
<img width="1711" height="383" alt="image" src="https://github.com/user-attachments/assets/5ef03323-ebde-4c15-af10-db40ab8ff731" />
<img width="1653" height="1216" alt="image" src="https://github.com/user-attachments/assets/13b3c072-2df2-42fb-80b4-435b2328bb84" />

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="996" height="355" alt="image" src="https://github.com/user-attachments/assets/d2c3fd8f-cce9-4ef2-948b-f474443c1137" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage rule engine rule in CDN service.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cdn -f TestAccRuleEngineRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccRuleEngineRule_basic -timeout 360m -parallel 10
=== RUN   TestAccRuleEngineRule_basic
=== PAUSE TestAccRuleEngineRule_basic
=== CONT  TestAccRuleEngineRule_basic
--- PASS: TestAccRuleEngineRule_basic (28.55s)
PASS
coverage: 11.3% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       28.630s coverage: 11.3% of statements in ./huaweicloud/services/cdn
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="659" height="640" alt="image" src="https://github.com/user-attachments/assets/0f181191-e4ca-44e7-b604-2ada15af6a94" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1133" height="864" alt="image" src="https://github.com/user-attachments/assets/a559e634-e1eb-48d4-95a5-d086903ae84a" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
