### PR TITLE
feat(cdn): add new resource to apply template to domains

### DIFF
--- a/docs/resources/cdn_domain_template_apply.md
+++ b/docs/resources/cdn_domain_template_apply.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_domain_template_apply"
+description: |-
+  Manages a CDN domain template apply resource within HuaweiCloud.
+---
+
+# huaweicloud_cdn_domain_template_apply
+
+Manages a CDN domain template apply resource within HuaweiCloud.
+
+-> This resource is a one-time action resource for applying CDN domain template to domains. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "template_id" {}
+variable "apply_domain_names" {
+  type = list(string)
+}
+
+resource "huaweicloud_cdn_domain_template_apply" "test" {
+  template_id = var.template_id
+  resources   = join(",", var.apply_domain_names)
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `template_id` - (Required, String) Specifies the ID of the domain template to apply.
+
+* `resources` - (Required, String) Specifies the list of domain names to apply the template.  
+  Multiple domain names are separated by commas (,).  
+  A maximum of 50 domains can be applied in a single operation.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2623,6 +2623,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_domain_owner_verify":           cdn.ResourceDomainOwnerVerify(),
 			"huaweicloud_cdn_domain_rule":                   cdn.ResourceDomainRule(),
 			"huaweicloud_cdn_domain_template":               cdn.ResourceDomainTemplate(),
+			"huaweicloud_cdn_domain_template_apply":         cdn.ResourceDomainTemplateApply(),
 			"huaweicloud_cdn_rule_engine_rule":              cdn.ResourceRuleEngineRule(),
 			"huaweicloud_cdn_statistic_configuration":       cdn.ResourceStatisticConfiguration(),
 

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_template_apply_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_template_apply_test.go
@@ -1,0 +1,75 @@
+package cdn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDomainTemplateApply_basic(t *testing.T) {
+	var (
+		rName = "huaweicloud_cdn_domain_template_apply.test"
+	)
+
+	// Avoid CheckDestroy, because there is nothing in the resource destroy method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCdnDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainTemplateApply_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rName, "id"),
+					resource.TestCheckResourceAttrSet(rName, "template_id"),
+					resource.TestCheckResourceAttrSet(rName, "resources"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDomainTemplateApply_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_domain_template" "test" {
+  name        = "%[1]s"
+  description = "Created by terraform for template apply test"
+  configs     = jsonencode({
+    "cache_rules": [
+      {
+        "force_cache": "on",
+        "follow_origin": "off",
+        "match_type": "all",
+        "priority": 1,
+        "stale_while_revalidate": "off",
+        "ttl": 20,
+        "ttl_unit": "d",
+        "url_parameter_type": "full_url",
+        "url_parameter_value": ""
+      }
+    ],
+    "origin_follow302_status": "off",
+    "compress": {
+      "type": "gzip",
+      "status": "on",
+      "file_type": ".js,.html,.css"
+    },
+    "ip_filter": {
+      "type": "white",
+      "value": "1.1.1.1"
+    }
+  })
+}
+
+resource "huaweicloud_cdn_domain_template_apply" "test" {
+  template_id = huaweicloud_cdn_domain_template.test.id
+  resources   = "%[2]s"
+}
+`, acceptance.RandomAccResourceNameWithDash(), acceptance.HW_CDN_DOMAIN_NAME)
+}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_template_apply.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain_template_apply.go
@@ -1,0 +1,125 @@
+package cdn
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CDN POST /v1.0/cdn/configuration/templates/{tml_id}/apply
+func ResourceDomainTemplateApply() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDomainTemplateApplyCreate,
+		ReadContext:   resourceDomainTemplateApplyRead,
+		UpdateContext: resourceDomainTemplateApplyUpdate,
+		DeleteContext: resourceDomainTemplateApplyDelete,
+
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"template_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the domain template.`,
+			},
+			"resources": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The list of domain names to apply the template. Multiple domain names are separated by commas.`,
+			},
+		},
+	}
+}
+
+func applyDomainTemplate(client *golangsdk.ServiceClient, templateId, resources string) error {
+	httpUrl := "v1.0/cdn/configuration/templates/{tml_id}/apply"
+	applyPath := client.Endpoint + httpUrl
+	applyPath = strings.ReplaceAll(applyPath, "{tml_id}", templateId)
+
+	applyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"resources": resources,
+		},
+	}
+
+	requestResp, err := client.Request("POST", applyPath, &applyOpt)
+	if err != nil {
+		return err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return err
+	}
+	if utils.PathSearch("status", respBody, nil) == "success" {
+		return nil
+	}
+
+	jobDetails := utils.PathSearch("detail", respBody, make([]interface{}, 0)).([]interface{})
+	if len(jobDetails) < 1 {
+		log.Printf("[ERROR] Unable to find the job details (with field `detail`) in the API response: %+v", respBody)
+		return nil
+	}
+
+	for _, jobDetail := range jobDetails {
+		if utils.PathSearch("status", jobDetail, nil) == "success" {
+			continue
+		}
+		log.Printf("[ERROR] The job (about domain `%v`) is applied failed, the error message is: %v",
+			utils.PathSearch("domain_name", jobDetail, ""), utils.PathSearch("error_msg", jobDetail, ""))
+	}
+	return nil
+}
+
+func resourceDomainTemplateApplyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("cdn", "")
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	err = applyDomainTemplate(client, d.Get("template_id").(string), d.Get("resources").(string))
+	if err != nil {
+		return diag.Errorf("error applying CDN domain template: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceDomainTemplateApplyRead(ctx, d, meta)
+}
+
+func resourceDomainTemplateApplyRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDomainTemplateApplyUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDomainTemplateApplyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to apply CDN domain template. Deleting this resource
+	will not clear the corresponding request record, but will only remove the resource information from the tf state
+    file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource that used to apply a CDN template to domain(s).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to apply template to domains
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cdn -f TestAccDomainTemplateApply_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccDomainTemplateApply_basic -timeout 360m -parallel 10
=== RUN   TestAccDomainTemplateApply_basic
=== PAUSE TestAccDomainTemplateApply_basic
=== CONT  TestAccDomainTemplateApply_basic
--- PASS: TestAccDomainTemplateApply_basic (11.81s)
PASS
coverage: 6.4% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       11.887s coverage: 6.4% of statements in ./huaweicloud/services/cdn
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
