### PR TITLE
feat(eg): add new fields of EG data source and resource

### DIFF
--- a/docs/data-sources/eg_connections.md
+++ b/docs/data-sources/eg_connections.md
@@ -98,7 +98,9 @@ The `kafka_detail` block supports:
 
 * `user_name` - The username of the Kafka instance.
 
-* `acks` - The number of confirmation signals the producer‌ needs to receive to consider the message sent successfully.
+* `acks` - The number of confirmation signals the producer needs to receive to consider the message sent successfully.
+
+* `address` - The connection address of Kafka instance.
 
 <a name="data_connections_flavor"></a>
 The `flavor` block supports:

--- a/docs/data-sources/eg_custom_event_channels.md
+++ b/docs/data-sources/eg_custom_event_channels.md
@@ -28,6 +28,10 @@ The following arguments are supported:
 
 * `name` - (Optional, String) Specifies the channel name used to query specified custom event channel.
 
+* `fuzzy_name` - (Optional, String) Specifies the name of the channels to be queried for fuzzy matching.
+
+* `sort` - (Optional, String) Specifies the sorting method for query results.
+
 * `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the custom event
   channels belong.
 

--- a/docs/data-sources/eg_custom_event_sources.md
+++ b/docs/data-sources/eg_custom_event_sources.md
@@ -33,6 +33,10 @@ The following arguments are supported:
 
 * `name` - (Optional, String) Specifies the event source name used to query specified custom event source.
 
+* `fuzzy_name` - (Optional, String) Specifies the name of the channels to be queried for fuzzy matching.
+
+* `sort` - (Optional, String) Specifies the sorting method for query results.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -40,7 +44,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The data source ID.
 
 * `sources` - The filtered custom event source.
-  The [object](#eg_custom_event_sources) structure is documented below.
+  The [sources](#eg_custom_event_sources) structure is documented below.
 
 <a name="eg_custom_event_sources"></a>
 The `sources` block supports:
@@ -62,6 +66,20 @@ The `sources` block supports:
   + **RUNNING**
   + **ERROR**
 
+* `detail` - The message instance link information, in JSON format.
+
+* `error_info` - The error information of the custom event source.  
+  The [error_info](#data_custom_event_sources_error_info) structure is documented below.
+
 * `created_at` - The creation time of the custom event source.
 
 * `updated_at` - The update time of the custom event source.
+
+<a name="data_custom_event_sources_error_info"></a>
+The `error_info` block supports:
+
+* `error_code` - The error code of current source.
+
+* `error_detail` - The error detail of current source.
+
+* `error_msg` - The error message of current source.

--- a/docs/resources/eg_connection.md
+++ b/docs/resources/eg_connection.md
@@ -120,6 +120,10 @@ The `KafkaDetail` block supports:
 
   Changing this parameter will create a new resource.
 
+* `security_protocol` - (Optional, String, ForceNew) Specifies the security protocol of the kafka instance.
+
+  Changing this parameter will create a new resource.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -128,9 +132,25 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - Indicates the status of the connection.
 
+* `agency` - Indicates the user-delegated name used for private network target connection.
+
 * `created_at` - The creation time of the connection.
 
 * `updated_at` - The last update time of the connection.
+
+* `flavor` - The configuration details of the kafka instance.  
+  The [flavor](#connection_flavor) structure is documented below.
+
+<a name="connection_flavor"></a>
+The `flavor` block supports:
+
+* `name` - The name of the kafka instance.
+
+* `bandwidth_type` - The bandwidth type of the kafka instance.
+
+* `concurrency` - The concurrency number of the kafka instance.
+
+* `concurrency_type` - The concurrency type of the kafka instance.
 
 ## Import
 

--- a/docs/resources/eg_event_stream.md
+++ b/docs/resources/eg_event_stream.md
@@ -187,7 +187,7 @@ The `source` block supports:
 -> Exactly one of `kafka`, `mobile_rocketmq`, `community_rocketmq` and `dms_rocketmq` must be provided.
 
 <a name="stream_sink"></a>
-The `targets` block supports:
+The `sink` block supports:
 
 * `name` - (Required, String) Specifies the name of the event target type.  
   The valid values are as follows:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20251126072204-3155794cc3f1
+	github.com/chnsz/golangsdk v0.0.0-20251127015004-ebde1bc60776
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20251126072204-3155794cc3f1 h1:HzYFeWPMoLOiIJcu1xuUz+d9ezAV14pc0jzR/1AnQU4=
-github.com/chnsz/golangsdk v0.0.0-20251126072204-3155794cc3f1/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
+github.com/chnsz/golangsdk v0.0.0-20251127015004-ebde1bc60776 h1:axCwsEmKcUJRq2TH/6hYQyMFXqxwJXDAlLVYFU0saDw=
+github.com/chnsz/golangsdk v0.0.0-20251127015004-ebde1bc60776/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_connections_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_connections_test.go
@@ -135,6 +135,7 @@ output "is_kafka_detail_and_valid" {
     lookup(local.kafka_connection_filter_result, "enable_sasl_ssl", "") == true,
     lookup(local.kafka_connection_filter_result, "user_name", "") != "",
     lookup(local.kafka_connection_filter_result, "acks", "") != "",
+    lookup(local.kafka_connection_filter_result, "address", "") != "",
   ])
 }
 `, acceptance.HW_EG_CONNECTION_IDS)

