### PR TITLE
feat(workspace): add new one-time action resource to operate user

### DIFF
--- a/docs/resources/workspace_user_action.md
+++ b/docs/resources/workspace_user_action.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_user_action"
+description: |-
+  Use this resource to operate Workspace users within HuaweiCloud.
+---
+
+# huaweicloud_workspace_user_action
+
+Use this resource to operate Workspace users within HuaweiCloud.
+
+-> This resource is a one-time action resource for operating user. Deleting this resource will not clear
+   the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "user_id" {}
+variable "operation_type" {}
+
+resource "huaweicloud_workspace_user_action" "test" {
+  user_id = var.user_id
+  op_type = var.operation_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the user is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `user_id` - (Required, String, NonUpdatable) Specifies the ID of the user to be operated.
+
+* `op_type` - (Required, String, NonUpdatable) Specifies the operation type.  
+  The valid values are as follows:
+  + **LOCK** - Lock the user.
+  + **UNLOCK** - Unlock the user.
+  + **RESET_PWD** - Reset the user password.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3761,6 +3761,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_service":                              workspace.ResourceService(),
 			"huaweicloud_workspace_terminal_binding":                     workspace.ResourceTerminalBinding(),
 			"huaweicloud_workspace_user":                                 workspace.ResourceUser(),
+			"huaweicloud_workspace_user_action":                          workspace.ResourceUserAction(),
 			"huaweicloud_workspace_user_group":                           workspace.ResourceUserGroup(),
 
 			// Workspace APP

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_user_action_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_user_action_test.go
@@ -1,0 +1,108 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccUserAction_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		password   = acceptance.RandomPassword()
+		rName      = "huaweicloud_workspace_user_action.test"
+		baseConfig = testAccUserAction_base(name, password)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserAction_basic_step1(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "op_type", "LOCK"),
+					resource.TestCheckResourceAttrSet(rName, "user_id"),
+				),
+			},
+			{
+				Config: testAccUserAction_basic_step2(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "op_type", "UNLOCK"),
+					resource.TestCheckResourceAttrSet(rName, "user_id"),
+				),
+			},
+			{
+				Config: testAccUserAction_basic_step3(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "op_type", "RESET_PWD"),
+					resource.TestCheckResourceAttrSet(rName, "user_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccUserAction_base(name, password string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_user" "test" {
+  name        = "%[1]s"
+  description = "Created by terraform script"
+  active_type = "ADMIN_ACTIVATE"
+  email       = "terraform@test.com"
+  password    = "%[2]s"
+
+  account_expires            = "0"
+  password_never_expires     = false
+  enable_change_password     = true
+  next_login_change_password = true
+  disabled                   = false
+}`, name, password)
+}
+
+func testAccUserAction_basic_step1(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_user_action" "test" {
+  user_id = huaweicloud_workspace_user.test.id
+  op_type = "LOCK"
+
+  enable_force_new = "true"
+}
+`, baseConfig)
+}
+
+func testAccUserAction_basic_step2(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_user_action" "test" {
+  user_id = huaweicloud_workspace_user.test.id
+  op_type = "UNLOCK"
+
+  enable_force_new = "true"
+}
+`, baseConfig)
+}
+
+func testAccUserAction_basic_step3(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_user_action" "test" {
+  user_id = huaweicloud_workspace_user.test.id
+  op_type = "RESET_PWD"
+
+  enable_force_new = "true"
+}
+`, baseConfig)
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_user_action.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_user_action.go
@@ -1,0 +1,129 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var userActionNonUpdatableParams = []string{
+	"user_id",
+	"op_type",
+}
+
+// @API Workspace POST /v2/{project_id}/users/{user_id}/actions
+func ResourceUserAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceUserActionCreate,
+		ReadContext:   resourceUserActionRead,
+		UpdateContext: resourceUserActionUpdate,
+		DeleteContext: resourceUserActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(userActionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the user is located.`,
+			},
+
+			// Required parameters.
+			"user_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the user to be operated.`,
+			},
+			"op_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The operation type.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildUserActionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"op_type": d.Get("op_type"),
+	}
+}
+
+func resourceUserActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	var (
+		httpUrl = "v2/{project_id}/users/{user_id}/actions"
+		userId  = d.Get("user_id").(string)
+	)
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{user_id}", userId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildUserActionBodyParams(d),
+		OkCodes:  []int{204},
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error operating Workspace user: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceUserActionRead(ctx, d, meta)
+}
+
+func resourceUserActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceUserActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceUserActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource for operating user. Deleting this resource will not clear
+the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new one-time action resource that used to operate Workspace users
There are some supported operation types:
- **LOCK**
- **UNLOCK**
- **RESET_PWD**

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1131" height="230" alt="image" src="https://github.com/user-attachments/assets/fbec2cd9-78b8-4070-851b-7d5fa0969e8e" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new one-time action resource to operate user
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccUserAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccUserAction_basic -timeout 360m -parallel 10
=== RUN   TestAccUserAction_basic
=== PAUSE TestAccUserAction_basic
=== CONT  TestAccUserAction_basic
--- PASS: TestAccUserAction_basic (38.16s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 38.270s coverage: 3.8% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
