### PR TITLE
feat(cdn): supports new data source and resource for domain template

### DIFF
--- a/docs/data-sources/cdn_domain_templates.md
+++ b/docs/data-sources/cdn_domain_templates.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_domain_templates"
+description: |-
+  Use this data source to get a list of domain templates within HuaweiCloud.
+---
+
+# huaweicloud_cdn_domain_templates
+
+Use this data source to get a list of domain templates within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cdn_domain_templates" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `templates` - The list of domain templates.  
+  The [templates](#cdn_domain_templates_attr) structure is documented below.
+
+<a name="cdn_domain_templates_attr"></a>
+The `templates` block supports:
+
+* `id` - The ID of the domain template.
+
+* `name` - The name of the domain template.
+
+* `description` - The description of the domain template.
+
+* `configs` - The configuration of the domain template, in JSON format.
+
+* `type` - The type of the domain template.  
+  Valid values are:
+  + **1** - System preset template.
+  + **2** - Tenant custom template.
+
+* `account_id` - The account ID.
+
+* `create_time` - The creation time of the domain template, in RFC3339 format.
+
+* `modify_time` - The modification time of the domain template, in RFC3339 format.

--- a/docs/resources/cdn_domain_template.md
+++ b/docs/resources/cdn_domain_template.md
@@ -1,0 +1,118 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_domain_template"
+description: |-
+  Manages a CDN domain template resource within HuaweiCloud.
+---
+
+# huaweicloud_cdn_domain_template
+
+Manages a CDN domain template resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "template_name" {}
+
+resource "huaweicloud_cdn_domain_template" "test" {
+  name        = var.template_name
+  description = "Created by terraform"
+  configs     = jsonencode({
+    "cache_rules": [
+      {
+        "force_cache": "on",
+        "follow_origin": "off",
+        "match_type": "all",
+        "priority": 1,
+        "stale_while_revalidate": "off",
+        "ttl": 20,
+        "ttl_unit": "d",
+        "url_parameter_type": "full_url",
+        "url_parameter_value": ""
+      }
+    ],
+    "http_response_header": [
+      {
+        "action": "set",
+        "name": "Content-Disposition",
+        "value": "1235"
+      }
+    ],
+    "origin_follow302_status": "off",
+    "compress": {
+      "type": "gzip,br",
+      "status": "on",
+      "file_type": ".js,.html,.css,.xml,.json,.shtml,.htmx"
+    },
+    "origin_range_status": "on",
+    "referer": {
+      "type": "black",
+      "value": "1.2.1.1",
+      "include_empty": false
+    },
+    "ip_filter": {
+      "type": "white",
+      "value": "1.1.2.2"
+    },
+    "user_agent_filter": {
+      "type": "white",
+      "ua_list": [
+        "1.1.3.3"
+      ],
+      "include_empty": false
+    },
+    "flow_limit_strategy": [
+      {
+        "strategy_type": "instant",
+        "item_type": "bandwidth",
+        "limit_value": 1000001,
+        "alarm_percent_threshold": null,
+        "ban_time": 60
+      }
+    ]
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) Specifies the name of the domain template.
+
+* `configs` - (Required, String) Specifies the configuration of the domain template, in JSON format.  
+  The configuration includes cache rules, HTTP response headers, compression settings, origin settings, access control,
+  and other CDN configurations.
+
+* `description` - (Optional, String) Specifies the description of the domain template.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `type` - The type of the domain template.
+  + **1** - System preset template.
+  + **2** - Tenant custom template.
+
+* `account_id` - The account ID.
+
+* `create_time` - The creation time of the domain template, in RFC3339 format.
+
+* `modify_time` - The modification time of the domain template, in RFC3339 format.
+
+## Import
+
+The domain template can be imported using the `id` or `name`, e.g.
+
+```bash
+$ terraform import huaweicloud_cdn_domain_template.test <id>
+```
+
+or
+
+```bash
+$ terraform import huaweicloud_cdn_domain_template.test <name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -750,6 +750,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_cache_history_tasks":       cdn.DataSourceCacheHistoryTasks(),
 			"huaweicloud_cdn_cache_sharing_groups":      cdn.DataSourceCacheSharingGroups(),
 			"huaweicloud_cdn_domains":                   cdn.DataSourceDomains(),
+			"huaweicloud_cdn_domain_templates":          cdn.DataSourceDomainTemplates(),
 			"huaweicloud_cdn_domain_certificates":       cdn.DataSourceDomainCertificates(),
 			"huaweicloud_cdn_domain_owner_verification": cdn.DataSourceDomainOwnerVerification(),
 			"huaweicloud_cdn_domain_tags":               cdn.DataSourceDomainTags(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2611,6 +2611,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_domain_batch_copy":             cdn.ResourceDomainBatchCopy(),
 			"huaweicloud_cdn_domain_owner_verify":           cdn.ResourceDomainOwnerVerify(),
 			"huaweicloud_cdn_domain_rule":                   cdn.ResourceDomainRule(),
+			"huaweicloud_cdn_domain_template":               cdn.ResourceDomainTemplate(),
 			"huaweicloud_cdn_rule_engine_rule":              cdn.ResourceRuleEngineRule(),
 
 			"huaweicloud_ces_alarmrule":                                     ces.ResourceAlarmRule(),

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domain_templates_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domain_templates_test.go
@@ -1,0 +1,125 @@
+package cdn
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataDomainTemplates_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_cdn_domain_templates.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataDomainTemplates_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName, "templates.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.type"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.account_id"),
+					resource.TestCheckResourceAttrSet(rName, "templates.0.configs"),
+					resource.TestMatchResourceAttr(rName, "templates.0.create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(rName, "templates.0.modify_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckOutput("is_domain_template_found", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataDomainTemplates_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_domain_template" "test" {
+  name        = "%[1]s"
+  description = "Created by terraform"
+  configs = jsonencode({
+    "cache_rules": [
+      {
+        "force_cache": "on",
+        "follow_origin": "off",
+        "match_type": "all",
+        "priority": 1,
+        "stale_while_revalidate": "off",
+        "ttl": 20,
+        "ttl_unit": "d",
+        "url_parameter_type": "full_url",
+        "url_parameter_value": ""
+      }
+    ],
+    "http_response_header": [
+      {
+        "action": "set",
+        "name": "Content-Disposition",
+        "value": "1235"
+      }
+    ],
+    "origin_follow302_status": "off",
+    "compress": {
+      "type": "gzip,br",
+      "status": "on",
+      "file_type": ".js,.html,.css,.xml,.json,.shtml,.htmx"
+    },
+    "origin_range_status": "on",
+    "referer": {
+      "type": "black",
+      "value": "1.2.1.1",
+      "include_empty": false
+    },
+    "ip_filter": {
+      "type": "white",
+      "value": "1.1.2.2"
+    },
+    "user_agent_filter": {
+      "type": "white",
+      "ua_list": [
+        "1.1.3.3"
+      ],
+      "include_empty": false
+    },
+    "flow_limit_strategy": [
+      {
+        "strategy_type": "instant",
+        "item_type": "bandwidth",
+        "limit_value": 1000001,
+        "alarm_percent_threshold": null,
+        "ban_time": 60
+      }
+    ]
+  })
+}
+
+data "huaweicloud_cdn_domain_templates" "test" {
+  depends_on = [
+    huaweicloud_cdn_domain_template.test
+  ]
+}
+
+locals {
+  domain_template_id           = huaweicloud_cdn_domain_template.test.id
+  domain_template_query_result = try([
+    for v in data.huaweicloud_cdn_domain_templates.test.templates : v if v.id == local.domain_template_id
+  ][0], null)
+}
+
+output "is_domain_template_found" {
+  value = local.domain_template_query_result != null && local.domain_template_query_result.id == local.domain_template_id
+}
+`, name)
+}

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_template_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_template_test.go
@@ -1,0 +1,219 @@
+package cdn
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cdn"
+)
+
+func getDomainTemplateFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	tmlId := state.Primary.ID
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return nil, fmt.Errorf("error creating CDN client: %s", err)
+	}
+
+	return cdn.GetDomainTemplateById(client, tmlId)
+}
+
+func TestAccDomainTemplate_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_cdn_domain_template.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDomainTemplateFunc)
+
+		name = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainTemplate_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform"),
+					resource.TestCheckResourceAttrSet(resourceName, "configs"),
+					resource.TestCheckResourceAttrSet(resourceName, "type"),
+					resource.TestCheckResourceAttrSet(resourceName, "account_id"),
+					resource.TestMatchResourceAttr(resourceName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccDomainTemplate_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by terraform"),
+					resource.TestCheckResourceAttrSet(resourceName, "configs"),
+					resource.TestMatchResourceAttr(resourceName, "modify_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testDomainTemplateImportStateWithName(resourceName),
+			},
+		},
+	})
+}
+
+func testDomainTemplateImportStateWithName(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		templateName := rs.Primary.Attributes["name"]
+		if templateName == "" {
+			return "", fmt.Errorf("template name is missing, want '<name>', but got '%s'", templateName)
+		}
+		return templateName, nil
+	}
+}
+
+func testAccDomainTemplate_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_domain_template" "test" {
+  name        = "%[1]s"
+  description = "Created by terraform"
+  configs     = jsonencode({
+    "cache_rules": [
+      {
+        "force_cache": "on",
+        "follow_origin": "off",
+        "match_type": "all",
+        "priority": 1,
+        "stale_while_revalidate": "off",
+        "ttl": 20,
+        "ttl_unit": "d",
+        "url_parameter_type": "full_url",
+        "url_parameter_value": ""
+      }
+    ],
+    "http_response_header": [
+      {
+        "action": "set",
+        "name": "Content-Disposition",
+        "value": "1235"
+      }
+    ],
+    "origin_follow302_status": "off",
+    "compress": {
+      "type": "gzip,br",
+      "status": "on",
+      "file_type": ".js,.html,.css,.xml,.json,.shtml,.htmx"
+    },
+    "origin_range_status": "on",
+    "referer": {
+      "type": "black",
+      "value": "1.2.1.1",
+      "include_empty": false
+    },
+    "ip_filter": {
+      "type": "white",
+      "value": "1.1.2.2"
+    },
+    "user_agent_filter": {
+      "type": "white",
+      "ua_list": [
+        "1.1.3.3"
+      ],
+      "include_empty": false
+    },
+    "flow_limit_strategy": [
+      {
+        "strategy_type": "instant",
+        "item_type": "bandwidth",
+        "limit_value": 1000001,
+        "alarm_percent_threshold": null,
+        "ban_time": 60
+      }
+    ]
+  })
+}
+`, name)
+}
+
+func testAccDomainTemplate_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_domain_template" "test" {
+  name        = "%[1]s"
+  description = "Updated by terraform"
+  configs     = jsonencode({
+    "cache_rules": [
+      {
+        "force_cache": "off",
+        "follow_origin": "on",
+        "match_type": "all",
+        "priority": 1,
+        "stale_while_revalidate": "on",
+        "ttl": 30,
+        "ttl_unit": "d",
+        "url_parameter_type": "full_url",
+        "url_parameter_value": ""
+      }
+    ],
+    "http_response_header": [
+      {
+        "action": "set",
+        "name": "Content-Disposition",
+        "value": "updated_value"
+      }
+    ],
+    "origin_follow302_status": "on",
+    "compress": {
+      "type": "gzip",
+      "status": "off",
+      "file_type": ".js,.html"
+    },
+    "origin_range_status": "off",
+    "referer": {
+      "type": "white",
+      "value": "2.2.2.2",
+      "include_empty": true
+    },
+    "ip_filter": {
+      "type": "black",
+      "value": "2.2.3.3"
+    },
+    "user_agent_filter": {
+      "type": "black",
+      "ua_list": [
+        "2.2.4.4"
+      ],
+      "include_empty": true
+    },
+    "flow_limit_strategy": [
+      {
+        "strategy_type": "instant",
+        "item_type": "bandwidth",
+        "limit_value": 2000002,
+        "alarm_percent_threshold": null,
+        "ban_time": 720
+      }
+    ]
+  })
+}
+`, name)
+}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_templates.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_templates.go
@@ -1,0 +1,129 @@
+package cdn
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CDN GET /v1.0/cdn/configuration/templates
+func DataSourceDomainTemplates() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDomainTemplatesRead,
+
+		Schema: map[string]*schema.Schema{
+			// Attributes.
+			"templates": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        domainTemplateSchema(),
+				Description: `The list of domain templates.`,
+			},
+		},
+	}
+}
+
+func domainTemplateSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the domain template.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the domain template.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the domain template.`,
+			},
+			"configs": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The configuration of the domain template, in JSON format.`,
+			},
+			"type": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The type of the domain template. Valid values are 1 (system preset template) and 2 (tenant custom template).`,
+			},
+			"account_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The account ID.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the domain template.`,
+			},
+			"modify_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The modification time of the domain template.`,
+			},
+		},
+	}
+}
+
+func flattenDomainTemplates(templates []interface{}) []map[string]interface{} {
+	if len(templates) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(templates))
+	for _, template := range templates {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("tml_id", template, nil),
+			"name":        utils.PathSearch("tml_name", template, nil),
+			"description": utils.PathSearch("remark", template, nil),
+			"configs":     utils.JsonToString(utils.PathSearch("configs", template, nil)),
+			"type":        utils.PathSearch("type", template, nil),
+			"account_id":  utils.PathSearch("account_id", template, nil),
+			"create_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", template,
+				float64(0)).(float64))/1000, false),
+			"modify_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("modify_time", template,
+				float64(0)).(float64))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceDomainTemplatesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg = meta.(*config.Config)
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	templates, err := listDomainTemplates(client)
+	if err != nil {
+		return diag.Errorf("error querying CDN domain templates: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("templates", flattenDomainTemplates(templates)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_template.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_template.go
@@ -1,0 +1,336 @@
+package cdn
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CDN POST /v1.0/cdn/configuration/templates
+// @API CDN GET /v1.0/cdn/configuration/templates
+// @API CDN PUT /v1.0/cdn/configuration/templates/{tml_id}
+// @API CDN DELETE /v1.0/cdn/configuration/templates/{tml_id}
+func ResourceDomainTemplate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDomainTemplateCreate,
+		ReadContext:   resourceDomainTemplateRead,
+		UpdateContext: resourceDomainTemplateUpdate,
+		DeleteContext: resourceDomainTemplateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDomainTemplateImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the domain template.`,
+			},
+			"configs": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Description:  `The configuration of the domain template, in JSON format.`,
+			},
+
+			// Optional parameters.
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the domain template.`,
+			},
+
+			// Attributes.
+			"type": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The type of the domain template. Valid values are 1 (system preset template) and 2 (tenant custom template).`,
+			},
+			"account_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The account ID.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the domain template.`,
+			},
+			"modify_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The modification time of the domain template.`,
+			},
+		},
+	}
+}
+
+func buildDomainTemplateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return utils.RemoveNil(map[string]interface{}{
+		"tml_name": d.Get("name").(string),
+		"configs":  utils.StringToJson(d.Get("configs").(string)),
+		"remark":   utils.ValueIgnoreEmpty(d.Get("description")),
+	})
+}
+
+func createDomainTemplate(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1.0/cdn/configuration/templates"
+	createPath := client.Endpoint + httpUrl
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDomainTemplateBodyParams(d),
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	return err
+}
+
+func listDomainTemplates(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v1.0/cdn/configuration/templates?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		templates := utils.PathSearch("templates", respBody, make([]interface{}, 0)).([]interface{})
+		if len(templates) < 1 {
+			break
+		}
+		result = append(result, templates...)
+		if len(templates) < limit {
+			break
+		}
+		offset += len(templates)
+	}
+
+	return result, nil
+}
+
+func GetDomainTemplateById(client *golangsdk.ServiceClient, tmlId string) (interface{}, error) {
+	templates, err := listDomainTemplates(client)
+	if err != nil {
+		return nil, err
+	}
+
+	template := utils.PathSearch(fmt.Sprintf("[?tml_id =='%s']|[0]", tmlId), templates, nil)
+	if template == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1.0/cdn/configuration/templates",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the template with ID '%s' has been removed", tmlId)),
+			},
+		}
+	}
+	return template, nil
+}
+
+func GetDomainTemplateByName(client *golangsdk.ServiceClient, tmlName string) (interface{}, error) {
+	templates, err := listDomainTemplates(client)
+	if err != nil {
+		return nil, err
+	}
+
+	template := utils.PathSearch(fmt.Sprintf("[?tml_name =='%s']|[0]", tmlName), templates, nil)
+	if template == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1.0/cdn/configuration/templates",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the template with name '%s' has been removed", tmlName)),
+			},
+		}
+	}
+	return template, nil
+}
+
+func resourceDomainTemplateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		tmlName = d.Get("name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	if err := createDomainTemplate(client, d); err != nil {
+		return diag.Errorf("error creating CDN domain template: %s", err)
+	}
+
+	template, err := GetDomainTemplateByName(client, tmlName)
+	if err != nil {
+		return diag.Errorf("unable to find the created template with name '%s': %s", tmlName, err)
+	}
+
+	tmlId := utils.PathSearch("tml_id", template, "").(string)
+	if tmlId == "" {
+		return diag.Errorf("unable to find the template ID from the API response")
+	}
+
+	d.SetId(tmlId)
+
+	return resourceDomainTemplateRead(ctx, d, meta)
+}
+
+func resourceDomainTemplateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg   = meta.(*config.Config)
+		tmlId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	template, err := GetDomainTemplateById(client, tmlId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CDN domain template")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("name", utils.PathSearch("tml_name", template, nil)),
+		d.Set("description", utils.PathSearch("remark", template, nil)),
+		d.Set("type", utils.PathSearch("type", template, nil)),
+		d.Set("account_id", utils.PathSearch("account_id", template, nil)),
+		d.Set("configs", utils.JsonToString(utils.PathSearch("configs", template, nil))),
+		d.Set("create_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", template,
+			float64(0)).(float64))/1000, false)),
+		d.Set("modify_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("modify_time", template,
+			float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func updateDomainTemplate(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1.0/cdn/configuration/templates/{tml_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{tml_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDomainTemplateBodyParams(d),
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func resourceDomainTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg = meta.(*config.Config)
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	err = updateDomainTemplate(client, d)
+	if err != nil {
+		return diag.Errorf("error updating CDN domain template: %s", err)
+	}
+
+	return resourceDomainTemplateRead(ctx, d, meta)
+}
+
+func deleteDomainTemplate(client *golangsdk.ServiceClient, tmlId string) error {
+	httpUrl := "v1.0/cdn/configuration/templates/{tml_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{tml_id}", tmlId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceDomainTemplateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg   = meta.(*config.Config)
+		tmlId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	err = deleteDomainTemplate(client, tmlId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting CDN domain template (%s)", tmlId))
+	}
+
+	return nil
+}
+
+func resourceDomainTemplateImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	importId := d.Id()
+
+	// If the ID is a UUID, set the ID directly
+	if utils.IsUUID(importId) {
+		d.SetId(importId)
+		return []*schema.ResourceData{d}, nil
+	}
+
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return nil, fmt.Errorf("error creating CDN client: %s", err)
+	}
+
+	// If the ID is not a UUID, get the template by name and set the ID
+	template, err := GetDomainTemplateByName(client, importId)
+	if err != nil {
+		return nil, err
+	}
+	d.SetId(utils.PathSearch("tml_id", template, "").(string))
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source and resource for domain template

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source and resource for domain template
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cdn -f TestAccDomainTemplate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccDomainTemplate_basic -timeout 360m -parallel 10
=== RUN   TestAccDomainTemplate_basic
=== PAUSE TestAccDomainTemplate_basic
=== CONT  TestAccDomainTemplate_basic
--- PASS: TestAccDomainTemplate_basic (30.69s)
PASS
coverage: 6.8% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       30.763s coverage: 6.8% of statements in ./huaweicloud/services/cdn
```
```
./scripts/coverage.sh -o cdn -f TestAccDataDomainTemplates_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccDataDomainTemplates_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDomainTemplates_basic
=== PAUSE TestAccDataDomainTemplates_basic
=== CONT  TestAccDataDomainTemplates_basic
--- PASS: TestAccDataDomainTemplates_basic (13.67s)
PASS
coverage: 6.3% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       13.742s coverage: 6.3% of statements in ./huaweicloud/services/cdn
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
