### PR TITLE
feat(workspace): add new resource to manage log configuraiton

### DIFF
--- a/docs/resources/workspace_log_configuration.md
+++ b/docs/resources/workspace_log_configuration.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_log_configuration"
+description: |-
+  Use this resource to manage Workspace log configuration for user events within HuaweiCloud.
+---
+
+# huaweicloud_workspace_log_configuration
+
+Use this resource to manage Workspace log configuration for user events within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "log_group_id" {}
+variable "log_stream_id" {}
+
+resource "huaweicloud_workspace_log_configuration" "test" {
+  log_group_id  = var.log_group_id
+  log_stream_id = var.log_stream_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the log configuration is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `log_group_id` - (Required, String) Specifies the ID of the log group.  
+  The length ranges from `1` to `64` characters.
+
+* `log_stream_id` - (Required, String) Specifies the ID of the log stream.  
+  The length ranges from `1` to `64` characters.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is the project ID of the region.
+
+## Import
+
+The log configuration can be imported using the `id` (it can be any UUID), e.g.
+
+```bash
+$ terraform import huaweicloud_workspace_log_configuration.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3721,7 +3721,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_instance_group_associate":            waf.ResourceWafInstGroupAssociate(),
 
 			// Workspace
-			"huaweicloud_workspace_user_group":                           workspace.ResourceUserGroup(),
 			"huaweicloud_workspace_access_policy":                        workspace.ResourceAccessPolicy(),
 			"huaweicloud_workspace_application":                          workspace.ResourceApplication(),
 			"huaweicloud_workspace_application_batch_authorize":          workspace.ResourceApplicationBatchAuthorize(),
@@ -3737,12 +3736,13 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_desktop_pool":                         workspace.ResourceDesktopPool(),
 			"huaweicloud_workspace_desktop_pool_action":                  workspace.ResourceDesktopPoolAction(),
 			"huaweicloud_workspace_desktop_pool_notification":            workspace.ResourceDesktopPoolNotification(),
+			"huaweicloud_workspace_eip_associate":                        workspace.ResourceEipAssociate(),
+			"huaweicloud_workspace_log_configuration":                    workspace.ResourceLogConfiguration(),
 			"huaweicloud_workspace_policy_group":                         workspace.ResourcePolicyGroup(),
 			"huaweicloud_workspace_service":                              workspace.ResourceService(),
-			"huaweicloud_workspace_app_service_action":                   workspace.ResourceAppServiceAction(),
 			"huaweicloud_workspace_terminal_binding":                     workspace.ResourceTerminalBinding(),
 			"huaweicloud_workspace_user":                                 workspace.ResourceUser(),
-			"huaweicloud_workspace_eip_associate":                        workspace.ResourceEipAssociate(),
+			"huaweicloud_workspace_user_group":                           workspace.ResourceUserGroup(),
 
 			// Workspace APP
 			"huaweicloud_workspace_app_application_batch_attach":                workspace.ResourceAppApplicationBatchAttach(),
@@ -3765,6 +3765,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_server_group":                            workspace.ResourceAppServerGroup(),
 			"huaweicloud_workspace_app_server_group_batch_disassociate":         workspace.ResourceAppServerGroupBatchDisassociate(),
 			"huaweicloud_workspace_app_server_group_scaling_policy":             workspace.ResourceAppServerGroupScalingPolicy(),
+			"huaweicloud_workspace_app_service_action":                          workspace.ResourceAppServiceAction(),
 			"huaweicloud_workspace_app_shared_folder":                           workspace.ResourceAppSharedFolder(),
 			"huaweicloud_workspace_app_storage_policy":                          workspace.ResourceAppStoragePolicy(),
 			"huaweicloud_workspace_app_warehouse_application":                   workspace.ResourceAppWarehouseApplication(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_log_configuration_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_log_configuration_test.go
@@ -1,0 +1,104 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/workspace"
+)
+
+func getLogConfigurationResourceFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("workspace", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace client: %s", err)
+	}
+
+	return workspace.GetLogConfiguration(client)
+}
+
+func TestAccLogConfiguration_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_workspace_log_configuration.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getLogConfigurationResourceFunc)
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+		baseConfig = testLogConfiguration_base(name)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testLogConfiguration_basic_step1(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "log_group_id", "huaweicloud_lts_group.test.0", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "log_stream_id", "huaweicloud_lts_stream.test.0", "id"),
+				),
+			},
+			{
+				Config: testLogConfiguration_basic_step2(baseConfig, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "log_group_id", "huaweicloud_lts_group.test.1", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "log_stream_id", "huaweicloud_lts_stream.test.1", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testLogConfiguration_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_group" "test" {
+  count = 2
+
+  group_name  = format("%[1]s_%%d", count.index)
+  ttl_in_days = 10
+}
+
+resource "huaweicloud_lts_stream" "test" {
+  count = 2
+
+  group_id    = huaweicloud_lts_group.test[count.index].id
+  stream_name = format("%[1]s_%%d", count.index)
+}
+`, name)
+}
+
+func testLogConfiguration_basic_step1(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_log_configuration" "test" {
+  log_group_id  = huaweicloud_lts_group.test[0].id
+  log_stream_id = huaweicloud_lts_stream.test[0].id
+}
+`, baseConfig, name)
+}
+
+func testLogConfiguration_basic_step2(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_log_configuration" "test" {
+  log_group_id  = huaweicloud_lts_group.test[1].id
+  log_stream_id = huaweicloud_lts_stream.test[1].id
+}
+`, baseConfig, name)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_log_configuration.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_log_configuration.go
@@ -1,0 +1,217 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace POST /v2/{project_id}/user-events/lts-configurations
+// @API Workspace GET /v2/{project_id}/user-events/lts-configurations
+func ResourceLogConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceLogConfigurationCreate,
+		ReadContext:   resourceLogConfigurationRead,
+		UpdateContext: resourceLogConfigurationUpdate,
+		DeleteContext: resourceLogConfigurationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the log configuration is located.`,
+			},
+
+			// Required parameters.
+			"log_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the log group.`,
+			},
+			"log_stream_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the log stream.`,
+			},
+		},
+	}
+}
+
+func buildLogConfigurationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"enable":        true,
+		"log_group_id":  d.Get("log_group_id"),
+		"log_stream_id": d.Get("log_stream_id"),
+	}
+
+	return utils.RemoveNil(bodyParams)
+}
+
+func resourceLogConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	httpUrl := "v2/{project_id}/user-events/lts-configurations"
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildLogConfigurationBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating Workspace log configuration: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	return resourceLogConfigurationRead(ctx, d, meta)
+}
+
+func GetLogConfiguration(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v2/{project_id}/user-events/lts-configurations"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	if isEnabled := utils.PathSearch("enable", respBody, false).(bool); !isEnabled {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/user-events/lts-configurations",
+				RequestId: "NONE",
+				Body:      []byte("the LTS log configuration has been disabled"),
+			},
+		}
+	}
+	return respBody, nil
+}
+
+func resourceLogConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	respBody, err := GetLogConfiguration(client)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Workspace log configuration")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("log_group_id", utils.PathSearch("log_group_id", respBody, nil)),
+		d.Set("log_stream_id", utils.PathSearch("log_stream_id", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceLogConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v2/{project_id}/user-events/lts-configurations"
+	)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildLogConfigurationBodyParams(d),
+	}
+
+	_, err = client.Request("POST", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating Workspace log configuration: %s", err)
+	}
+
+	return resourceLogConfigurationRead(ctx, d, meta)
+}
+
+func resourceLogConfigurationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	httpUrl := "v2/{project_id}/user-events/lts-configurations"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"enable": false,
+		},
+	}
+
+	_, err = client.Request("POST", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error getting Workspace log configuration: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource that used to manage Workspace log configuration.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage log configuraiton.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccLogConfiguration_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccLogConfiguration_basic -timeout 360m -parallel 10
=== RUN   TestAccLogConfiguration_basic
=== PAUSE TestAccLogConfiguration_basic
=== CONT  TestAccLogConfiguration_basic
--- PASS: TestAccLogConfiguration_basic (30.52s)
PASS
coverage: 3.6% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 30.602s coverage: 3.6% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
