### PR TITLE
feat(SWR): support to manually synchronize image

### DIFF
--- a/docs/resources/swr_image_manual_sync.md
+++ b/docs/resources/swr_image_manual_sync.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_swr_image_manual_sync"
+description: |-
+  Manages a SWR image manual sync resource within HuaweiCloud.
+---
+
+# huaweicloud_swr_image_manual_sync
+
+Manages a SWR image manual sync resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "organization_name" {}
+variable "repository_name" {}
+variable "image_tag" {}
+variable "target_region" {}
+variable "target_organization" {}
+
+resource "huaweicloud_swr_image_manual_sync" "test" {
+  organization        = var.organization_name
+  repository          = var.repository_name
+  image_tag           = var.image_tag
+  target_region       = var.target_region
+  target_organization = var.target_organization
+  override            = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `organization` - (Required, String, NonUpdatable) Specifies the name of the organization.
+
+* `repository` - (Required, String, NonUpdatable) Specifies the name of the repository.
+
+* `image_tag` - (Required, List, NonUpdatable) Specifies the iamge tags.
+
+* `target_organization` - (Required, String, NonUpdatable) Specifies the target organization name.
+
+* `target_region` - (Required, String, NonUpdatable) Specifies the target region name.
+
+* `override` - (Optional, Bool, NonUpdatable) Specifies whether to overwrite. Default to **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3598,6 +3598,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_swr_image_trigger":            swr.ResourceSwrImageTrigger(),
 			"huaweicloud_swr_image_retention_policy":   swr.ResourceSwrImageRetentionPolicy(),
 			"huaweicloud_swr_image_auto_sync":          swr.ResourceSwrImageAutoSync(),
+			"huaweicloud_swr_image_manual_sync":        swr.ResourceSwrImageManualSync(),
 			"huaweicloud_swr_temporary_login_command":  swr.ResourceSwrTemporaryLoginCommand(),
 
 			"huaweicloud_swr_enterprise_instance":                          swrenterprise.ResourceSwrEnterpriseInstance(),

--- a/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_manual_sync_test.go
+++ b/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_manual_sync_test.go
@@ -1,0 +1,47 @@
+package swr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccSwrImageManualSync_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSwrRepository(t)
+			acceptance.TestAccPreCheckSwrOrigination(t)
+			acceptance.TestAccPreCheckSwrTargetRegion(t)
+			acceptance.TestAccPreCheckSwrTargetOrigination(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSwrImageManualSync_basic(),
+			},
+		},
+	})
+}
+
+func testAccSwrImageManualSync_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_swr_image_tags" "test" {
+  organization = "%[1]s"
+  repository   = "%[2]s"
+}
+
+resource "huaweicloud_swr_image_manual_sync" "test" {
+  organization        = "%[1]s"
+  repository          = "%[2]s"
+  image_tag           = [data.huaweicloud_swr_image_tags.test.image_tags[0].name]
+  target_region       = "%[3]s"
+  target_organization = "%[4]s"
+  override            = true
+}
+`, acceptance.HW_SWR_ORGANIZATION, acceptance.HW_SWR_REPOSITORY, acceptance.HW_SWR_TARGET_REGION, acceptance.HW_SWR_TARGET_ORGANIZATION)
+}

--- a/huaweicloud/services/swr/resource_huaweicloud_swr_image_manual_sync.go
+++ b/huaweicloud/services/swr/resource_huaweicloud_swr_image_manual_sync.go
@@ -1,0 +1,140 @@
+package swr
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var swrImageManualSyncNonUpdatableParams = []string{
+	"organization", "repository", "image_tag", "target_region", "target_organization", "override",
+}
+
+// @API SWR POST /v2/manage/namespaces/{namespace}/repos/{repository}/sync_images
+func ResourceSwrImageManualSync() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSwrImageManualSyncCreate,
+		ReadContext:   resourceSwrImageManualSyncRead,
+		UpdateContext: resourceSwrImageManualSyncUpdate,
+		DeleteContext: resourceSwrImageManualSyncDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(swrImageManualSyncNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"organization": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of the organization.`,
+			},
+			"repository": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of the repository.`,
+			},
+			"image_tag": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the iamge tags.`,
+			},
+			"target_region": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the target region name.`,
+			},
+			"target_organization": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the target organization name.`,
+			},
+			"override": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Specifies whether to overwrite. Default to **false**.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceSwrImageManualSyncCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	organization := d.Get("organization").(string)
+	repository := d.Get("repository").(string)
+
+	createHttpUrl := "v2/manage/namespaces/{namespace}/repos/{repository}/sync_images"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{namespace}", organization)
+	createPath = strings.ReplaceAll(createPath, "{repository}", repository)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateSwrImageManualSyncBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating SWR image manual sync: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	return resourceSwrImageManualSyncRead(ctx, d, meta)
+}
+
+func buildCreateSwrImageManualSyncBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"remoteRegionId":  d.Get("target_region"),
+		"remoteNamespace": d.Get("target_organization"),
+		"imageTag":        d.Get("image_tag"),
+		"override":        utils.ValueIgnoreEmpty(d.Get("override")),
+	}
+	return bodyParams
+}
+
+func resourceSwrImageManualSyncRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSwrImageManualSyncUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSwrImageManualSyncDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting SWR image manual sync resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to manually synchronize image
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to manually synchronize image
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/swr' TESTARGS='-run TestAccSwrImageManualSync_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccSwrImageManualSync_basic -timeout 360m -parallel 4
=== RUN   TestAccSwrImageManualSync_basic
=== PAUSE TestAccSwrImageManualSync_basic
=== CONT  TestAccSwrImageManualSync_basic
--- PASS: TestAccSwrImageManualSync_basic (17.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       17.627s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
