### PR TITLE
feat(ESW): add esw instance resource and data source

### DIFF
--- a/docs/data-sources/esw_instances.md
+++ b/docs/data-sources/esw_instances.md
@@ -1,0 +1,94 @@
+---
+subcategory: "Enterprise Switch (ESW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_esw_instances"
+description: |-
+  Use this data source to get the list of ESW instances.
+---
+
+# huaweicloud_esw_instances
+
+Use this data source to get the list of ESW instances.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_esw_instances" "test" {}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the instances. If omitted, the provider-level region will be
+  used.
+
+* `instance_id` - (Optional, String) Specifies the ID of the instance.
+
+* `name` - (Optional, String) Specifies the name of the instance.
+
+* `description` - (Optional, String) Specifies the description of the instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances` - Indicates the list of instances.
+  The [instances](#instances_struct) structure is documented below.
+
+<a name="instances_struct"></a>
+The `instances` block supports:
+
+* `id` - Indicates the ID of the instance.
+
+* `name` - Indicates the name of the instance.
+
+* `project_id` - Indicates the project ID.
+
+* `region` - Indicates the region.
+
+* `flavor_ref` - Indicates the flavor of the instance.
+
+* `ha_mode` - Indicates the high availability mode of the instance.
+
+* `status` - Indicates the status of the instance.
+
+* `created_at` - Indicates the created time of the instance.
+
+* `updated_at` - Indicates the updated time of the instance.
+
+* `description` - Indicates the description of the instance.
+
+* `availability_zones` - Indicates the availability zones of the instance.
+  The [availability_zones](#availability_zones_struct) structure is documented below.
+
+* `tunnel_info` - Indicates the local tunnel information of the instance.
+  The [tunnel_info](#tunnel_info_struct) structure is documented below.
+
+* `charge_infos` - Indicates the charge infos of the instance.
+  The [charge_infos](#charge_infos_struct) structure is documented below.
+
+<a name="availability_zones_struct"></a>
+The `availability_zones` block supports:
+
+* `primary` - Indicates the availability zones where the default primary node is located.
+
+* `standby` - Indicates the availability zones where the default standby node is located.
+
+<a name="tunnel_info_struct"></a>
+The `tunnel_info` block supports:
+
+* `vpc_id` - Indicates the vpc ID.
+
+* `virsubnet_id` - Indicates the subnet ID.
+
+* `tunnel_ip` - Indicates the tunnel IP.
+
+* `tunnel_port` - Indicates the tunnel port.
+
+* `tunnel_type` - Indicates the tunnel type.
+
+<a name="charge_infos_struct"></a>
+The `charge_infos` block supports:
+
+* `charge_mode` - Indicates the charge mode.

--- a/docs/resources/esw_instance.md
+++ b/docs/resources/esw_instance.md
@@ -1,0 +1,122 @@
+---
+subcategory: "Enterprise Switch (ESW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_esw_instance"
+description: |-
+  Manages an ESW instance resource within HuaweiCloud.
+---
+
+# huaweicloud_esw_instance
+
+Manages an ESW instance resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "vpc_id" {}
+variable "virsubnet_id" {}
+
+resource "huaweicloud_esw_instance" "test" {
+  name        = "test_name"
+  flavor_ref  = "l2cg.small.ha"
+  ha_mode     = "ha"
+  description = "terraform test description"
+
+  availability_zones {
+    primary = "cn-north-4a"
+    standby = "cn-north-4b"
+  }
+
+  tunnel_info {
+    vpc_id       = var.vpc_id
+    virsubnet_id = var.virsubnet_id
+    tunnel_ip    = "192.168.0.192"
+  }
+
+  charge_infos {
+    charge_mode = "postPaid"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the ESW instance resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `name` - (Required, String) Specifies the name of the instance.
+
+* `flavor_ref` - (Required, String, NonUpdatable) Specifies the flavor of the instance.
+
+* `ha_mode` - (Required, String, NonUpdatable) Specifies the high availability mode of the instance. Value options: **ha**.
+
+* `availability_zones` - (Required, List, NonUpdatable) Specifies the availability zones of the instance.
+  The [availability_zones](#availability_zones_struct) structure is documented below.
+
+* `tunnel_info` - (Required, List, NonUpdatable) Specifies the local tunnel information of the instance.
+  The [tunnel_info](#tunnel_info_struct) structure is documented below.
+
+* `charge_infos` - (Required, List, NonUpdatable) Specifies the charge infos of the instance.
+  The [charge_infos](#charge_infos_struct) structure is documented below.
+
+* `description` - (Optional, String) Specifies the description of the instance.
+
+<a name="availability_zones_struct"></a>
+The `availability_zones` block supports:
+
+* `primary` - (Required, String, NonUpdatable) Specifies the availability zones where the default primary node is located.
+
+* `standby` - (Required, String, NonUpdatable) Specifies the availability zones where the default standby node is located.
+
+<a name="tunnel_info_struct"></a>
+The `tunnel_info` block supports:
+
+* `vpc_id` - (Required, String, NonUpdatable) Specifies the vpc ID.
+
+* `virsubnet_id` - (Required, String, NonUpdatable) Specifies the subnet ID.
+
+* `tunnel_ip` - (Optional, String, NonUpdatable) Specifies the tunnel IP.
+
+<a name="charge_infos_struct"></a>
+The `charge_infos` block supports:
+
+* `charge_mode` - (Required, String, NonUpdatable) Specifies the charge mode. Value options: **postPaid**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `tunnel_info` - Indicates the local tunnel information of the instance.
+  The [tunnel_info](#tunnel_info_attribute) structure is documented below.
+
+* `status` - Indicates the status of the instance.
+
+* `created_at` - Indicates the created time of the instance.
+
+* `updated_at` - Indicates the updated time of the instance.
+
+<a name="tunnel_info_attribute"></a>
+The `tunnel_info` block supports:
+
+* `tunnel_port` - Indicates the tunnel port.
+
+* `tunnel_type` - Indicates the tunnel type.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+This resource can be imported using the `id`, e.g.:
+
+```bash
+$ terraform import huaweicloud_esw_instance.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1232,6 +1232,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_esw_flavors":            esw.DataSourceEswFlavors(),
 			"huaweicloud_esw_availability_zones": esw.DataSourceEswAvailabilityZones(),
 			"huaweicloud_esw_quotas":             esw.DataSourceEswQuotas(),
