### PR TITLE
feat(SWR): support to delete enterprise instance artifact

### DIFF
--- a/docs/resources/swr_enterprise_instance_artifact_delete.md
+++ b/docs/resources/swr_enterprise_instance_artifact_delete.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_swr_enterprise_instance_artifact_delete"
+description: |-
+  Manages a SWR enterprise instance artifact delete resource within HuaweiCloud.
+---
+
+# huaweicloud_swr_enterprise_instance_artifact_delete
+
+Manages a SWR enterprise instance artifact delete resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "namespace_name" {}
+variable "repository_name" {}
+variable "reference" {}
+
+resource "huaweicloud_swr_enterprise_instance_artifact_delete" "test" {
+  instance_id     = var.instance_id
+  namespace_name  = var.namespace_name
+  repository_name = var.repository_name
+  reference       = var.reference
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the enterprise instance ID.
+
+* `namespace_name` - (Required, String, NonUpdatable) Specifies the namespace name.
+
+* `repository_name` - (Required, String, NonUpdatable) Specifies the repository name.
+
+* `reference` - (Required, String, NonUpdatable) Specifies the artifact digest.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3600,6 +3600,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_swr_enterprise_image_signature_policy":            swrenterprise.ResourceSwrEnterpriseImageSignaturePolicy(),
 			"huaweicloud_swr_enterprise_image_signature_policy_execute":    swrenterprise.ResourceSwrEnterpriseImageSignaturePolicyExecute(),
 			"huaweicloud_swr_enterprise_job_delete":                        swrenterprise.ResourceSwrEnterpriseJobDelete(),
+			"huaweicloud_swr_enterprise_instance_artifact_delete":          swrenterprise.ResourceSwrEnterpriseInstanceArtifactDelete(),
 			"huaweicloud_swr_enterprise_domain_name":                       swrenterprise.ResourceSwrEnterpriseDomainName(),
 			"huaweicloud_swr_enterprise_long_term_credential":              swrenterprise.ResourceSwrEnterpriseLongTermCredential(),
 			"huaweicloud_swr_enterprise_temporary_credential":              swrenterprise.ResourceSwrEnterpriseTemporaryCredential(),

--- a/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_instance_artifact_delete_test.go
+++ b/huaweicloud/services/acceptance/swrenterprise/resource_huaweicloud_swr_enterprise_instance_artifact_delete_test.go
@@ -1,0 +1,53 @@
+package swrenterprise
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccSwrEnterpriseArtifactDelete_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSwrSignatureWithImageEnabled(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSwrEnterpriseArtifactDelete_basic(),
+			},
+		},
+	})
+}
+
+func testAccSwrEnterpriseArtifactDelete_basic() string {
+	return `
+data "huaweicloud_swr_enterprise_instances" "test" {}
+
+data "huaweicloud_swr_enterprise_repositories" "test" {
+  instance_id = data.huaweicloud_swr_enterprise_instances.test.instances[0].id
+}
+
+data "huaweicloud_swr_enterprise_instance_artifacts" "test" {
+  instance_id     = data.huaweicloud_swr_enterprise_instances.test.instances[0].id
+  namespace_name  = data.huaweicloud_swr_enterprise_repositories.test.repositories[0].namespace_name
+  repository_name = data.huaweicloud_swr_enterprise_repositories.test.repositories[0].name
+}
+
+resource "huaweicloud_swr_enterprise_instance_artifact_delete" "test" {
+  instance_id     = data.huaweicloud_swr_enterprise_instances.test.instances[0].id
+  namespace_name  = data.huaweicloud_swr_enterprise_repositories.test.repositories[0].namespace_name
+  repository_name = data.huaweicloud_swr_enterprise_repositories.test.repositories[0].name
+  reference       = try(data.huaweicloud_swr_enterprise_instance_artifacts.test.artifacts[0].digest, "")
+
+  lifecycle {
+    ignore_changes = [
+      reference,
+    ]
+  }
+}`
+}

--- a/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_instance_artifact_delete.go
+++ b/huaweicloud/services/swrenterprise/resource_huaweicloud_swr_enterprise_instance_artifact_delete.go
@@ -1,0 +1,119 @@
+package swrenterprise
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var enterpriseInstanceArtifactDeleteNonUpdatableParams = []string{
+	"instance_id", "namespace_name", "repository_name", "reference",
+}
+
+// @API SWR DELETE /v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/repositories/{repository_name}/artifacts/{reference}
+func ResourceSwrEnterpriseInstanceArtifactDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSwrEnterpriseInstanceArtifactDeleteCreate,
+		UpdateContext: resourceSwrEnterpriseInstanceArtifactDeleteUpdate,
+		ReadContext:   resourceSwrEnterpriseInstanceArtifactDeleteRead,
+		DeleteContext: resourceSwrEnterpriseInstanceArtifactDeleteDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(enterpriseInstanceArtifactDeleteNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the enterprise instance ID.`,
+			},
+			"namespace_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the namespace name.`,
+			},
+			"repository_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the repository name.`,
+			},
+			"reference": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the artifact digest.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceSwrEnterpriseInstanceArtifactDeleteCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	namespaceName := d.Get("namespace_name").(string)
+	repositoryName := d.Get("repository_name").(string)
+	reference := d.Get("reference").(string)
+
+	deleteHttpUrl := "v2/{project_id}/instances/{instance_id}/namespaces/{namespace_name}/repositories/{repository_name}/artifacts/{reference}"
+	deletePath := client.Endpoint + deleteHttpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{namespace_name}", namespaceName)
+	deletePath = strings.ReplaceAll(deletePath, "{repository_name}", repositoryName)
+	deletePath = strings.ReplaceAll(deletePath, "{reference}", reference)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting SWR enterprise artifact: %s", err)
+	}
+
+	d.SetId(instanceId + "/" + namespaceName + "/" + repositoryName + "/" + reference)
+
+	return nil
+}
+
+func resourceSwrEnterpriseInstanceArtifactDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSwrEnterpriseInstanceArtifactDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSwrEnterpriseInstanceArtifactDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting SWR enterprise artifact delete resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to delete enterprise instance artifact
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to delete enterprise instance artifact
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/swrenterprise' TESTARGS='-run TestAccSwrEnterpriseArtifactDelete_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swrenterprise -v -run TestAccSwrEnterpriseArtifactDelete_basic -timeout 360m -parallel 4
=== RUN   TestAccSwrEnterpriseArtifactDelete_basic
=== PAUSE TestAccSwrEnterpriseArtifactDelete_basic
=== CONT  TestAccSwrEnterpriseArtifactDelete_basic
--- PASS: TestAccSwrEnterpriseArtifactDelete_basic (17.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swrenterprise     17.396s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
