### PR TITLE
feat(eg): add new fields of EG data source and resource

### DIFF
--- a/docs/data-sources/eg_connections.md
+++ b/docs/data-sources/eg_connections.md
@@ -98,7 +98,9 @@ The `kafka_detail` block supports:
 
 * `user_name` - The username of the Kafka instance.
 
-* `acks` - The number of confirmation signals the producer‌ needs to receive to consider the message sent successfully.
+* `acks` - The number of confirmation signals the producer needs to receive to consider the message sent successfully.
+
+* `address` - The connection address of Kafka instance.
 
 <a name="data_connections_flavor"></a>
 The `flavor` block supports:

--- a/docs/data-sources/eg_custom_event_channels.md
+++ b/docs/data-sources/eg_custom_event_channels.md
@@ -28,6 +28,10 @@ The following arguments are supported:
 
 * `name` - (Optional, String) Specifies the channel name used to query specified custom event channel.
 
+* `fuzzy_name` - (Optional, String) Specifies the name of the channels to be queried for fuzzy matching.
+
+* `sort` - (Optional, String) Specifies the sorting method for query results.
+
 * `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the custom event
   channels belong.
 

--- a/docs/data-sources/eg_custom_event_sources.md
+++ b/docs/data-sources/eg_custom_event_sources.md
@@ -33,6 +33,10 @@ The following arguments are supported:
 
 * `name` - (Optional, String) Specifies the event source name used to query specified custom event source.
 
+* `fuzzy_name` - (Optional, String) Specifies the name of the channels to be queried for fuzzy matching.
+
+* `sort` - (Optional, String) Specifies the sorting method for query results.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -40,7 +44,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The data source ID.
 
 * `sources` - The filtered custom event source.
-  The [object](#eg_custom_event_sources) structure is documented below.
+  The [sources](#eg_custom_event_sources) structure is documented below.
 
 <a name="eg_custom_event_sources"></a>
 The `sources` block supports:
@@ -62,6 +66,20 @@ The `sources` block supports:
   + **RUNNING**
   + **ERROR**
 
+* `detail` - The message instance link information, in JSON format.
+
+* `error_info` - The error information of the custom event source.  
+  The [error_info](#data_custom_event_sources_error_info) structure is documented below.
+
 * `created_at` - The creation time of the custom event source.
 
 * `updated_at` - The update time of the custom event source.
+
+<a name="data_custom_event_sources_error_info"></a>
+The `error_info` block supports:
+
+* `error_code` - The error code of current source.
+
+* `error_detail` - The error detail of current source.
+
+* `error_msg` - The error message of current source.

--- a/docs/resources/eg_connection.md
+++ b/docs/resources/eg_connection.md
@@ -120,6 +120,10 @@ The `KafkaDetail` block supports:
 
   Changing this parameter will create a new resource.
 
+* `security_protocol` - (Optional, String, ForceNew) Specifies the security protocol of the kafka instance.
+
+  Changing this parameter will create a new resource.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -128,9 +132,25 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - Indicates the status of the connection.
 
+* `agency` - Indicates the user-delegated name used for private network target connection.
+
 * `created_at` - The creation time of the connection.
 
 * `updated_at` - The last update time of the connection.
+
+* `flavor` - The configuration details of the kafka instance.  
+  The [flavor](#connection_flavor) structure is documented below.
+
+<a name="connection_flavor"></a>
+The `flavor` block supports:
+
+* `name` - The name of the kafka instance.
+
+* `bandwidth_type` - The bandwidth type of the kafka instance.
+
+* `concurrency` - The concurrency number of the kafka instance.
+
+* `concurrency_type` - The concurrency type of the kafka instance.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_connections_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_connections_test.go
@@ -135,6 +135,7 @@ output "is_kafka_detail_and_valid" {
     lookup(local.kafka_connection_filter_result, "enable_sasl_ssl", "") == true,
     lookup(local.kafka_connection_filter_result, "user_name", "") != "",
     lookup(local.kafka_connection_filter_result, "acks", "") != "",
+    lookup(local.kafka_connection_filter_result, "address", "") != "",
   ])
 }
 `, acceptance.HW_EG_CONNECTION_IDS)

