### PR TITLE
feat(kafka): add data source to query version information

### DIFF
--- a/docs/data-sources/dms_kafka_instance_upgrade_information.md
+++ b/docs/data-sources/dms_kafka_instance_upgrade_information.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_instance_upgrade_information"
+description: |-
+  Use this data source to get the version information of the Kafka instance within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_instance_upgrade_information
+
+Use this data source to get the version information of the Kafka instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_dms_kafka_instance_upgrade_information" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the Kafka instance is located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the Kafka instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `current_version` - The current version of the instance.
+
+* `latest_version` - The latest version of the instance.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1096,6 +1096,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_extend_flavors":                   kafka.DataSourceDmsKafkaExtendFlavors(),
 			"huaweicloud_dms_kafka_flavors":                          kafka.DataSourceKafkaFlavors(),
 			"huaweicloud_dms_kafka_instance_coordinators":            kafka.DataSourceInstanceCoordinators(),
+			"huaweicloud_dms_kafka_instance_upgrade_information":     kafka.DataSourceInstanceUpgradeInformation(),
 			"huaweicloud_dms_kafka_instances":                        kafka.DataSourceInstances(),
 			"huaweicloud_dms_kafka_maintainwindows":                  kafka.DataSourceMaintainWindows(),
 			"huaweicloud_dms_kafka_message_diagnosis_tasks":          kafka.DataSourceDmsKafkaMessageDiagnosisTasks(),

--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_instance_upgrade_information_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_instance_upgrade_information_test.go
@@ -1,0 +1,58 @@
+package kafka
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataInstanceUpgradeInformation_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dms_kafka_instance_upgrade_information.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataInstanceUpgradeInformation_instanceNotFound(),
+				ExpectError: regexp.MustCompile(`This DMS instance does not exist`),
+			},
+			{
+				Config: testAccDataInstanceUpgradeInformation_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "current_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "latest_version"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataInstanceUpgradeInformation_instanceNotFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dms_kafka_instance_upgrade_information" "test" {
+  instance_id = "%[1]s"
+}
+`, randomId)
+}
+
+func testAccDataInstanceUpgradeInformation_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dms_kafka_instance_upgrade_information" "test" {
+  instance_id = "%[1]s"
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID)
+}

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_instance_upgrade_information.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_instance_upgrade_information.go
@@ -1,0 +1,96 @@
+package kafka
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Kafka GET /v2/{project_id}/kafka/instances/{instance_id}/upgrade
+func DataSourceInstanceUpgradeInformation() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceUpgradeInformationRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the Kafka instance is located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the Kafka instance.`,
+			},
+			"current_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current version of the instance.`,
+			},
+			"latest_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest version of the instance.`,
+			},
+		},
+	}
+}
+
+func dataSourceInstanceUpgradeInformationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		httpUrl    = "v2/{project_id}/kafka/instances/{instance_id}/upgrade"
+	)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf-8",
+		},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error querying the version information of the instance (%s): %s", instanceId, err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(randomId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("current_version", utils.PathSearch("current_version", getRespBody, nil)),
+		d.Set("latest_version", utils.PathSearch("latest_version", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source (`huaweicloud_dms_kafka_instance_upgrade_information`) to query current version and latest version information of the Kafka instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o kafka -f TestAccDataInstanceUpgradeInformation_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataInstanceUpgradeInformation_basic -timeout 360m -parallel 10
=== RUN   TestAccDataInstanceUpgradeInformation_basic
=== PAUSE TestAccDataInstanceUpgradeInformation_basic
=== CONT  TestAccDataInstanceUpgradeInformation_basic
--- PASS: TestAccDataInstanceUpgradeInformation_basic (16.10s)
PASS
coverage: 2.0% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     16.202s coverage: 2.0% of statements in ./huaweicloud/services/kafka
```
<img width="1061" height="271" alt="image" src="https://github.com/user-attachments/assets/bc23d92f-2140-4203-84f1-38f929c5b3ec" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
