### PR TITLE
fix(workspace): repair some issues for desktop pool resource

### DIFF
--- a/docs/data-sources/workspace_desktop_pools.md
+++ b/docs/data-sources/workspace_desktop_pools.md
@@ -151,5 +151,3 @@ The `autoscale_policy` block supports:
 * `max_auto_created` - The maximum number of auto-created desktops.
 
 * `min_idle` - The minimum number of idle desktops.
-
-* `once_auto_created` - The number of desktops will create in one auto scaling operation.

--- a/docs/resources/workspace_desktop_pool.md
+++ b/docs/resources/workspace_desktop_pool.md
@@ -209,9 +209,6 @@ The `autoscale_policy` block supports:
   less than this value.  
   The valid value ranges from `1` to `1,000`.
 
-* `once_auto_created` - (Optional, Int) Specifies the number of desktops automatically created at one time.  
-  The valid value ranges from `1` to `100`.
-
 <a name="desktop_pool_security_groups"></a>
 The `security_groups` block supports:
 

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_pool_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_pool_test.go
@@ -147,20 +147,12 @@ func testAccDesktopPool_basic_base(name string) string {
 
 %[2]s
 
-resource "huaweicloud_workspace_service" "test" {
-  access_mode = "INTERNET"
-  vpc_id      = huaweicloud_vpc.test.id
-  network_ids = [
-    huaweicloud_vpc_subnet.test.id
-  ]
-}
+data "huaweicloud_workspace_service" "test" {}
 
 resource "huaweicloud_workspace_user" "test" {
   count = 2
   name  = "%[3]s${count.index}"
   email = "user@test.com"
-
-  depends_on = [huaweicloud_workspace_service.test]
 }
 `, common.TestBaseNetwork(name), testAccDesktopPool_base(name), name)
 }
@@ -195,7 +187,7 @@ resource "huaweicloud_workspace_desktop_pool" "test" {
   }
 
   security_groups {
-    id = huaweicloud_workspace_service.test.desktop_security_group.0.id
+    id = data.huaweicloud_workspace_service.test.desktop_security_group.0.id
   }
   security_groups {
     id = huaweicloud_networking_secgroup.test.id
@@ -261,7 +253,7 @@ resource "huaweicloud_workspace_desktop_pool" "test" {
 
 
   security_groups {
-    id = huaweicloud_workspace_service.test.desktop_security_group.0.id
+    id = data.huaweicloud_workspace_service.test.desktop_security_group.0.id
   }
   security_groups {
     id = huaweicloud_networking_secgroup.test.id

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_desktop_pools.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_desktop_pools.go
@@ -306,9 +306,14 @@ func desktopPoolAutoscalePolicySchema() *schema.Resource {
 				Description: "The minimum number of idle desktops.",
 			},
 			"once_auto_created": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "The number of desktops will create in one auto scaling operation.",
+				Type:     schema.TypeInt,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The number of desktops will create in one auto scaling operation.`,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					},
+				),
 			},
 		},
 	}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
@@ -304,7 +304,7 @@ func waitForWorkspaceJobCompleted(ctx context.Context, client *golangsdk.Service
 	return utils.PathSearch("entities.desktop_id", resp, "").(string), nil
 }
 
-func refreshWorkspaceJobFunc(client *golangsdk.ServiceClient, jobId string) resource.StateRefreshFunc {
+func refreshWorkspaceJobFunc(client *golangsdk.ServiceClient, jobId string, queryParams ...string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		var (
 			httpUrl  = "v2/{project_id}/workspace-sub-jobs"
@@ -319,6 +319,10 @@ func refreshWorkspaceJobFunc(client *golangsdk.ServiceClient, jobId string) reso
 		listPath := client.Endpoint + httpUrl
 		listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 		listPath = fmt.Sprintf("%s?job_id=%s", listPath, jobId)
+		if len(queryParams) > 0 {
+			listPath += queryParams[0]
+		}
+
 		resp, err := client.Request("GET", listPath, &listOpts)
 		if err != nil {
 			return resp, "ERROR", err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Repair some issues for desktop pool resource
- deprecate autoscale_policy.once_auto_created field
- ignore once_auto_created if other parameters are null
- sub-job query should supplement pool_id parameter
- supports a new flatten function for the security group response

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. repair some issues for desktop pool resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDesktopPool_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktopPool_basic -timeout 360m -parallel 10
=== RUN   TestAccDesktopPool_basic
--- PASS: TestAccDesktopPool_basic (515.93s)
PASS
coverage: 9.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 516.009s        coverage: 9.8% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
