### PR TITLE
feat(hss): add data source to get the prompt information configuration

### DIFF
--- a/docs/data-sources/hss_setting_malware_reminders.md
+++ b/docs/data-sources/hss_setting_malware_reminders.md
@@ -1,0 +1,39 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_setting_malware_reminders"
+description: |-
+  Use this data source to query the prompt information configuration.
+---
+
+# huaweicloud_hss_setting_malware_reminders
+
+Use this data source to query the prompt information configuration.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_setting_malware_reminders" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `reminders` - Indicates send reminders or not.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1459,6 +1459,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_setting_login_common_ips":                   hss.DataSourceSettingLoginCommonIps(),
 			"huaweicloud_hss_setting_login_common_locations":             hss.DataSourceSettingLoginCommonLocations(),
 			"huaweicloud_hss_setting_login_white_ips":                    hss.DataSourceSettingLoginWhiteIps(),
+			"huaweicloud_hss_setting_malware_reminders":                  hss.DataSourceSettingMalwareReminders(),
 			"huaweicloud_hss_setting_two_factor_login_hosts":             hss.DataSourceSettingTwoFactorLoginHosts(),
 			"huaweicloud_hss_tags":                                       hss.DataSourceHssTags(),
 			"huaweicloud_hss_vulnerabilities":                            hss.DataSourceVulnerabilities(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_setting_malware_reminders_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_setting_malware_reminders_test.go
@@ -1,0 +1,39 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSettingMalwareReminders_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_setting_malware_reminders.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSettingMalwareReminders_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "reminders"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceSettingMalwareReminders_basic = `
+data "huaweicloud_hss_setting_malware_reminders" "test" {
+  enterprise_project_id = "0"
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_setting_malware_reminders.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_setting_malware_reminders.go
@@ -1,0 +1,88 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/setting/malware/reminders
+func DataSourceSettingMalwareReminders() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSettingMalwareRemindersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"reminders": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceSettingMalwareRemindersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/setting/malware/reminders"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	if epsId != "" {
+		getPath = fmt.Sprintf("%s?enterprise_project_id=%s", getPath, epsId)
+	}
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the prompt information configuration: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("reminders", utils.PathSearch("reminders", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to get the prompt information configuration.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceSettingMalwareReminders_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceSettingMalwareReminders_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSettingMalwareReminders_basic
--- PASS: TestAccDataSourceSettingMalwareReminders_basic (16.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       16.924s
```
<img width="1208" height="20" alt="image" src="https://github.com/user-attachments/assets/c343a8ac-8fb0-4c16-bd60-44d5e81c8280" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
