### PR TITLE
feat(ESW): add esw connection resource and data sources

### DIFF
--- a/docs/data-sources/esw_all_connections.md
+++ b/docs/data-sources/esw_all_connections.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Enterprise Switch (ESW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_esw_all_connections"
+description: |-
+  Use this data source to get the list of ESW all connections.
+---
+
+# huaweicloud_esw_all_connections
+
+Use this data source to get the list of ESW all connections.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_esw_all_connections" "test" {}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the all instances. If omitted, the provider-level region
+  will be used.
+
+* `instance_id` - (Optional, String) Specifies the ID of the instance.
+
+* `connection_id` - (Optional, String) Specifies the ID of the connection.
+
+* `name` - (Optional, String) Specifies the name of the connection.
+
+* `vpc_id` - (Optional, String) Specifies the vpc ID.
+
+* `virsubnet_id` - (Optional, String) Specifies the subnet ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `connections` - Indicates the list of connections.
+  The [connections](#connections_struct) structure is documented below.
+
+<a name="connections_struct"></a>
+The `connections` block supports:
+
+* `id` - Indicates the ID of the connection.
+
+* `instance_id` - Indicates the ID of the instance.
+
+* `name` - Indicates the name of the connection.
+
+* `project_id` - Indicates the project ID.
+
+* `fixed_ips` - Indicates the downlink network port primary and standby IPs.
+
+* `remote_infos` - Indicates the remote tunnel infos.
+  The [remote_infos](#remote_infos_struct) structure is documented below.
+
+* `vpc_id` - Indicates the vpc ID.
+
+* `virsubnet_id` - Indicates the subnet ID.
+
+* `status` - Indicates the status of the connection.
+
+* `created_at` - Indicates the created time of the connection.
+
+* `updated_at` - Indicates the updated time of the connection.
+
+<a name="remote_infos_struct"></a>
+The `remote_infos` block supports:
+
+* `segmentation_id` - Indicates the tunnel number for the connection corresponds to the VXLAN network identifier (VNI).
+
+* `tunnel_ip` - Indicates the remote tunnel IP of the ESW instance.
+
+* `tunnel_port` - Indicates the remote tunnel port.
+
+* `tunnel_type` - Indicates the remote tunnel type.

--- a/docs/data-sources/esw_connections.md
+++ b/docs/data-sources/esw_connections.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Enterprise Switch (ESW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_esw_connections"
+description: |-
+  Use this data source to get the list of ESW instance connections.
+---
+
+# huaweicloud_esw_connections
+
+Use this data source to get the list of ESW instance connections.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_esw_connections" "test" {
+  instance_id= var.instance_id
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the connections. If omitted, the provider-level region will
+  be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the instance.
+
+* `name` - (Optional, String) Specifies the name of the connection.
+
+* `connection_id` - (Optional, String) Specifies the ID of the connection.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `connections` - Indicates the list of connections.
+  The [connections](#connections_struct) structure is documented below.
+
+<a name="connections_struct"></a>
+The `connections` block supports:
+
+* `id` - Indicates the ID of the connection.
+
+* `instance_id` - Indicates the ID of the instance.
+
+* `name` - Indicates the name of the connection.
+
+* `project_id` - Indicates the project ID.
+
+* `fixed_ips` - Indicates the downlink network port primary and standby IPs.
+
+* `remote_infos` - Indicates the remote tunnel infos.
+  The [remote_infos](#remote_infos_struct) structure is documented below.
+
+* `vpc_id` - Indicates the vpc ID.
+
+* `virsubnet_id` - Indicates the subnet ID.
+
+* `status` - Indicates the status of the connection.
+
+* `created_at` - Indicates the created time of the connection.
+
+* `updated_at` - Indicates the updated time of the connection.
+
+<a name="remote_infos_struct"></a>
+The `remote_infos` block supports:
+
+* `segmentation_id` - Indicates the tunnel number for the connection corresponds to the VXLAN network identifier (VNI).
+
+* `tunnel_ip` - Indicates the remote tunnel IP of the ESW instance.
+
+* `tunnel_port` - Indicates the remote tunnel port.
+
+* `tunnel_type` - Indicates the remote tunnel type.

--- a/docs/resources/esw_connection.md
+++ b/docs/resources/esw_connection.md
@@ -1,0 +1,98 @@
+---
+subcategory: "Enterprise Switch (ESW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_esw_connection"
+description: |-
+  Manages an ESW connection resource within HuaweiCloud.
+---
+
+# huaweicloud_esw_connection
+
+Manages an ESW connection resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "vpc_id" {}
+variable "virsubnet_id" {}
+
+resource "huaweicloud_esw_connection" "test" {
+  instance_id  = var.instance_id
+  name         = "test_name"
+  vpc_id       = var.vpc_id
+  virsubnet_id = var.virsubnet_id
+  fixed_ips    = ["192.168.1.80", "192.168.1.100"]
+
+  remote_infos {
+    segmentation_id = 9999
+    tunnel_ip       = "11.11.11.11"
+    tunnel_port     = "8888"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the ESW connection resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the instance.
+
+* `name` - (Required, String) Specifies the name of the connection.
+
+* `vpc_id` - (Required, String, NonUpdatable) Specifies the vpc ID.
+
+* `virsubnet_id` - (Required, String, NonUpdatable) Specifies the subnet ID.
+
+* `remote_infos` - (Required, List, NonUpdatable) Specifies the remote tunnel infos.
+  The [remote_infos](#remote_infos_struct) structure is documented below.
+
+* `fixed_ips` - (Optional, List, NonUpdatable) Specifies the downlink network port primary and standby IPs.
+
+<a name="remote_infos_struct"></a>
+The `remote_infos` block supports:
+
+* `segmentation_id` - (Required, Int, NonUpdatable) Specifies the tunnel number for the connection corresponds to the
+  VXLAN network identifier (VNI).
+
+* `tunnel_ip` - (Required, String, NonUpdatable) Specifies the remote tunnel IP of the ESW instance.
+
+* `tunnel_port` - (Optional, Int, NonUpdatable) Specifies the remote tunnel port.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `remote_infos` - Indicates the remote tunnel infos.
+  The [remote_infos](#remote_infos_attribute) structure is documented below.
+
+* `status` - Indicates the status of the connection.
+
+* `created_at` - Indicates the created time of the connection.
+
+* `updated_at` - Indicates the updated time of the connection.
+
+<a name="remote_infos_attribute"></a>
+The `remote_infos` block supports:
+
+* `tunnel_type` - Indicates the tunnel type.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+This resource can be imported using the `instance_id` and `id` separated by a slash, e.g.:
+
+```bash
+$ terraform import huaweicloud_esw_connection.test <instance_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1234,6 +1234,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_esw_availability_zones": esw.DataSourceEswAvailabilityZones(),
 			"huaweicloud_esw_quotas":             esw.DataSourceEswQuotas(),
 			"huaweicloud_esw_instances":          esw.DataSourceEswInstances(),
+			"huaweicloud_esw_connections":        esw.DataSourceEswConnections(),
+			"huaweicloud_esw_all_connections":    esw.DataSourceEswAllConnections(),
 
 			"huaweicloud_fgs_applications":                fgs.DataSourceApplications(),
 			"huaweicloud_fgs_application_templates":       fgs.DataSourceApplicationTemplates(),
@@ -3019,7 +3021,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_evs_recycle_bin_volume_delete":  evs.ResourceRecycleBinVolumeDelete(),
 			"huaweicloud_evs_recycle_bin_volume_revert":  evs.ResourceRecycleBinVolumeRevert(),
 
-			"huaweicloud_esw_instance": esw.ResourceInstance(),
+			"huaweicloud_esw_instance":   esw.ResourceInstance(),
+			"huaweicloud_esw_connection": esw.ResourceConnection(),
 
 			"huaweicloud_fgs_application":                    fgs.ResourceApplication(),
 			"huaweicloud_fgs_async_invoke_configuration":     fgs.ResourceAsyncInvokeConfiguration(),

--- a/huaweicloud/services/acceptance/esw/data_source_huaweicloud_esw_all_connections_test.go
+++ b/huaweicloud/services/acceptance/esw/data_source_huaweicloud_esw_all_connections_test.go
@@ -1,0 +1,129 @@
+package esw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccEswAllConnections_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_esw_all_connections.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceEswAllConnections_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "connections.#"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.instance_id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.project_id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.fixed_ips.#"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.remote_infos.#"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.remote_infos.0.segmentation_id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.remote_infos.0.tunnel_ip"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.remote_infos.0.tunnel_port"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.remote_infos.0.tunnel_type"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.virsubnet_id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.updated_at"),
+					resource.TestCheckOutput("instance_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("connection_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("vpc_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("virsubnet_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceEswAllConnections_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_esw_all_connections" "test" {
+  depends_on = [huaweicloud_esw_connection.test]
+}
+
+locals{
+  instance_id = huaweicloud_esw_instance.test.id
+}
+data "huaweicloud_esw_all_connections" "instance_id_filter" {
+  depends_on = [huaweicloud_esw_connection.test]
+
+  instance_id = huaweicloud_esw_instance.test.id
+}
+output "instance_id_filter_is_useful" {
+  value = length(data.huaweicloud_esw_all_connections.instance_id_filter.connections) > 0 && alltrue(
+    [for v in data.huaweicloud_esw_all_connections.instance_id_filter.connections[*].instance_id : v == local.instance_id]
+  )
+}
+
+locals{
+  connection_id = huaweicloud_esw_connection.test.id
+}
+data "huaweicloud_esw_all_connections" "connection_id_filter" {
+  depends_on = [huaweicloud_esw_connection.test]
+
+  connection_id = huaweicloud_esw_connection.test.id
+}
+output "connection_id_filter_is_useful" {
+  value = length(data.huaweicloud_esw_all_connections.connection_id_filter.connections) > 0 && alltrue(
+    [for v in data.huaweicloud_esw_all_connections.connection_id_filter.connections[*].id : v == local.connection_id]
+  )
+}
+
+locals{
+  name = huaweicloud_esw_connection.test.name
+}
+data "huaweicloud_esw_all_connections" "name_filter" {
+  depends_on = [huaweicloud_esw_connection.test]
+
+  name = huaweicloud_esw_connection.test.name
+}
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_esw_all_connections.name_filter.connections) > 0 && alltrue(
+    [for v in data.huaweicloud_esw_all_connections.name_filter.connections[*].name : v == local.name]
+  )
+}
+
+locals{
+  vpc_id = huaweicloud_esw_connection.test.vpc_id
+}
+data "huaweicloud_esw_all_connections" "vpc_id_filter" {
+  depends_on = [huaweicloud_esw_connection.test]
+
+  vpc_id = huaweicloud_esw_connection.test.vpc_id
+}
+output "vpc_id_filter_is_useful" {
+  value = length(data.huaweicloud_esw_all_connections.vpc_id_filter.connections) > 0 && alltrue(
+    [for v in data.huaweicloud_esw_all_connections.vpc_id_filter.connections[*].vpc_id : v == local.vpc_id]
+  )
+}
+
+locals{
+  virsubnet_id = huaweicloud_esw_connection.test.virsubnet_id
+}
+data "huaweicloud_esw_all_connections" "virsubnet_id_filter" {
+  depends_on = [huaweicloud_esw_connection.test]
+
+  virsubnet_id = huaweicloud_esw_connection.test.virsubnet_id
+}
+output "virsubnet_id_filter_is_useful" {
+  value = length(data.huaweicloud_esw_all_connections.virsubnet_id_filter.connections) > 0 && alltrue(
+    [for v in data.huaweicloud_esw_all_connections.virsubnet_id_filter.connections[*].virsubnet_id : v == local.virsubnet_id]
+  )
+}
+`, testAccEswConnection_basic(name))
+}

--- a/huaweicloud/services/acceptance/esw/data_source_huaweicloud_esw_connections_test.go
+++ b/huaweicloud/services/acceptance/esw/data_source_huaweicloud_esw_connections_test.go
@@ -1,0 +1,88 @@
+package esw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccEswConnections_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_esw_connections.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceEswConnections_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "connections.#"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.instance_id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.project_id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.fixed_ips.#"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.remote_infos.#"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.remote_infos.0.segmentation_id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.remote_infos.0.tunnel_ip"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.remote_infos.0.tunnel_port"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.remote_infos.0.tunnel_type"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.virsubnet_id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.updated_at"),
+					resource.TestCheckOutput("connection_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceEswConnections_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_esw_connections" "test" {
+  depends_on = [huaweicloud_esw_connection.test]
+
+  instance_id = huaweicloud_esw_instance.test.id
+}
+
+locals{
+  connection_id = huaweicloud_esw_connection.test.id
+}
+data "huaweicloud_esw_connections" "connection_id_filter" {
+  depends_on = [huaweicloud_esw_connection.test]
+
+  instance_id   = huaweicloud_esw_instance.test.id
+  connection_id = huaweicloud_esw_connection.test.id
+}
+output "connection_id_filter_is_useful" {
+  value = length(data.huaweicloud_esw_connections.connection_id_filter.connections) > 0 && alltrue(
+    [for v in data.huaweicloud_esw_connections.connection_id_filter.connections[*].id : v == local.connection_id]
+  )
+}
+
+locals{
+  name = huaweicloud_esw_connection.test.name
+}
+data "huaweicloud_esw_connections" "name_filter" {
+  depends_on = [huaweicloud_esw_connection.test]
+
+  instance_id = huaweicloud_esw_instance.test.id
+  name        = huaweicloud_esw_connection.test.name
+}
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_esw_connections.name_filter.connections) > 0 && alltrue(
+    [for v in data.huaweicloud_esw_connections.name_filter.connections[*].name : v == local.name]
+  )
+}
+`, testAccEswConnection_basic(name))
+}

--- a/huaweicloud/services/acceptance/esw/resource_huaweicloud_esw_connection_test.go
+++ b/huaweicloud/services/acceptance/esw/resource_huaweicloud_esw_connection_test.go
@@ -1,0 +1,208 @@
+package esw
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getEswConnection(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	var (
+		httpUrl = "v3/{project_id}/l2cg/instances/{instance_id}/connections/{connection_id}"
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ESW client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", state.Primary.Attributes["instance_id"])
+	getPath = strings.ReplaceAll(getPath, "{connection_id}", state.Primary.ID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccEswConnection_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_esw_connection.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getEswConnection,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEswConnection_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id",
+						"huaweicloud_esw_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "virsubnet_id",
+						"huaweicloud_vpc_subnet.test.1", "id"),
+					resource.TestCheckResourceAttr(resourceName, "fixed_ips.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "remote_infos.0.segmentation_id", "9999"),
+					resource.TestCheckResourceAttrPair(resourceName, "remote_infos.0.tunnel_ip",
+						"huaweicloud_esw_instance.test", "tunnel_info.0.tunnel_ip"),
+					resource.TestCheckResourceAttrPair(resourceName, "remote_infos.0.tunnel_port",
+						"huaweicloud_esw_instance.test", "tunnel_info.0.tunnel_port"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "remote_infos.0.tunnel_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccEswConnection_basic_update(rName, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id",
+						"huaweicloud_esw_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "virsubnet_id",
+						"huaweicloud_vpc_subnet.test.1", "id"),
+					resource.TestCheckResourceAttr(resourceName, "fixed_ips.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "remote_infos.0.segmentation_id", "9999"),
+					resource.TestCheckResourceAttrPair(resourceName, "remote_infos.0.tunnel_ip",
+						"huaweicloud_esw_instance.test", "tunnel_info.0.tunnel_ip"),
+					resource.TestCheckResourceAttrPair(resourceName, "remote_infos.0.tunnel_port",
+						"huaweicloud_esw_instance.test", "tunnel_info.0.tunnel_port"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testEswConnectionResourceImportState(resourceName),
+				ImportStateVerifyIgnore: []string{"status", "updated_at"},
+			},
+		},
+	})
+}
+
+func testAccEswConnection_base(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_esw_flavors" "test" {}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  count = 2
+
+  name       = "%[1]s-${count.index}"
+  vpc_id     = huaweicloud_vpc.test.id
+  cidr       = "192.168.${count.index}.0/24"
+  gateway_ip = "192.168.${count.index}.1"
+}
+
+resource "huaweicloud_esw_instance" "test" {
+  name        = "%[1]s"
+  flavor_ref  = data.huaweicloud_esw_flavors.test.flavors[0].name
+  ha_mode     = "ha"
+  description = "test description"
+
+  availability_zones {
+    primary = data.huaweicloud_esw_flavors.test.flavors.0.available_zones[0]
+    standby = data.huaweicloud_esw_flavors.test.flavors.0.available_zones[1]
+  }
+
+  tunnel_info {
+    vpc_id       = huaweicloud_vpc.test.id
+    virsubnet_id = huaweicloud_vpc_subnet.test[0].id
+    tunnel_ip    = "192.168.0.192"
+  }
+
+  charge_infos {
+    charge_mode = "postPaid"
+  }
+}
+`, rName)
+}
+
+func testAccEswConnection_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_esw_connection" "test" {
+  instance_id  = huaweicloud_esw_instance.test.id
+  name         = "%[2]s"
+  vpc_id       = huaweicloud_vpc.test.id
+  virsubnet_id = huaweicloud_vpc_subnet.test[1].id
+  fixed_ips    = ["192.168.1.80", "192.168.1.100"]
+
+  remote_infos {
+    segmentation_id = 9999
+    tunnel_ip       = huaweicloud_esw_instance.test.tunnel_info[0].tunnel_ip
+    tunnel_port     = huaweicloud_esw_instance.test.tunnel_info[0].tunnel_port
+  }
+}
+`, testAccEswConnection_base(rName), rName)
+}
+
+func testAccEswConnection_basic_update(rName, updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_esw_connection" "test" {
+  instance_id  = huaweicloud_esw_instance.test.id
+  name         = "%[2]s"
+  vpc_id       = huaweicloud_vpc.test.id
+  virsubnet_id = huaweicloud_vpc_subnet.test[1].id
+  fixed_ips    = ["192.168.1.80", "192.168.1.100"]
+
+  remote_infos {
+    segmentation_id = 9999
+    tunnel_ip       = huaweicloud_esw_instance.test.tunnel_info[0].tunnel_ip
+    tunnel_port     = huaweicloud_esw_instance.test.tunnel_info[0].tunnel_port
+  }
+}
+`, testAccEswConnection_base(rName), updateName)
+}
+
+func testEswConnectionResourceImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+		instanceID := rs.Primary.Attributes["instance_id"]
+		return fmt.Sprintf("%s/%s", instanceID, rs.Primary.ID), nil
+	}
+}

