### PR TITLE
feat(cdn): remove region parameter from the global resources and data sources

### DIFF
--- a/docs/data-sources/cdn_cache_sharing_groups.md
+++ b/docs/data-sources/cdn_cache_sharing_groups.md
@@ -16,13 +16,6 @@ Use this data source to get a list of cache sharing groups within HuaweiCloud.
 data "huaweicloud_cdn_cache_sharing_groups" "test" {}
 ```
 
-## Argument Reference
-
-The following arguments are supported:
-
-* `region` - (Optional, String) Specifies the region where the cache sharing groups are located.  
-  If omitted, the provider-level region will be used.
-
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/data-sources/cdn_rule_engine_rules.md
+++ b/docs/data-sources/cdn_rule_engine_rules.md
@@ -24,9 +24,6 @@ data "huaweicloud_cdn_rule_engine_rules" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region where the rule engine rules are located.  
-  If omitted, the provider-level region will be used.
-
 * `domain_name` - (Required, String) Specifies the accelerated domain name to which the rule engine rules belong.
 
 ## Attribute Reference

--- a/docs/resources/cdn_cache_sharing_group.md
+++ b/docs/resources/cdn_cache_sharing_group.md
@@ -37,9 +37,6 @@ resource "huaweicloud_cdn_cache_sharing_group" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region where the cache sharing group is located.  
-  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
-
 * `name` - (Required, String, NonUpdatable) Specifies the name of the cache sharing group.
 
 * `primary_domain` - (Required, String, NonUpdatable) Specifies the primary domain name of the cache sharing group.

--- a/docs/resources/cdn_rule_engine_rule.md
+++ b/docs/resources/cdn_rule_engine_rule.md
@@ -213,9 +213,6 @@ resource "huaweicloud_cdn_rule_engine_rule" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region where the rule engine rule is located.  
-  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
-
 * `domain_name` - (Required, String, NonUpdatable) Specifies the accelerated domain name to which the rule engine rule
   belongs.
 

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_cache_sharing_groups_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_cache_sharing_groups_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceCacheSharingGroups_basic(t *testing.T) {
+func TestAccDataCacheSharingGroups_basic(t *testing.T) {
 	var (
 		rName     = "data.huaweicloud_cdn_cache_sharing_groups.test"
 		dc        = acceptance.InitDataSourceCheck(rName)
@@ -25,7 +25,7 @@ func TestAccDataSourceCacheSharingGroups_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceCacheSharingGroups_basic(groupName),
+				Config: testAccDataCacheSharingGroups_basic(groupName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestMatchResourceAttr(rName, "groups.#", regexp.MustCompile(`^[0-9]+$`)),
@@ -43,7 +43,7 @@ func TestAccDataSourceCacheSharingGroups_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceCacheSharingGroups_base(name string) string {
+func testAccDataCacheSharingGroups_base(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cdn_cache_sharing_group" "test" {
   name           = "%[1]s"
@@ -60,7 +60,7 @@ resource "huaweicloud_cdn_cache_sharing_group" "test" {
 `, name, acceptance.HW_CDN_DOMAIN_NAMES)
 }
 
