### PR TITLE
feat(workspace/app): add new data source to query server metrics

### DIFF
--- a/docs/data-sources/workspace_app_server_metric_data.md
+++ b/docs/data-sources/workspace_app_server_metric_data.md
@@ -1,0 +1,110 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_server_metric_data"
+description: |-
+  Use this data source to query the monitoring metric data of the Workspace APP server within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_server_metric_data
+
+Use this data source to query the monitoring metric data of the Workspace APP server within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "server_id" {}
+variable "start_time" {}
+variable "end_time" {}
+
+data "huaweicloud_workspace_app_server_metric_data" "test" {
+  server_id   = var.server_id
+  namespace   = "SYS.ECS"
+  metric_name = "cpu_util"
+  from        = var.start_time
+  to          = var.end_time
+  period      = 1
+  filter      = "average"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the server metric data are located.  
+  If omitted, the provider-level region will be used.
+
+* `server_id` - (Required, String) Specifies the ID of the server.
+
+* `namespace` - (Required, String) Specifies the namespace of the service.  
+  The valid values are as follows:
+  + **SYS.ECS**: Basic monitoring metrics of Elastic Cloud Server (ECS).
+  + **AGT.ECS**: Operating system monitoring metrics of ECS (GPU metrics).
+
+* `metric_name` - (Required, String) Specifies the name of the monitoring metric.
+  + For **SYS.ECS** namespace, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/usermanual-ecs/ecs_03_1002.html).
+  + For **AGT.ECS** namespace, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/usermanual-ecs/ecs_03_1003.html#section11).
+
+* `from` - (Required, String) Specifies the start time of the query data, in RFC3339 format.
+
+* `to` - (Required, String) Specifies the end time of the query data, in RFC3339 format.
+
+* `period` - (Required, Int) Specifies the granularity of monitoring data.  
+  The valid values are as follows:
+  + **1**: Real-time data.
+  + **300**: `5` minute granularity.
+  + **1200**: `20` minute granularity.
+  + **3600**: `1` hour granularity.
+  + **14400**: `4` hour granularity.
+  + **86400**: `1` day granularity.
+
+* `filter` - (Required, String) Specifies the data aggregation method.  
+  The valid values are as follows:
+  + **average**: The average value of the metric data within the aggregation period.
+  + **max**: The maximum value of the metric data within the aggregation period.
+  + **min**: The minimum value of the metric data within the aggregation period.
+  + **sum**: The sum value of the metric data within the aggregation period.
+  + **variance**: The variance of the metric data within the aggregation period.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `metrics` - The list of server metric data.  
+  The [metrics](#app_server_metric_data) structure is documented below.
+
+<a name="app_server_metric_data"></a>
+The `metrics` block supports:
+
+* `metric_name` - The name of the monitoring metric.
+
+* `dimension_value` - The dimension value.  
+  This field is valid only when querying GPU monitoring information.
+
+* `datapoints` - The list of metric data points.  
+  The [datapoints](#app_server_metric_data_datapoints) structure is documented below.
+
+<a name="app_server_metric_data_datapoints"></a>
+The `datapoints` block supports:
+
+* `average` - The average value of the metric data within the aggregation period.  
+  This field is valid only when the `filter` is set to `average`.
+
+* `max` - The maximum value of the metric data within the aggregation period.  
+  This field is valid only when the `filter` is set to `max`.
+
+* `min` - The minimum value of the metric data within the aggregation period.  
+  This field is valid only when the `filter` is set to `min`.
+
+* `sum` - The sum value of the metric data within the aggregation period.  
+  This field is valid only when the `filter` is set to `sum`.
+
+* `variance` - The variance of the metric data within the aggregation period.  
+  This field is valid only when the `filter` is set to `variance`.
+
+* `collection_time` - The collection time of the metric, in RFC3339 format.
+
+* `unit` - The unit of the metric.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2255,6 +2255,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_server_group_restrict":                    workspace.DataSourceAppServerGroupRestrict(),
 			"huaweicloud_workspace_app_server_group_status":                      workspace.DataSourceAppServerGroupStatus(),
 			"huaweicloud_workspace_app_server_group_tags":                        workspace.DataSourceAppServerGroupTags(),
+			"huaweicloud_workspace_app_server_metric_data":                       workspace.DataSourceAppServerMetricData(),
 			"huaweicloud_workspace_app_server_quotas":                            workspace.DataSourceAppServerQuotas(),
 			"huaweicloud_workspace_app_session_types":                            workspace.DataSourceSessionTypes(),
 			"huaweicloud_workspace_app_storage_policies":                         workspace.DataSourceAppStoragePolicies(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_server_metric_data_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_server_metric_data_test.go
@@ -1,0 +1,140 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataAppServerMetricData_basic(t *testing.T) {
+	var (
+		byAverage   = "data.huaweicloud_workspace_app_server_metric_data.average"
+		dcByAverage = acceptance.InitDataSourceCheck(byAverage)
+
+		byMax   = "data.huaweicloud_workspace_app_server_metric_data.max"
+		dcByMax = acceptance.InitDataSourceCheck(byMax)
+
+		byMin   = "data.huaweicloud_workspace_app_server_metric_data.min"
+		dcByMin = acceptance.InitDataSourceCheck(byMin)
+
+		bySum   = "data.huaweicloud_workspace_app_server_metric_data.sum"
+		dcBySum = acceptance.InitDataSourceCheck(bySum)
+
+		byVariance   = "data.huaweicloud_workspace_app_server_metric_data.variance"
+		dcByVariance = acceptance.InitDataSourceCheck(byVariance)
+
+		currentTime = time.Now()
+		startTime   = currentTime.Add(-1 * time.Hour).Format(time.RFC3339)
+		endTime     = currentTime.Format(time.RFC3339)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAppServerMetricData_serverIdNotFound(startTime, endTime),
+				ExpectError: regexp.MustCompile("The cloud application server requested by the client was not found, and '" +
+					".+" + "' is a non-existing cloud application server."),
+			},
+			{
+				Config: testAccDataAppServerMetricData_basic(startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					dcByAverage.CheckResourceExists(),
+					resource.TestMatchResourceAttr(byAverage, "metrics.#", regexp.MustCompile(`[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(byAverage, "metrics.0.metric_name"),
+					resource.TestMatchResourceAttr(byAverage, "metrics.0.datapoints.#", regexp.MustCompile(`[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(byAverage, "metrics.0.datapoints.0.average"),
+					resource.TestCheckResourceAttrSet(byAverage, "metrics.0.datapoints.0.collection_time"),
+					resource.TestCheckResourceAttrSet(byAverage, "metrics.0.datapoints.0.unit"),
+					dcByMax.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(byMax, "metrics.0.datapoints.0.max"),
+					dcByMin.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(byMin, "metrics.0.datapoints.0.min"),
+					dcBySum.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(bySum, "metrics.0.datapoints.0.sum"),
+					dcByVariance.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(byVariance, "metrics.0.datapoints.0.variance"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataAppServerMetricData_serverIdNotFound(startTime, endTime string) string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_app_server_metric_data" "test" {
+  server_id   = "%[1]s"
+  namespace   = "SYS.ECS"
+  metric_name = "cpu_util"
+  from        = "%[2]s"
+  to          = "%[3]s"
+  period      = 1
+  filter      = "average"
+}
+`, randomId, startTime, endTime)
+}
+
+func testAccDataAppServerMetricData_basic(startTime, endTime string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_app_server_metric_data" "average" {
+  server_id   = "%[1]s"
+  namespace   = "SYS.ECS"
+  metric_name = "cpu_util"
+  from        = "%[2]s"
+  to          = "%[3]s"
+  period      = 1
+  filter      = "average"
+}
+
+data "huaweicloud_workspace_app_server_metric_data" "max" {
+  server_id   = "%[1]s"
+  namespace   = "SYS.ECS"
+  metric_name = "cpu_util"
+  from        = "%[2]s"
+  to          = "%[3]s"
+  period      = 1
+  filter      = "max"
+}
+
+data "huaweicloud_workspace_app_server_metric_data" "min" {
+  server_id   = "%[1]s"
+  namespace   = "SYS.ECS"
+  metric_name = "cpu_util"
+  from        = "%[2]s"
+  to          = "%[3]s"
+  period      = 1
+  filter      = "min"
+}
+
+data "huaweicloud_workspace_app_server_metric_data" "sum" {
+  server_id   = "%[1]s"
+  namespace   = "SYS.ECS"
+  metric_name = "cpu_util"
+  from        = "%[2]s"
+  to          = "%[3]s"
+  period      = 1
+  filter      = "sum"
+}
+
+data "huaweicloud_workspace_app_server_metric_data" "variance" {
+  server_id   = "%[1]s"
+  namespace   = "SYS.ECS"
+  metric_name = "cpu_util"
+  from        = "%[2]s"
+  to          = "%[3]s"
+  period      = 1
+  filter      = "variance"
+}
+`, acceptance.HW_WORKSPACE_APP_SERVER_ID, startTime, endTime)
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_server_metric_data.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_server_metric_data.go
@@ -1,0 +1,235 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/app-servers/server-metric-data/{server_id}
+func DataSourceAppServerMetricData() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppServerMetricDataRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the server metric data are located.`,
+			},
+			"server_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the server.`,
+			},
+			"namespace": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The namespace of the service.`,
+			},
+			"metric_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the monitoring metric.`,
+			},
+			"from": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The start time of the query data, in RFC3339 format.`,
+			},
+			"to": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The end time of the query data, in RFC3339 format.`,
+			},
+			"period": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The granularity of monitoring data.`,
+			},
+			"filter": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The data aggregation method.`,
+			},
+			"metrics": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of server metric data.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"metric_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the monitoring metric.`,
+						},
+						"dimension_value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The dimension value.`,
+						},
+						"datapoints": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of metric data points.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"average": {
+										Type:        schema.TypeFloat,
+										Computed:    true,
+										Description: `The average value of the metric data within the aggregation period.`,
+									},
+									"max": {
+										Type:        schema.TypeFloat,
+										Computed:    true,
+										Description: `The maximum value of the metric data within the aggregation period.`,
+									},
+									"min": {
+										Type:        schema.TypeFloat,
+										Computed:    true,
+										Description: `The minimum value of the metric data within the aggregation period.`,
+									},
+									"sum": {
+										Type:        schema.TypeFloat,
+										Computed:    true,
+										Description: `The sum value of the metric data within the aggregation period.`,
+									},
+									"variance": {
+										Type:        schema.TypeFloat,
+										Computed:    true,
+										Description: `The variance of the metric data within the aggregation period.`,
+									},
+									"collection_time": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The collection time of the metric, in RFC3339 format.`,
+									},
+									"unit": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The unit of the metric.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAppServerMetricDataQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?namespace=%v&metric_name=%v&from=%v&to=%v&period=%v&filter=%v",
+		d.Get("namespace"),
+		d.Get("metric_name"),
+		utils.ConvertTimeStrToNanoTimestamp(d.Get("from").(string)),
+		utils.ConvertTimeStrToNanoTimestamp(d.Get("to").(string)),
+		d.Get("period"),
+		d.Get("filter"),
+	)
+}
+
+func listAppServerMetricData(client *golangsdk.ServiceClient, d *schema.ResourceData, serverId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/app-servers/server-metric-data/{server_id}"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{server_id}", serverId)
+	listPath += buildAppServerMetricDataQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func dataSourceAppServerMetricDataRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		serverId = d.Get("server_id").(string)
+	)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	respBody, err := listAppServerMetricData(client, d, serverId)
+	if err != nil {
+		return diag.Errorf("error querying APP server (%s) metric data: %s", serverId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("metrics", flattenAppServerMetricDataMetrics(utils.PathSearch("server_metrics",
+			respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAppServerMetricDataMetrics(metrics []interface{}) []map[string]interface{} {
+	if len(metrics) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(metrics))
+	for _, metric := range metrics {
+		result = append(result, map[string]interface{}{
+			"metric_name":     utils.PathSearch("metric_name", metric, nil),
+			"dimension_value": utils.PathSearch("dimension_value", metric, nil),
+			"datapoints": flattenAppServerMetricDataMetricDatapoints(utils.PathSearch("datapoints",
+				metric, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func flattenAppServerMetricDataMetricDatapoints(datapoints []interface{}) []map[string]interface{} {
+	if len(datapoints) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(datapoints))
+	for _, v := range datapoints {
+		result = append(result, map[string]interface{}{
+			"average":  utils.PathSearch("average", v, nil),
+			"max":      utils.PathSearch("max", v, nil),
+			"min":      utils.PathSearch("min", v, nil),
+			"sum":      utils.PathSearch("sum", v, nil),
+			"variance": utils.PathSearch("variance", v, nil),
+			"collection_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("timestamp",
+				v, float64(0)).(float64))/1000, false),
+			"unit": utils.PathSearch("unit", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_workspace_app_server_metric_data`) to query metrics of the specified Workspace APP server.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o workspace -f TestAccDataAppServerMetricData_
basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppServerMetricData_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppServerMetricData_basic
=== PAUSE TestAccDataAppServerMetricData_basic
=== CONT  TestAccDataAppServerMetricData_basic
--- PASS: TestAccDataAppServerMetricData_basic (19.92s)
PASS
coverage: 3.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 20.066s coverage: 3.2% of statements in ./huaweicloud/services/workspace
```
<img width="1092" height="508" alt="image" src="https://github.com/user-attachments/assets/d9478732-923b-4fb5-a60d-98035981a147" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