--- a/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_connection_test.go
+++ b/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_connection_test.go
@@ -81,6 +81,7 @@ func TestAccConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "status"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
 					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "agency"),
 				),
 			},
 			{
@@ -157,6 +158,11 @@ func TestAccConnection_kafka(t *testing.T) {
 						"huaweicloud_dms_kafka_instance.test", "connect_address"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "flavor"),
+					resource.TestCheckResourceAttrSet(rName, "flavor.0.bandwidth_type"),
+					resource.TestCheckResourceAttrSet(rName, "flavor.0.concurrency"),
+					resource.TestCheckResourceAttrSet(rName, "flavor.0.concurrency_type"),
+					resource.TestCheckResourceAttrSet(rName, "flavor.0.name"),
 				),
 			},
 			{

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_connections.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_connections.go
@@ -119,6 +119,11 @@ func DataSourceConnections() *schema.Resource {
 										Description: `The number of confirmation signals the producer
 											needs to receive to consider the message sent successfully.`,
 									},
+									"address": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The connection address of Kafka instance.`,
+									},
 								},
 							},
 							Description: `The Kafka detail information for the connection.`,
@@ -300,6 +305,7 @@ func flattenConnectionKafkaDetail(kafkaDetail interface{}) []interface{} {
 			"enable_sasl_ssl":   utils.PathSearch("enable_sasl_ssl", kafkaDetail, nil),
 			"user_name":         utils.PathSearch("user_name", kafkaDetail, nil),
 			"acks":              utils.PathSearch("acks", kafkaDetail, nil),
+			"address":           utils.PathSearch("addr", kafkaDetail, nil),
 		},
 	}
 }

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
@@ -46,6 +46,16 @@ func DataSourceCustomEventChannels() *schema.Resource {
 				Optional:    true,
 				Description: `The channel name used to query specified custom event channel.`,
 			},
+			"fuzzy_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the channels to be queried for fuzzy matching.`,
+			},
+			"sort": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sorting method for query results.`,
+			},
 			"enterprise_project_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -111,6 +121,12 @@ func buildEventChannelsQueryParams(d *schema.ResourceData, providerTypeInput ...
 	}
 	if channelId, ok := d.GetOk("channel_id"); ok {
 		res = fmt.Sprintf("%s&channel_id=%v", res, channelId)
+	}
+	if sort, ok := d.GetOk("sort"); ok {
+		res = fmt.Sprintf("%s&sort=%v", res, sort)
+	}
+	if fuzzyName, ok := d.GetOk("fuzzy_name"); ok {
+		res = fmt.Sprintf("%s&fuzzy_name=%v", res, fuzzyName)
 	}
 
 	if len(providerTypeInput) > 0 {

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_sources.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_sources.go
@@ -43,6 +43,18 @@ func DataSourceCustomEventSources() *schema.Resource {
 				Optional:    true,
 				Description: `The event source name used to query specified custom event source.`,
 			},
+			"fuzzy_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the channels to be queried for fuzzy matching.`,
+			},
+			"sort": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sorting method for query results.`,
+			},
+
+			// Attributes
 			"sources": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -93,8 +105,36 @@ func DataSourceCustomEventSources() *schema.Resource {
 							Computed:    true,
 							Description: `The update time of the custom event source.`,
 						},
+						"error_info": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The error information of the custom event source.`,
+							Elem:        errorInfoSchema(),
+						},
 					},
 				},
+			},
+		},
+	}
+}
+
+func errorInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"error_code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The error code of current source.`,
+			},
+			"error_detail": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The error detail of current source.`,
+			},
+			"error_msg": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The error message of current source.`,
 			},
 		},
 	}
