### PR TITLE
feat(aom): alarm action rule supports polling logic to handle asynchronous deletion

### DIFF
--- a/docs/resources/aom_alarm_action_rule.md
+++ b/docs/resources/aom_alarm_action_rule.md
@@ -82,6 +82,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `updated_at` - The last update time.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `delete` - Default is 5 minutes.
+
 ## Import
 
 The application operations management can be imported using the `id` (name), e.g.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Alarm action rule supports polling logic to handle asynchronous deletion

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. resource supports polling logic to handle asynchronous deletion
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o aom -f TestAccAlarmActionRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/aom" -v -coverprofile="./huaweicloud/services/acceptance/aom/aom_coverage.cov" -coverpkg="./huaweicloud/services/aom" -run TestAccAlarmActionRule_basic -timeout 360m -parallel 10
=== RUN   TestAccAlarmActionRule_basic
=== PAUSE TestAccAlarmActionRule_basic
=== CONT  TestAccAlarmActionRule_basic
--- PASS: TestAccAlarmActionRule_basic (44.39s)
PASS
coverage: 5.7% of statements in ./huaweicloud/services/aom
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       44.473s coverage: 5.7% of statements in ./huaweicloud/services/aom
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
