### PR TITLE
feat(workspace/app): add a new data source to query original policy

### DIFF
--- a/docs/data-sources/workspace_app_original_policy.md
+++ b/docs/data-sources/workspace_app_original_policy.md
@@ -1,0 +1,32 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_original_policy"
+description: |-
+  Use this data source to get the original policy of the Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_original_policy
+
+Use this data source to get the original policy of the Workspace APP within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_workspace_app_original_policy" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the original policy is located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `policy` - The original policy configuration, in JSON format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2282,6 +2282,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_image_servers":                            workspace.DataSourceWorkspaceAppImageServers(),
 			"huaweicloud_workspace_app_latest_attached_applications":             workspace.DataSourceLatestAttachedApplications(),
 			"huaweicloud_workspace_app_nas_storages":                             workspace.DataSourceAppNasStorages(),
+			"huaweicloud_workspace_app_original_policy":                          workspace.DataSourceAppOriginalPolicy(),
 			"huaweicloud_workspace_app_policy_groups":                            workspace.DataSourceAppPolicyGroups(),
 			"huaweicloud_workspace_app_publishable_applications":                 workspace.DataSourceAppPublishableApplications(),
 			"huaweicloud_workspace_app_schedule_tasks":                           workspace.DataSourceAppScheduleTasks(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_original_policy_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_original_policy_test.go
@@ -1,0 +1,34 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataAppOriginalPolicy_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_workspace_app_original_policy.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAppOriginalPolicy_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dcName, "policy"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataAppOriginalPolicy_basic = `
+data "huaweicloud_workspace_app_original_policy" "test" {}
+`

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_original_policy.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_original_policy.go
@@ -1,0 +1,82 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/policy-groups/actions/list-original-policy
+func DataSourceAppOriginalPolicy() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppOriginalPolicyRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the original policy is located.`,
+			},
+			"policy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The original policy configuration, in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataSourceAppOriginalPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/policy-groups/actions/list-original-policy"
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.Errorf("error querying original policy information: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("policy", utils.JsonToString(utils.PathSearch("policies", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_workspace_app_original_policy`)  to query the original policy of the Workspace APP.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataAppOriginalPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppOriginalPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppOriginalPolicy_basic
=== PAUSE TestAccDataAppOriginalPolicy_basic
=== CONT  TestAccDataAppOriginalPolicy_basic
--- PASS: TestAccDataAppOriginalPolicy_basic (18.61s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 19.330s coverage: 3.0% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