@@ -107,6 +147,12 @@ func buildEventSourcesQueryParams(d *schema.ResourceData, providerTypeInput ...s
 	}
 	if channelId, ok := d.GetOk("channel_id"); ok {
 		res = fmt.Sprintf("%s&channel_id=%v", res, channelId)
+	}
+	if fuzzyName, ok := d.GetOk("fuzzy_name"); ok {
+		res = fmt.Sprintf("%s&fuzzy_name=%v", res, fuzzyName)
+	}
+	if sort, ok := d.GetOk("sort"); ok {
+		res = fmt.Sprintf("%s&sort=%v", res, sort)
 	}
 
 	if len(providerTypeInput) > 0 {
@@ -174,6 +220,8 @@ func flattenDataCustomEventSources(eventSources []interface{}) []interface{} {
 			"status":       utils.PathSearch("status", eventSource, nil),
 			"created_at":   utils.PathSearch("created_at", eventSource, nil),
 			"updated_at":   utils.PathSearch("updated_at", eventSource, nil),
+			"error_info": flattenConnectionErrorInfo(utils.PathSearch(
+				"error_info", eventSource, make(map[string]interface{})).(map[string]interface{})),
 		})
 	}
 

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_connection.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_connection.go
@@ -80,10 +80,23 @@ func ResourceConnection() *schema.Resource {
 				ForceNew:    true,
 				Description: `Specifies the configuration details of the kafka intance.`,
 			},
+
+			// Attributes
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `Indicates the status of the connection.`,
+			},
+			"agency": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user-delegated name used for private network target connection.`,
+			},
+			"flavor": {
+				Type:        schema.TypeList,
+				Elem:        connectionKafkaFlavorSchema(),
+				Computed:    true,
+				Description: `The configuration details of the kafka instance.`,
 			},
 			"created_at": {
 				Type:        schema.TypeString,
@@ -106,20 +119,20 @@ func connectionKafkaDetailSchema() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: `Specifies the ID of the kafka intance.`,
+				Description: `Specifies the ID of the kafka instance.`,
 			},
 			"connect_address": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: `Specifies the IP address of the kafka intance.`,
+				Description: `Specifies the IP address of the kafka instance.`,
 			},
 			"user_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				Description: `Specifies the user name of the kafka intance.`,
+				Description: `Specifies the user name of the kafka instance.`,
 			},
 			"password": {
 				Type:        schema.TypeString,
@@ -127,7 +140,7 @@ func connectionKafkaDetailSchema() *schema.Resource {
 				Computed:    true,
 				ForceNew:    true,
 				Sensitive:   true,
-				Description: `Specifies the password of the kafka intance.`,
+				Description: `Specifies the password of the kafka instance.`,
 			},
 			"acks": {
 				Type:     schema.TypeString,
@@ -136,6 +149,41 @@ func connectionKafkaDetailSchema() *schema.Resource {
 				ForceNew: true,
 				Description: `Specifies the number of confirmation signals the procuder
                     needs to receive to consider the message sent successfully.`,
+			},
+			"security_protocol": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the security protocol of the kafka instance.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func connectionKafkaFlavorSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"bandwidth_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The bandwidth type of the kafka instance.`,
+			},
+			"concurrency": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The concurrency number of the kafka instance..`,
+			},
+			"concurrency_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The concurrency type of the kafka instance.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the kafka instance.`,
 			},
 		},
 	}