-func testAccDataSourceCacheSharingGroups_basic(name string) string {
+func testAccDataCacheSharingGroups_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -80,5 +80,5 @@ locals {
 output "is_cache_sharing_group_found" {
   value = local.cache_sharing_group_query_result != null && local.cache_sharing_group_query_result.id == local.cache_sharing_group_id
 }
-`, testAccDataSourceCacheSharingGroups_base(name))
+`, testAccDataCacheSharingGroups_base(name))
 }

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_cache_sharing_groups.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_cache_sharing_groups.go
@@ -18,13 +18,6 @@ func DataSourceCacheSharingGroups() *schema.Resource {
 		ReadContext: dataSourceCacheSharingGroupsRead,
 
 		Schema: map[string]*schema.Schema{
-			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: `The region where the cache sharing groups are located.`,
-			},
-
 			// Attributes.
 			"groups": {
 				Type:        schema.TypeList,
@@ -117,7 +110,6 @@ func dataSourceCacheSharingGroupsRead(_ context.Context, d *schema.ResourceData,
 	d.SetId(randomUUID)
 
 	mErr := multierror.Append(nil,
-		d.Set("region", cfg.GetRegion(d)),
 		d.Set("groups", flattenCacheSharingGroups(groups)),
 	)
 	return diag.FromErr(mErr.ErrorOrNil())

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_rule_engine_rules.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_rule_engine_rules.go
@@ -18,13 +18,6 @@ func DataSourceRuleEngineRules() *schema.Resource {
 		ReadContext: dataSourceRuleEngineRulesRead,
 
 		Schema: map[string]*schema.Schema{
-			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: `The region where the rule engine rules are located.`,
-			},
-
 			// Required parameters.
 			"domain_name": {
 				Type:        schema.TypeString,
@@ -461,7 +454,6 @@ func dataSourceRuleEngineRulesRead(_ context.Context, d *schema.ResourceData, me
 	d.SetId(randomUUID)
 
 	mErr := multierror.Append(nil,
-		d.Set("region", cfg.GetRegion(d)),
 		d.Set("rules", flattenRuleEngineRules(rules)),
 	)
 	return diag.FromErr(mErr.ErrorOrNil())

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_sharing_group.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_sharing_group.go
@@ -38,14 +38,6 @@ func ResourceCacheSharingGroup() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				ForceNew:    true,
-				Description: `The region where the cache sharing group is located.`,
-			},
-
 			// Required parameters.
 			"name": {
 				Type:        schema.TypeString,
@@ -261,7 +253,6 @@ func resourceCacheSharingGroupRead(_ context.Context, d *schema.ResourceData, me
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("region", cfg.GetRegion(d)),
 		d.Set("name", utils.PathSearch("group_name", group, nil)),
 		d.Set("primary_domain", utils.PathSearch("primary_domain", group, nil)),
 		d.Set("share_cache_records", flattenShareCacheRecords(utils.PathSearch("share_cache_records", group,

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_rule_engine_rule.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_rule_engine_rule.go
@@ -37,14 +37,6 @@ func ResourceRuleEngineRule() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				ForceNew:    true,
-				Description: `The region where the rule engine rule is located.`,
-			},
-
 			// Required parameters.
 			"domain_name": {
 				Type:        schema.TypeString,
@@ -1029,7 +1021,6 @@ func resourceRuleEngineRuleRead(_ context.Context, d *schema.ResourceData, meta 
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("region", cfg.GetRegion(d)),
 		d.Set("domain_name", domainName),
 		d.Set("name", utils.PathSearch("name", rule, nil)),
 		d.Set("status", utils.PathSearch("status", rule, nil)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CDN is the global service, all request URL do not have the **project_id**, so region parameter is useless.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove region parameter from the global resources and data sources.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cdn -f TestAccDataCacheSharingGroups_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccDataCacheSharingGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccDataCacheSharingGroups_basic
=== PAUSE TestAccDataCacheSharingGroups_basic
=== CONT  TestAccDataCacheSharingGroups_basic
--- PASS: TestAccDataCacheSharingGroups_basic (11.77s)
PASS
coverage: 7.4% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       11.867s coverage: 7.4% of statements in ./huaweicloud/services/cdn
```
```
./scripts/coverage.sh -o cdn -f TestAccCacheSharingGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccCacheSharingGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccCacheSharingGroup_basic
=== PAUSE TestAccCacheSharingGroup_basic
=== CONT  TestAccCacheSharingGroup_basic
--- PASS: TestAccCacheSharingGroup_basic (24.61s)
PASS
coverage: 7.6% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       24.692s coverage: 7.6% of statements in ./huaweicloud/services/cdn
```
```
./scripts/coverage.sh -o cdn -f TestAccDataRuleEngineRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccDataRuleEngineRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataRuleEngineRules_basic
=== PAUSE TestAccDataRuleEngineRules_basic
=== CONT  TestAccDataRuleEngineRules_basic
--- PASS: TestAccDataRuleEngineRules_basic (12.44s)
PASS
coverage: 10.6% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       12.540s coverage: 10.6% of statements in ./huaweicloud/services/cdn
```
```
./scripts/coverage.sh -o cdn -f TestAccRuleEngineRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccRuleEngineRule_basic -timeout 360m -parallel 10
=== RUN   TestAccRuleEngineRule_basic
=== PAUSE TestAccRuleEngineRule_basic
=== CONT  TestAccRuleEngineRule_basic
--- PASS: TestAccRuleEngineRule_basic (24.48s)
PASS
coverage: 11.2% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       24.554s coverage: 11.2% of statements in ./huaweicloud/services/cdn
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
