### PR TITLE
feat(workspace): add new data source to query user groups

### DIFF
--- a/docs/data-sources/workspace_user_groups.md
+++ b/docs/data-sources/workspace_user_groups.md
@@ -1,0 +1,89 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_user_groups"
+description: |-
+  Use this data source to query the Workspace user groups under a specified region within HuaweiCloud.
+---
+
+# huaweicloud_workspace_user_groups
+
+Use this data source to query the Workspace user groups under a specified region within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_workspace_user_groups" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the user groups are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `groups` - The list of user groups that matched filter parameters.  
+  The [groups](#workspace_user_groups) structure is documented below.
+
+<a name="workspace_user_groups"></a>
+The `groups` block supports:
+
+* `id` - The ID of the user group.
+
+* `name` - The name of the user group.
+
+* `create_time` - The creation time of the user group, in RFC3339 format.
+
+* `description` - The description of the user group.
+
+* `user_quantity` - The number of users in the user list.
+
+* `parent` - The parent user group of the user group.  
+  The [parent](#workspace_user_groups_parent) structure is documented below.
+
+* `realm_id` - The domain ID of the user group.
+
+* `platform_type` - The type of the user group.  
+  The valid values are as follows:
+  + **AD**: AD domain user group
+  + **LOCAL**: Local liteAs user group
+
+* `group_dn` - The distinguished name of the user group.
+
+* `domain` - The domain name of the user group.
+
+* `sid` - The SID of the user group.
+
+* `total_desktops` - The number of users in the user list.
+
+<a name="workspace_user_groups_parent"></a>
+The `parent` block supports:
+
+* `id` - The ID of the parent user group.
+
+* `name` - The name of the parent user group.
+
+* `create_time` - The creation time of the parent user group, in RFC3339 format.
+
+* `description` - The description of the parent user group.
+
+* `user_quantity` - The number of users in the parent user group.
+
+* `realm_id` - The domain ID of the parent user group.
+
+* `platform_type` - The type of the parent user group.
+
+* `group_dn` - The distinguished name of the parent user group.
+
+* `domain` - The domain name of the parent user group.
+
+* `sid` - The SID of the parent user group.
+
+* `total_desktops` - The number of users in the parent user group.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2243,6 +2243,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_tags":                                 workspace.DataSourceTags(),
 			"huaweicloud_workspace_timezones":                            workspace.DataSourceTimeZones(),
 			"huaweicloud_workspace_users":                                workspace.DataSourceUsers(),
+			"huaweicloud_workspace_user_groups":                          workspace.DataSourceUserGroups(),
 			"huaweicloud_workspace_volume_products":                      workspace.DataSourceVolumeProducts(),
 
 			// Workspace APP

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_user_groups_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_user_groups_test.go
@@ -1,0 +1,58 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataUserGroups_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_workspace_user_groups.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataUserGroups_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "groups.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "groups.0.id"),
+					resource.TestCheckResourceAttrSet(all, "groups.0.name"),
+					resource.TestCheckResourceAttrSet(all, "groups.0.platform_type"),
+					resource.TestMatchResourceAttr(all, "groups.0.create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(all, "groups.0.user_quantity"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataUserGroups_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_user_group" "test" {
+  name        = "%[1]s"
+  type        = "LOCAL"
+  description = "Created by terraform script"
+}
+
+# Without any filter parameter.
+data "huaweicloud_workspace_user_groups" "all" {
+  depends_on = [
+    huaweicloud_workspace_user_group.test,
+  ]
+}
+`, name)
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_user_groups.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_user_groups.go
@@ -1,0 +1,290 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v2/{project_id}/groups
+func DataSourceUserGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceUserGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the user groups are located.`,
+			},
+
+			// Attributes.
+			"groups": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        userGroupSchema(),
+				Description: `The list of user groups.`,
+			},
+		},
+	}
+}
+
+func userGroupSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the user group.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the user group.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the user group, in RFC3339 format.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the user group.`,
+			},
+			"user_quantity": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of users in the user list.`,
+			},
+			"parent": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        userGroupParentSchema(),
+				Description: `The parent user group of the user group.`,
+			},
+			"realm_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain ID of the user group.`,
+			},
+			"platform_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the user group.`,
+			},
+			"group_dn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The distinguished name of the user group.`,
+			},
+			"domain": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain name of the user group.`,
+			},
+			"sid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The SID of the user group.`,
+			},
+			"total_desktops": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of users in the user list.`,
+			},
+		},
+	}
+}
+
+func userGroupParentSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the parent user group.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the parent user group.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the parent user group, in RFC3339 format.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the parent user group.`,
+			},
+			"user_quantity": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of users in the parent user group.`,
+			},
+			"realm_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain ID of the parent user group.`,
+			},
+			"platform_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the parent user group.`,
+			},
+			"group_dn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The distinguished name of the parent user group.`,
+			},
+			"domain": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain name of the parent user group.`,
+			},
+			"sid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The SID of the parent user group.`,
+			},
+			"total_desktops": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of users in the parent user group.`,
+			},
+		},
+	}
+}
+
+func listUserGroups(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/groups?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		userGroups := utils.PathSearch("user_groups", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, userGroups...)
+		if len(userGroups) < limit {
+			break
+		}
+		offset += len(userGroups)
+	}
+
+	return result, nil
+}
+
+func flattenUserGroupParent(item map[string]interface{}) []map[string]interface{} {
+	if len(item) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"id":   utils.PathSearch("id", item, nil),
+			"name": utils.PathSearch("name", item, nil),
+			"create_time": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
+				item, "").(string))/1000, false),
+			"description":    utils.PathSearch("description", item, nil),
+			"user_quantity":  utils.PathSearch("user_quantity", item, nil),
+			"realm_id":       utils.PathSearch("realm_id", item, nil),
+			"platform_type":  utils.PathSearch("platform_type", item, nil),
+			"group_dn":       utils.PathSearch("group_dn", item, nil),
+			"domain":         utils.PathSearch("domain", item, nil),
+			"sid":            utils.PathSearch("sid", item, nil),
+			"total_desktops": utils.PathSearch("total_desktops", item, nil),
+		},
+	}
+}
+
+func flattenUserGroups(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(items))
+	for i, item := range items {
+		result[i] = map[string]interface{}{
+			"id":   utils.PathSearch("id", item, nil),
+			"name": utils.PathSearch("name", item, nil),
+			"create_time": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
+				item, "").(string))/1000, false),
+			"description":   utils.PathSearch("description", item, nil),
+			"user_quantity": utils.PathSearch("user_quantity", item, nil),
+			"parent": flattenUserGroupParent(utils.PathSearch("parent", item,
+				make(map[string]interface{})).(map[string]interface{})),
+			"realm_id":       utils.PathSearch("realm_id", item, nil),
+			"platform_type":  utils.PathSearch("platform_type", item, nil),
+			"group_dn":       utils.PathSearch("group_dn", item, nil),
+			"domain":         utils.PathSearch("domain", item, nil),
+			"sid":            utils.PathSearch("sid", item, nil),
+			"total_desktops": utils.PathSearch("total_desktops", item, nil),
+		}
+	}
+
+	return result
+}
+
+func dataSourceUserGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	userGroups, err := listUserGroups(client)
+	if err != nil {
+		return diag.Errorf("error querying Workspace user groups: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("groups", flattenUserGroups(userGroups)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source that used to query Workspace user groups

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1144" height="275" alt="image" src="https://github.com/user-attachments/assets/dc47f20b-6fcb-4205-8935-e81673c1bef2" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query user groups
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataUserGroups_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataUserGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccDataUserGroups_basic
--- PASS: TestAccDataUserGroups_basic (16.13s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 16.265s coverage: 4.1% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
