### PR TITLE
feat(cdn): add new resource to manage share cache group

### DIFF
--- a/docs/resources/cdn_share_cache_group.md
+++ b/docs/resources/cdn_share_cache_group.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_share_cache_group"
+description: |-
+  Manages a share cache group resource within HuaweiCloud.
+---
+
+# huaweicloud_cdn_share_cache_group
+
+Manages a share cache group resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "share_cache_group_name" {}
+variable "primary_domain_name" {}
+variable "share_cache_records" {
+  type = list(string)
+}
+
+resource "huaweicloud_cdn_share_cache_group" "test" {
+  name           = var.share_cache_group_name
+  primary_domain = var.primary_domain_name
+
+  dynamic "share_cache_records" {
+    for_each = var.share_cache_records
+
+    content {
+      domain_name = share_cache_records.value
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the share cache group is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the share cache group.
+
+* `primary_domain` - (Required, String, NonUpdatable) Specifies the primary domain name.
+
+* `share_cache_records` - (Required, List) Specifies the list of associated domain names.  
+  The [share_cache_records](#cdn_share_cache_group_share_cache_records) structure is documented below.
+
+<a name="cdn_share_cache_group_share_cache_records"></a>
+The `share_cache_records` block supports:
+
+* `domain_name` - (Required, String) Specifies the associated domain name.
+
+-> The primary domain will not be automatically join the cache sharing, users need to explicitly declare in the
+   `share_cache_records` list.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `create_time` - The creation time of the share cache group, in RFC3339 format.
+
+## Import
+
+The share cache group can be imported using the `id` or `group_name`, e.g.
+
+```bash
+$ terraform import huaweicloud_cdn_share_cache_group.test <id>
+```
+
+or
+
+```bash
+$ terraform import huaweicloud_cdn_share_cache_group.test <group_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2602,6 +2602,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_domain_batch_copy":             cdn.ResourceDomainBatchCopy(),
 			"huaweicloud_cdn_domain_owner_verify":           cdn.ResourceDomainOwnerVerify(),
 			"huaweicloud_cdn_domain_rule":                   cdn.ResourceDomainRule(),
+			"huaweicloud_cdn_share_cache_group":             cdn.ResourceShareCacheGroup(),
 			"huaweicloud_cdn_rule_engine_rule":              cdn.ResourceRuleEngineRule(),
 
 			"huaweicloud_ces_alarmrule":                                     ces.ResourceAlarmRule(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -187,7 +187,8 @@ var (
 	HW_RMS_REQUESTER_ACCOUNT_ID              = os.Getenv("HW_RMS_REQUESTER_ACCOUNT_ID")
 	HW_RMS_POLICY_ASSIGNMENT_EVALUATION_HASH = os.Getenv("HW_RMS_POLICY_ASSIGNMENT_EVALUATION_HASH")
 
-	HW_CDN_DOMAIN_NAME = os.Getenv("HW_CDN_DOMAIN_NAME")
+	HW_CDN_DOMAIN_NAME  = os.Getenv("HW_CDN_DOMAIN_NAME")
+	HW_CDN_DOMAIN_NAMES = os.Getenv("HW_CDN_DOMAIN_NAMES")
 	// `HW_CDN_CERT_DOMAIN_NAME` Configure the domain name environment variable of the certificate type.
 	HW_CDN_CERT_DOMAIN_NAME   = os.Getenv("HW_CDN_CERT_DOMAIN_NAME")
 	HW_CDN_DOMAIN_URL         = os.Getenv("HW_CDN_DOMAIN_URL")
@@ -3388,6 +3389,13 @@ func TestAccPreCheckCdnDomainName(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPreCheckCdntDomainNames(t *testing.T, n int) {
+	if HW_CDN_DOMAIN_NAMES == "" || len(strings.Split(HW_CDN_DOMAIN_NAMES, ",")) < n {
+		t.Skipf("at lease %d domain name(s) for HW_CDN_DOMAIN_NAMES must be set, separated by the comma (,) character", n)
+	}
+}
+
+// lintignore:AT003
 func TestAccPreCheckCertCDN(t *testing.T) {
 	if HW_CDN_CERT_DOMAIN_NAME == "" {
 		t.Skip("HW_CDN_CERT_DOMAIN_NAME must be set for the acceptance test")
@@ -3403,7 +3411,7 @@ func TestAccPreCheckCDNURL(t *testing.T) {
 
 // lintignore:AT003
 func TestAccPreCheckCDNTargetDomainUrls(t *testing.T, n int) {
-	if len(strings.Split(HW_CDN_TARGET_DOMAIN_URLS, ",")) < n {
+	if HW_CDN_TARGET_DOMAIN_URLS == "" || len(strings.Split(HW_CDN_TARGET_DOMAIN_URLS, ",")) < n {
 		t.Skipf("at lease %d domain URL(s) for HW_CDN_TARGET_DOMAIN_URLS must be set, separated by the comma (,) character", n)
 	}
 }

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_share_cache_group_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_share_cache_group_test.go
@@ -1,0 +1,129 @@
+package cdn
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cdn"
+)
+
+func getShareCacheGroupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return nil, fmt.Errorf("error creating CDN client: %s", err)
+	}
+
+	return cdn.GetShareCacheGroupById(client, state.Primary.ID)
+}
+
+func TestAccShareCacheGroup_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_cdn_share_cache_group.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getShareCacheGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCdntDomainNames(t, 2)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccShareCacheGroup_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrSet(rName, "primary_domain"),
+					resource.TestCheckResourceAttr(rName, "share_cache_records.#", "2"),
+					resource.TestMatchResourceAttr(rName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccShareCacheGroup_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrSet(rName, "primary_domain"),
+					resource.TestCheckResourceAttr(rName, "share_cache_records.#", "1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testShareCacheGroupImportStateWithName(rName),
+			},
+		},
+	})
+}
+
+func testShareCacheGroupImportStateWithName(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		groupName := rs.Primary.Attributes["name"]
+		if groupName == "" {
+			return "", errors.New("The share cache group name is missing, want '<name>'")
+		}
+		return groupName, nil
+	}
+}
+
+func testAccShareCacheGroup_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_share_cache_group" "test" {
+  name           = "%[1]s"
+  primary_domain = try(element(split(",", "%[2]s"), 0), "")
+
+  dynamic "share_cache_records" {
+    for_each = split(",", "%[2]s")
+
+    content {
+      domain_name = share_cache_records.value
+    }
+  }
+}
+`, name, acceptance.HW_CDN_DOMAIN_NAMES)
+}
+
+func testAccShareCacheGroup_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_share_cache_group" "test" {
+  name           = "%[1]s"
+  primary_domain = try(element(split(",", "%[2]s"), 0), "")
+
+  dynamic "share_cache_records" {
+    for_each = slice(split(",", "%[2]s"), 0, 1)
+
+    content {
+      domain_name = share_cache_records.value
+    }
+  }
+}
+`, name, acceptance.HW_CDN_DOMAIN_NAMES)
+}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_share_cache_group.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_share_cache_group.go
@@ -1,0 +1,384 @@
+package cdn
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var shareCacheGroupNonUpdatableParams = []string{"name", "primary_domain"}
+
+// @API CDN POST /v1.0/cdn/configuration/share-cache-groups
+// @API CDN GET /v1.0/cdn/configuration/share-cache-groups
+// @API CDN PUT /v1.0/cdn/configuration/share-cache-groups/{id}
+// @API CDN DELETE /v1.0/cdn/configuration/share-cache-groups/{id}
+func ResourceShareCacheGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceShareCacheGroupCreate,
+		ReadContext:   resourceShareCacheGroupRead,
+		UpdateContext: resourceShareCacheGroupUpdate,
+		DeleteContext: resourceShareCacheGroupDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(shareCacheGroupNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceShareCacheGroupImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the share cache group is located.`,
+			},
+
+			// Required parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the share cache group.`,
+			},
+			"primary_domain": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The primary domain name.`,
+			},
+			"share_cache_records": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"domain_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The associated domain name.`,
+						},
+					},
+				},
+				Description: `The list of associated domain names.`,
+			},
+
+			// Attributes.
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the share cache group, in RFC3339 format.`,
+			},
+
+			// Internal parameter.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildShareCacheRecordsBodyParams(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"domain_name": utils.PathSearch("domain_name", item, nil),
+		})
+	}
+
+	return result
+}
+
+func buildShareCacheGroupCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"group_name":          d.Get("name").(string),
+		"primary_domain":      d.Get("primary_domain").(string),
+		"share_cache_records": buildShareCacheRecordsBodyParams(d.Get("share_cache_records").(*schema.Set).List()),
+	}
+}
+
+func createShareCacheGroup(client *golangsdk.ServiceClient, bodyParams map[string]interface{}) error {
+	httpUrl := "v1.0/cdn/configuration/share-cache-groups"
+	createPath := client.Endpoint + httpUrl
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(bodyParams),
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	return err
+}
+
+func listShareCacheGroups(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v1.0/cdn/configuration/share-cache-groups?limit={limit}"
+		limit   = 1000
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		groups := utils.PathSearch("share_cache_groups", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, groups...)
+		if len(groups) < limit {
+			break
+		}
+		offset += len(groups)
+	}
+
+	return result, nil
+}
+
+func GetShareCacheGroupByName(client *golangsdk.ServiceClient, groupName string) (interface{}, error) {
+	groups, err := listShareCacheGroups(client)
+	if err != nil {
+		return nil, err
+	}
+
+	group := utils.PathSearch(fmt.Sprintf("[?group_name == '%s']|[0]", groupName), groups, nil)
+	if group == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1.0/cdn/configuration/share-cache-groups",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the share cache group with name '%s' has been removed", groupName)),
+			},
+		}
+	}
+	return group, nil
+}
+
+func resourceShareCacheGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	bodyParams := buildShareCacheGroupCreateBodyParams(d)
+	if err := createShareCacheGroup(client, bodyParams); err != nil {
+		return diag.Errorf("error creating CDN share cache group: %s", err)
+	}
+
+	groupName := d.Get("name").(string)
+	group, err := GetShareCacheGroupByName(client, groupName)
+	if err != nil {
+		return diag.Errorf("error querying CDN share cache groups: %s", err)
+	}
+
+	d.SetId(utils.PathSearch("id", group, "").(string))
+
+	return resourceShareCacheGroupRead(ctx, d, meta)
+}
+
+func GetShareCacheGroupById(client *golangsdk.ServiceClient, groupId string) (interface{}, error) {
+	groups, err := listShareCacheGroups(client)
+	if err != nil {
+		return nil, err
+	}
+
+	group := utils.PathSearch(fmt.Sprintf("[?id == '%s']|[0]", groupId), groups, nil)
+	if group == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1.0/cdn/configuration/share-cache-groups",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the share cache group with ID '%s' has been removed", groupId)),
+			},
+		}
+	}
+	return group, nil
+}
+
+func flattenShareCacheRecords(records []interface{}) []map[string]interface{} {
+	if len(records) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(records))
+	for _, record := range records {
+		result = append(result, map[string]interface{}{
+			"domain_name": utils.PathSearch("domain_name", record, nil),
+		})
+	}
+
+	return result
+}
+
+func resourceShareCacheGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		groupId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	group, err := GetShareCacheGroupById(client, groupId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error getting share cache group (%s)", groupId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", cfg.GetRegion(d)),
+		d.Set("name", utils.PathSearch("group_name", group, nil)),
+		d.Set("primary_domain", utils.PathSearch("primary_domain", group, nil)),
+		d.Set("share_cache_records", flattenShareCacheRecords(utils.PathSearch("share_cache_records", group,
+			make([]interface{}, 0)).([]interface{}))),
+		d.Set("create_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", group, float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildShareCacheGroupUpdateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"share_cache_records": buildShareCacheRecordsBodyParams(d.Get("share_cache_records").(*schema.Set).List()),
+	}
+}
+
+func updateShareCacheGroup(client *golangsdk.ServiceClient, groupId string, bodyParams map[string]interface{}) error {
+	httpUrl := "v1.0/cdn/configuration/share-cache-groups/{id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{id}", groupId)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(bodyParams),
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func resourceShareCacheGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		groupId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	bodyParams := buildShareCacheGroupUpdateBodyParams(d)
+	if err := updateShareCacheGroup(client, groupId, bodyParams); err != nil {
+		return diag.Errorf("error updating share cache group (%s): %s", groupId, err)
+	}
+
+	return resourceShareCacheGroupRead(ctx, d, meta)
+}
+
+func deleteShareCacheGroup(client *golangsdk.ServiceClient, groupId string) error {
+	httpUrl := "v1.0/cdn/configuration/share-cache-groups/{id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{id}", groupId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceShareCacheGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                     = meta.(*config.Config)
+		groupId                 = d.Id()
+		cacheGroupNotFoundCodes = []string{
+			"CDN.0001", // The share cache group does not exist.
+		}
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	// Before deleting the share cache group, clean up the share cache records.
+	if d.Get("share_cache_records").(*schema.Set).Len() > 0 {
+		bodyParams := map[string]interface{}{
+			"share_cache_records": make([]interface{}, 0),
+		}
+		if err := updateShareCacheGroup(client, groupId, bodyParams); err != nil {
+			return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error.error_code", cacheGroupNotFoundCodes...),
+				fmt.Sprintf("error cleaning up share cache records for share cache group (%s)", groupId))
+		}
+	}
+
+	err = deleteShareCacheGroup(client, groupId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error.error_code", cacheGroupNotFoundCodes...),
+			fmt.Sprintf("error deleting share cache group (%s)", groupId))
+	}
+
+	return nil
+}
+
+func resourceShareCacheGroupImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+
+	if utils.IsUUID(importedId) {
+		d.SetId(importedId)
+		return []*schema.ResourceData{d}, nil
+	}
+
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return nil, fmt.Errorf("error creating CDN client: %s", err)
+	}
+
+	group, err := GetShareCacheGroupByName(client, importedId)
+	if err != nil {
+		return nil, err
+	}
+	d.SetId(utils.PathSearch("id", group, "").(string))
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource that used to manage the CDN share cache group.

<img width="1045" height="466" alt="image" src="https://github.com/user-attachments/assets/c26fbd45-c095-43cd-b095-1463e02d0688" />
<img width="497" height="312" alt="image" src="https://github.com/user-attachments/assets/37a21d2c-67b8-48d3-91fa-b154c52f9efb" />

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="948" height="455" alt="image" src="https://github.com/user-attachments/assets/aa204ca1-f8fd-4f31-a19a-2453562f3555" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage share cache group
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cdn -f TestAccShareCacheGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccShareCacheGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccShareCacheGroup_basic
=== PAUSE TestAccShareCacheGroup_basic
=== CONT  TestAccShareCacheGroup_basic
--- PASS: TestAccShareCacheGroup_basic (25.71s)
PASS
coverage: 7.1% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       25.785s coverage: 7.1% of statements in ./huaweicloud/services/cdn
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="607" height="399" alt="image" src="https://github.com/user-attachments/assets/cc758f8e-e105-4509-821d-16b0617cc8bc" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="640" height="474" alt="image" src="https://github.com/user-attachments/assets/d20c1576-ee7b-43f9-b60b-5315bf1b91ff" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