@@ -210,9 +258,10 @@ func buildCreateConnectionRequestBodyKafkaDetail(rawParams interface{}) map[stri
 		}
 
 		params := map[string]interface{}{
-			"instance_id": utils.ValueIgnoreEmpty(raw["instance_id"]),
-			"addr":        utils.ValueIgnoreEmpty(raw["connect_address"]),
-			"acks":        utils.ValueIgnoreEmpty(raw["acks"]),
+			"instance_id":       utils.ValueIgnoreEmpty(raw["instance_id"]),
+			"addr":              utils.ValueIgnoreEmpty(raw["connect_address"]),
+			"acks":              utils.ValueIgnoreEmpty(raw["acks"]),
+			"security_protocol": utils.ValueIgnoreEmpty(raw["security_protocol"]),
 		}
 
 		if raw["user_name"].(string) != "" {
@@ -273,7 +322,9 @@ func resourceConnectionRead(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("description", utils.PathSearch("description", getConnectionRespBody, nil)),
 		d.Set("type", utils.PathSearch("type", getConnectionRespBody, nil)),
 		d.Set("kafka_detail", flattenGetConnectionResponseBodyKafkaDetail(getConnectionRespBody)),
+		d.Set("flavor", flattenGetConnectionResponseBodyKafkaFlavor(getConnectionRespBody)),
 		d.Set("status", utils.PathSearch("status", getConnectionRespBody, nil)),
+		d.Set("agency", utils.PathSearch("agency", getConnectionRespBody, nil)),
 		d.Set("created_at", utils.PathSearch("created_time", getConnectionRespBody, nil)),
 		d.Set("updated_at", utils.PathSearch("updated_time", getConnectionRespBody, nil)),
 	)
@@ -290,11 +341,12 @@ func flattenGetConnectionResponseBodyKafkaDetail(resp interface{}) []interface{}
 
 	rst = []interface{}{
 		map[string]interface{}{
-			"instance_id":     utils.PathSearch("instance_id", curJson, nil),
-			"connect_address": utils.PathSearch("addr", curJson, nil),
-			"user_name":       utils.PathSearch("username", curJson, nil),
-			"password":        utils.PathSearch("password", curJson, nil),
-			"acks":            utils.PathSearch("acks", curJson, nil),
+			"instance_id":       utils.PathSearch("instance_id", curJson, nil),
+			"connect_address":   utils.PathSearch("addr", curJson, nil),
+			"user_name":         utils.PathSearch("username", curJson, nil),
+			"password":          utils.PathSearch("password", curJson, nil),
+			"acks":              utils.PathSearch("acks", curJson, nil),
+			"security_protocol": utils.PathSearch("security_protocol", curJson, nil),
 		},
 	}
 	return rst
@@ -379,4 +431,22 @@ func resourceConnectionDelete(_ context.Context, d *schema.ResourceData, meta in
 	}
 
 	return nil
+}
+
+func flattenGetConnectionResponseBodyKafkaFlavor(resp interface{}) []interface{} {
+	var rst []interface{}
+	curJson := utils.PathSearch("flavor", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
+		return rst
+	}
+
+	rst = []interface{}{
+		map[string]interface{}{
+			"bandwidth_type":   utils.PathSearch("bandwidth_type", curJson, nil),
+			"concurrency":      utils.PathSearch("concurrency", curJson, nil),
+			"concurrency_type": utils.PathSearch("concurrency_type", curJson, nil),
+			"name":             utils.PathSearch("name", curJson, nil),
+		},
+	}
+	return rst
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new fields of EG data source and resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist
```go
# data.eg_custom_event_sources
=== RUN   TestAccDataCustomEventSources_filterByFuzzyName
=== PAUSE TestAccDataCustomEventSources_filterByFuzzyName
=== CONT  TestAccDataCustomEventSources_filterByFuzzyName
--- PASS: TestAccDataCustomEventSources_filterByFuzzyName (12.67s)
PASS


=== RUN   TestAccDataCustomEventSources_filterBySort
=== PAUSE TestAccDataCustomEventSources_filterBySort
=== CONT  TestAccDataCustomEventSources_filterBySort
--- PASS: TestAccDataCustomEventSources_filterBySort (12.09s)
PASS


# data.eg_connections
=== RUN   TestAccDataConnections_basic
=== PAUSE TestAccDataConnections_basic
=== CONT  TestAccDataConnections_basic
--- PASS: TestAccDataConnections_basic (11.56s)
PASS

# data.custom_event_channels
=== RUN   TestAccDataCustomEventChannels_fuzzyName
=== PAUSE TestAccDataCustomEventChannels_fuzzyName
=== CONT  TestAccDataCustomEventChannels_fuzzyName
--- PASS: TestAccDataCustomEventChannels_fuzzyName (19.92s)
PASS

=== RUN   TestAccDataCustomEventChannels_sort
=== PAUSE TestAccDataCustomEventChannels_sort
=== CONT  TestAccDataCustomEventChannels_sort
--- PASS: TestAccDataCustomEventChannels_sort (14.72s)
PASS

# resource.eg_connection
=== RUN   TestAccConnection_basic
=== PAUSE TestAccConnection_basic
=== CONT  TestAccConnection_basic
--- PASS: TestAccConnection_basic (68.20s)

```

