### PR TITLE
feat(hss): new resource to manage ransomware protection policy

### DIFF
--- a/docs/resources/hss_ransomware_protection_policy.md
+++ b/docs/resources/hss_ransomware_protection_policy.md
@@ -1,0 +1,149 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_ransomware_protection_policy"
+description: |-
+  Manages a ransomware protection policy resource within HuaweiCloud HSS.
+---
+
+# huaweicloud_hss_ransomware_protection_policy
+
+Manages a ransomware protection policy resource within HuaweiCloud HSS.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_hss_ransomware_protection_policy" "test" {
+  policy_name              = "test-policy"
+  protection_mode          = "alarm_only"
+  protection_directory     = "/root;/home"
+  protection_type          = "rtf,doc,txt"
+  operating_system         = "Linux"
+  enterprise_project_id    = "all_granted_eps"
+  deploy_mode              = "opened"
+  exclude_directory        = "/boot;/lib;/roo"
+  runtime_detection_status = "closed"
+  ai_protection_status     = "opened"
+  bait_protection_status   = "opened"
+
+  process_whitelist {
+    path = "/usr/bin/safe_process"
+    hash = "a1b2c3d4e5f6"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region to which the HSS ransomware protection policy belongs.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `policy_name` - (Required, String) Specifies the name of the ransomware protection policy.
+
+* `protection_mode` - (Required, String) Specifies the protection mode of the policy.
+  The valid values are as follows:
+  + **alarm_and_isolation**: Report an alarm and isolate.
+  + **alarm_only**: Only report alarms.
+
+* `protection_directory` - (Required, String) Specifies the directory to be protected.
+  Separate multiple directories with semicolons (;). You can configure up to `20` directories.
+
+* `protection_type` - (Required, String) Specifies the protection type. For example, **rtf,doc,txt**.
+
+* `operating_system` - (Required, String, NonUpdatable) Specifies the OS. Its value can be **Windows** or **Linux**.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID to which the policy belongs.
+  This parameter only needs to be configured after the Enterprise Project feature is enabled.
+  For enterprise users, if omitted, default enterprise project will be used.
+  Value **0** means default enterprise project.
+  Value **all_granted_eps** means all enterprise projects to which the user has been granted access.
+
+* `deploy_mode` - (Optional, String) Specifies whether to enable dynamic honeypots.
+  The options are **opened** and **closed**. By default, dynamic honeypot protection is disabled.
+
+* `exclude_directory` - (Optional, String) Specifies the directory to be excluded from protection.
+  Separate multiple directories with semicolons (;). You can configure up to `20` directories.
+
+* `process_whitelist` - (Optional, List) Specifies the process whitelist. The value of this field will not be filled back.
+  Please check the attribute field `process_whitelist_attribute`.
+  The [process_whitelist](#process_whitelist_object) structure is documented below.
+
+* `agent_id_list` - (Optional, List) Specifies the list of agent IDs that have enabled this ransomware protection policy.
+  The list can contain a maximum of `1000` items. The value of this field will not be filled back.
+
+* `runtime_detection_status` - (Optional, String) Specifies whether to detect at runtime.
+  The valid values are **opened** and **closed**. Defaults to **closed**.
+
+* `ai_protection_status` - (Optional, String) Specifies whether to enable AI ransomware protection.
+  Valid values are **opened** and **closed**.
+
+* `bait_protection_status` - (Optional, String) Specifies whether to enable decoy protection.
+  Valid value is **opened**.
+
+<a name="process_whitelist_object"></a>
+The `process_whitelist` block supports:
+
+* `path` - (Optional, String) Specifies the path of the process to be added to the whitelist.
+  The value can contain `0` to `128` characters.
+
+* `hash` - (Optional, String) Specifies the hash value of the process to be added to the whitelist.
+  The value can contain `0` to `128` characters.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also the policy ID).
+
+* `process_whitelist_attribute` - The list of whitelisted processes with their attributes.
+  The [process_whitelist_attribute](#process_whitelist_attribute_object) structure is documented below.
+
+* `count_associated_server` - The number of servers associated with the policy.
+
+* `default_policy` - Whether it is the default policy. Valid values are:
+  + `0`: Not the default policy.
+  + `1`: The default policy.
+
+<a name="process_whitelist_attribute_object"></a>
+The `process_whitelist_attribute` block supports:
+
+* `path` - The path of the process to be added to the whitelist.
+
+* `hash` - The hash value of the process to be added to the whitelist.
+
+## Import
+
+Ransomware protection policy can be imported using the `enterprise_project_id` and `id` separated by a slash, e.g.
+
+### Import resource under the default enterprise project
+
+```bash
+$ terraform import huaweicloud_hss_ransomware_protection_policy.test 0/<id>
+```
+
+### Import resource from non default enterprise project
+
+```bash
+$ terraform import huaweicloud_hss_ransomware_protection_policy.test <enterprise_project_id>/<id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `enterprise_project_id`,
+`process_whitelist`, `agent_id_list`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition
+should be updated to align with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_hss_ransomware_protection_policy" "test" { 
+  # ...
+
+  lifecycle {
+    ignore_changes = [
+      enterprise_project_id, process_whitelist, agent_id_list,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3118,6 +3118,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_host_protection":                                hss.ResourceHostProtection(),
 			"huaweicloud_hss_webtamper_protection":                           hss.ResourceWebTamperProtection(),
 			"huaweicloud_hss_quota":                                          hss.ResourceQuota(),
+			"huaweicloud_hss_ransomware_protection_policy":                   hss.ResourceRansomwareProtectionPolicy(),
 			"huaweicloud_hss_policy_group_deploy":                            hss.ResourcePolicyGroupDeploy(),
 			"huaweicloud_hss_event_unblock_ip":                               hss.ResourceEventUnblockIp(),
 			"huaweicloud_hss_event_delete_isolated_file":                     hss.ResourceEventDeleteIsolatedFile(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_ransomware_protection_policy_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_ransomware_protection_policy_test.go
@@ -1,0 +1,153 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/hss"
+)
+
+func getRansomwareProtectionPolicyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region   = acceptance.HW_REGION_NAME
+		epsId    = acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
+		policyId = state.Primary.ID
+		product  = "hss"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HSS client: %s", err)
+	}
+
+	return hss.QueryProtectionPolicyByPolicyId(client, policyId, epsId, region)
+}
+
+func TestAccRansomwareProtectionPolicy_basic(t *testing.T) {
+	var (
+		policy interface{}
+		name   = acceptance.RandomAccResourceName()
+		rName  = "huaweicloud_hss_ransomware_protection_policy.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&policy,
+		getRansomwareProtectionPolicyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRansomwareProtectionPolicy_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "runtime_detection_status", "closed"),
+					resource.TestCheckResourceAttr(rName, "protection_type", "rtf,doc,txt"),
+					resource.TestCheckResourceAttr(rName, "protection_mode", "alarm_only"),
+					resource.TestCheckResourceAttr(rName, "protection_directory", "/root;/home"),
+					resource.TestCheckResourceAttr(rName, "policy_name", name),
+					resource.TestCheckResourceAttr(rName, "operating_system", "Linux"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "deploy_mode", "opened"),
+					resource.TestCheckResourceAttr(rName, "ai_protection_status", "opened"),
+					resource.TestCheckResourceAttr(rName, "bait_protection_status", "opened"),
+					resource.TestCheckResourceAttrSet(rName, "count_associated_server"),
+					resource.TestCheckResourceAttrSet(rName, "default_policy"),
+					resource.TestCheckResourceAttrSet(rName, "process_whitelist_attribute.#"),
+				),
+			},
+			{
+				Config: testAccRansomwareProtectionPolicy_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "policy_name", fmt.Sprintf("%s-update", name)),
+					resource.TestCheckResourceAttr(rName, "protection_mode", "alarm_and_isolation"),
+					resource.TestCheckResourceAttr(rName, "protection_directory", "/data"),
+					resource.TestCheckResourceAttr(rName, "protection_type", "xls,ppt"),
+					resource.TestCheckResourceAttr(rName, "exclude_directory", "/tmp"),
+					resource.TestCheckResourceAttr(rName, "runtime_detection_status", "closed"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccRansomwareProtectionPolicyImportStateIDFunc(rName),
+				// The following fields will be ignored during import verification
+				ImportStateVerifyIgnore: []string{
+					"process_whitelist",
+					"agent_id_list",
+				},
+			},
+		},
+	})
+}
+
+func testAccRansomwareProtectionPolicy_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_ransomware_protection_policy" "test" {
+  policy_name              = "%s"
+  protection_mode          = "alarm_only"
+  protection_directory     = "/root;/home"
+  protection_type          = "rtf,doc,txt"
+  operating_system         = "Linux"
+  enterprise_project_id    = "%s"
+  deploy_mode              = "opened"
+  runtime_detection_status = "closed"
+  ai_protection_status     = "opened"
+  bait_protection_status   = "opened"
+
+  process_whitelist {
+    path = "/usr/bin/safe_process"
+    hash = "a1b2c3d4e5f6"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccRansomwareProtectionPolicy_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_ransomware_protection_policy" "test" {
+  policy_name              = "%s-update"
+  protection_mode          = "alarm_and_isolation"
+  protection_directory     = "/data"
+  protection_type          = "xls,ppt"
+  operating_system         = "Linux"
+  enterprise_project_id    = "%s"
+  deploy_mode              = "opened"
+  exclude_directory        = "/tmp"
+  runtime_detection_status = "closed"
+  ai_protection_status     = "opened"
+  bait_protection_status   = "opened"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccRansomwareProtectionPolicyImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", resourceName)
+		}
+
+		epsId := rs.Primary.Attributes["enterprise_project_id"]
+		id := rs.Primary.ID
+		if epsId == "" || id == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, "+
+				"want '<enterprise_project_id>/<id>', but got '%s/%s'", epsId, id)
+		}
+		return fmt.Sprintf("%s/%s", epsId, id), nil
+	}
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_ransomware_protection_policy.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_ransomware_protection_policy.go
@@ -1,0 +1,514 @@
+package hss
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS POST /v5/{project_id}/ransomware/protection/policy
+// @API HSS DELETE /v5/{project_id}/ransomware/protection/policy
+// @API HSS PUT /v5/{project_id}/ransomware/protection/policy
+// @API HSS GET /v5/{project_id}/ransomware/protection/policy
+func ResourceRansomwareProtectionPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRansomwareProtectionPolicyCreate,
+		ReadContext:   resourceRansomwareProtectionPolicyRead,
+		UpdateContext: resourceRansomwareProtectionPolicyUpdate,
+		DeleteContext: resourceRansomwareProtectionPolicyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceRansomwareProtectionPolicyImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"enterprise_project_id",
+			"operating_system",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"policy_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"protection_mode": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"protection_directory": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"protection_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"operating_system": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// The field `enterprise_project_id` does not exist in API response body.
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"deploy_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"exclude_directory": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// The field `process_whitelist.hash` does not exist in API response body.
+			// Instead of backfilling data for this field, provide an another attribute field.
+			"process_whitelist": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     processWhitelistSchema(),
+			},
+			// The field `agent_id_list` does not exist in API response body.
+			// Field `agent_id_list` using only in update operation.
+			"agent_id_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// Field `runtime_detection_status` using only in update operation.
+			"runtime_detection_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"ai_protection_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// Field `bait_protection_status` using only in update operation.
+			"bait_protection_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"process_whitelist_attribute": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     processWhitelistAttributeSchema(),
+			},
+			"count_associated_server": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"default_policy": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func processWhitelistAttributeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hash": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func processWhitelistSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"hash": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func buildRansomwareProtectionPolicyQueryParams(epsId string) string {
+	if epsId == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+}
+
+func buildProcessWhitelistRequestOpt(processWhitelist []interface{}) []map[string]interface{} {
+	if len(processWhitelist) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(processWhitelist))
+	for _, v := range processWhitelist {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"path": utils.ValueIgnoreEmpty(rawMap["path"]),
+			"hash": utils.ValueIgnoreEmpty(rawMap["hash"]),
+		})
+	}
+
+	return rst
+}
+
+func buildCreateRansomwareProtectionPolicyRequestOpt(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"policy_name":          d.Get("policy_name"),
+		"protection_mode":      d.Get("protection_mode"),
+		"protection_directory": d.Get("protection_directory"),
+		"protection_type":      d.Get("protection_type"),
+		"operating_system":     d.Get("operating_system"),
+		"deploy_mode":          utils.ValueIgnoreEmpty(d.Get("deploy_mode")),
+		"exclude_directory":    utils.ValueIgnoreEmpty(d.Get("exclude_directory")),
+		"process_whitelist":    buildProcessWhitelistRequestOpt(d.Get("process_whitelist").([]interface{})),
+		"ai_protection_status": utils.ValueIgnoreEmpty(d.Get("ai_protection_status")),
+	}
+}
+
+func buildProtectionPolicyByPolicyNameQueryParams(policyName, epsId string) string {
+	rst := fmt.Sprintf("?policy_name=%s", policyName)
+	if epsId == "" {
+		return rst
+	}
+
+	return fmt.Sprintf("%s&enterprise_project_id=%s", rst, epsId)
+}
+
+func buildProtectionPolicyByPolicyNameQueryParamsWithOffset(requestPath string, offset int) string {
+	if offset == 0 {
+		return requestPath
+	}
+
+	return fmt.Sprintf("%s&offset=%d", requestPath, offset)
+}
+
+// The search for policy_name is a fuzzy search, so pagination is required.
+func QueryProtectionPolicyByPolicyName(client *golangsdk.ServiceClient, policyName, epsId, region string) (interface{}, error) {
+	requestPath := client.Endpoint + "v5/{project_id}/ransomware/protection/policy"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildProtectionPolicyByPolicyNameQueryParams(policyName, epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	var (
+		allResult []interface{}
+		offset    int
+	)
+
+	for {
+		requestPathWithOffset := buildProtectionPolicyByPolicyNameQueryParamsWithOffset(requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		allResult = append(allResult, dataList...)
+		offset += len(dataList)
+	}
+
+	expression := fmt.Sprintf("[?policy_name == '%s']|[0]", policyName)
+	targetPolicy := utils.PathSearch(expression, allResult, nil)
+	if targetPolicy == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return targetPolicy, nil
+}
+
+func resourceRansomwareProtectionPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		epsId      = cfg.GetEnterpriseProjectID(d, QueryAllEpsValue)
+		product    = "hss"
+		httpUrl    = "v5/{project_id}/ransomware/protection/policy"
+		policyName = d.Get("policy_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildRansomwareProtectionPolicyQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+		JSONBody:         utils.RemoveNil(buildCreateRansomwareProtectionPolicyRequestOpt(d)),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating HSS ransomware protection policy: %s", err)
+	}
+
+	policyDetail, err := QueryProtectionPolicyByPolicyName(client, policyName, epsId, region)
+	if err != nil {
+		return diag.Errorf("error querying HSS ransomware protection policy by policy name: %s", err)
+	}
+
+	policyId := utils.PathSearch("policy_id", policyDetail, "").(string)
+	if policyId == "" {
+		return diag.Errorf("error creating HSS ransomware protection policy: policy ID is empty")
+	}
+
+	d.SetId(policyId)
+
+	// Fields `agent_id_list`, `runtime_detection_status`, `bait_protection_status` using only in update operation.
+	updateFields := []string{"agent_id_list", "runtime_detection_status", "bait_protection_status"}
+	if d.HasChanges(updateFields...) {
+		if err := updateRansomwareProtectionPolicy(client, d, cfg); err != nil {
+			return diag.Errorf("error updating HSS ransomware protection policy in create operation: %s", err)
+		}
+	}
+
+	return resourceRansomwareProtectionPolicyRead(ctx, d, meta)
+}
+
+func buildProtectionPolicyByPolicyIdQueryParams(policyId, epsId string) string {
+	rst := fmt.Sprintf("?protect_policy_id=%s", policyId)
+	if epsId == "" {
+		return rst
+	}
+
+	return fmt.Sprintf("%s&enterprise_project_id=%s", rst, epsId)
+}
+
+func QueryProtectionPolicyByPolicyId(client *golangsdk.ServiceClient, policyId, epsId, region string) (interface{}, error) {
+	requestPath := client.Endpoint + "v5/{project_id}/ransomware/protection/policy"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildProtectionPolicyByPolicyIdQueryParams(policyId, epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	policyDetail := utils.PathSearch("data_list|[0]", respBody, nil)
+	if policyDetail == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return policyDetail, nil
+}
+
+func resourceRansomwareProtectionPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d, QueryAllEpsValue)
+		product = "hss"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	policyDetail, err := QueryProtectionPolicyByPolicyId(client, d.Id(), epsId, region)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving HSS ransomware protection policy")
+	}
+
+	processWhitelistAttribute := utils.PathSearch("process_whitelist", policyDetail, make([]interface{}, 0)).([]interface{})
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("policy_name", utils.PathSearch("policy_name", policyDetail, nil)),
+		d.Set("protection_mode", utils.PathSearch("protection_mode", policyDetail, nil)),
+		d.Set("bait_protection_status", utils.PathSearch("bait_protection_status", policyDetail, nil)),
+		d.Set("deploy_mode", utils.PathSearch("deploy_mode", policyDetail, nil)),
+		d.Set("protection_directory", utils.PathSearch("protection_directory", policyDetail, nil)),
+		d.Set("protection_type", utils.PathSearch("protection_type", policyDetail, nil)),
+		d.Set("exclude_directory", utils.PathSearch("exclude_directory", policyDetail, nil)),
+		d.Set("runtime_detection_status", utils.PathSearch("runtime_detection_status", policyDetail, nil)),
+		d.Set("count_associated_server", utils.PathSearch("count_associated_server", policyDetail, nil)),
+		d.Set("operating_system", utils.PathSearch("operating_system", policyDetail, nil)),
+		d.Set("process_whitelist_attribute", flattenProcessWhitelistAttribute(processWhitelistAttribute)),
+		d.Set("default_policy", utils.PathSearch("default_policy", policyDetail, nil)),
+		d.Set("ai_protection_status", utils.PathSearch("ai_protection_status", policyDetail, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenProcessWhitelistAttribute(processWhitelistAttribute []interface{}) []interface{} {
+	if len(processWhitelistAttribute) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(processWhitelistAttribute))
+	for _, v := range processWhitelistAttribute {
+		rst = append(rst, map[string]interface{}{
+			"path": utils.PathSearch("path", v, nil),
+			"hash": utils.PathSearch("hash", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func buildUpdateRansomwareProtectionPolicyRequestOpt(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"policy_id":                d.Id(),
+		"policy_name":              d.Get("policy_name"),
+		"protection_mode":          d.Get("protection_mode"),
+		"protection_directory":     d.Get("protection_directory"),
+		"protection_type":          d.Get("protection_type"),
+		"operating_system":         d.Get("operating_system"),
+		"bait_protection_status":   utils.ValueIgnoreEmpty(d.Get("bait_protection_status")),
+		"deploy_mode":              utils.ValueIgnoreEmpty(d.Get("deploy_mode")),
+		"exclude_directory":        utils.ValueIgnoreEmpty(d.Get("exclude_directory")),
+		"agent_id_list":            utils.ExpandToStringList(d.Get("agent_id_list").([]interface{})),
+		"runtime_detection_status": utils.ValueIgnoreEmpty(d.Get("runtime_detection_status")),
+		"process_whitelist":        buildProcessWhitelistRequestOpt(d.Get("process_whitelist").([]interface{})),
+		"ai_protection_status":     utils.ValueIgnoreEmpty(d.Get("ai_protection_status")),
+	}
+}
+
+func updateRansomwareProtectionPolicy(client *golangsdk.ServiceClient, d *schema.ResourceData, cfg *config.Config) error {
+	requestPath := client.Endpoint + "v5/{project_id}/ransomware/protection/policy"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildRansomwareProtectionPolicyQueryParams(cfg.GetEnterpriseProjectID(d, QueryAllEpsValue))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": cfg.GetRegion(d)},
+		JSONBody:         utils.RemoveNil(buildUpdateRansomwareProtectionPolicyRequestOpt(d)),
+	}
+
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	return err
+}
+
+func resourceRansomwareProtectionPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	if err = updateRansomwareProtectionPolicy(client, d, cfg); err != nil {
+		return diag.Errorf("error updating HSS ransomware protection policy in update operation: %s", err)
+	}
+
+	return resourceRansomwareProtectionPolicyRead(ctx, d, meta)
+}
+
+func buildDeleteRansomwareProtectionPolicyQueryParams(policyId, epsId string) string {
+	rst := fmt.Sprintf("?policy_id=%s", policyId)
+	if epsId == "" {
+		return rst
+	}
+
+	return fmt.Sprintf("%s&enterprise_project_id=%s", rst, epsId)
+}
+
+func resourceRansomwareProtectionPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		epsId   = cfg.GetEnterpriseProjectID(d, QueryAllEpsValue)
+		product = "hss"
+		httpUrl = "v5/{project_id}/ransomware/protection/policy"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildDeleteRansomwareProtectionPolicyQueryParams(d.Id(), epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting HSS ransomware protection policy: %s", err)
+	}
+
+	return nil
+}
+
+func resourceRansomwareProtectionPolicyImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
+	[]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, errors.New("invalid format of import ID, must be <enterprise_project_id>/<id>")
+	}
+
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, d.Set("enterprise_project_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage ransomware protection policy

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccRansomwareProtectionPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccRansomwareProtectionPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccRansomwareProtectionPolicy_basic
=== PAUSE TestAccRansomwareProtectionPolicy_basic
=== CONT  TestAccRansomwareProtectionPolicy_basic
--- PASS: TestAccRansomwareProtectionPolicy_basic (25.75s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       25.864s coverage: 3.8% of statements in ./huaweicloud/services/hss
```
<img width="1375" height="83" alt="image" src="https://github.com/user-attachments/assets/70cf5cad-aa5f-438a-ba8d-01dbf3793be5" />


* [X] Documentation updated.
* [X] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="886" height="181" alt="image" src="https://github.com/user-attachments/assets/b0554c4c-5c57-40fd-9ea5-3ff91df4756f" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
