### PR TITLE
feat(workspace/app): add one-time resource to batch operate applications

### DIFF
--- a/docs/resources/workspace_app_application_batch_action.md
+++ b/docs/resources/workspace_app_application_batch_action.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_application_batch_action"
+description: |-
+  Use this resource to batch enable or disable applications of the Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_application_batch_action
+
+Use this resource to batch enable or disable applications of the Workspace APP within HuaweiCloud.
+
+-> This resource is a one-time action resource used to batch enable or disable applications. Deleting this
+   resource will not clear the corresponding request record, but will only remove the resource information
+   from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "app_group_id" {}
+variable "application_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_app_application_batch_action" "test" {
+  app_group_id    = var.app_group_id
+  action          = "disable"
+  application_ids = var.application_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the applications to be operated are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `app_group_id` - (Required, String, NonUpdatable) Specifies the ID of the application group.
+
+* `action` - (Required, String, NonUpdatable) Specifies the type of the action.  
+  The valid values are as follows:
+  + **enable**
+  + **disable**
+
+* `application_ids` - (Required, List, NonUpdatable) Specifies the list of application IDs to be operated.  
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3745,6 +3745,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_eip_associate":                        workspace.ResourceEipAssociate(),
 
 			// Workspace APP
+			"huaweicloud_workspace_app_application_batch_action":                workspace.ResourceAppApplicationBatchAction(),
 			"huaweicloud_workspace_app_application_batch_attach":                workspace.ResourceAppApplicationBatchAttach(),
 			"huaweicloud_workspace_app_bucket_authorize":                        workspace.ResourceAppBucketAuthorize(),
 			"huaweicloud_workspace_app_group_authorization":                     workspace.ResourceAppGroupAuthorization(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_application_batch_action_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_application_batch_action_test.go
@@ -1,0 +1,85 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAppApplicationBatchAction_basic(t *testing.T) {
+	var (
+		rName           = "huaweicloud_workspace_app_application_batch_action.test"
+		rNameWithEnable = "huaweicloud_workspace_app_application_batch_action.enable"
+		name            = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppApplicationBatchAction_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "action", "disable"),
+					resource.TestCheckResourceAttr(rName, "application_ids.#", "1"),
+				),
+			},
+			{
+				Config: testAccAppApplicationBatchAction_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameWithEnable, "action", "enable"),
+					resource.TestCheckResourceAttr(rNameWithEnable, "application_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAppApplicationBatchAction_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_group" "test" {
+  server_group_id = "%[1]s"
+  name            = "%[2]s"
+}
+
+# The application is enabled by default.
+resource "huaweicloud_workspace_app_publishment" "test" {
+  app_group_id = huaweicloud_workspace_app_group.test.id
+  name         = "%[2]s"
+  type         = 3
+  execute_path = "C:\\Program Files\\terraform\\terraform.exe"
+}
+`, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_ID, name)
+}
+
+func testAccAppApplicationBatchAction_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_application_batch_action" "test" {
+  app_group_id    = huaweicloud_workspace_app_group.test.id
+  action          = "disable"
+  application_ids = huaweicloud_workspace_app_publishment.test[*].id
+}
+`, testAccAppApplicationBatchAction_base(name))
+}
+
+func testAccAppApplicationBatchAction_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_application_batch_action" "enable" {
+  app_group_id    = huaweicloud_workspace_app_group.test.id
+  action          = "enable"
+  application_ids = huaweicloud_workspace_app_publishment.test[*].id
+}
+`, testAccAppApplicationBatchAction_base(name))
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_application_batch_action.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_application_batch_action.go
@@ -1,0 +1,131 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var appApplicationBatchActionNonUpdatableParams = []string{"app_group_id", "action", "application_ids"}
+
+// @API Workspace POST /v1/{project_id}/app-groups/{app_group_id}/apps/actions/enable
+// @API Workspace POST /v1/{project_id}/app-groups/{app_group_id}/apps/actions/disable
+func ResourceAppApplicationBatchAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppApplicationBatchActionCreate,
+		ReadContext:   resourceAppApplicationBatchActionRead,
+		UpdateContext: resourceAppApplicationBatchActionUpdate,
+		DeleteContext: resourceAppApplicationBatchActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(appApplicationBatchActionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the applications to be operated are located.`,
+			},
+			"app_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the application group.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the action.`,
+				ValidateFunc: validation.StringInSlice([]string{
+					"enable",
+					"disable",
+				}, false),
+			},
+			"application_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of application IDs to be operated.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceAppApplicationBatchActionCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		appGroupId = d.Get("app_group_id").(string)
+		action     = d.Get("action").(string)
+		httpUrl    = "v1/{project_id}/app-groups/{app_group_id}/apps/actions/{action}"
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{app_group_id}", appGroupId)
+	createPath = strings.ReplaceAll(createPath, "{action}", action)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"ids": d.Get("application_ids"),
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("unable to %s applications: %s", action, err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	return nil
+}
+
+func resourceAppApplicationBatchActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppApplicationBatchActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppApplicationBatchActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch enable or disable applications. Deleting this
+resource will not clear the corresponding request record, but will only remove the resource information from the tfstate
+file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a one-time resource(`huaweicloud_workspace_app_application_batch_action`) to batch operate applications.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppBatchAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppBatchAction_basic -timeout 360m -parallel 10
=== RUN   TestAccAppBatchAction_basic
=== PAUSE TestAccAppBatchAction_basic
=== CONT  TestAccAppBatchAction_basic
--- PASS: TestAccAppBatchAction_basic (25.10s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 25.230s coverage: 4.5% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