--- a/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_connection_test.go
+++ b/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_connection_test.go
@@ -81,6 +81,7 @@ func TestAccConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "status"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
 					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "agency"),
 				),
 			},
 			{
@@ -157,6 +158,11 @@ func TestAccConnection_kafka(t *testing.T) {
 						"huaweicloud_dms_kafka_instance.test", "connect_address"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "flavor"),
+					resource.TestCheckResourceAttrSet(rName, "flavor.0.bandwidth_type"),
+					resource.TestCheckResourceAttrSet(rName, "flavor.0.concurrency"),
+					resource.TestCheckResourceAttrSet(rName, "flavor.0.concurrency_type"),
+					resource.TestCheckResourceAttrSet(rName, "flavor.0.name"),
 				),
 			},
 			{

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_connections.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_connections.go
@@ -119,6 +119,11 @@ func DataSourceConnections() *schema.Resource {
 										Description: `The number of confirmation signals the producer
 											needs to receive to consider the message sent successfully.`,
 									},
+									"address": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The connection address of Kafka instance.`,
+									},
 								},
 							},
 							Description: `The Kafka detail information for the connection.`,
@@ -300,6 +305,7 @@ func flattenConnectionKafkaDetail(kafkaDetail interface{}) []interface{} {
 			"enable_sasl_ssl":   utils.PathSearch("enable_sasl_ssl", kafkaDetail, nil),
 			"user_name":         utils.PathSearch("user_name", kafkaDetail, nil),
 			"acks":              utils.PathSearch("acks", kafkaDetail, nil),
+			"address":           utils.PathSearch("addr", kafkaDetail, nil),
 		},
 	}
 }

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
@@ -46,6 +46,16 @@ func DataSourceCustomEventChannels() *schema.Resource {
 				Optional:    true,
 				Description: `The channel name used to query specified custom event channel.`,
 			},
+			"fuzzy_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the channels to be queried for fuzzy matching.`,
+			},
+			"sort": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sorting method for query results.`,
+			},
 			"enterprise_project_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -111,6 +121,12 @@ func buildEventChannelsQueryParams(d *schema.ResourceData, providerTypeInput ...
 	}
 	if channelId, ok := d.GetOk("channel_id"); ok {
 		res = fmt.Sprintf("%s&channel_id=%v", res, channelId)
+	}
+	if sort, ok := d.GetOk("sort"); ok {
+		res = fmt.Sprintf("%s&sort=%v", res, sort)
+	}
+	if fuzzyName, ok := d.GetOk("fuzzy_name"); ok {
+		res = fmt.Sprintf("%s&fuzzy_name=%v", res, fuzzyName)
 	}
 
 	if len(providerTypeInput) > 0 {

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
@@ -234,11 +234,11 @@ type UpdateNodeTemplate struct {
 	// ID of the dedicated host to which nodes will be scheduled
 	DedicatedHostID string `json:"dedicatedHostId,omitempty"`
 	// Node login parameters
-	Login *nodes.LoginSpec `json:"login,omitempty"`
+	Login nodes.LoginSpec `json:"login,omitempty"`
 	// System disk parameter of the node
-	RootVolume *nodes.VolumeSpec `json:"rootVolume,omitempty"`
+	RootVolume *nodes.VolumeSpec `json:"rootVolumeUpdate,omitempty"`
 	// The data disk parameter of the node must currently be a disk
-	DataVolumes []nodes.VolumeSpec `json:"dataVolumes,omitempty"`
+	DataVolumes []nodes.VolumeSpec `json:"dataVolumesUpdate,omitempty"`
 	// Disk initialization configuration management parameters
 	// If omit, disk management is performed according to the DockerLVMConfigOverride parameter in extendParam
 	Storage *nodes.StorageSpec `json:"storage,omitempty"`
@@ -282,6 +282,10 @@ type UpdateSpec struct {
 	IgnoreInitialNodeCount bool `json:"ignoreInitialNodeCount"`
 	// Auto scaling parameters
 	Autoscaling AutoscalingSpec `json:"autoscaling"`
+	// Pod security group configurations
+	PodSecurityGroups []PodSecurityGroupSpec `json:"podSecurityGroups,omitempty"`
+	// Node security group configurations
+	CustomSecurityGroups []string `json:"customSecurityGroups,omitempty"`
 	// label (k8s tag) policy on existing nodes
 	LabelPolicyOnExistingNodes string `json:"labelPolicyOnExistingNodes,omitempty"`
 	// tag policy on existing nodes

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodes/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodes/results.go
@@ -144,6 +144,10 @@ type LoginSpec struct {
 	SshKey string `json:"sshKey,omitempty"`
 	// Select the user/password when logging in
 	UserPassword UserPassword `json:"userPassword,omitempty"`
+	// Remove password login
+	RemoveUserPassword bool `json:"removeUserPassword,omitempty"`
+	// Remove the SSH key login
+	RemoveSshKey bool `json:"removeSSHKey,omitempty"`
 }
 
 type UserPassword struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20251126072204-3155794cc3f1
+# github.com/chnsz/golangsdk v0.0.0-20251127015004-ebde1bc60776
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(eg): add new fields of EG data source and resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

```go
# data.eg_custom_event_sources
=== RUN   TestAccDataCustomEventSources_filterByFuzzyName
=== PAUSE TestAccDataCustomEventSources_filterByFuzzyName
=== CONT  TestAccDataCustomEventSources_filterByFuzzyName
--- PASS: TestAccDataCustomEventSources_filterByFuzzyName (12.67s)
PASS


