### PR TITLE
feat(workspace): add new one-time action resource to install apps

### DIFF
--- a/docs/resources/workspace_application_batch_auto_install.md
+++ b/docs/resources/workspace_application_batch_auto_install.md
@@ -1,0 +1,116 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_application_batch_auto_install"
+description: |-
+  Use this resource to batch auto install applications within HuaweiCloud.
+---
+
+# huaweicloud_workspace_application_batch_auto_install
+
+Use this resource to batch auto install applications within HuaweiCloud.
+
+-> This resource is a one-time action resource for batch auto installing applications. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+-> Applications must support silent installation or unzip installation for batch auto installation.
+
+## Example Usage
+
+### Batch auto install applications for all users
+
+```hcl
+resource "huaweicloud_workspace_application_batch_auto_install" "test" {
+  app_ids      = ["app_id_1", "app_id_2"]
+  assign_scope = "ALL_USER"
+}
+```
+
+### Batch auto install applications with assigned users
+
+```hcl
+variable "application_ids" {
+  type = list(string)
+}
+variable "user_names" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_application_batch_auto_install" "test" {
+  app_ids      = var.application_ids
+  assign_scope = "ASSIGN_USER"
+
+  dynamic "users" {
+    for_each = var.user_names
+
+    content {
+      account      = users.value
+      account_type = "SIMPLE"
+    }
+  }
+}
+```
+
+### Batch auto install applications with user groups
+
+```hcl
+resource "huaweicloud_workspace_application_batch_auto_install" "test" {
+  app_ids      = ["app_id_1", "app_id_2"]
+  assign_scope = "ASSIGN_USER"
+
+  users {
+    account       = "group_name"
+    account_type  = "USER_GROUP"
+    domain        = "example.com"
+    platform_type = "AD"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the applications are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `app_ids` - (Required, List, NonUpdatable) Specifies the list of application IDs to be automatically installed.  
+  The number of applications in a single request ranges from `1` to `50`.
+
+* `assign_scope` - (Required, String, NonUpdatable) Specifies the assignment scope.  
+  The valid values are as follows:
+  + **ALL_USER** - All users can access the applications.  
+    When set to this value, all application authorizations will be modified to all users.
+  + **ASSIGN_USER** - Only assigned users can access the applications.  
+    When set to this value, the `users` parameter must be specified. If users do not have access permissions for the
+    corresponding applications, the permissions will be automatically added.
+
+* `users` - (Optional, List, NonUpdatable) Specifies the list of users.  
+  Required when `assign_scope` is set to **ASSIGN_USER**.  
+  The number of users in a single request ranges from `1` to `50`.  
+  The [users](#application_batch_auto_install_user) structure is documented below.
+
+<a name="application_batch_auto_install_user"></a>
+The `users` block supports:
+
+* `account` - (Required, String) Specifies the account name.  
+  The account format must be: account(group).
+
+* `account_type` - (Required, String) Specifies the account type.  
+  The valid values are as follows:
+  + **SIMPLE** - Simple user.
+  + **USER_GROUP** - User group.
+
+* `domain` - (Optional, String) Specifies the domain name.  
+  Required for user groups, and defaults to local.com if not specified.
+
+* `platform_type` - (Optional, String) Specifies the platform type.  
+  The valid values are as follows:
+  + **AD** - AD domain.
+  + **LOCAL** - LiteAs.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3722,6 +3722,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_access_policy":                        workspace.ResourceAccessPolicy(),
 			"huaweicloud_workspace_application":                          workspace.ResourceApplication(),
 			"huaweicloud_workspace_application_batch_authorize":          workspace.ResourceApplicationBatchAuthorize(),
+			"huaweicloud_workspace_application_batch_auto_install":       workspace.ResourceApplicationBatchAutoInstall(),
 			"huaweicloud_workspace_application_rule":                     workspace.ResourceApplicationRule(),
 			"huaweicloud_workspace_application_rule_restriction":         workspace.ResourceApplicationRuleRestriction(),
 			"huaweicloud_workspace_application_rule_restriction_setting": workspace.ResourceApplicationRuleRestrictionSetting(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_application_batch_auto_install_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_application_batch_auto_install_test.go
@@ -1,0 +1,129 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApplicationBatchAutoInstall_basic(t *testing.T) {
+	var (
+		name         = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_workspace_application_batch_auto_install.test"
+		baseConfig   = testAccApplicationBatchAutoInstall_base(name)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationBatchAutoInstall_basic_step1(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "assign_scope", "ALL_USER"),
+					resource.TestCheckResourceAttr(resourceName, "app_ids.#", "2"),
+				),
+			},
+			{
+				Config: testAccApplicationBatchAutoInstall_basic_step2(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "assign_scope", "ASSIGN_USER"),
+					resource.TestCheckResourceAttr(resourceName, "app_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "users.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccApplicationBatchAutoInstall_base(name string) string {
+	randomPhoneNum := acctest.RandIntRange(1000000000, 1999999999)
+
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_application_catalogs" "test" {}
+
+resource "huaweicloud_workspace_application" "test" {
+  count = 2
+
+  name               = format("%%s_%%d", "%[1]s", count.index)
+  version            = "1.0.0"
+  authorization_type = "ALL_USER"
+  install_type       = "QUIET_INSTALL"
+  support_os         = "Windows"
+  catalog_id         = try(data.huaweicloud_workspace_application_catalogs.test.catalogs[0].id, "NOT_FOUND")
+  install_command    = "terraform test install"
+  description        = "Created by terraform script"
+
+  application_file_store {
+    store_type = "LINK"
+    file_link  = "https://www.huaweicloud.com/TerraformTest.msi"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      authorization_type
+    ]
+  }
+}
+
+resource "huaweicloud_workspace_user" "test" {
+  count = 2
+
+  name  = format("%[1]s_%%d", count.index)
+  email = format("test%%d@example.com", count.index)
+  phone = format("+%[2]d%%d", count.index)
+}
+`, name, randomPhoneNum)
+}
+
+func testAccApplicationBatchAutoInstall_basic_step1(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_application_batch_auto_install" "test" {
+  depends_on = [
+    huaweicloud_workspace_application.test
+  ]
+
+  app_ids      = huaweicloud_workspace_application.test[*].id
+  assign_scope = "ALL_USER"
+
+  enable_force_new = "true"
+}
+`, baseConfig)
+}
+
+func testAccApplicationBatchAutoInstall_basic_step2(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_application_batch_auto_install" "test" {
+  depends_on = [
+    huaweicloud_workspace_user.test
+  ]
+
+  app_ids      = huaweicloud_workspace_application.test[*].id
+  assign_scope = "ASSIGN_USER"
+
+  dynamic "users" {
+    for_each = huaweicloud_workspace_user.test
+
+    content {
+      account      = users.value.name
+      account_type = "SIMPLE"
+    }
+  }
+
+  enable_force_new = "true"
+}
+`, baseConfig)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_application_batch_auto_install.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_application_batch_auto_install.go
@@ -1,0 +1,191 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var applicationBatchAutoInstallNonUpdatableParams = []string{
+	"app_ids",
+	"assign_scope",
+	"users",
+}
+
+// @API Workspace POST /v1/{project_id}/app-center/apps/actions/batch-auto-install
+func ResourceApplicationBatchAutoInstall() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceApplicationBatchAutoInstallCreate,
+		ReadContext:   resourceApplicationBatchAutoInstallRead,
+		UpdateContext: resourceApplicationBatchAutoInstallUpdate,
+		DeleteContext: resourceApplicationBatchAutoInstallDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(applicationBatchAutoInstallNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the applications are located.`,
+			},
+
+			// Required parameters.
+			"app_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MinItems:    1,
+				MaxItems:    50,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of application IDs to be automatically installed.`,
+			},
+			"assign_scope": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The assignment scope.`,
+			},
+
+			// Optional parameters.
+			"users": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MinItems:    1,
+				MaxItems:    50,
+				Elem:        applicationBatchAutoInstallUserSchema(),
+				Description: `The list of users. Required when assign_scope is ASSIGN_USER.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func applicationBatchAutoInstallUserSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"account": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The account name. The account format must be: account(group).`,
+			},
+			"account_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The account type.`,
+			},
+			"domain": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The domain name. Required for user groups, and defaults to local.com if not specified.`,
+			},
+			"platform_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The platform type.`,
+			},
+		},
+	}
+}
+
+func buildApplicationBatchAutoInstallUsersBodyParams(users []interface{}) []interface{} {
+	if len(users) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(users))
+	for _, user := range users {
+		result = append(result, utils.RemoveNil(map[string]interface{}{
+			"account":       utils.PathSearch("account", user, ""),
+			"account_type":  utils.PathSearch("account_type", user, ""),
+			"domain":        utils.ValueIgnoreEmpty(utils.PathSearch("domain", user, "")),
+			"platform_type": utils.ValueIgnoreEmpty(utils.PathSearch("platform_type", user, "")),
+		}))
+	}
+
+	return result
+}
+
+func buildApplicationBatchAutoInstallBodyParams(d *schema.ResourceData) map[string]interface{} {
+	body := map[string]interface{}{
+		"app_ids":      d.Get("app_ids").([]interface{}),
+		"assign_scope": d.Get("assign_scope"),
+	}
+
+	if v, ok := d.GetOk("users"); ok {
+		body["users"] = buildApplicationBatchAutoInstallUsersBodyParams(v.([]interface{}))
+	}
+
+	return body
+}
+
+func resourceApplicationBatchAutoInstallCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/app-center/apps/actions/batch-auto-install"
+	)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildApplicationBatchAutoInstallBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating application batch auto install: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceApplicationBatchAutoInstallRead(ctx, d, meta)
+}
+
+func resourceApplicationBatchAutoInstallRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceApplicationBatchAutoInstallUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceApplicationBatchAutoInstallDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource for batch auto installing applications. Deleting this resource will
+	not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new one-time action resource that used to batch install applications

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1143" height="381" alt="image" src="https://github.com/user-attachments/assets/bd726a3b-520b-41e5-bab3-b52c33c8fb91" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new one-time action resource to install apps
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccApplicationBatchAutoInstall_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccApplicationBatchAutoInstall_basic -timeout 360m -parallel 10
=== RUN   TestAccApplicationBatchAutoInstall_basic
=== PAUSE TestAccApplicationBatchAutoInstall_basic
=== CONT  TestAccApplicationBatchAutoInstall_basic
--- PASS: TestAccApplicationBatchAutoInstall_basic (32.37s)
PASS
coverage: 5.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 32.453s coverage: 5.5% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
