### PR TITLE
feat(cdn): add new resource and data source for statistic configuration

### DIFF
--- a/docs/data-sources/cdn_statistic_configuration.md
+++ b/docs/data-sources/cdn_statistic_configuration.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_statistic_configuration"
+description: |-
+  Use this data source to get a list of CDN statistic configurations within HuaweiCloud.
+---
+
+# huaweicloud_cdn_statistic_configuration
+
+Use this data source to get a list of CDN statistic configurations within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cdn_statistic_configuration" "test" {
+  config_type = 0
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `config_type` - (Required, Int) Specifies the configuration category.  
+  The valid values are as follows:
+  + **0**: Hotspot statistics category.
+  + **1**: CES reporting category.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `configurations` - The list of statistic configurations.  
+  The [configurations](#cdn_statistic_configuration_configurations) structure is documented below.
+
+<a name="cdn_statistic_configuration_configurations"></a>
+The `configurations` block supports:
+
+* `config_type` - The configuration category.
+
+* `resource_type` - The resource type.
+  + **domain**: The `resource_name` is a domain name.
+  + **account**: The `resource_name` is an account.
+
+* `resource_name` - The resource name.  
+  Multiple domain names are separated by commas.
+
+* `config_info` - The statistics configuration information.  
+  The [config_info](#cdn_statistic_configuration_config_info) structure is documented below.
+
+* `expired_time` - The expiration time of the statistics configuration, in seconds timestamp.
+
+<a name="cdn_statistic_configuration_config_info"></a>
+The `config_info` block supports:
+
+* `url` - The top URL statistics configuration.  
+  The [url](#cdn_statistic_configuration_url) structure is documented below.
+
+* `ua` - The top UA statistics configuration.  
+  The [ua](#cdn_statistic_configuration_ua) structure is documented below.
+
+<a name="cdn_statistic_configuration_url"></a>
+The `url` block supports:
+
+* `enable` - Whether the top URL statistics configuration is enabled.
+
+* `limit` - The number of top URL statistics to report.
+
+* `sort_by_code` - Whether to support reporting by status code.
+
+<a name="cdn_statistic_configuration_ua"></a>
+The `ua` block supports:
+
+* `enable` - Whether the top UA statistics configuration is enabled.

--- a/docs/resources/cdn_statistic_configuration.md
+++ b/docs/resources/cdn_statistic_configuration.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_statistic_configuration"
+description: |-
+  Manages the CDN statistic configuration resource within HuaweiCloud.
+---
+
+# huaweicloud_cdn_statistic_configuration
+
+Manages the CDN statistic configuration resource within HuaweiCloud.
+
+-> This resource is a one-time action resource for setting CDN statistic configuration. Deleting this resource will
+   not restore the corresponding configuration, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_cdn_statistic_configuration" "test" {
+  resource_type = "domain"
+  resource_name = "www.example.com,www.example2.com"
+  config_type   = 0
+
+  config_info {
+    url {
+      enable = true
+    }
+    ua {
+      enable = true
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_type` - (Required, String, NonUpdatable) Specifies the resource type.  
+  The valid values are as follows:
+  + **domain**: The `resource_name` is a domain name.
+  + **account**: The `resource_name` is an account.
+
+* `resource_name` - (Required, String, NonUpdatable) Specifies the resource name, which can be an account or domain
+  name.  
+  Multiple domain names are separated by commas.  
+  When `resource_type` is set to **account**, the value can be **all** to represent all accounts.
+
+* `config_info` - (Required, List, NonUpdatable) Specifies the statistics configuration information.  
+  Top indicators only support ua, refer, url, and origin url.  
+  The [config_info](#cdn_statistic_configuration_config_info) structure is documented below.
+
+* `config_type` - (Optional, Int, NonUpdatable) Specifies the configuration category.  
+  The valid values are as follows:
+  + **0**: Hotspot statistics category.
+
+<a name="cdn_statistic_configuration_config_info"></a>
+The `config_info` block supports:
+
+* `url` - (Optional, List) Specifies the top URL statistics configuration.  
+  The [url](#cdn_statistic_configuration_url) structure is documented below.
+
+* `ua` - (Optional, List) Specifies the top UA statistics configuration.  
+  The [ua](#cdn_statistic_configuration_ua) structure is documented below.
+
+<a name="cdn_statistic_configuration_url"></a>
+The `url` block supports:
+
+* `enable` - (Required, Bool) Specifies whether to enable the top URL statistics configuration.
+
+<a name="cdn_statistic_configuration_ua"></a>
+The `ua` block supports:
+
+* `enable` - (Required, Bool) Specifies whether to enable the top UA statistics configuration.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2607,6 +2607,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_domain_owner_verify":           cdn.ResourceDomainOwnerVerify(),
 			"huaweicloud_cdn_domain_rule":                   cdn.ResourceDomainRule(),
 			"huaweicloud_cdn_rule_engine_rule":              cdn.ResourceRuleEngineRule(),
+			"huaweicloud_cdn_statistic_configuration":       cdn.ResourceStatisticConfiguration(),
 
 			"huaweicloud_ces_alarmrule":                                     ces.ResourceAlarmRule(),
 			"huaweicloud_ces_alarm_template":                                ces.ResourceCesAlarmTemplate(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -758,6 +758,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_quotas":                    cdn.DataSourceQuotas(),
 			"huaweicloud_cdn_domain_statistics":         cdn.DataSourceStatistics(),
 			"huaweicloud_cdn_rule_engine_rules":         cdn.DataSourceRuleEngineRules(),
+			"huaweicloud_cdn_statistic_configuration":   cdn.DataSourceStatisticConfiguration(),
 			"huaweicloud_cdn_top_referrer_statistics":   cdn.DataSourceTopReferrerStatistics(),
 			"huaweicloud_cdn_top_url_statistics":        cdn.DataSourceTopUrlStatistics(),
 

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_statistic_configuration_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_statistic_configuration_test.go
@@ -1,0 +1,95 @@
+package cdn
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataStatisticConfiguration_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_cdn_statistic_configuration.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataStatisticConfiguration_invalid,
+				ExpectError: regexp.MustCompile(`config type is invalid`),
+			},
+			{
+				Config: testAccDataStatisticConfiguration_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "config_type", "0"),
+					resource.TestCheckResourceAttrSet(rName, "configurations.#"),
+					resource.TestCheckOutput("is_config_type_set_and_valid", "true"),
+					resource.TestCheckOutput("is_resource_type_set_and_valid", "true"),
+					resource.TestCheckOutput("is_resource_name_set_and_valid", "true"),
+					resource.TestCheckOutput("is_config_info_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataStatisticConfiguration_invalid = `
+data "huaweicloud_cdn_statistic_configuration" "test" {
+  config_type = 5
+}
+`
+
+func testAccDataStatisticConfiguration_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_statistic_configuration" "test" {
+  resource_type = "domain"
+  resource_name = "%[1]s"
+  config_type   = 0
+
+  config_info {
+    url {
+      enable = true
+    }
+    ua {
+      enable = true
+    }
+  }
+}
+
+data "huaweicloud_cdn_statistic_configuration" "test" {
+  depends_on = [huaweicloud_cdn_statistic_configuration.test]
+
+  config_type = 0
+}
+
+locals {
+  configurations = data.huaweicloud_cdn_statistic_configuration.test.configurations
+  first_config   = length(local.configurations) > 0 ? local.configurations[0] : null
+}
+
+output "is_config_type_set_and_valid" {
+  value = local.first_config != null && local.first_config.config_type != null
+}
+
+output "is_resource_type_set_and_valid" {
+  value = local.first_config != null && local.first_config.resource_type != null
+}
+
+output "is_resource_name_set_and_valid" {
+  value = local.first_config != null && local.first_config.resource_name != null
+}
+
+output "is_config_info_set_and_valid" {
+  value = local.first_config != null && length(local.first_config.config_info) > 0
+}
+`, acceptance.HW_CDN_DOMAIN_NAME)
+}

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_statistic_configuration_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_statistic_configuration_test.go
@@ -1,0 +1,81 @@
+package cdn
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccStatisticConfiguration_basic(t *testing.T) {
+	var (
+		rName = "huaweicloud_cdn_statistic_configuration.test"
+	)
+
+	// Avoid CheckDestroy, because there is nothing in the resource destroy method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCdnDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccStatisticConfiguration_invalid(),
+				ExpectError: regexp.MustCompile(`config type is invalid`),
+			},
+			{
+				Config: testAccStatisticConfiguration_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "resource_type", "domain"),
+					resource.TestCheckResourceAttr(rName, "resource_name", acceptance.HW_CDN_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(rName, "config_type", "0"),
+					resource.TestCheckResourceAttr(rName, "config_info.0.url.0.enable", "true"),
+					resource.TestCheckResourceAttr(rName, "config_info.0.ua.0.enable", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccStatisticConfiguration_invalid() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_statistic_configuration" "test" {
+  resource_type = "domain"
+  resource_name = "%[1]s"
+  config_type   = 100      # Invalid config type
+
+  config_info {
+    url {
+      enable = true
+    }
+    ua {
+      enable = true
+    }
+  }
+}
+`, acceptance.HW_CDN_DOMAIN_NAME)
+}
+
+func testAccStatisticConfiguration_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_statistic_configuration" "test" {
+  resource_type = "domain"
+  resource_name = "%[1]s"
+  config_type   = 0
+
+  config_info {
+    url {
+      enable = true
+    }
+    ua {
+      enable = true
+    }
+  }
+}
+`, acceptance.HW_CDN_DOMAIN_NAME)
+}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_statistic_configuration.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_statistic_configuration.go
@@ -1,0 +1,240 @@
+package cdn
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CDN GET /v1/cdn/statistics/stats-configs
+func DataSourceStatisticConfiguration() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceStatisticConfigurationRead,
+
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"config_type": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The configuration category.`,
+			},
+
+			// Attributes.
+			"configurations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"config_type": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The configuration category.`,
+						},
+						"resource_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The resource type.`,
+						},
+						"resource_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The resource name.`,
+						},
+						"config_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"url": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: `The top URL statistics configuration.`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enable": {
+													Type:        schema.TypeBool,
+													Computed:    true,
+													Description: `Whether the top URL statistics configuration is enabled.`,
+												},
+												"limit": {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: `The number of top URL statistics to report.`,
+												},
+												"sort_by_code": {
+													Type:        schema.TypeBool,
+													Computed:    true,
+													Description: `Whether to support reporting by status code.`,
+												},
+											},
+										},
+									},
+									"ua": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: `The top UA statistics configuration.`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enable": {
+													Type:        schema.TypeBool,
+													Computed:    true,
+													Description: `Whether the top UA statistics configuration is enabled.`,
+												},
+											},
+										},
+									},
+								},
+							},
+							Description: `The statistics configuration information.`,
+						},
+						"expired_time": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The expiration time of the statistics configuration, in seconds timestamp.`,
+						},
+					},
+				},
+				Description: `The list of statistic configurations.`,
+			},
+		},
+	}
+}
+
+func listStatisticConfigurations(client *golangsdk.ServiceClient, configType int) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/cdn/statistics/stats-configs?config_type={config_type}&limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{config_type}", strconv.Itoa(configType))
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithMarker := fmt.Sprintf("%s&offset=%v", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithMarker, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		configurations := utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, configurations...)
+		if len(configurations) < limit {
+			break
+		}
+
+		offset += len(configurations)
+	}
+
+	return result, nil
+}
+
+func flattenStatisticConfigurationConfigInfoUrl(urlConfig map[string]interface{}) []map[string]interface{} {
+	if len(urlConfig) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"enable":       utils.PathSearch("enable", urlConfig, nil),
+			"limit":        utils.PathSearch("limit", urlConfig, nil),
+			"sort_by_code": utils.PathSearch("sort_by_code", urlConfig, nil),
+		},
+	}
+}
+
+func flattenStatisticConfigurationConfigInfoUa(uaConfig map[string]interface{}) []map[string]interface{} {
+	if len(uaConfig) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"enable": utils.PathSearch("enable", uaConfig, nil),
+		},
+	}
+}
+
+func flattenStatisticConfigurationConfigInfo(configInfo map[string]interface{}) []map[string]interface{} {
+	if len(configInfo) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"url": flattenStatisticConfigurationConfigInfoUrl(utils.PathSearch("url", configInfo,
+				make(map[string]interface{})).(map[string]interface{})),
+			"ua": flattenStatisticConfigurationConfigInfoUa(utils.PathSearch("ua", configInfo,
+				make(map[string]interface{})).(map[string]interface{})),
+		},
+	}
+}
+
+func flattenStatisticConfigurations(configurations []interface{}) []map[string]interface{} {
+	if len(configurations) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(configurations))
+	for _, configuration := range configurations {
+		result = append(result, map[string]interface{}{
+			"config_type":   utils.PathSearch("config_type", configuration, nil),
+			"resource_type": utils.PathSearch("resource_type", configuration, nil),
+			"resource_name": utils.PathSearch("resource_name", configuration, nil),
+			"config_info": flattenStatisticConfigurationConfigInfo(utils.PathSearch("config_info", configuration,
+				make(map[string]interface{})).(map[string]interface{})),
+			"expired_time": utils.PathSearch("expired_time", configuration, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceStatisticConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	configType := d.Get("config_type").(int)
+
+	configurations, err := listStatisticConfigurations(client, configType)
+	if err != nil {
+		return diag.Errorf("error querying CDN statistic configurations: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("configurations", flattenStatisticConfigurations(configurations)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_statistic_configuration.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_statistic_configuration.go
@@ -1,0 +1,198 @@
+package cdn
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var statisticConfigurationNonUpdatableParams = []string{
+	"config_type",
+	"resource_type",
+	"resource_name",
+	"config_info",
+}
+
+// @API CDN POST /v1/cdn/statistics/stats-configs
+func ResourceStatisticConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStatisticConfigurationCreate,
+		ReadContext:   resourceStatisticConfigurationRead,
+		UpdateContext: resourceStatisticConfigurationUpdate,
+		DeleteContext: resourceStatisticConfigurationDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(statisticConfigurationNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"resource_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource type.`,
+			},
+			"resource_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource name, which can be an account or domain name.`,
+			},
+			"config_info": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"url": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enable": {
+										Type:        schema.TypeBool,
+										Required:    true,
+										Description: `Whether to enable the top URL statistics configuration.`,
+									},
+								},
+							},
+							Description: `The top URL statistics configuration.`,
+						},
+						"ua": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enable": {
+										Type:        schema.TypeBool,
+										Required:    true,
+										Description: `Whether to enable the top UA statistics configuration.`,
+									},
+								},
+							},
+							Description: `The top UA statistics configuration.`,
+						},
+					},
+				},
+				Description: `The statistics configuration information.`,
+			},
+
+			// Optional parameters.
+			"config_type": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The configuration category.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildStatisticConfigurationConfigInfoUrl(urlConfigs []interface{}) map[string]interface{} {
+	if len(urlConfigs) < 1 {
+		return nil
+	}
+
+	urlConfig := urlConfigs[0]
+	return map[string]interface{}{
+		"enable": utils.PathSearch("enable", urlConfig, false),
+	}
+}
+
+func buildStatisticConfigurationConfigInfoUa(uaConfigs []interface{}) map[string]interface{} {
+	if len(uaConfigs) < 1 {
+		return nil
+	}
+
+	uaConfig := uaConfigs[0]
+	return map[string]interface{}{
+		"enable": utils.PathSearch("enable", uaConfig, false),
+	}
+}
+
+func buildStatisticConfigurationConfigInfo(configInfos []interface{}) map[string]interface{} {
+	if len(configInfos) < 1 {
+		return nil
+	}
+
+	configInfo := configInfos[0]
+	return utils.RemoveNil(map[string]interface{}{
+		"url": buildStatisticConfigurationConfigInfoUrl(utils.PathSearch("url", configInfo, make([]interface{}, 0)).([]interface{})),
+		"ua":  buildStatisticConfigurationConfigInfoUa(utils.PathSearch("ua", configInfo, make([]interface{}, 0)).([]interface{})),
+	})
+}
+
+func buildStatisticConfigurationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return utils.RemoveNil(map[string]interface{}{
+		"resource_type": d.Get("resource_type"),
+		"resource_name": d.Get("resource_name"),
+		"config_info":   buildStatisticConfigurationConfigInfo(d.Get("config_info").([]interface{})),
+		"config_type":   utils.ValueIgnoreEmpty(d.Get("config_type")),
+	})
+}
+
+func resourceStatisticConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	httpUrl := "v1/cdn/statistics/stats-configs"
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildStatisticConfigurationBodyParams(d),
+		OkCodes:  []int{204},
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating CDN statistic configuration: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceStatisticConfigurationRead(ctx, d, meta)
+}
+
+func resourceStatisticConfigurationRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceStatisticConfigurationUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceStatisticConfigurationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to set CDN statistic configuration. Deleting this resource
+	will not clear the corresponding request record, but will only remove the resource information from the tf state
+    file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new resource that used to manage statistic configuration and supports a new data source to query statistic configuration information.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1053" height="471" alt="image" src="https://github.com/user-attachments/assets/cee3ac40-28ec-4752-8bba-cce8de795f15" />
<img width="1053" height="471" alt="image" src="https://github.com/user-attachments/assets/3770c666-6d2f-45dd-a714-b459a5300aa7" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage statistic configuration
2. add new data source to query statistic configuration information
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cdn -f TestAccStatisticConfiguration_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccStatisticConfiguration_basic -timeout 360m -parallel 10
=== RUN   TestAccStatisticConfiguration_basic
=== PAUSE TestAccStatisticConfiguration_basic
=== CONT  TestAccStatisticConfiguration_basic
--- PASS: TestAccStatisticConfiguration_basic (15.80s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       15.912s coverage: 4.2% of statements in ./huaweicloud/services/cdn
```
```
./scripts/coverage.sh -o cdn -f TestAccDataStatisticConfiguration_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccDataStatisticConfiguration_basic -timeout 360m -parallel 10
=== RUN   TestAccDataStatisticConfiguration_basic
=== PAUSE TestAccDataStatisticConfiguration_basic
=== CONT  TestAccDataStatisticConfiguration_basic
--- PASS: TestAccDataStatisticConfiguration_basic (10.23s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       10.308s coverage: 4.7% of statements in ./huaweicloud/services/cdn
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