--- a/huaweicloud/services/acceptance/esw/resource_huaweicloud_esw_instance_test.go
+++ b/huaweicloud/services/acceptance/esw/resource_huaweicloud_esw_instance_test.go
@@ -114,6 +114,11 @@ func TestAccEswInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/huaweicloud/services/esw/data_source_huaweicloud_esw_all_connections.go
+++ b/huaweicloud/services/esw/data_source_huaweicloud_esw_all_connections.go
@@ -1,0 +1,204 @@
+package esw
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API ESW GET /v3/{project_id}/l2cg/connections
+func DataSourceEswAllConnections() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEswAllConnectionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"connection_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"virsubnet_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"connections": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fixed_ips": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"remote_infos": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     allRemoteInfosSchema(),
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"virsubnet_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func allRemoteInfosSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"segmentation_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"tunnel_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tunnel_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"tunnel_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceEswAllConnectionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	var (
+		httpUrl = "v3/{project_id}/l2cg/connections"
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ESW client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	listQueryParams := buildListAllConnectionsQueryParams(d)
+	listPath += listQueryParams
+
+	listResp, err := pagination.ListAllItems(
+		client,
+		"marker",
+		listPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return diag.Errorf("error retrieving ESW all connections: %s", err)
+	}
+
+	listRespJson, err := json.Marshal(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var listRespBody interface{}
+	err = json.Unmarshal(listRespJson, &listRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("connections", flattenEswConnectionsBody(listRespBody)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildListAllConnectionsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("connection_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("instance_id"); ok {
+		res = fmt.Sprintf("%s&instance_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("vpc_id"); ok {
+		res = fmt.Sprintf("%s&vpc_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("virsubnet_id"); ok {
+		res = fmt.Sprintf("%s&virsubnet_id=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}

--- a/huaweicloud/services/esw/data_source_huaweicloud_esw_connections.go
+++ b/huaweicloud/services/esw/data_source_huaweicloud_esw_connections.go
@@ -1,0 +1,234 @@
+package esw
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ESW GET /v3/{project_id}/l2cg/instances/{instance_id}/connections
+func DataSourceEswConnections() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEswConnectionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"connection_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"connections": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fixed_ips": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"remote_infos": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     remoteInfosSchema(),
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"virsubnet_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func remoteInfosSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"segmentation_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"tunnel_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tunnel_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"tunnel_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceEswConnectionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	var (
+		httpUrl = "v3/{project_id}/l2cg/instances/{instance_id}/connections"
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ESW client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+
+	listQueryParams := buildListConnectionsQueryParams(d)
+	listPath += listQueryParams
+
+	listResp, err := pagination.ListAllItems(
+		client,
+		"marker",
+		listPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return diag.Errorf("error retrieving ESW connections: %s", err)
+	}
+
+	listRespJson, err := json.Marshal(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var listRespBody interface{}
+	err = json.Unmarshal(listRespJson, &listRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("connections", flattenEswConnectionsBody(listRespBody)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildListConnectionsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("connection_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}
+
+func flattenEswConnectionsBody(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("connections", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":           utils.PathSearch("id", v, nil),
+			"instance_id":  utils.PathSearch("instance_id", v, nil),
+			"name":         utils.PathSearch("name", v, nil),
+			"project_id":   utils.PathSearch("project_id", v, nil),
+			"fixed_ips":    utils.PathSearch("fixed_ips", v, nil),
+			"remote_infos": flattenConnectionsRemoteInfos(v),
+			"vpc_id":       utils.PathSearch("vpc_id", v, nil),
+			"virsubnet_id": utils.PathSearch("virsubnet_id", v, nil),
+			"status":       utils.PathSearch("status", v, nil),
+			"created_at":   utils.PathSearch("created_at", v, nil),
+			"updated_at":   utils.PathSearch("updated_at", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenConnectionsRemoteInfos(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("remote_infos", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"segmentation_id": utils.PathSearch("segmentation_id", v, nil),
+			"tunnel_ip":       utils.PathSearch("tunnel_ip", v, nil),
+			"tunnel_port":     utils.PathSearch("tunnel_port", v, nil),
+			"tunnel_type":     utils.PathSearch("tunnel_type", v, nil),
+		})
+	}
+	return rst
+}

--- a/huaweicloud/services/esw/data_source_huaweicloud_esw_instances.go
+++ b/huaweicloud/services/esw/data_source_huaweicloud_esw_instances.go
@@ -178,7 +178,7 @@ func dataSourceEswInstancesRead(_ context.Context, d *schema.ResourceData, meta 
 	listPath := client.Endpoint + httpUrl
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 
-	listQueryParams := buildListQueryParams(d)
+	listQueryParams := buildListInstancesQueryParams(d)
 	listPath += listQueryParams
 
 	listResp, err := pagination.ListAllItems(
@@ -214,7 +214,7 @@ func dataSourceEswInstancesRead(_ context.Context, d *schema.ResourceData, meta 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func buildListQueryParams(d *schema.ResourceData) string {
+func buildListInstancesQueryParams(d *schema.ResourceData) string {
 	res := ""
 	if v, ok := d.GetOk("instance_id"); ok {
 		res = fmt.Sprintf("%s&id=%v", res, v)

--- a/huaweicloud/services/esw/resource_huaweicloud_esw_connection.go
+++ b/huaweicloud/services/esw/resource_huaweicloud_esw_connection.go
@@ -1,0 +1,422 @@
+package esw
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var connectionNonUpdatableParams = []string{"instance_id", "vpc_id", "virsubnet_id", "remote_infos", "fixed_ips"}
+
+// @API ESW POST /v3/{project_id}/l2cg/instances/{instance_id}/connections
+// @API ESW GET /v3/{project_id}/l2cg/instances/{instance_id}/connections/{connection_id}
+// @API ESW PUT /v3/{project_id}/l2cg/instances/{instance_id}/connections/{connection_id}
+// @API ESW DELETE /v3/{project_id}/l2cg/instances/{instance_id}/connections/{connection_id}
+func ResourceConnection() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceConnectionCreate,
+		ReadContext:   resourceConnectionRead,
+		UpdateContext: resourceConnectionUpdate,
+		DeleteContext: resourceConnectionDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceEswConnectionImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(connectionNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"virsubnet_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"remote_infos": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     connectionRemoteInfosSchema(),
+			},
+			"fixed_ips": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func connectionRemoteInfosSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"segmentation_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"tunnel_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tunnel_port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"tunnel_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/l2cg/instances/{instance_id}/connections"
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ESW client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateConnectionBodyParams(d))
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating ESW connection: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	connectionId := utils.PathSearch("connection.id", createRespBody, "").(string)
+	if connectionId == "" {
+		return diag.Errorf("unable to find the ESW connection ID from the API response")
+	}
+	d.SetId(connectionId)
+
+	err = waitForConnectionReady(ctx, client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return resourceConnectionRead(ctx, d, meta)
+}
+
+func buildCreateConnectionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":         d.Get("name"),
+		"vpc_id":       d.Get("vpc_id"),
+		"virsubnet_id": d.Get("virsubnet_id"),
+		"remote_infos": buildCreateConnectionRemoteInfosBody(d),
+		"fixed_ips":    utils.ValueIgnoreEmpty(d.Get("fixed_ips").(*schema.Set).List()),
+	}
+	return map[string]interface{}{
+		"connection": bodyParams,
+	}
+}
+
+func buildCreateConnectionRemoteInfosBody(d *schema.ResourceData) []interface{} {
+	rawParams := d.Get("remote_infos").(*schema.Set)
+	if rawParams.Len() == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, rawParams.Len())
+	for _, rawParam := range rawParams.List() {
+		if remoteInfo, ok := rawParam.(map[string]interface{}); ok {
+			rst = append(rst, map[string]interface{}{
+				"segmentation_id": remoteInfo["segmentation_id"],
+				"tunnel_ip":       remoteInfo["tunnel_ip"],
+				"tunnel_port":     utils.ValueIgnoreEmpty(remoteInfo["tunnel_port"]),
+			})
+		}
+	}
+
+	return rst
+}
+
+func resourceConnectionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ESW client: %s", err)
+	}
+
+	connection, err := getConnectionIdById(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving ESW connection")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("instance_id", utils.PathSearch("connection.instance_id", connection, nil)),
+		d.Set("name", utils.PathSearch("connection.name", connection, nil)),
+		d.Set("vpc_id", utils.PathSearch("connection.vpc_id", connection, nil)),
+		d.Set("virsubnet_id", utils.PathSearch("connection.virsubnet_id", connection, nil)),
+		d.Set("remote_infos", flattenConnectionRemoteInfos(connection)),
+		d.Set("fixed_ips", utils.PathSearch("connection.fixed_ips", connection, nil)),
+		d.Set("status", utils.PathSearch("connection.status", connection, nil)),
+		d.Set("created_at", utils.PathSearch("connection.created_at", connection, nil)),
+		d.Set("updated_at", utils.PathSearch("connection.updated_at", connection, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenConnectionRemoteInfos(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("connection.remote_infos", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"segmentation_id": utils.PathSearch("segmentation_id", v, nil),
+			"tunnel_ip":       utils.PathSearch("tunnel_ip", v, nil),
+			"tunnel_port":     utils.PathSearch("tunnel_port", v, nil),
+			"tunnel_type":     utils.PathSearch("tunnel_type", v, nil),
+		})
+	}
+	return rst
+}
+
+func getConnectionIdById(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/l2cg/instances/{instance_id}/connections/{connection_id}"
+	)
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", d.Get("instance_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{connection_id}", d.Id())
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/l2cg/instances/{instance_id}/connections/{connection_id}"
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ESW Client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Get("instance_id").(string))
+	updatePath = strings.ReplaceAll(updatePath, "{connection_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	updateOpt.JSONBody = buildUpdateConnectionBodyParams(d)
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating ESW connection: %s", err)
+	}
+
+	return resourceConnectionRead(ctx, d, meta)
+}
+
+func buildUpdateConnectionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name": d.Get("name"),
+	}
+	return map[string]interface{}{
+		"connection": bodyParams,
+	}
+}
+
+func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/l2cg/instances/{instance_id}/connections/{connection_id}"
+		product = "esw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ESW client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", d.Get("instance_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{connection_id}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting ESW connection")
+	}
+
+	err = waitForConnectionDeleted(ctx, client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func waitForConnectionReady(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"Pending"},
+		Target:       []string{"Ready"},
+		Refresh:      connectionStatusRefreshFunc(client, d),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for ESW connection(%s) to ready: %s ", d.Id(), err)
+	}
+	return nil
+}
+
+func waitForConnectionDeleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"Pending"},
+		Target:       []string{"Deleted"},
+		Refresh:      connectionStatusRefreshFunc(client, d),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for ESW connection(%s) to be deleted: %s ", d.Id(), err)
+	}
+	return nil
+}
+
+func connectionStatusRefreshFunc(client *golangsdk.ServiceClient, d *schema.ResourceData) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		connection, err := getConnectionIdById(client, d)
+		if err != nil {
+			var errDefault404 golangsdk.ErrDefault404
+			if errors.As(err, &errDefault404) {
+				return "", "Deleted", nil
+			}
+			return nil, "Failed", err
+		}
+
+		status := utils.PathSearch("connection.status", connection, "").(string)
+		if status == "" {
+			return nil, "Failed", errors.New("status is not found")
+		}
+
+		if utils.StrSliceContains([]string{"failed", "abnormal"}, status) {
+			return connection, "Failed", fmt.Errorf("the connection status is: %s", status)
+		}
+		if utils.StrSliceContains([]string{"connected", "disconnect"}, status) {
+			return connection, "Ready", nil
+		}
+
+		return connection, "Pending", nil
+	}
+}
+
+func resourceEswConnectionImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, errors.New("invalid format specified for import ID, must be <instance_id>/<id>")
+	}
+
+	d.SetId(parts[1])
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}

--- a/huaweicloud/services/esw/resource_huaweicloud_esw_instance.go
+++ b/huaweicloud/services/esw/resource_huaweicloud_esw_instance.go
@@ -24,10 +24,10 @@ var instanceNonUpdatableParams = []string{"flavor_ref", "ha_mode", "availability
 	"availability_zones.*.standby", "tunnel_info", "tunnel_info.*.vpc_id", "tunnel_info.*.virsubnet_id",
 	"tunnel_info.*.tunnel_ip", "charge_infos", "charge_infos.*.charge_mode"}
 
-// @API RDS POST /v3/{project_id}/l2cg/instances
-// @API RDS GET /v3/{project_id}/l2cg/instances/{instance_id}
-// @API RDS PUT /v3/{project_id}/l2cg/instances/{instance_id}
-// @API RDS DELETE /v3/{project_id}/l2cg/instances/{instance_id}
+// @API ESW POST /v3/{project_id}/l2cg/instances
+// @API ESW GET /v3/{project_id}/l2cg/instances/{instance_id}
+// @API ESW PUT /v3/{project_id}/l2cg/instances/{instance_id}
+// @API ESW DELETE /v3/{project_id}/l2cg/instances/{instance_id}
 func ResourceInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceInstanceCreate,
@@ -86,6 +86,12 @@ func ResourceInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -97,12 +103,6 @@ func ResourceInstance() *schema.Resource {
 			"updated_at": {
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-			"enable_force_new": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
-				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add esw connection resource and data sources
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add esw connection resource and data sources
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/esw/ TESTARGS='-run TestAccEswInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/esw/ -v -run TestAccEswInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccEswInstance_basic
=== PAUSE TestAccEswInstance_basic
=== CONT  TestAccEswInstance_basic
--- PASS: TestAccEswInstance_basic (479.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/esw       480.073s

make testacc TEST=./huaweicloud/services/acceptance/esw/ TESTARGS='-run TestAccEswConnection_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/esw/ -v -run TestAccEswConnection_basic -timeout 360m -parallel 4
=== RUN   TestAccEswConnection_basic
=== PAUSE TestAccEswConnection_basic
=== CONT  TestAccEswConnection_basic
--- PASS: TestAccEswConnection_basic (582.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/esw       582.283s

make testacc TEST=./huaweicloud/services/acceptance/esw/ TESTARGS='-run TestAccEswConnections_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/esw/ -v -run TestAccEswConnections_basic -timeout 360m -parallel 4
=== RUN   TestAccEswConnections_basic
=== PAUSE TestAccEswConnections_basic
=== CONT  TestAccEswConnections_basic
--- PASS: TestAccEswConnections_basic (624.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/esw       624.168s

make testacc TEST=./huaweicloud/services/acceptance/esw/ TESTARGS='-run TestAccEswAllConnections_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/esw/ -v -run TestAccEswAllConnections_basic -timeout 360m -parallel 4
=== RUN   TestAccEswAllConnections_basic
=== PAUSE TestAccEswAllConnections_basic
=== CONT  TestAccEswAllConnections_basic
--- PASS: TestAccEswAllConnections_basic (643.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/esw       644.088s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