+			"huaweicloud_esw_instances":          esw.DataSourceEswInstances(),
 
 			"huaweicloud_fgs_applications":                fgs.DataSourceApplications(),
 			"huaweicloud_fgs_application_templates":       fgs.DataSourceApplicationTemplates(),
@@ -3015,6 +3016,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_evs_recycle_bin_policy":         evs.ResourceRecycleBinPolicy(),
 			"huaweicloud_evs_recycle_bin_volume_delete":  evs.ResourceRecycleBinVolumeDelete(),
 			"huaweicloud_evs_recycle_bin_volume_revert":  evs.ResourceRecycleBinVolumeRevert(),
+
+			"huaweicloud_esw_instance": esw.ResourceInstance(),
 
 			"huaweicloud_fgs_application":                    fgs.ResourceApplication(),
 			"huaweicloud_fgs_async_invoke_configuration":     fgs.ResourceAsyncInvokeConfiguration(),

--- a/huaweicloud/services/acceptance/esw/data_source_huaweicloud_esw_instances_test.go
+++ b/huaweicloud/services/acceptance/esw/data_source_huaweicloud_esw_instances_test.go
@@ -1,0 +1,105 @@
+package esw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccEswInstances_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_esw_instances.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceEswInstances_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "instances.#"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.project_id"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.region"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.flavor_ref"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.ha_mode"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.availability_zones.#"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.availability_zones.0.primary"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.availability_zones.0.standby"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.tunnel_info.#"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.tunnel_info.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.tunnel_info.0.virsubnet_id"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.tunnel_info.0.tunnel_ip"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.tunnel_info.0.tunnel_port"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.tunnel_info.0.tunnel_type"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.charge_infos.#"),
+					resource.TestCheckResourceAttrSet(rName, "instances.0.charge_infos.0.charge_mode"),
+					resource.TestCheckOutput("instance_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("description_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceEswInstances_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_esw_instances" "test" {
+  depends_on = [huaweicloud_esw_instance.test]
+}
+
+locals{
+  instance_id = huaweicloud_esw_instance.test.id
+}
+data "huaweicloud_esw_instances" "instance_id_filter" {
+  depends_on = [huaweicloud_esw_instance.test]
+
+  instance_id = huaweicloud_esw_instance.test.id
+}
+output "instance_id_filter_is_useful" {
+  value = length(data.huaweicloud_esw_instances.instance_id_filter.instances) > 0 && alltrue(
+    [for v in data.huaweicloud_esw_instances.instance_id_filter.instances[*].id : v == local.instance_id]
+  )
+}
+
+locals{
+  name = huaweicloud_esw_instance.test.name
+}
+data "huaweicloud_esw_instances" "name_filter" {
+  depends_on = [huaweicloud_esw_instance.test]
+
+  name = huaweicloud_esw_instance.test.name
+}
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_esw_instances.name_filter.instances) > 0 && alltrue(
+    [for v in data.huaweicloud_esw_instances.name_filter.instances[*].name : v == local.name]
+  )
+}
+
+locals{
+  description = huaweicloud_esw_instance.test.description
+}
+data "huaweicloud_esw_instances" "description_filter" {
+  depends_on = [huaweicloud_esw_instance.test]
+
+  description = huaweicloud_esw_instance.test.description
+}
+output "description_filter_is_useful" {
+  value = length(data.huaweicloud_esw_instances.description_filter.instances) > 0 && alltrue(
+    [for v in data.huaweicloud_esw_instances.description_filter.instances[*].description : v == local.description]
+  )
+}
+`, testAccEswInstance_basic(name))
+}

--- a/huaweicloud/services/acceptance/esw/resource_huaweicloud_esw_instance_test.go
+++ b/huaweicloud/services/acceptance/esw/resource_huaweicloud_esw_instance_test.go
@@ -1,0 +1,179 @@
+package esw
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getEswInstance(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	var (
+		httpUrl = "v3/{project_id}/l2cg/instances/{instance_id}"
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ESW client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", state.Primary.ID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccEswInstance_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_esw_instance.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getEswInstance,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEswInstance_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor_ref",
+						"data.huaweicloud_esw_flavors.test", "flavors.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "ha_mode", "ha"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0.primary",
+						"data.huaweicloud_esw_flavors.test", "flavors.0.available_zones.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0.standby",
+						"data.huaweicloud_esw_flavors.test", "flavors.0.available_zones.1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tunnel_info.0.vpc_id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "tunnel_info.0.virsubnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_info.0.tunnel_ip", "192.168.0.192"),
+					resource.TestCheckResourceAttr(resourceName, "charge_infos.0.charge_mode", "postPaid"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel_info.0.tunnel_port"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel_info.0.tunnel_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccEswInstance_basic_update(rName, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor_ref",
+						"data.huaweicloud_esw_flavors.test", "flavors.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "ha_mode", "ha"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description update"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0.primary",
+						"data.huaweicloud_esw_flavors.test", "flavors.0.available_zones.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0.standby",
+						"data.huaweicloud_esw_flavors.test", "flavors.0.available_zones.1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tunnel_info.0.vpc_id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "tunnel_info.0.virsubnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_info.0.tunnel_ip", "192.168.0.192"),
+					resource.TestCheckResourceAttr(resourceName, "charge_infos.0.charge_mode", "postPaid"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel_info.0.tunnel_port"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel_info.0.tunnel_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEswInstance_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_esw_flavors" "test" {}
+
+resource "huaweicloud_esw_instance" "test" {
+  name        = "%[2]s"
+  flavor_ref  = data.huaweicloud_esw_flavors.test.flavors[0].name
+  ha_mode     = "ha"
+  description = "test description"
+
+  availability_zones {
+    primary = data.huaweicloud_esw_flavors.test.flavors.0.available_zones[0]
+    standby = data.huaweicloud_esw_flavors.test.flavors.0.available_zones[1]
+  }
+
+  tunnel_info {
+    vpc_id       = huaweicloud_vpc.test.id
+    virsubnet_id = huaweicloud_vpc_subnet.test.id
+    tunnel_ip    = "192.168.0.192"
+  }
+
+  charge_infos {
+    charge_mode = "postPaid"
+  }
+}
+`, common.TestVpc(rName), rName)
+}
+
+func testAccEswInstance_basic_update(rName, updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_esw_flavors" "test" {}
+
+resource "huaweicloud_esw_instance" "test" {
+  name        = "%[2]s"
+  flavor_ref  = data.huaweicloud_esw_flavors.test.flavors.0.name
+  ha_mode     = "ha"
+  description = "test description update"
+
+  availability_zones {
+    primary = data.huaweicloud_esw_flavors.test.flavors.0.available_zones[0]
+    standby = data.huaweicloud_esw_flavors.test.flavors.0.available_zones[1]
+  }
+
+  tunnel_info {
+    vpc_id       = huaweicloud_vpc.test.id
+    virsubnet_id = huaweicloud_vpc_subnet.test.id
+    tunnel_ip    = "192.168.0.192"
+  }
+
+  charge_infos {
+    charge_mode = "postPaid"
+  }
+}
+`, common.TestVpc(rName), updateName)
+}

--- a/huaweicloud/services/esw/data_source_huaweicloud_esw_instances.go
+++ b/huaweicloud/services/esw/data_source_huaweicloud_esw_instances.go
@@ -1,0 +1,307 @@
+package esw
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ESW GET /v3/{project_id}/l2cg/instances
+func DataSourceEswInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEswInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"flavor_ref": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ha_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zones": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     availabilityZonesSchema(),
+						},
+						"tunnel_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     tunnelInfoSchema(),
+						},
+						"charge_infos": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     chargeInfosSchema(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func availabilityZonesSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"primary": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"standby": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func tunnelInfoSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"virsubnet_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tunnel_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tunnel_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"tunnel_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func chargeInfosSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"charge_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceEswInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	var (
+		httpUrl = "v3/{project_id}/l2cg/instances"
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ESW client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	listQueryParams := buildListQueryParams(d)
+	listPath += listQueryParams
+
+	listResp, err := pagination.ListAllItems(
+		client,
+		"marker",
+		listPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return diag.Errorf("error retrieving ESW instances: %s", err)
+	}
+
+	listRespJson, err := json.Marshal(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var listRespBody interface{}
+	err = json.Unmarshal(listRespJson, &listRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instances", flattenEswInstancesBody(listRespBody)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildListQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("instance_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("description"); ok {
+		res = fmt.Sprintf("%s&description=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}
+
+func flattenEswInstancesBody(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("instances", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":                 utils.PathSearch("id", v, nil),
+			"name":               utils.PathSearch("name", v, nil),
+			"project_id":         utils.PathSearch("project_id", v, nil),
+			"region":             utils.PathSearch("region", v, nil),
+			"flavor_ref":         utils.PathSearch("flavor_ref", v, nil),
+			"ha_mode":            utils.PathSearch("ha_mode", v, nil),
+			"status":             utils.PathSearch("status", v, nil),
+			"created_at":         utils.PathSearch("created_at", v, nil),
+			"updated_at":         utils.PathSearch("updated_at", v, nil),
+			"description":        utils.PathSearch("description", v, nil),
+			"availability_zones": flattenInstancesAvailabilityZones(v),
+			"tunnel_info":        flattenInstancesTunnelInfo(v),
+			"charge_infos":       flattenInstancesChargeInfos(v),
+		})
+	}
+	return rst
+}
+
+func flattenInstancesAvailabilityZones(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("availability_zones", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	rst := []interface{}{
+		map[string]interface{}{
+			"primary": utils.PathSearch("primary", curJson, nil),
+			"standby": utils.PathSearch("standby", curJson, nil),
+		},
+	}
+	return rst
+}
+
+func flattenInstancesTunnelInfo(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("tunnel_info", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	rst := []interface{}{
+		map[string]interface{}{
+			"vpc_id":       utils.PathSearch("vpc_id", curJson, nil),
+			"virsubnet_id": utils.PathSearch("virsubnet_id", curJson, nil),
+			"tunnel_ip":    utils.PathSearch("tunnel_ip", curJson, nil),
+			"tunnel_port":  int(utils.PathSearch("tunnel_port", curJson, float64(0)).(float64)),
+			"tunnel_type":  utils.PathSearch("tunnel_type", curJson, nil),
+		},
+	}
+	return rst
+}
+
+func flattenInstancesChargeInfos(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("charge_infos", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	rst := []interface{}{
+		map[string]interface{}{
+			"charge_mode": utils.PathSearch("charge_mode", curJson, nil),
+		},
+	}
+	return rst
+}

--- a/huaweicloud/services/esw/resource_huaweicloud_esw_instance.go
+++ b/huaweicloud/services/esw/resource_huaweicloud_esw_instance.go
@@ -1,0 +1,514 @@
+package esw
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var instanceNonUpdatableParams = []string{"flavor_ref", "ha_mode", "availability_zones", "availability_zones.*.primary",
+	"availability_zones.*.standby", "tunnel_info", "tunnel_info.*.vpc_id", "tunnel_info.*.virsubnet_id",
+	"tunnel_info.*.tunnel_ip", "charge_infos", "charge_infos.*.charge_mode"}
+
+// @API RDS POST /v3/{project_id}/l2cg/instances
+// @API RDS GET /v3/{project_id}/l2cg/instances/{instance_id}
+// @API RDS PUT /v3/{project_id}/l2cg/instances/{instance_id}
+// @API RDS DELETE /v3/{project_id}/l2cg/instances/{instance_id}
+func ResourceInstance() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInstanceCreate,
+		ReadContext:   resourceInstanceRead,
+		UpdateContext: resourceInstanceUpdate,
+		DeleteContext: resourceInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(instanceNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"flavor_ref": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ha_mode": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"availability_zones": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem:     instanceAvailabilityZonesSchema(),
+			},
+			"tunnel_info": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem:     instanceTunnelInfoSchema(),
+			},
+			"charge_infos": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem:     instanceChargeInfosSchema(),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func instanceAvailabilityZonesSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"primary": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"standby": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func instanceTunnelInfoSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"virsubnet_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tunnel_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tunnel_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"tunnel_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func instanceChargeInfosSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"charge_mode": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/l2cg/instances"
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ESW client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateInstanceBodyParams(d))
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating ESW instance: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	instanceId := utils.PathSearch("instance.id", createRespBody, "").(string)
+	if instanceId == "" {
+		return diag.Errorf("unable to find the ESW instance ID from the API response")
+	}
+	d.SetId(instanceId)
+
+	err = waitForInstanceActive(ctx, client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return resourceInstanceRead(ctx, d, meta)
+}
+
+func buildCreateInstanceBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":               d.Get("name"),
+		"flavor_ref":         d.Get("flavor_ref"),
+		"ha_mode":            d.Get("ha_mode"),
+		"availability_zones": buildCreateInstanceAvailabilityZonesBody(d),
+		"tunnel_info":        buildCreateInstanceTunnelInfoBody(d),
+		"charge_infos":       buildCreateInstanceChargeInfosBody(d),
+		"description":        utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+	return map[string]interface{}{
+		"instance": bodyParams,
+	}
+}
+
+func buildCreateInstanceAvailabilityZonesBody(d *schema.ResourceData) map[string]interface{} {
+	rawParams := d.Get("availability_zones").([]interface{})
+	if len(rawParams) == 0 {
+		return nil
+	}
+
+	raw, ok := rawParams[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	rst := map[string]interface{}{
+		"primary": raw["primary"],
+		"standby": raw["standby"],
+	}
+
+	return rst
+}
+
+func buildCreateInstanceTunnelInfoBody(d *schema.ResourceData) map[string]interface{} {
+	rawParams := d.Get("tunnel_info").([]interface{})
+	if len(rawParams) == 0 {
+		return nil
+	}
+
+	raw, ok := rawParams[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	rst := map[string]interface{}{
+		"vpc_id":       raw["vpc_id"],
+		"virsubnet_id": raw["virsubnet_id"],
+		"tunnel_ip":    utils.ValueIgnoreEmpty(raw["tunnel_ip"]),
+	}
+
+	return rst
+}
+
+func buildCreateInstanceChargeInfosBody(d *schema.ResourceData) map[string]interface{} {
+	rawParams := d.Get("charge_infos").([]interface{})
+	if len(rawParams) == 0 {
+		return nil
+	}
+
+	raw, ok := rawParams[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	rst := map[string]interface{}{
+		"charge_mode": raw["charge_mode"],
+	}
+
+	return rst
+}
+
+func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ESW client: %s", err)
+	}
+
+	instance, err := getInstanceById(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving ESW instance")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("instance.name", instance, nil)),
+		d.Set("flavor_ref", utils.PathSearch("instance.flavor_ref", instance, nil)),
+		d.Set("ha_mode", utils.PathSearch("instance.ha_mode", instance, nil)),
+		d.Set("availability_zones", flattenInstanceAvailabilityZones(instance)),
+		d.Set("tunnel_info", flattenInstanceTunnelInfo(instance)),
+		d.Set("charge_infos", flattenInstanceChargeInfos(instance)),
+		d.Set("description", utils.PathSearch("instance.description", instance, nil)),
+		d.Set("status", utils.PathSearch("instance.status", instance, nil)),
+		d.Set("created_at", utils.PathSearch("instance.created_at", instance, nil)),
+		d.Set("updated_at", utils.PathSearch("instance.updated_at", instance, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInstanceAvailabilityZones(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("instance.availability_zones", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	rst := []interface{}{
+		map[string]interface{}{
+			"primary": utils.PathSearch("primary", curJson, nil),
+			"standby": utils.PathSearch("standby", curJson, nil),
+		},
+	}
+	return rst
+}
+
+func flattenInstanceTunnelInfo(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("instance.tunnel_info", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	rst := []interface{}{
+		map[string]interface{}{
+			"vpc_id":       utils.PathSearch("vpc_id", curJson, nil),
+			"virsubnet_id": utils.PathSearch("virsubnet_id", curJson, nil),
+			"tunnel_ip":    utils.PathSearch("tunnel_ip", curJson, nil),
+			"tunnel_port":  int(utils.PathSearch("tunnel_port", curJson, float64(0)).(float64)),
+			"tunnel_type":  utils.PathSearch("tunnel_type", curJson, nil),
+		},
+	}
+	return rst
+}
+
+func flattenInstanceChargeInfos(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("instance.charge_infos", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	rst := []interface{}{
+		map[string]interface{}{
+			"charge_mode": utils.PathSearch("charge_mode", curJson, nil),
+		},
+	}
+	return rst
+}
+
+func getInstanceById(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/l2cg/instances/{instance_id}"
+	)
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/l2cg/instances/{instance_id}"
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ESW Client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	updateOpt.JSONBody = buildUpdateInstanceBodyParams(d)
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating ESW instance: %s", err)
+	}
+
+	return resourceInstanceRead(ctx, d, meta)
+}
+
+func buildUpdateInstanceBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": d.Get("description"),
+	}
+	return map[string]interface{}{
+		"instance": bodyParams,
+	}
+}
+
+func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/l2cg/instances/{instance_id}"
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ESW client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting ESW instance")
+	}
+
+	err = waitForInstanceDeleted(ctx, client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func waitForInstanceActive(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"Pending"},
+		Target:       []string{"Active"},
+		Refresh:      instanceStatusRefreshFunc(client, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for ESW instance(%s) to active: %s ", d.Id(), err)
+	}
+	return nil
+}
+
+func waitForInstanceDeleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"Pending"},
+		Target:       []string{"Deleted"},
+		Refresh:      instanceStatusRefreshFunc(client, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for ESW instance(%s) to be deleted: %s ", d.Id(), err)
+	}
+	return nil
+}
+
+func instanceStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		instance, err := getInstanceById(client, instanceId)
+		if err != nil {
+			var errDefault404 golangsdk.ErrDefault404
+			if errors.As(err, &errDefault404) {
+				return "", "Deleted", nil
+			}
+			return nil, "Failed", err
+		}
+
+		status := utils.PathSearch("instance.status", instance, "").(string)
+		if status == "" {
+			return nil, "Failed", errors.New("status is not found")
+		}
+
+		if utils.StrSliceContains([]string{"failed", "abnormal"}, status) {
+			return instance, "Failed", fmt.Errorf("the isntance status is: %s", status)
+		}
+		if status == "active" {
+			return instance, "Active", nil
+		}
+
+		return instance, "Pending", nil
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  dd esw instance resource and data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  dd esw instance resource and data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/esw/ TESTARGS='-run TestAccEswInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/esw/ -v -run TestAccEswInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccEswInstance_basic
=== PAUSE TestAccEswInstance_basic
=== CONT  TestAccEswInstance_basic
--- PASS: TestAccEswInstance_basic (475.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/esw       475.139s

make testacc TEST=./huaweicloud/services/acceptance/esw/ TESTARGS='-run TestAccEswInstances_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/esw/ -v -run TestAccEswInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccEswInstances_basic
=== PAUSE TestAccEswInstances_basic
=== CONT  TestAccEswInstances_basic
--- PASS: TestAccEswInstances_basic (475.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/esw       475.828s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
