### PR TITLE
feat(workspace/app): the server supports restart, stop and start operations

### DIFF
--- a/docs/resources/workspace_app_server_batch_action.md
+++ b/docs/resources/workspace_app_server_batch_action.md
@@ -102,6 +102,53 @@ resource "huaweicloud_workspace_app_server_batch_action" "maintain_status" {
 }
 ```
 
+### Reboot Server
+
+```hcl
+variable "operate_server_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_app_server_batch_action" "reboot" {
+  type    = "batch-reboot"
+  content = jsonencode({
+    items = var.operate_server_ids
+    type  = "SOFT"
+  })
+}
+```
+
+### Stop Server
+
+```hcl
+variable "operate_server_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_app_server_batch_action" "stop" {
+  type    = "batch-stop"
+  content = jsonencode({
+    items = var.operate_server_ids
+    type  = "SOFT"
+  })
+}
+```
+
+### Start Server
+
+```hcl
+variable "operate_server_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_app_server_batch_action" "start" {
+  type    = "batch-start"
+  content = jsonencode({
+    items = var.operate_server_ids
+  })
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -116,6 +163,9 @@ The following arguments are supported:
   + **batch-rejoin-domain**: Rejoin AD domain.
   + **batch-update-tsvi**: Update virtual session IP configuration.
   + **batch-maint**: Mark server maintenance status.
+  + **batch-reboot**: Reboot server.
+  + **batch-start**: Start server.
+  + **batch-stop**: Stop server.
 
 * `content` - (Required, String, NonUpdatable) Specifies the JSON string content for the batch operation (action)
   request.

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_batch_action_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_batch_action_test.go
@@ -291,3 +291,103 @@ resource "huaweicloud_workspace_app_server_batch_action" "test" {
 }
 `, testAccAppServerBatchAction_base(name))
 }
+
+func TestAccAppServerBatchAction_rebootStopStart(t *testing.T) {
+	var (
+		rNameReboot = "huaweicloud_workspace_app_server_batch_action.reboot"
+		rNameStop   = "huaweicloud_workspace_app_server_batch_action.stop"
+		rNameStart  = "huaweicloud_workspace_app_server_batch_action.start"
+		name        = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time batch action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppServerBatchAction_batchReboot(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameReboot, "type", "batch-reboot"),
+				),
+			},
+			{
+				Config: testAccAppServerBatchAction_batchStop(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameStop, "type", "batch-stop"),
+				),
+			},
+			{
+				Config: testAccAppServerBatchAction_batchStart(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameStart, "type", "batch-start"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAppServerBatchAction_batchReboot(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_server_batch_action" "reboot" {
+  type    = "batch-reboot"
+  content = jsonencode({
+    items = [huaweicloud_workspace_app_server.test.id]
+    type  = "SOFT"
+  })
+
+  max_retries = 3
+
+  provisioner "local-exec" {
+    command = "sleep 180"
+  }
+}
+`, testAccAppServerBatchAction_base(name))
+}
+
+func testAccAppServerBatchAction_batchStop(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_server_batch_action" "stop" {
+  type    = "batch-stop"
+  content = jsonencode({
+    items = [huaweicloud_workspace_app_server.test.id]
+    type  = "SOFT"
+  })
+
+  max_retries = 3
+
+  provisioner "local-exec" {
+    command = "sleep 180"
+  }
+}
+`, testAccAppServerBatchAction_base(name))
+}
+
+func testAccAppServerBatchAction_batchStart(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_server_batch_action" "start" {
+  type    = "batch-start"
+  content = jsonencode({
+    items = [huaweicloud_workspace_app_server.test.id]
+  })
+
+  max_retries = 3
+
+  provisioner "local-exec" {
+    command = "sleep 180"
+  }
+}
+`, testAccAppServerBatchAction_base(name))
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server_batch_action.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server_batch_action.go
@@ -22,6 +22,9 @@ var batchActionHTTPMethodMap = map[string]string{
 	"batch-rejoin-domain": "PATCH",
 	"batch-update-tsvi":   "PATCH",
 	"batch-maint":         "PATCH",
+	"batch-reboot":        "PATCH",
+	"batch-start":         "PATCH",
+	"batch-stop":          "PATCH",
 }
 
 var appServerBatchActionNonUpdatableParams = []string{"type", "content"}
@@ -31,6 +34,9 @@ var appServerBatchActionNonUpdatableParams = []string{"type", "content"}
 // @API Workspace PATCH /v1/{project_id}/app-servers/actions/batch-rejoin-domain
 // @API Workspace PATCH /v1/{project_id}/app-servers/actions/batch-update-tsvi
 // @API Workspace PATCH /v1/{project_id}/app-servers/actions/batch-maint
+// @API Workspace PATCH /v1/{project_id}/app-servers/actions/batch-reboot
+// @API Workspace PATCH /v1/{project_id}/app-servers/actions/batch-start
+// @API Workspace PATCH /v1/{project_id}/app-servers/actions/batch-stop
 func ResourceAppServerBatchAction() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceAppServerBatchActionCreate,
@@ -60,12 +66,16 @@ func ResourceAppServerBatchAction() *schema.Resource {
 					"batch-rejoin-domain",
 					"batch-update-tsvi",
 					"batch-maint",
+					"batch-reboot",
+					"batch-start",
+					"batch-stop",
 				}, false),
 			},
 			"content": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: `The JSON string content for the batch operation (action) request.`,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Description:  `The JSON string content for the batch operation (action) request.`,
 			},
 
 			// Optional parameter(s).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The Workspace APP server supports restart, stop and start operations.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppServerBatchAction_rebootStopStart
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppServerBatchAction_rebootStopStart -timeout 360m -parallel 10
=== RUN   TestAccAppServerBatchAction_rebootStopStart
=== PAUSE TestAccAppServerBatchAction_rebootStopStart
=== CONT  TestAccAppServerBatchAction_rebootStopStart
--- PASS: TestAccAppServerBatchAction_rebootStopStart (1183.71s)
PASS
coverage: 5.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1183.808s       coverage: 5.9% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
