### PR TITLE
feat(workspace/app): add new one-time resource to migrate server

### DIFF
--- a/docs/resources/workspace_app_server_batch_migrate.md
+++ b/docs/resources/workspace_app_server_batch_migrate.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_server_batch_migrate"
+description: |-
+  Use this resource to batch migrate servers to the target cloud office host within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_server_batch_migrate
+
+Use this resource to batch migrate servers to the target cloud office host within HuaweiCloud.
+
+-> This resource is a one-time action resource used to batch migrate servers. Deleting this resource will not
+   clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "server_ids" {
+  type = list(string)
+}
+variable "target_host_id" {}
+
+resource "huaweicloud_workspace_app_server_batch_migrate" "test" {
+  server_ids = var.server_ids
+  host_id    = var.target_host_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the servers to be migrated are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `server_ids` - (Required, List, NonUpdatable) Specifies the list of server IDs to be migrated.  
+
+* `host_id` - (Required, String, NonUpdatable) Specifies the ID of the target cloud office host.  
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3762,6 +3762,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_server":                                  workspace.ResourceAppServer(),
 			"huaweicloud_workspace_app_server_action":                           workspace.ResourceAppServerAction(),
 			"huaweicloud_workspace_app_server_batch_action":                     workspace.ResourceAppServerBatchAction(),
+			"huaweicloud_workspace_app_server_batch_migrate":                    workspace.ResourceAppServerBatchMigrate(),
 			"huaweicloud_workspace_app_server_group":                            workspace.ResourceAppServerGroup(),
 			"huaweicloud_workspace_app_server_group_batch_disassociate":         workspace.ResourceAppServerGroupBatchDisassociate(),
 			"huaweicloud_workspace_app_server_group_scaling_policy":             workspace.ResourceAppServerGroupScalingPolicy(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -313,18 +313,22 @@ var (
 	HW_WORKSPACE_AD_VPC_ID     = os.Getenv("HW_WORKSPACE_AD_VPC_ID")     // The VPC ID to which the AD servers and desktops belong.
 	HW_WORKSPACE_AD_NETWORK_ID = os.Getenv("HW_WORKSPACE_AD_NETWORK_ID") // The network ID to which the AD servers belong.
 	// The internet access port to which the Workspace service.
-	HW_WORKSPACE_INTERNET_ACCESS_PORT              = os.Getenv("HW_WORKSPACE_INTERNET_ACCESS_PORT")
+	HW_WORKSPACE_INTERNET_ACCESS_PORT  = os.Getenv("HW_WORKSPACE_INTERNET_ACCESS_PORT")
+	HW_WORKSPACE_OU_NAME               = os.Getenv("HW_WORKSPACE_OU_NAME")
+	HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID = os.Getenv("HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID")
+	HW_WORKSPACE_SCHEDULED_TASK_ID     = os.Getenv("HW_WORKSPACE_SCHEDULED_TASK_ID")
+
 	HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID        = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID")
 	HW_WORKSPACE_APP_SERVER_GROUP_ID               = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_ID")
 	HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID         = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID")
 	HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID")
 	HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE  = os.Getenv("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_SPEC_CODE")
 	HW_WORKSPACE_APP_SERVER_ID                     = os.Getenv("HW_WORKSPACE_APP_SERVER_ID")
-	HW_WORKSPACE_OU_NAME                           = os.Getenv("HW_WORKSPACE_OU_NAME")
-	HW_WORKSPACE_APP_FILE_NAME                     = os.Getenv("HW_WORKSPACE_APP_FILE_NAME")
-	HW_WORKSPACE_USER_NAMES                        = os.Getenv("HW_WORKSPACE_USER_NAMES")
-	HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID             = os.Getenv("HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID")
-	HW_WORKSPACE_SCHEDULED_TASK_ID                 = os.Getenv("HW_WORKSPACE_SCHEDULED_TASK_ID")
+	// The list of server IDs to be migrated, separated by commas (,).
+	HW_WORKSPACE_APP_SERVER_BATCH_MIGRATE_SERVER_IDS = os.Getenv("HW_WORKSPACE_APP_SERVER_BATCH_MIGRATE_SERVER_IDS")
+	HW_WORKSPACE_APP_SERVER_BATCH_MIGRATE_HOST_ID    = os.Getenv("HW_WORKSPACE_APP_SERVER_BATCH_MIGRATE_HOST_ID")
+	HW_WORKSPACE_APP_FILE_NAME                       = os.Getenv("HW_WORKSPACE_APP_FILE_NAME")
+	HW_WORKSPACE_USER_NAMES                          = os.Getenv("HW_WORKSPACE_USER_NAMES")
 
 	HW_FGS_AGENCY_NAME         = os.Getenv("HW_FGS_AGENCY_NAME")
 	HW_FGS_APP_AGENCY_NAME     = os.Getenv("HW_FGS_APP_AGENCY_NAME")
@@ -2451,6 +2455,17 @@ func TestAccPreCheckWorkspaceAppServerGroupId(t *testing.T) {
 func TestAccPreCheckWorkspaceAppServerId(t *testing.T) {
 	if HW_WORKSPACE_APP_SERVER_ID == "" {
 		t.Skip("HW_WORKSPACE_APP_SERVER_ID must be set for Workspace APP acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckWorkspaceAppServerBatchMigrate(t *testing.T, min int) {
+	if HW_WORKSPACE_APP_SERVER_BATCH_MIGRATE_SERVER_IDS == "" || len(strings.Split(HW_WORKSPACE_APP_SERVER_BATCH_MIGRATE_SERVER_IDS, ",")) < min {
+		t.Skip("At least one of server must be configured in the HW_WORKSPACE_APP_SERVER_BATCH_MIGRATE_SERVER_IDS, and separated by commas (,).")
+	}
+
+	if HW_WORKSPACE_APP_SERVER_BATCH_MIGRATE_HOST_ID == "" {
+		t.Skip("HW_WORKSPACE_APP_SERVER_BATCH_MIGRATE_HOST_ID must be set for Workspace APP acceptance test.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_batch_migrate_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_batch_migrate_test.go
@@ -1,0 +1,43 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAppServerBatchMigrate_basic(t *testing.T) {
+	resourceName := "huaweicloud_workspace_app_server_batch_migrate.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerBatchMigrate(t, 1)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppServerBatchMigrate_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "server_ids.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(resourceName, "host_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAppServerBatchMigrate_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_server_batch_migrate" "test" {
+  server_ids = split(",", "%[1]s")
+  host_id    = "%[2]s"
+}
+`, acceptance.HW_WORKSPACE_APP_SERVER_BATCH_MIGRATE_SERVER_IDS, acceptance.HW_WORKSPACE_APP_SERVER_BATCH_MIGRATE_HOST_ID)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server_batch_migrate.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server_batch_migrate.go
@@ -1,0 +1,141 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var appServerBatchMigrateNonUpdatableParams = []string{"server_ids", "host_id"}
+
+// @API Workspace PATCH /v1/{project_id}/app-servers/hosts/batch-migrate
+// @API Workspace GET /v2/{project_id}/job/{job_id}
+func ResourceAppServerBatchMigrate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppServerBatchMigrateCreate,
+		ReadContext:   resourceAppServerBatchMigrateRead,
+		UpdateContext: resourceAppServerBatchMigrateUpdate,
+		DeleteContext: resourceAppServerBatchMigrateDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(appServerBatchMigrateNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the servers to be migrated are located.`,
+			},
+			"server_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of server IDs to be migrated.`,
+			},
+			"host_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the target cloud office host.`,
+			},
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildAppServerBatchMigrateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"server_ids": d.Get("server_ids"),
+		"host_id":    d.Get("host_id"),
+	}
+}
+
+func resourceAppServerBatchMigrateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/app-servers/hosts/batch-migrate"
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: buildAppServerBatchMigrateBodyParams(d),
+	}
+
+	resp, err := client.Request("PATCH", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error migrating servers to target cloud office host: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find job ID from API response")
+	}
+
+	_, err = waitForAppServerJobCompleted(ctx, client, d.Timeout(schema.TimeoutCreate), jobId)
+	if err != nil {
+		return diag.Errorf("error waiting for the migration job (%s) completed: %s", jobId, err)
+	}
+
+	return nil
+}
+
+func resourceAppServerBatchMigrateRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppServerBatchMigrateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppServerBatchMigrateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch migrate servers to target cloud office host. Deleting this
+resource will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new one-time resource(`huaweicloud_workspace_app_server_batch_migrate`) to migrate servers to the target cloud office host.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new one-time resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o workspace -f TestAccAppServerBatchMigrate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppServerBatchMigrate_basic -timeout 360m -parallel 10
=== RUN   TestAccAppServerBatchMigrate_basic
=== PAUSE TestAccAppServerBatchMigrate_basic
=== CONT  TestAccAppServerBatchMigrate_basic
--- PASS: TestAccAppServerBatchMigrate_basic (24.38s)
PASS
coverage: 3.3% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 24.799s coverage: 3.3% of statements in ./huaweicloud/services/workspace
```
<img width="1174" height="509" alt="image" src="https://github.com/user-attachments/assets/409071bb-ec5f-485b-b1fd-679b3b1afd0e" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
