### PR TITLE
refactor(cdn): rewrite the domain status refresh function and supports update

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -10,6 +10,8 @@ description: |-
 
 Manages a CDN domain resource within HuaweiCloud.
 
+-> Before updating the domain configuration, please make sure that the status value is **online**.
+
 ## Example Usage
 
 ### Create a CDN domain
@@ -316,6 +318,11 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the domain.
+
+* `status` - (Optional, String) Specifies the status of the domain.
+  The valid values are as follows:
+  + **online**
+  + **offline**
 
 <a name="sources_cdn_domain"></a>
 The `sources` block supports:
@@ -1165,9 +1172,6 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The acceleration domain name ID.
 
 * `cname` - The CNAME of the acceleration domain name.
-
-* `domain_status` - The status of the acceleration domain name. The available values are
-  **online**, **offline**, **configuring**, **configure_failed**, **checking**, **check_failed** and **deleting**.
 
 * `configs/https_settings/https_status` - The status of the https. The available values are **on** and **off**.
 

--- a/huaweicloud/services/cdn/common.go
+++ b/huaweicloud/services/cdn/common.go
@@ -2,58 +2,19 @@ package cdn
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/chnsz/golangsdk"
-
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
-
-func waitingForCdnDomainStatusOnline(ctx context.Context, client *golangsdk.ServiceClient, domainName string,
-	epsID string, timeout time.Duration) error {
-	unexpectedStatus := []string{"offline", "configure_failed", "check_failed", "deleting"}
-
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING"},
-		Target:  []string{"COMPLETED"},
-		Refresh: func() (interface{}, string, error) {
-			domainResp, err := ReadCdnDomainDetail(client, domainName, epsID)
-			if err != nil {
-				return nil, "ERROR", err
-			}
-
-			domainStatus := utils.PathSearch("domain.domain_status", domainResp, "").(string)
-			if domainStatus == "" {
-				return nil, "ERROR", errors.New("error retrieving CDN domain: domain_status is not found in API response")
-			}
-
-			if domainStatus == "online" {
-				return domainResp, "COMPLETED", nil
-			}
-
-			if utils.StrSliceContains(unexpectedStatus, domainStatus) {
-				return domainResp, domainStatus, nil
-			}
-			return domainResp, "PENDING", nil
-		},
-		Timeout:      timeout,
-		Delay:        20 * time.Second,
-		PollInterval: 20 * time.Second,
-	}
-	_, err := stateConf.WaitForStateContext(ctx)
-	return err
-}
 
 func waitingForCdnDomainListStatusOnline(ctx context.Context, client *golangsdk.ServiceClient, domainNameList []string,
 	epsID string, timeout time.Duration) error {
 	mErr := multierror.Append(nil)
 	for _, domainName := range domainNameList {
-		if err := waitingForCdnDomainStatusOnline(ctx, client, domainName, epsID, timeout); err != nil {
+		if err := waitForDomainStatusAvailable(ctx, client, domainName, epsID, []string{"online"}, timeout); err != nil {
 			mErr = multierror.Append(fmt.Errorf("error waiting for domain (%s) to become online: %s", domainName, err))
 		}
 	}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_rule.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_rule.go
@@ -623,7 +623,7 @@ func resourceDomainRuleCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	d.SetId(domainName)
 
-	if err := waitingForCdnDomainStatusOnline(ctx, client, d.Get("name").(string), cfg.GetEnterpriseProjectID(d),
+	if err := waitForDomainStatusAvailable(ctx, client, d.Get("name").(string), cfg.GetEnterpriseProjectID(d), []string{"online"},
 		d.Timeout(schema.TimeoutCreate)); err != nil {
 		return diag.Errorf("error waiting for CDN domain (%s) to become online in create operation: %s", domainName, err)
 	}
@@ -903,7 +903,7 @@ func resourceDomainRuleUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error updating CDN domain rule, error_code: %s; error_msg: %s", errorCode, errorMsg)
 	}
 
-	if err := waitingForCdnDomainStatusOnline(ctx, client, d.Get("name").(string), cfg.GetEnterpriseProjectID(d),
+	if err := waitForDomainStatusAvailable(ctx, client, d.Get("name").(string), cfg.GetEnterpriseProjectID(d), []string{"online"},
 		d.Timeout(schema.TimeoutCreate)); err != nil {
 		return diag.Errorf("error waiting for CDN domain (%s) to become online in update operation: %s", d.Id(), err)
 	}
@@ -939,7 +939,7 @@ func resourceDomainRuleDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error deleting CDN domain rule, error_code: %s; error_msg: %s", errorCode, errorMsg)
 	}
 
-	if err := waitingForCdnDomainStatusOnline(ctx, client, d.Get("name").(string), cfg.GetEnterpriseProjectID(d),
+	if err := waitForDomainStatusAvailable(ctx, client, d.Get("name").(string), cfg.GetEnterpriseProjectID(d), []string{"online"},
 		d.Timeout(schema.TimeoutCreate)); err != nil {
 		return diag.Errorf("error waiting for CDN domain (%s) to become online in delete operation: %s", d.Id(), err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CDN domain resource supports update its status and refactor the corresponding parameter and logics
+ deprecate the attribute `domain_status` and supports new parameter `status`.
+ supports a new refresh function to combine the online and offline check logics.
+ remove the domain status check in CreateContext phase because at the end of CreateContext phase, it will enter the UpdateContext phase. And cause the d.IsNewResource() logic check, online refresh check will always executing.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. rewrite the domain status refresh function and supports update
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
