### PR TITLE
feat(cdn): add new data source to query rule engine rules

### DIFF
--- a/docs/data-sources/cdn_rule_engine_rules.md
+++ b/docs/data-sources/cdn_rule_engine_rules.md
@@ -1,0 +1,201 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_rule_engine_rules"
+description: |-
+  Use this data source to get a list of rule engine rules within HuaweiCloud.
+---
+
+# huaweicloud_cdn_rule_engine_rules
+
+Use this data source to get a list of rule engine rules within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "domain_name" {}
+
+data "huaweicloud_cdn_rule_engine_rules" "test" {
+  domain_name = var.domain_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the rule engine rules are located.  
+  If omitted, the provider-level region will be used.
+
+* `domain_name` - (Required, String) Specifies the accelerated domain name to which the rule engine rules belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `rules` - The list of the rule engine rules.  
+  The [rules](#cdn_rule_engine_rules_rules) structure is documented below.
+
+<a name="cdn_rule_engine_rules_rules"></a>
+The `rules` block supports:
+
+* `id` - The ID of the rule engine rule.
+
+* `name` - The name of the rule engine rule.
+
+* `status` - Whether the rule is enabled.
+
+* `priority` - The priority of the rule engine rule.
+
+* `conditions` - The trigger conditions of the current rule, in JSON format.
+
+* `actions` - The list of actions to be performed when the rules are met.  
+  The [actions](#cdn_rule_engine_rules_rules_actions) structure is documented below.
+
+<a name="cdn_rule_engine_rules_rules_actions"></a>
+The `actions` block supports:
+
+* `flexible_origin` - The list of flexible origin configurations.  
+  The [flexible_origin](#cdn_rule_engine_rules_rules_actions_flexible_origin) structure is documented below.
+
+* `origin_request_header` - The list of origin request header configurations.  
+  The [origin_request_header](#cdn_rule_engine_rules_rules_actions_origin_request_header) structure is documented below.
+
+* `http_response_header` - The list of HTTP response header configurations.  
+  The [http_response_header](#cdn_rule_engine_rules_rules_actions_http_response_header) structure is documented below.
+
+* `access_control` - The access control configuration.  
+  The [access_control](#cdn_rule_engine_rules_rules_actions_access_control) structure is documented below.
+
+* `request_limit_rule` - The request rate limit configuration.  
+  The [request_limit_rule](#cdn_rule_engine_rules_rules_actions_request_limit_rule) structure is documented below.
+
+* `origin_request_url_rewrite` - The origin request URL rewrite configuration.  
+  The [origin_request_url_rewrite](#cdn_rule_engine_rules_rules_actions_origin_request_url_rewrite) structure is
+  documented below.
+
+* `cache_rule` - The cache rule configuration.  
+  The [cache_rule](#cdn_rule_engine_rules_rules_actions_cache_rule) structure is documented below.
+
+* `request_url_rewrite` - The access URL rewrite configuration.  
+  The [request_url_rewrite](#cdn_rule_engine_rules_rules_actions_request_url_rewrite) structure is documented below.
+
+* `browser_cache_rule` - The browser cache rule configuration.  
+  The [browser_cache_rule](#cdn_rule_engine_rules_rules_actions_browser_cache_rule) structure is documented below.
+
+* `error_code_cache` - The list of error code cache configurations.  
+  The [error_code_cache](#cdn_rule_engine_rules_rules_actions_error_code_cache) structure is documented below.
+
+* `origin_range` - The origin range configuration.  
+  The [origin_range](#cdn_rule_engine_rules_rules_actions_origin_range) structure is documented below.
+
+<a name="cdn_rule_engine_rules_rules_actions_flexible_origin"></a>
+The `flexible_origin` block supports:
+
+* `sources_type` - The source type.
+
+* `ip_or_domain` - The origin IP or domain name.
+
+* `priority` - The origin priority.
+
+* `weight` - The origin weight.
+
+* `obs_bucket_type` - The OBS bucket type.
+
+* `bucket_access_key` - The third-party object storage access key.
+
+* `bucket_region` - The third-party object storage region.
+
+* `bucket_name` - The third-party object storage name.
+
+* `host_name` - The origin host name.
+
+* `origin_protocol` - The origin protocol.
+
+* `http_port` - The HTTP port number.
+
+* `https_port` - The HTTPS port number.
+
+<a name="cdn_rule_engine_rules_rules_actions_origin_request_header"></a>
+The `origin_request_header` block supports:
+
+* `name` - The back-to-origin request header parameter name.
+
+* `action` - The back-to-origin request header setting type.
+
+* `value` - The back-to-origin request header parameter value.
+
+<a name="cdn_rule_engine_rules_rules_actions_http_response_header"></a>
+The `http_response_header` block supports:
+
+* `name` - The HTTP response header parameter name.
+
+* `action` - The operation type of setting HTTP response header.
+
+* `value` - The HTTP response header parameter value.
+
+<a name="cdn_rule_engine_rules_rules_actions_access_control"></a>
+The `access_control` block supports:
+
+* `type` - The access control type.
+
+<a name="cdn_rule_engine_rules_rules_actions_request_limit_rule"></a>
+The `request_limit_rule` block supports:
+
+* `limit_rate_after` - The rate limit condition.
+
+* `limit_rate_value` - The rate limit value.
+
+<a name="cdn_rule_engine_rules_rules_actions_origin_request_url_rewrite"></a>
+The `origin_request_url_rewrite` block supports:
+
+* `rewrite_type` - The rewrite type.
+
+* `target_url` - The target URL.
+
+* `source_url` - The source URL to be rewritten.
+
+<a name="cdn_rule_engine_rules_rules_actions_cache_rule"></a>
+The `cache_rule` block supports:
+
+* `ttl` - The cache expiration time.
+
+* `ttl_unit` - The cache expiration time unit.
+
+* `follow_origin` - The cache expiration time source.
+
+* `force_cache` - Whether to enable forced caching.
+
+<a name="cdn_rule_engine_rules_rules_actions_request_url_rewrite"></a>
+The `request_url_rewrite` block supports:
+
+* `redirect_url` - The redirect URL.
+
+* `execution_mode` - The execution mode.
+
+* `redirect_status_code` - The redirect status code.
+
+* `redirect_host` - The redirect host.
+
+<a name="cdn_rule_engine_rules_rules_actions_browser_cache_rule"></a>
+The `browser_cache_rule` block supports:
+
+* `cache_type` - The cache effective type.
+
+* `ttl` - The cache expiration time.
+
+* `ttl_unit` - The cache expiration time unit.
+
+<a name="cdn_rule_engine_rules_rules_actions_error_code_cache"></a>
+The `error_code_cache` block supports:
+
+* `code` - The error code to be cached.
+
+* `ttl` - The error code cache time.
+
+<a name="cdn_rule_engine_rules_rules_actions_origin_range"></a>
+The `origin_range` block supports:
+
+* `status` - The origin range status.

--- a/docs/resources/cdn_rule_engine_rule.md
+++ b/docs/resources/cdn_rule_engine_rule.md
@@ -217,8 +217,7 @@ The following arguments are supported:
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
 * `domain_name` - (Required, String, NonUpdatable) Specifies the accelerated domain name to which the rule engine rule
-  belongs.  
-  Changing this parameter will create a new resource.
+  belongs.
 
 * `name` - (Required, String) Specifies the name of the rule engine rule.  
   The valid length is limit from `1` to `50`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -755,6 +755,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_logs":                      cdn.DataSourceLogs(),
 			"huaweicloud_cdn_quotas":                    cdn.DataSourceQuotas(),
 			"huaweicloud_cdn_domain_statistics":         cdn.DataSourceStatistics(),
+			"huaweicloud_cdn_rule_engine_rules":         cdn.DataSourceRuleEngineRules(),
 			"huaweicloud_cdn_top_referrer_statistics":   cdn.DataSourceTopReferrerStatistics(),
 			"huaweicloud_cdn_top_url_statistics":        cdn.DataSourceTopUrlStatistics(),
 

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_rule_engine_rules_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_rule_engine_rules_test.go
@@ -1,0 +1,83 @@
+package cdn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataRuleEngineRules_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_cdn_rule_engine_rules.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCdnDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataRuleEngineRules_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "domain_name", acceptance.HW_CDN_DOMAIN_NAME),
+					resource.TestCheckResourceAttrSet(rName, "rules.#"),
+					resource.TestCheckOutput("is_rule_id_set_and_valid", "true"),
+					resource.TestCheckOutput("is_rule_name_set_and_valid", "true"),
+					resource.TestCheckOutput("is_rule_status_set_and_valid", "true"),
+					resource.TestCheckOutput("is_rule_priority_set_and_valid", "true"),
+					resource.TestCheckOutput("is_rule_conditions_set_and_valid", "true"),
+					resource.TestCheckOutput("is_rule_actions_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataRuleEngineRules_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_cdn_rule_engine_rules" "test" {
+  depends_on = [huaweicloud_cdn_rule_engine_rule.test]
+
+  domain_name = "%[2]s"
+}
+
+locals {
+  rule_name    = huaweicloud_cdn_rule_engine_rule.test.name
+  queried_rule = [for rule in data.huaweicloud_cdn_rule_engine_rules.test.rules : rule if rule.name == local.rule_name]
+}
+
+output "is_rule_id_set_and_valid" {
+  value = length(local.queried_rule) >= 1 && local.queried_rule[0].id == huaweicloud_cdn_rule_engine_rule.test.id
+}
+
+output "is_rule_name_set_and_valid" {
+  value = length(local.queried_rule) >= 1 && local.queried_rule[0].name == huaweicloud_cdn_rule_engine_rule.test.name
+}
+
+output "is_rule_status_set_and_valid" {
+  value = length(local.queried_rule) >= 1 && local.queried_rule[0].status == huaweicloud_cdn_rule_engine_rule.test.status
+}
+
+output "is_rule_priority_set_and_valid" {
+  value = length(local.queried_rule) >= 1 && local.queried_rule[0].priority == huaweicloud_cdn_rule_engine_rule.test.priority
+}
+
+output "is_rule_conditions_set_and_valid" {
+  value = length(local.queried_rule) >= 1 && local.queried_rule[0].conditions != ""
+}
+
+output "is_rule_actions_set_and_valid" {
+  value = length(local.queried_rule) >= 1 && length(local.queried_rule[0].actions) == length(huaweicloud_cdn_rule_engine_rule.test.actions)
+}
+`, testAccRuleEngineRule_basic_step1(name), acceptance.HW_CDN_DOMAIN_NAME)
+}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_rule_engine_rules.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_rule_engine_rules.go
@@ -1,0 +1,468 @@
+package cdn
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CDN GET /v1.0/cdn/configuration/domains/{domain_name}/rules
+func DataSourceRuleEngineRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRuleEngineRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the rule engine rules are located.`,
+			},
+
+			// Required parameters.
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The accelerated domain name to which the rule engine rules belong.`,
+			},
+
+			// Attributes.
+			"rules": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        ruleEngineRulesAttrRulesElemSchema(),
+				Description: `The list of the rule engine rules.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRulesAttrRulesElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the rule engine rule.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the rule engine rule.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Whether the rule is enabled.`,
+			},
+			"priority": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The priority of the rule engine rule.`,
+			},
+			"conditions": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The trigger conditions of the current rule, in JSON format.`,
+			},
+			"actions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"flexible_origin": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        ruleEngineRulesAttrFlexibleOriginElemSchema(),
+							Description: `The list of flexible origin configurations.`,
+						},
+						"origin_request_header": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        ruleEngineRulesAttrOriginRequestHeaderElemSchema(),
+							Description: `The list of origin request header configurations.`,
+						},
+						"http_response_header": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        ruleEngineRulesAttrHttpResponseHeaderElemSchema(),
+							Description: `The list of HTTP response header configurations.`,
+						},
+						"access_control": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        ruleEngineRulesAttrAccessControlElemSchema(),
+							Description: `The access control configuration.`,
+						},
+						"request_limit_rule": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        ruleEngineRulesAttrRequestLimitRuleElemSchema(),
+							Description: `The request rate limit configuration.`,
+						},
+						"origin_request_url_rewrite": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        ruleEngineRulesAttrOriginRequestUrlRewriteElemSchema(),
+							Description: `The origin request URL rewrite configuration.`,
+						},
+						"cache_rule": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        ruleEngineRulesAttrCacheRuleElemSchema(),
+							Description: `The cache rule configuration.`,
+						},
+						"request_url_rewrite": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        ruleEngineRulesAttrRequestUrlRewriteElemSchema(),
+							Description: `The access URL rewrite configuration.`,
+						},
+						"browser_cache_rule": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        ruleEngineRulesAttrBrowserCacheRuleElemSchema(),
+							Description: `The browser cache rule configuration.`,
+						},
+						"error_code_cache": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        ruleEngineRulesAttrErrorCodeCacheElemSchema(),
+							Description: `The list of error code cache configurations.`,
+						},
+						"origin_range": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        ruleEngineRulesAttrOriginRangeElemSchema(),
+							Description: `The origin range configuration.`,
+						},
+					},
+				},
+				Description: `The list of actions to be performed when the rules are met.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRulesAttrFlexibleOriginElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"sources_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The source type.`,
+			},
+			"ip_or_domain": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The origin IP or domain name.`,
+			},
+			"priority": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The origin priority.`,
+			},
+			"weight": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The origin weight.`,
+			},
+			"obs_bucket_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The OBS bucket type.`,
+			},
+			"bucket_access_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The third-party object storage access key.`,
+			},
+			"bucket_region": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The third-party object storage region.`,
+			},
+			"bucket_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The third-party object storage name.`,
+			},
+			"host_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The origin host name.`,
+			},
+			"origin_protocol": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The origin protocol.`,
+			},
+			"http_port": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The HTTP port number.`,
+			},
+			"https_port": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The HTTPS port number.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRulesAttrOriginRequestHeaderElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The back-to-origin request header parameter name.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The back-to-origin request header setting type.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The back-to-origin request header parameter value.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRulesAttrHttpResponseHeaderElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The HTTP response header parameter name.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The operation type of setting HTTP response header.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The HTTP response header parameter value.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRulesAttrAccessControlElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The access control type.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRulesAttrRequestLimitRuleElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"limit_rate_after": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The rate limit condition.`,
+			},
+			"limit_rate_value": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The rate limit value.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRulesAttrOriginRequestUrlRewriteElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"rewrite_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The rewrite type.`,
+			},
+			"target_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The target URL.`,
+			},
+			"source_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The source URL to be rewritten.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRulesAttrCacheRuleElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"ttl": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The cache expiration time.`,
+			},
+			"ttl_unit": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The cache expiration time unit.`,
+			},
+			"follow_origin": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The cache expiration time source.`,
+			},
+			"force_cache": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Whether to enable forced caching.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRulesAttrRequestUrlRewriteElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"redirect_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The redirect URL.`,
+			},
+			"execution_mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The execution mode.`,
+			},
+			"redirect_status_code": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The redirect status code.`,
+			},
+			"redirect_host": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The redirect host.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRulesAttrBrowserCacheRuleElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cache_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The cache effective type.`,
+			},
+			"ttl": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The cache expiration time.`,
+			},
+			"ttl_unit": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The cache expiration time unit.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRulesAttrErrorCodeCacheElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"code": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The error code to be cached.`,
+			},
+			"ttl": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The error code cache time.`,
+			},
+		},
+	}
+}
+
+func ruleEngineRulesAttrOriginRangeElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The origin range status.`,
+			},
+		},
+	}
+}
+
+func flattenRuleEngineRules(rules []interface{}) []map[string]interface{} {
+	if len(rules) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(rules))
+	for _, rule := range rules {
+		result = append(result, map[string]interface{}{
+			"id":         utils.PathSearch("rule_id", rule, nil),
+			"name":       utils.PathSearch("name", rule, nil),
+			"status":     utils.PathSearch("status", rule, nil),
+			"priority":   utils.PathSearch("priority", rule, nil),
+			"conditions": utils.JsonToString(utils.PathSearch("conditions", rule, nil)),
+			"actions": flattenRuleEngineRuleActionsAttribute(utils.PathSearch("actions", rule,
+				make([]interface{}, 0)).([]interface{}), nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceRuleEngineRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		domainName = d.Get("domain_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	rules, err := listRuleEngineRules(client, domainName)
+	if err != nil {
+		return diag.Errorf("error querying CDN rule engine rules: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", cfg.GetRegion(d)),
+		d.Set("rules", flattenRuleEngineRules(rules)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_rule_engine_rule.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_rule_engine_rule.go
@@ -814,21 +814,24 @@ func flattenRuleEngineRuleActionsFlexibleOrigin(items, originItems []interface{}
 
 	result := make([]interface{}, 0, len(items))
 	for i, item := range items {
-		result = append(result, map[string]interface{}{
+		elem := map[string]interface{}{
 			"priority":          utils.PathSearch("priority", item, nil),
 			"weight":            utils.PathSearch("weight", item, nil),
 			"sources_type":      utils.PathSearch("sources_type", item, nil),
 			"ip_or_domain":      utils.PathSearch("ip_or_domain", item, nil),
 			"obs_bucket_type":   utils.PathSearch("obs_bucket_type", item, nil),
 			"bucket_access_key": utils.PathSearch("bucket_access_key", item, nil),
-			"bucket_secret_key": utils.PathSearch(fmt.Sprintf("[%d].bucket_secret_key", i), originItems, nil),
 			"bucket_region":     utils.PathSearch("bucket_region", item, nil),
 			"bucket_name":       utils.PathSearch("bucket_name", item, nil),
 			"host_name":         utils.PathSearch("host_name", item, nil),
 			"origin_protocol":   utils.PathSearch("origin_protocol", item, nil),
 			"http_port":         utils.PathSearch("http_port", item, nil),
 			"https_port":        utils.PathSearch("https_port", item, nil),
-		})
+		}
+		if bucketSecretKey := utils.PathSearch(fmt.Sprintf("[%d].bucket_secret_key", i), originItems, nil); bucketSecretKey != nil {
+			elem["bucket_secret_key"] = bucketSecretKey
+		}
+		result = append(result, elem)
 	}
 
 	return result


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source that used to query the rule list of the CDN rule engine.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1038" height="630" alt="image" src="https://github.com/user-attachments/assets/8464b784-ade9-44e0-866f-f5dd4ecf1e1a" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query rule engine rules.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cdn -f TestAccDataRuleEngineRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccDataRuleEngineRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataRuleEngineRules_basic
=== PAUSE TestAccDataRuleEngineRules_basic
=== CONT  TestAccDataRuleEngineRules_basic
--- PASS: TestAccDataRuleEngineRules_basic (15.53s)
PASS
coverage: 11.2% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       15.675s coverage: 11.2% of statements in ./huaweicloud/services/cdn
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
