### PR TITLE
feat(workspace): add new resource to manage notification rule

### DIFF
--- a/docs/resources/workspace_notification_rule.md
+++ b/docs/resources/workspace_notification_rule.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_notification_rule"
+description: |-
+  Use this resource to manage notification rules for metrics within HuaweiCloud.
+---
+
+# huaweicloud_workspace_notification_rule
+
+Use this resource to manage notification rules for metrics within HuaweiCloud.
+
+-> You need to add delegate authorization for the cloud service first, otherwise notifications cannot be sent to SMN
+   normally.
+
+## Example Usage
+
+```hcl
+variable "metric_name" {}
+variable "notified_topic_urn" {}
+
+resource "huaweicloud_workspace_notification_rule" "test" {
+  metric_name         = var.metric_name
+  comparison_operator = ">="
+  enable              = true
+  notify_object       = var.notified_topic_urn
+  threshold           = 30
+  interval            = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the notification rule is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `metric_name` - (Required, String, ForceNew) Specifies the name of the metric.  
+  The valid values are as follows:
+  + **desktop_idle_duration**
+
+* `comparison_operator` - (Required, String) Specifies the comparison operator for the metric value and threshold.  
+  The valid values are as follows:
+  + **>=** - Trigger when the metric value is greater than or equal to the threshold.
+
+* `enable` - (Required, Bool) Specifies whether to enable the rule.
+
+* `notify_object` - (Required, String) Specifies the notification object, which is the SMN topic URN.
+
+* `threshold` - (Optional, Int) Specifies the threshold (in days) for the rule configuration.
+
+* `interval` - (Optional, Int) Specifies the interval time (in days) for the next notification after triggering.  
+  Default is once per day.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The notification rule can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_workspace_notification_rule.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3757,6 +3757,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_desktop_pool_notification":            workspace.ResourceDesktopPoolNotification(),
 			"huaweicloud_workspace_eip_associate":                        workspace.ResourceEipAssociate(),
 			"huaweicloud_workspace_log_configuration":                    workspace.ResourceLogConfiguration(),
+			"huaweicloud_workspace_notification_rule":                    workspace.ResourceNotificationRule(),
 			"huaweicloud_workspace_policy_group":                         workspace.ResourcePolicyGroup(),
 			"huaweicloud_workspace_service":                              workspace.ResourceService(),
 			"huaweicloud_workspace_terminal_binding":                     workspace.ResourceTerminalBinding(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_notification_rule_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_notification_rule_test.go
@@ -1,0 +1,114 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/workspace"
+)
+
+func getNotificationRuleFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("workspace", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace client: %s", err)
+	}
+
+	return workspace.GetNotificationRuleById(client, state.Primary.ID)
+}
+
+func TestAccNotificationRule_basic(t *testing.T) {
+	var (
+		rName            = "huaweicloud_workspace_notification_rule.test"
+		notificationRule interface{}
+		rc               = acceptance.InitResourceCheck(rName, &notificationRule, getNotificationRuleFunc)
+		baseConfig       = testAccNotificationRule_base(acceptance.RandomAccResourceNameWithDash())
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rc.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationRule_basic_step1(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "metric_name", "desktop_idle_duration"),
+					resource.TestCheckResourceAttr(rName, "comparison_operator", ">="),
+					resource.TestCheckResourceAttr(rName, "enable", "true"),
+					resource.TestCheckResourceAttrSet(rName, "notify_object"),
+					resource.TestCheckResourceAttr(rName, "threshold", "30"),
+					resource.TestCheckResourceAttr(rName, "interval", "1"),
+				),
+			},
+			{
+				Config: testAccNotificationRule_basic_step2(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "metric_name", "desktop_idle_duration"),
+					resource.TestCheckResourceAttr(rName, "comparison_operator", ">="),
+					resource.TestCheckResourceAttr(rName, "enable", "false"),
+					resource.TestCheckResourceAttrSet(rName, "notify_object"),
+					resource.TestCheckResourceAttr(rName, "threshold", "15"),
+					resource.TestCheckResourceAttr(rName, "interval", "2"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNotificationRule_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name = "%[1]s"
+}
+`, name)
+}
+
+func testAccNotificationRule_basic_step1(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_notification_rule" "test" {
+  depends_on = [huaweicloud_smn_topic.test]
+
+  metric_name         = "desktop_idle_duration"
+  comparison_operator = ">="
+  enable              = true
+  notify_object       = huaweicloud_smn_topic.test.topic_urn
+  threshold           = 30
+  interval            = 1
+}
+`, baseConfig)
+}
+
+func testAccNotificationRule_basic_step2(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_notification_rule" "test" {
+  depends_on = [huaweicloud_smn_topic.test]
+
+  metric_name         = "desktop_idle_duration"
+  comparison_operator = ">="
+  enable              = false
+  notify_object       = huaweicloud_smn_topic.test.topic_urn
+  threshold           = 15
+  interval            = 2
+}
+`, baseConfig)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_notification_rule.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_notification_rule.go
@@ -1,0 +1,288 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace POST /v2/{project_id}/statistics/notify-rules
+// @API Workspace GET /v2/{project_id}/statistics/notify-rules
+// @API Workspace PUT /v2/{project_id}/statistics/notify-rules/{rule_id}
+// @API Workspace DELETE /v2/{project_id}/statistics/notify-rules/{rule_id}
+func ResourceNotificationRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNotificationRuleCreate,
+		ReadContext:   resourceNotificationRuleRead,
+		UpdateContext: resourceNotificationRuleUpdate,
+		DeleteContext: resourceNotificationRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the notification rule is located.`,
+			},
+
+			// Required parameters.
+			"metric_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The name of the metric. Currently only supports "desktop_idle_duration".`,
+			},
+			"comparison_operator": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The comparison operator for the metric value and threshold.`,
+			},
+			"enable": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: `Whether to enable the rule.`,
+			},
+			"notify_object": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The notification object, which is the SMN topic URN.`,
+			},
+
+			// Optional parameters.
+			"threshold": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The threshold (in days) for the rule configuration.`,
+			},
+			"interval": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The interval time (in days) for the next notification after triggering. Default is once per day.`,
+			},
+		},
+	}
+}
+
+func buildNotificationRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"metric_name":         d.Get("metric_name"),
+		"comparison_operator": d.Get("comparison_operator"),
+		"enable":              d.Get("enable"),
+		"notify_object":       d.Get("notify_object"),
+		"threshold":           utils.ValueIgnoreEmpty(d.Get("threshold")),
+		"interval":            utils.ValueIgnoreEmpty(d.Get("interval")),
+	}
+
+	return utils.RemoveNil(bodyParams)
+}
+
+func resourceNotificationRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v2/{project_id}/statistics/notify-rules"
+	)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildNotificationRuleBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating Workspace notification rule: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	ruleId := utils.PathSearch("rule_id", respBody, "").(string)
+	if ruleId == "" {
+		return diag.Errorf("unable to find rule ID from API response")
+	}
+	d.SetId(ruleId)
+
+	return resourceNotificationRuleRead(ctx, d, meta)
+}
+
+func listNotificationRules(client *golangsdk.ServiceClient, ruleId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/statistics/notify-rules?rule_id={rule_id}&limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{rule_id}", ruleId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%v", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &getOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		items := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, items...)
+		if len(items) < limit {
+			break
+		}
+		offset += len(items)
+	}
+
+	return result, nil
+}
+
+func GetNotificationRuleById(client *golangsdk.ServiceClient, ruleId string) (interface{}, error) {
+	rules, err := listNotificationRules(client, ruleId)
+	if err != nil {
+		return nil, err
+	}
+
+	notificationRule := utils.PathSearch(fmt.Sprintf("[?rule_id=='%s']|[0]", ruleId), rules, nil)
+	if notificationRule == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/statistics/notify-rules",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the notification rule with ID '%s' has been removed", ruleId)),
+			},
+		}
+	}
+	return notificationRule, nil
+}
+
+func resourceNotificationRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	respBody, err := GetNotificationRuleById(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Workspace notification rule")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("metric_name", utils.PathSearch("metric_name", respBody, nil)),
+		d.Set("comparison_operator", utils.PathSearch("comparison_operator", respBody, nil)),
+		d.Set("enable", utils.PathSearch("enable", respBody, nil)),
+		d.Set("notify_object", utils.PathSearch("notify_object", respBody, nil)),
+		d.Set("threshold", utils.PathSearch("threshold", respBody, nil)),
+		d.Set("interval", utils.PathSearch("interval", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceNotificationRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v2/{project_id}/statistics/notify-rules/{rule_id}"
+	)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{rule_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildNotificationRuleBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating Workspace notification rule: %s", err)
+	}
+
+	return resourceNotificationRuleRead(ctx, d, meta)
+}
+
+func resourceNotificationRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v2/{project_id}/statistics/notify-rules/{rule_id}"
+	)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{rule_id}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	// When deleting a deleted rule, the API does not return an error, so CheckDeletedDiag is not used here.
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting Workspace notification rule: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource that used to manage Workspace notification rule.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1126" height="281" alt="image" src="https://github.com/user-attachments/assets/96dd5479-ecaa-4bdf-b24d-63e43d9e5ac4" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage notification rule
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccNotificationRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccNotificationRule_basic -timeout 360m -parallel 10
=== RUN   TestAccNotificationRule_basic
=== PAUSE TestAccNotificationRule_basic
=== CONT  TestAccNotificationRule_basic
--- PASS: TestAccNotificationRule_basic (39.32s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 39.409s coverage: 3.9% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="867" height="551" alt="image" src="https://github.com/user-attachments/assets/47b0af2b-4d72-4e81-97ea-f1a6c05fbad8" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
