### PR TITLE
feat(workspace): add new data source to query associated desktop pools for users

### DIFF
--- a/docs/data-sources/workspace_user_desktop_pool_associations.md
+++ b/docs/data-sources/workspace_user_desktop_pool_associations.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_user_desktop_pool_associations"
+description: |-
+  Use this data source to query the desktop pools associated with users within HuaweiCloud.
+---
+
+# huaweicloud_workspace_user_desktop_pool_associations
+
+Use this data source to query the desktop pools associated with users within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "user_ids" {
+  type = list(string)
+}
+
+data "huaweicloud_workspace_user_desktop_pool_associations" "test" {
+  user_ids = var.user_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the user desktop pool associations are located.  
+  If omitted, the provider-level region will be used.
+
+* `user_ids` - (Required, List) Specifies the list of user IDs to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `associations` - The list of user associations with desktop pools.  
+  The [associations](#workspace_user_desktop_pool_associations) structure is documented below.
+
+<a name="workspace_user_desktop_pool_associations"></a>
+The `associations` block supports:
+
+* `user_id` - The ID of the user.
+
+* `desktop_pools` - The list of desktop pools associated with the user.  
+  The [desktop_pools](#workspace_user_desktop_pool_associations_desktop_pools) structure is documented below.
+
+<a name="workspace_user_desktop_pool_associations_desktop_pools"></a>
+The `desktop_pools` block supports:
+
+* `id` - The ID of the desktop pool.
+
+* `name` - The name of the desktop pool.
+
+* `is_attached` - Whether a desktop is assigned.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2278,6 +2278,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_tenant_configurations":                workspace.DataSourceTenantConfigurations(),
 			"huaweicloud_workspace_timezones":                            workspace.DataSourceTimeZones(),
 			"huaweicloud_workspace_users":                                workspace.DataSourceUsers(),
+			"huaweicloud_workspace_user_desktop_pool_associations":       workspace.DataSourceUserDesktopPoolAssociations(),
 			"huaweicloud_workspace_user_groups":                          workspace.DataSourceUserGroups(),
 			"huaweicloud_workspace_volume_products":                      workspace.DataSourceVolumeProducts(),
 

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_user_desktop_pool_associations_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_user_desktop_pool_associations_test.go
@@ -1,0 +1,131 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataUserDesktopPoolAssociations_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		all = "data.huaweicloud_workspace_user_desktop_pool_associations.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceDesktopPoolImageId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataUserDesktopPoolAssociations_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "associations.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(all, "associations.0.user_id"),
+					resource.TestMatchResourceAttr(all, "associations.0.desktop_pools.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(all, "associations.0.desktop_pools.0.id"),
+					resource.TestCheckResourceAttrSet(all, "associations.0.desktop_pools.0.name"),
+					resource.TestCheckResourceAttrSet(all, "associations.0.desktop_pools.0.is_attached"),
+					resource.TestCheckOutput("is_user_ids_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataUserDesktopPoolAssociations_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
+data "huaweicloud_workspace_flavors" "test" {
+  os_type = "Windows"
+}
+
+locals {
+  cpu_flavors = [for v in data.huaweicloud_workspace_flavors.test.flavors : v if v.is_gpu == false]
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_workspace_user" "test" {
+  count = 2
+
+  name  = "%[1]s${count.index}"
+  email = "www.user${count.index}@test.com"
+}
+
+resource "huaweicloud_workspace_desktop_pool" "test" {
+  count                         = 2
+  name                          = "%[1]s-${count.index}"
+  type                          = "DYNAMIC"
+  size                          = 1
+  product_id                    = try(local.cpu_flavors[0].id, "")
+  image_type                    = "gold"
+  image_id                      = "%[2]s"
+  subnet_ids                    = data.huaweicloud_workspace_service.test.network_ids
+  vpc_id                        = data.huaweicloud_workspace_service.test.vpc_id
+  availability_zone             = data.huaweicloud_availability_zones.test.names[0]
+  disconnected_retention_period = 10
+  enable_autoscale              = false
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  security_groups {
+    id = data.huaweicloud_workspace_service.test.desktop_security_group[0].id
+  }
+
+  dynamic "authorized_objects" {
+    for_each = huaweicloud_workspace_user.test
+
+    content {
+      object_type = "USER"
+      object_id   = authorized_objects.value.id
+      object_name = authorized_objects.value.name
+      user_group  = "administrators"
+    }
+  }
+}
+`, name, acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID)
+}
+
+func testAccDataUserDesktopPoolAssociations_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  user_ids = huaweicloud_workspace_user.test[*].id
+}
+
+data "huaweicloud_workspace_user_desktop_pool_associations" "all" {
+  user_ids = local.user_ids
+
+  depends_on = [
+    huaweicloud_workspace_desktop_pool.test
+  ]
+}
+
+locals {
+  query_result = [
+    for v in data.huaweicloud_workspace_user_desktop_pool_associations.all.associations[*].user_id :
+    contains(local.user_ids, v)
+  ]
+}
+
+output "is_user_ids_filter_useful" {
+  value = length(local.query_result) > 0 && alltrue(local.query_result)
+}
+`, testAccDataUserDesktopPoolAssociations_base(name))
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_user_desktop_pool_associations.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_user_desktop_pool_associations.go
@@ -1,0 +1,204 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v2/{project_id}/desktop-pools/statistics/by-users
+func DataSourceUserDesktopPoolAssociations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceUserDesktopPoolAssociationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the user desktop pool associations are located.`,
+			},
+
+			// Required parameters.
+			// Although this parameter is optional in the documentation, in fact, if it is not defined, an empty list will be returned.
+			"user_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of user IDs to be queried.`,
+			},
+
+			// Attributes.
+			"associations": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        userDesktopPoolAssociationSchema(),
+				Description: `The list of user associations with desktop pools.`,
+			},
+		},
+	}
+}
+
+func userDesktopPoolAssociationSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the user.`,
+			},
+			"desktop_pools": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        userDesktopPoolAssociationDesktopPoolDetailsSchema(),
+				Description: `The list of desktop pools associated with the user.`,
+			},
+		},
+	}
+}
+
+func userDesktopPoolAssociationDesktopPoolDetailsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the desktop pool.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the desktop pool.`,
+			},
+			"is_attached": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether a desktop is assigned.`,
+			},
+		},
+	}
+}
+
+func buildUserDesktopPoolAssociationsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	userIds := d.Get("user_ids").([]interface{})
+	for _, userId := range userIds {
+		res = fmt.Sprintf("%s&user_ids=%v", res, userId)
+	}
+
+	return res
+}
+
+func listUserDesktopPoolAssociations(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/desktop-pools/statistics/by-users?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildUserDesktopPoolAssociationsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		users := utils.PathSearch("users", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, users...)
+		if len(users) < limit {
+			break
+		}
+		offset += len(users)
+	}
+
+	return result, nil
+}
+
+func flattenDesktopPoolAssociations(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, pool := range items {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("desktop_pool_id", pool, nil),
+			"name":        utils.PathSearch("desktop_pool_name", pool, nil),
+			"is_attached": utils.PathSearch("is_attached", pool, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenUserDesktopPoolAssociations(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"user_id": utils.PathSearch("user_id", item, nil),
+			"desktop_pools": flattenDesktopPoolAssociations(utils.PathSearch("desktop_pools", item,
+				make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func dataSourceUserDesktopPoolAssociationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	associations, err := listUserDesktopPoolAssociations(client, d)
+	if err != nil {
+		return diag.Errorf("error querying Workspace user desktop pool associations: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("associations", flattenUserDesktopPoolAssociations(associations)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop_pool.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop_pool.go
@@ -700,6 +700,7 @@ func resourceDesktopPoolRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("image_os_type", utils.PathSearch("image_os_type", desktopPool, nil)),
 		d.Set("image_os_version", utils.PathSearch("image_os_version", desktopPool, nil)),
 		d.Set("image_os_platform", utils.PathSearch("image_os_platform", desktopPool, nil)),
+		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("tags", desktopPool, make([]interface{}, 0)).([]interface{}))),
 	)
 
 	authorizedObjects, err := getAssociatedObjectsById(client, desktopPoolId)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new data source that used to query associated desktop pools for specified users.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1347" height="440" alt="image" src="https://github.com/user-attachments/assets/748052d8-ff49-44aa-84df-9fd88a1a5ea8" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query associated desktop pools for users
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataUserDesktopPoolAssociations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataUserDesktopPoolAssociations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataUserDesktopPoolAssociations_basic
--- PASS: TestAccDataUserDesktopPoolAssociations_basic (367.01s)
PASS
coverage: 9.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 367.093s        coverage: 9.0% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
