### PR TITLE
feat(workspace): add new data source to query app authorizations

### DIFF
--- a/docs/data-sources/workspace_application_authorizations.md
+++ b/docs/data-sources/workspace_application_authorizations.md
@@ -1,0 +1,76 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_application_authorizations"
+description: |-
+  Use this data source to get the list of the application authorizations within HuaweiCloud.
+---
+
+# huaweicloud_workspace_application_authorizations
+
+Use this data source to get the list of the application authorizations within HuaweiCloud.
+
+## Example Usage
+
+### Query all application authorizations
+
+```hcl
+variable "application_id" {}
+
+data "huaweicloud_workspace_application_authorizations" "test" {
+  app_id = var.application_id
+}
+```
+
+### Filter authorizations by name and target type
+
+```hcl
+variable "application_id" {}
+
+data "huaweicloud_workspace_application_authorizations" "test" {
+  app_id      = var.application_id
+  name        = "user_name"
+  target_type = "SIMPLE"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the application authorizations are located.  
+  If omitted, the provider-level region will be used.
+
+* `app_id` - (Required, String) Specifies the ID of the application.
+
+* `name` - (Optional, String) Specifies the username or user group name.  
+  Fuzzy search is supported.
+
+* `target_type` - (Optional, String) Specifies the type of the target.  
+  The valid values are as follows:
+  + **SIMPLE**: Normal user.
+  + **USER_GROUP**: User group.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `authorizations` - The list of application authorizations that matched filter parameters.  
+  The [authorizations](#workspace_application_authorizations_attr) structure is documented below.
+
+<a name="workspace_application_authorizations_attr"></a>
+The `authorizations` block supports:
+
+* `account_type` - The account type.
+  + **SIMPLE**: Normal user.
+  + **USER_GROUP**: User group.
+
+* `account` - The account information.
+
+* `domain` - The domain name.
+
+* `platform_type` - The platform type.
+  + **AD**: AD domain.
+  + **LOCAL**: LiteAs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2207,6 +2207,7 @@ func Provider() *schema.Provider {
 
 			// Workspace
 			"huaweicloud_workspace_applications":                         workspace.DataSourceApplications(),
+			"huaweicloud_workspace_application_authorizations":           workspace.DataSourceApplicationAuthorizations(),
 			"huaweicloud_workspace_application_catalogs":                 workspace.DataSourceApplicationCatalogs(),
 			"huaweicloud_workspace_application_restricted_rules":         workspace.DataSourceApplicationRestrictedRules(),
 			"huaweicloud_workspace_application_rules":                    workspace.DataSourceApplicationRules(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_application_authorizations_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_application_authorizations_test.go
@@ -1,0 +1,157 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataApplicationAuthorizations_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		dataSource = "data.huaweicloud_workspace_application_authorizations.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byName   = "data.huaweicloud_workspace_application_authorizations.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byTargetType   = "data.huaweicloud_workspace_application_authorizations.filter_by_target_type"
+		dcByTargetType = acceptance.InitDataSourceCheck(byTargetType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataApplicationAuthorizations_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "authorizations.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "authorizations.0.account"),
+					resource.TestCheckResourceAttrSet(dataSource, "authorizations.0.account_type"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByTargetType.CheckResourceExists(),
+					resource.TestCheckOutput("is_target_type_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataApplicationAuthorizations_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_application_catalogs" "test" {}
+
+resource "huaweicloud_workspace_application" "test" {
+  name               = "%[1]s"
+  version            = "1.0.0"
+  authorization_type = "ALL_USER"
+  install_type       = "QUIET_INSTALL"
+  support_os         = "Windows"
+  catalog_id         = try(data.huaweicloud_workspace_application_catalogs.test.catalogs[0].id, "NOT_FOUND")
+  install_command    = "terraform test install"
+  description        = "Created by terraform script"
+
+  application_file_store {
+    store_type = "LINK"
+    file_link  = "https://www.huaweicloud.com/TerraformTest.msi"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      authorization_type
+    ]
+  }
+}
+
+resource "huaweicloud_workspace_user" "test" {
+  name  = "%[1]s_user"
+  email = "test@example.com"
+  phone = "+8613800000000"
+}
+
+resource "huaweicloud_workspace_application_batch_authorize" "test" {
+  depends_on = [
+    huaweicloud_workspace_user.test
+  ]
+
+  app_ids            = [huaweicloud_workspace_application.test.id]
+  authorization_type = "ASSIGN_USER"
+
+  users {
+    account       = huaweicloud_workspace_user.test.name
+    account_type  = "SIMPLE"
+    platform_type = "LOCAL"
+  }
+
+  enable_force_new = "true"
+}
+`, name)
+}
+
+func testAccDataApplicationAuthorizations_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_workspace_application_authorizations" "test" {
+  app_id = huaweicloud_workspace_application.test.id
+
+  depends_on = [
+    huaweicloud_workspace_application_batch_authorize.test
+  ]
+}
+
+locals {
+  authorized_account   = huaweicloud_workspace_user.test.name
+  authorized_account_type = "SIMPLE"
+}
+
+# Filter by name
+data "huaweicloud_workspace_application_authorizations" "filter_by_name" {
+  app_id = huaweicloud_workspace_application.test.id
+  name   = local.authorized_account
+
+  depends_on = [
+    huaweicloud_workspace_application_batch_authorize.test
+  ]
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_workspace_application_authorizations.filter_by_name.authorizations[*].account :
+    strcontains(v, local.authorized_account)
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by target_type
+data "huaweicloud_workspace_application_authorizations" "filter_by_target_type" {
+  app_id     = huaweicloud_workspace_application.test.id
+  target_type = local.authorized_account_type
+
+  depends_on = [
+    huaweicloud_workspace_application_batch_authorize.test
+  ]
+}
+
+locals {
+  target_type_filter_result = [
+    for v in data.huaweicloud_workspace_application_authorizations.filter_by_target_type.authorizations[*].account_type :
+    v == local.authorized_account_type
+  ]
+}
+
+output "is_target_type_filter_useful" {
+  value = length(local.target_type_filter_result) > 0 && alltrue(local.target_type_filter_result)
+}
+`, testAccDataApplicationAuthorizations_base(name))
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_application_authorizations.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_application_authorizations.go
@@ -1,0 +1,188 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/app-center/apps/{app_id}/authorizations
+func DataSourceApplicationAuthorizations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceApplicationAuthorizationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the application authorizations are located.`,
+			},
+
+			// Required parameters.
+			"app_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the application.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The username or user group name.`,
+			},
+			"target_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of the target.`,
+			},
+
+			// Attributes.
+			"authorizations": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        applicationAuthorizationSchema(),
+				Description: `The list of application authorizations that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func applicationAuthorizationSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"account_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The account type.`,
+			},
+			"account": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The account information.`,
+			},
+			"domain": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain name.`,
+			},
+			"platform_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The platform type.`,
+			},
+		},
+	}
+}
+
+func buildApplicationAuthorizationsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("target_type"); ok {
+		res = fmt.Sprintf("%s&target_type=%v", res, v)
+	}
+
+	return res
+}
+
+func listApplicationAuthorizations(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/app-center/apps/{app_id}/authorizations?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	appId := d.Get("app_id").(string)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{app_id}", appId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildApplicationAuthorizationsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		authorizations := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, authorizations...)
+		if len(authorizations) < limit {
+			break
+		}
+		offset += len(authorizations)
+	}
+
+	return result, nil
+}
+
+func flattenApplicationAuthorizations(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"account":       utils.PathSearch("account", item, nil),
+			"domain":        utils.PathSearch("domain", item, nil),
+			"account_type":  utils.PathSearch("account_type", item, nil),
+			"platform_type": utils.PathSearch("platform_type", item, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceApplicationAuthorizationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	authorizations, err := listApplicationAuthorizations(client, d)
+	if err != nil {
+		return diag.Errorf("error querying Workspace application authorizations: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("authorizations", flattenApplicationAuthorizations(authorizations)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source that used to query application authorizations.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1137" height="543" alt="image" src="https://github.com/user-attachments/assets/a49a746a-233b-4044-84f9-895c6fc451b6" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query app authorizations
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataApplicationAuthorizations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataApplicationAuthorizations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataApplicationAuthorizations_basic
=== PAUSE TestAccDataApplicationAuthorizations_basic
=== CONT  TestAccDataApplicationAuthorizations_basic
--- PASS: TestAccDataApplicationAuthorizations_basic (19.02s)
PASS
coverage: 6.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 19.135s coverage: 6.2% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
