### PR TITLE
fix(RDS): fix rds pg account privileges resource

### DIFF
--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_account_privileges_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_account_privileges_test.go
@@ -138,7 +138,7 @@ resource "huaweicloud_rds_instance" "test" {
 
   db {
     type    = "PostgreSQL"
-    version = "12"
+    version = "14"
   }
 
   volume {

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_pg_account_privileges.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_pg_account_privileges.go
@@ -102,7 +102,7 @@ func resourcePgAccountPrivilegesCreate(ctx context.Context, d *schema.ResourceDa
 			return diag.FromErr(err)
 		}
 	}
-	if rolePrivileges.Len() > 0 {
+	if systemRolePrivileges.Len() > 0 {
 		requestBody := buildUpdatePgAccountPrivilegesBodyParams(username, "SYSTEM_ROLE", systemRolePrivileges.List())
 		err = updateAccountPrivileges(ctx, d, client, schema.TimeoutCreate, requestBody)
 		if err != nil {
@@ -256,7 +256,7 @@ func resourcePgAccountPrivilegesDelete(ctx context.Context, d *schema.ResourceDa
 			return diag.FromErr(err)
 		}
 	}
-	if rolePrivileges.Len() > 0 {
+	if systemRolePrivileges.Len() > 0 {
 		requestBody := buildUpdatePgAccountPrivilegesBodyParams(username, "RECYCLING_SYSTEM_ROLE", systemRolePrivileges.List())
 		err = updateAccountPrivileges(ctx, d, client, schema.TimeoutDelete, requestBody)
 		if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix rds pg account privileges resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rds pg account privileges resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccPgAccountPrivileges_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccPgAccountPrivileges_basic -timeout 360m -parallel 4
=== RUN   TestAccPgAccountPrivileges_basic
=== PAUSE TestAccPgAccountPrivileges_basic
=== CONT  TestAccPgAccountPrivileges_basic
--- PASS: TestAccPgAccountPrivileges_basic (734.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       734.164s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
