### PR TITLE
feat(workspace/app): add new data source to query policy groups

### DIFF
--- a/docs/data-sources/workspace_app_policy_groups.md
+++ b/docs/data-sources/workspace_app_policy_groups.md
@@ -1,0 +1,87 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_policy_groups"
+description: |-
+  Use this data source to get policy group list of the Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_policy_groups
+
+Use this data source to get policy group list of the Workspace APP within HuaweiCloud.
+
+## Example Usage
+
+### Query all policy groups
+
+```hcl
+data "huaweicloud_workspace_app_policy_groups" "test" {}
+```
+
+### Query policy groups by type
+
+```hcl
+data "huaweicloud_workspace_app_policy_groups" "test" {
+  policy_group_type = 4
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the policy groups are located.  
+  If omitted, the provider-level region will be used.
+
+* `policy_group_name` - (Optional, String) Specifies the name of the policy group.  
+  Fuzzy search is supported.
+
+* `policy_group_type` - (Optional, Int) Specifies the type of the policy group.  
+  The valid values are as follows:
+  + **0**: VM class.
+  + **4**: Custom policy template.
+
+  Defaults to **0**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `policy_groups` - The list of policy groups that match the filter parameters.  
+  The [policy_groups](#app_policy_groups) structure is documented below.
+
+<a name="app_policy_groups"></a>
+The `policy_groups` block supports:
+
+* `id` - The ID of the policy group.
+
+* `name` - The name of the policy group.
+
+* `priority` - The priority of the policy group.
+
+* `description` - The description of the policy group.
+
+* `targets` - The list of target objects.  
+  The [targets](#app_policy_groups_targets) structure is documented below.
+
+* `policies` - The policies of the policy group, in JSON format.
+
+* `created_at` - The creation time of the policy group, in RFC3339 format.
+
+* `updated_at` - The latest update time of the policy group, in RFC3339 format.
+
+<a name="app_policy_groups_targets"></a>
+The `targets` block supports:
+
+* `id` - The ID of the target object.
+
+* `name` - The name of the target object.
+
+* `type` - The type of the target object.  
+  + **USER**
+  + **USERGROUP**
+  + **APPGROUP**
+  + **OU**
+  + **ALL**

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2260,6 +2260,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_image_servers":                            workspace.DataSourceWorkspaceAppImageServers(),
 			"huaweicloud_workspace_app_latest_attached_applications":             workspace.DataSourceLatestAttachedApplications(),
 			"huaweicloud_workspace_app_nas_storages":                             workspace.DataSourceAppNasStorages(),
+			"huaweicloud_workspace_app_policy_groups":                            workspace.DataSourceAppPolicyGroups(),
 			"huaweicloud_workspace_app_publishable_applications":                 workspace.DataSourceAppPublishableApplications(),
 			"huaweicloud_workspace_app_schedule_tasks":                           workspace.DataSourceAppScheduleTasks(),
 			"huaweicloud_workspace_app_schedule_task_executions":                 workspace.DataSourceAppScheduleTaskExecutions(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_policy_groups_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_policy_groups_test.go
@@ -1,0 +1,175 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataAppPolicyGroups_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_workspace_app_policy_groups.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		filterByPolicyGroupName   = "data.huaweicloud_workspace_app_policy_groups.filter_by_policy_group_name"
+		dcFilterByPolicyGroupName = acceptance.InitDataSourceCheck(filterByPolicyGroupName)
+
+		filterByPolicyGroupType   = "data.huaweicloud_workspace_app_policy_groups.filter_by_policy_group_type"
+		dcFilterByPolicyGroupType = acceptance.InitDataSourceCheck(filterByPolicyGroupType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAppPolicyGroups_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "policy_groups.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					//  Filter by 'policy_group_name' parameter.
+					dcFilterByPolicyGroupName.CheckResourceExists(),
+					resource.TestCheckOutput("is_policy_group_name_filter_useful", "true"),
+					// Filter by 'policy_group_type' parameter.
+					dcFilterByPolicyGroupType.CheckResourceExists(),
+					resource.TestCheckOutput("is_policy_group_type_filter_useful", "true"),
+					// Check attributes.
+					resource.TestCheckResourceAttrSet(filterByPolicyGroupName, "policy_groups.0.id"),
+					resource.TestCheckResourceAttrSet(filterByPolicyGroupName, "policy_groups.0.name"),
+					resource.TestMatchResourceAttr(filterByPolicyGroupName, "policy_groups.0.targets.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(filterByPolicyGroupName, "policy_groups.0.targets.0.id"),
+					resource.TestCheckResourceAttrSet(filterByPolicyGroupName, "policy_groups.0.targets.0.name"),
+					resource.TestCheckResourceAttrSet(filterByPolicyGroupName, "policy_groups.0.targets.0.type"),
+					resource.TestCheckResourceAttrSet(filterByPolicyGroupName, "policy_groups.0.policies"),
+					resource.TestCheckResourceAttrSet(filterByPolicyGroupName, "policy_groups.0.priority"),
+					resource.TestCheckResourceAttrSet(filterByPolicyGroupName, "policy_groups.0.description"),
+					resource.TestMatchResourceAttr(filterByPolicyGroupName, "policy_groups.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(filterByPolicyGroupName, "policy_groups.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataAppPolicyGroups_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
+resource "huaweicloud_workspace_app_server_group" "test" {
+  name             = "%[1]s"
+  os_type          = "Windows"
+  app_type         = "SESSION_DESKTOP_APP"
+  flavor_id        = "%[2]s"
+  vpc_id           = data.huaweicloud_workspace_service.test.vpc_id
+  subnet_id        = data.huaweicloud_workspace_service.test.network_ids[0]
+  system_disk_type = "SAS"
+  system_disk_size = 90
+  is_vdi           = true
+  image_id         = "%[3]s"
+  image_type       = "gold"
+  image_product_id = "%[4]s"
+}
+
+resource "huaweicloud_workspace_app_group" "test" {
+  name            = "%[1]s"
+  type            = "SESSION_DESKTOP_APP"
+  server_group_id = huaweicloud_workspace_app_server_group.test.id
+}
+
+resource "huaweicloud_workspace_app_policy_group" "test" {
+  name        = "%[1]s"
+  description = "Created by terraform script"
+
+  targets {
+    id   = huaweicloud_workspace_app_group.test.id
+    name = huaweicloud_workspace_app_group.test.name
+    type = "APPGROUP"
+  }
+
+  policies = jsonencode({
+    client = {
+      automatic_reconnection_interval = 10
+      session_persistence_time        = 120
+      forbid_screen_capture           = true
+    }
+  })
+}
+
+resource "huaweicloud_workspace_app_policy_template" "test" {
+  name = "%[1]s"
+
+  policies = jsonencode({
+    client = {
+      automatic_reconnection_interval = 10
+      session_persistence_time        = 120
+      forbid_screen_capture           = true
+    }
+  })
+}
+`, name, acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
+}
+
+func testAccDataAppPolicyGroups_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameter.
+data "huaweicloud_workspace_app_policy_groups" "all" {
+  depends_on = [huaweicloud_workspace_app_policy_group.test]
+}
+
+# Filter by 'policy_group_name' parameter.
+locals {
+  policy_group_name = huaweicloud_workspace_app_policy_group.test.name
+}
+
+data "huaweicloud_workspace_app_policy_groups" "filter_by_policy_group_name" {
+  policy_group_name = local.policy_group_name
+
+  depends_on = [huaweicloud_workspace_app_policy_group.test]
+}
+
+locals {
+  policy_group_name_filter_result = [
+    for v in data.huaweicloud_workspace_app_policy_groups.filter_by_policy_group_name.policy_groups[*].name :
+    strcontains(v, local.policy_group_name)
+  ]
+}
+
+output "is_policy_group_name_filter_useful" {
+  value = length(local.policy_group_name_filter_result) > 0 && alltrue(local.policy_group_name_filter_result)
+}
+
+# Filter by 'policy_group_type' parameter.
+data "huaweicloud_workspace_app_policy_groups" "filter_by_policy_group_type" {
+  policy_group_type = 4
+
+  depends_on = [huaweicloud_workspace_app_policy_template.test]
+}
+
+locals {
+  policy_group_type_filter_result = data.huaweicloud_workspace_app_policy_groups.filter_by_policy_group_type.policy_groups[*].name
+}
+
+output "is_policy_group_type_filter_useful" {
+  value = (
+    length(local.policy_group_type_filter_result) > 0 &&
+    contains(local.policy_group_type_filter_result, huaweicloud_workspace_app_policy_template.test.name)
+  )
+}
+`, testAccDataAppPolicyGroups_base(name))
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_policy_groups.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_policy_groups.go
@@ -1,0 +1,233 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/policy-groups
+func DataSourceAppPolicyGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppPolicyGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the policy groups are located.`,
+			},
+			"policy_group_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the policy group.`,
+			},
+			"policy_group_type": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The type of the policy group.`,
+			},
+			"policy_groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the policy group.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the policy group.`,
+						},
+						"priority": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The priority of the policy group.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the policy group.`,
+						},
+						"targets": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of target objects.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the target object.`,
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the target object.`,
+									},
+									"type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The type of the target object.`,
+									},
+								},
+							},
+						},
+						"policies": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The policies of the policy group, in JSON format.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the policy group, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the policy group, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `The list of policy groups that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func listAppPolicyGroups(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/policy-groups"
+		offset  = 0
+		limit   = 100
+		result  = make([]interface{}, 0)
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?limit=%d", listPath, limit)
+	listPath += buildAppPolicyGroupsQueryParams(d)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		policyGroups := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, policyGroups...)
+		if len(policyGroups) < limit {
+			break
+		}
+		offset += len(policyGroups)
+	}
+
+	return result, nil
+}
+
+func dataSourceAppPolicyGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	policyGroups, err := listAppPolicyGroups(client, d)
+	if err != nil {
+		return diag.Errorf("error retrieving policy groups: %s", err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(randomId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("policy_groups", flattenAppPolicyGroups(policyGroups)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildAppPolicyGroupsQueryParams(d *schema.ResourceData) string {
+	var res string
+
+	if v, ok := d.GetOk("policy_group_name"); ok {
+		res = fmt.Sprintf("%s&policy_group_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("policy_group_type"); ok {
+		res = fmt.Sprintf("%s&policy_group_type=%v", res, v)
+	}
+
+	return res
+}
+
+func flattenAppPolicyGroups(policyGroups []interface{}) []interface{} {
+	if len(policyGroups) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(policyGroups))
+	for _, policyGroup := range policyGroups {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("id", policyGroup, nil),
+			"name":        utils.PathSearch("name", policyGroup, nil),
+			"priority":    utils.PathSearch("priority", policyGroup, 0),
+			"description": utils.PathSearch("description", policyGroup, nil),
+			"targets": flattenAppPolicyGroupsTargets(utils.PathSearch("targets",
+				policyGroup, make([]interface{}, 0)).([]interface{})),
+			"policies": utils.JsonToString(utils.PathSearch("policies", policyGroup, nil)),
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+				utils.PathSearch("create_time", policyGroup, "").(string))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+				utils.PathSearch("update_time", policyGroup, "").(string))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func flattenAppPolicyGroupsTargets(targets []interface{}) []interface{} {
+	if len(targets) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(targets))
+	for _, target := range targets {
+		result = append(result, map[string]interface{}{
+			"id":   utils.PathSearch("target_id", target, nil),
+			"name": utils.PathSearch("target_name", target, nil),
+			"type": utils.PathSearch("target_type", target, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_workspace_app_policy_groups`) to query policy groups.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataAppPolicyGroups_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppPolicyGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppPolicyGroups_basic
=== PAUSE TestAccDataAppPolicyGroups_basic
=== CONT  TestAccDataAppPolicyGroups_basic
--- PASS: TestAccDataAppPolicyGroups_basic (25.82s)
PASS
coverage: 7.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 25.927s coverage: 7.7% of statements in ./huaweicloud/services/workspace
```
<img width="1138" height="404" alt="image" src="https://github.com/user-attachments/assets/639108a0-390e-4306-a361-939a9cb811e8" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