=== RUN   TestAccDataCustomEventSources_filterBySort
=== PAUSE TestAccDataCustomEventSources_filterBySort
=== CONT  TestAccDataCustomEventSources_filterBySort
--- PASS: TestAccDataCustomEventSources_filterBySort (12.09s)
PASS


# data.eg_connections
=== RUN   TestAccDataConnections_basic
=== PAUSE TestAccDataConnections_basic
=== CONT  TestAccDataConnections_basic
--- PASS: TestAccDataConnections_basic (11.56s)
PASS

# data.custom_event_channels
=== RUN   TestAccDataCustomEventChannels_fuzzyName
=== PAUSE TestAccDataCustomEventChannels_fuzzyName
=== CONT  TestAccDataCustomEventChannels_fuzzyName
--- PASS: TestAccDataCustomEventChannels_fuzzyName (19.92s)
PASS

=== RUN   TestAccDataCustomEventChannels_sort
=== PAUSE TestAccDataCustomEventChannels_sort
=== CONT  TestAccDataCustomEventChannels_sort
--- PASS: TestAccDataCustomEventChannels_sort (14.72s)
PASS

# resource.eg_connection
=== RUN   TestAccConnection_basic
=== PAUSE TestAccConnection_basic
=== CONT  TestAccConnection_basic
--- PASS: TestAccConnection_basic (68.20s)


```
