### PR TITLE
feat(kafka): add a one-time resource to upgrade instance

### DIFF
--- a/docs/resources/dms_kafka_instance_upgrade.md
+++ b/docs/resources/dms_kafka_instance_upgrade.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_instance_upgrade"
+description: |-
+  Use this resource to upgrade Kafka instance within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_instance_upgrade
+
+Use this resource to upgrade Kafka instance within HuaweiCloud.
+
+-> This resource is a one-time action resource for upgrading the Kafka instance. Deleting this resource will not
+   recover the upgrade Kafka instance, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+### Immediate upgrade
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_kafka_instance_upgrade" "test" {
+  instance_id = var.instance_id
+}
+```
+
+### Scheduled upgrade
+
+```hcl
+variable "instance_id" {}
+variable "execute_at" {}
+
+resource "huaweicloud_dms_kafka_instance_upgrade" "test" {
+  instance_id = var.instance_id
+  is_schedule = true
+  execute_at  = var.execute_at
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the Kafka instance to be upgraded is located.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the Kafka instance.
+
+* `is_schedule` - (Optional, Bool, NonUpdatable) Specifies whether to execute as a scheduled task.  
+  Defaults to **false**.
+
+* `execute_at` - (Optional, Int, NonUpdatable) Specifies the scheduled time in Unix timestamp format, in milliseconds.
+  This parameter is **required** and available only when `is_schedule` is **true**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2845,6 +2845,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_consumer_group":                    kafka.ResourceDmsKafkaConsumerGroup(),
 			"huaweicloud_dms_kafka_instance_batch_action":             kafka.ResourceInstanceBatchAction(),
 			"huaweicloud_dms_kafka_instance":                          kafka.ResourceDmsKafkaInstance(),
+			"huaweicloud_dms_kafka_instance_upgrade":                  kafka.ResourceInstanceUpgrade(),
 			"huaweicloud_dms_kafka_instance_rebalance_log":            kafka.ResourceInstanceRebalanceLog(),
 			"huaweicloud_dms_kafka_instance_restart":                  kafka.ResourceDmsKafkaInstanceRestart(),
 			"huaweicloud_dms_kafka_message_diagnosis_task":            kafka.ResourceDmsKafkaMessageDiagnosisTask(),

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_instance_upgrade_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_instance_upgrade_test.go
@@ -1,0 +1,48 @@
+package kafka
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccInstanceUpgrade_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This is a one-time action resource, so it does not need to be destroyed.
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccInstanceUpgrade_instanceNotFound(),
+				ExpectError: regexp.MustCompile(`This DMS instance does not exist`),
+			},
+			{
+				Config: testAccInstanceUpgrade_basic(),
+			},
+		},
+	})
+}
+
+func testAccInstanceUpgrade_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_instance_upgrade" "test" {
+  instance_id = "%[1]s"
+}`, randomId)
+}
+
+func testAccInstanceUpgrade_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_instance_upgrade" "test" {
+  instance_id = "%[1]s"
+}`, acceptance.HW_DMS_KAFKA_INSTANCE_ID)
+}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance_upgrade.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance_upgrade.go
@@ -1,0 +1,147 @@
+package kafka
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var instanceUpgradeNonUpdatableParams = []string{"instance_id", "is_schedule", "execute_at"}
+
+// @API Kafka POST /v2/{project_id}/kafka/instances/{instance_id}/upgrade
+// @API Kafka GET /v2/{project_id}/instances/{instance_id}/tasks/{task_id}
+func ResourceInstanceUpgrade() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInstanceUpgradeCreate,
+		ReadContext:   resourceInstanceUpgradeRead,
+		UpdateContext: resourceInstanceUpgradeUpdate,
+		DeleteContext: resourceInstanceUpgradeDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(instanceUpgradeNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the Kafka instance to be upgraded is located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Kafka instance.`,
+			},
+			"is_schedule": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to execute as a scheduled task.`,
+			},
+			"execute_at": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The scheduled time in Unix timestamp format, in milliseconds.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceInstanceUpgradeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dms", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	respBody, err := upgradeInstance(d, client, instanceId)
+	if err != nil {
+		return diag.Errorf("error upgrading Kafka instance: %s", err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomId)
+
+	isSchedule := d.Get("is_schedule").(bool)
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	// The `job_id` field is not empty only when the task is not a scheduled task.
+	if !isSchedule && jobId != "" {
+		if err = waitForInstanceTaskStatusComplete(ctx, client, instanceId, jobId, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.Errorf("error waiting for upgrading instance (%s) task to complete: %s", instanceId, err)
+		}
+	}
+
+	return nil
+}
+
+func resourceInstanceUpgradeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInstanceUpgradeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInstanceUpgradeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource for upgrading the Kafka instance. Deleting this resource will not 
+recover the upgrade Kafka instance, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func buildUpgradeInstanceBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"is_schedule": d.Get("is_schedule").(bool),
+		"execute_at":  utils.ValueIgnoreEmpty(d.Get("execute_at")),
+	}
+}
+
+func upgradeInstance(d *schema.ResourceData, client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/kafka/instances/{instance_id}/upgrade"
+	upgradePath := client.Endpoint + httpUrl
+	upgradePath = strings.ReplaceAll(upgradePath, "{project_id}", client.ProjectID)
+	upgradePath = strings.ReplaceAll(upgradePath, "{instance_id}", instanceId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpgradeInstanceBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("POST", upgradePath, &requestOpt)
+	if err != nil {
+		return "", err
+	}
+
+	return utils.FlattenResponse(resp)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new one-time resource(`huaweicloud_dms_kafka_instance_upgrade`) to upgrade Kafka instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new one-time resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccInstanceUpgrade_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccInstanceUpgrade_basic -timeout 360m -parallel 10
=== RUN   TestAccInstanceUpgrade_basic
=== PAUSE TestAccInstanceUpgrade_basic
=== CONT  TestAccInstanceUpgrade_basic
--- PASS: TestAccInstanceUpgrade_basic (59.85s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     60.024s coverage: 3.0% of statements in ./huaweicloud/services/kafka
```
<img width="1035" height="501" alt="image" src="https://github.com/user-attachments/assets/7b103476-f7a2-4d0e-94e8-f0d883bc2271" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
