### PR TITLE
feat(hss): add new data source to get the list of dictionaries

### DIFF
--- a/docs/data-sources/hss_setting_dictionaries.md
+++ b/docs/data-sources/hss_setting_dictionaries.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_setting_dictionaries"
+description: |-
+  Use this data source to get the list of dictionaries.
+---
+
+# huaweicloud_hss_setting_dictionaries
+
+Use this data source to get the list of dictionaries.
+
+## Example Usage
+
+```hcl
+variable "group_code" {}
+
+data "huaweicloud_hss_setting_dictionaries" "test" {
+  group_code = var.group_code
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `group_code` - (Required, String) Specifies the dictionary group.
+  The valid values are as follows:
+  + **featureSwitch**: Page feature switch.
+
+* `scene` - (Optional, String) Specifies the application scenario.
+  The valid values are as follows:
+  + **hws**: Chinese mainland website.
+  + **hec-hk**: International website.
+
+* `code` - (Optional, String) Specifies the dictionary item code.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data_list` - The list of dictionaries.
+  The [data_list](#hosts_data_list) structure is documented below.
+
+<a name="hosts_data_list"></a>
+The `data_list` block supports:
+
+* `code` - The dictionary code.
+
+* `value` - The dictionary value (single value).
+
+* `values` - The dictionary values (multiple values).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1456,6 +1456,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_rasp_status":                                hss.DataSourceRaspStatus(),
 			"huaweicloud_hss_rasp_statistics":                            hss.DataSourceRaspStatistics(),
 			"huaweicloud_hss_resource_quotas":                            hss.DataSourceResourceQuotas(),
+			"huaweicloud_hss_setting_dictionaries":                       hss.DataSourceSettingDictionaries(),
 			"huaweicloud_hss_setting_login_common_ips":                   hss.DataSourceSettingLoginCommonIps(),
 			"huaweicloud_hss_setting_login_common_locations":             hss.DataSourceSettingLoginCommonLocations(),
 			"huaweicloud_hss_setting_login_white_ips":                    hss.DataSourceSettingLoginWhiteIps(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_setting_dictionaries_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_setting_dictionaries_test.go
@@ -1,0 +1,69 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSettingDictionaries_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_setting_dictionaries.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+
+			{
+				Config: testAccDataSourceSettingDictionaries_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.code"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.value"),
+
+					resource.TestCheckOutput("code_filter_useful", "true"),
+					resource.TestCheckOutput("scene_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceSettingDictionaries_basic = `
+data "huaweicloud_hss_setting_dictionaries" "test" {
+  group_code = "featureSwitch"
+}
+
+locals {
+  code = data.huaweicloud_hss_setting_dictionaries.test.data_list[0].code
+}
+
+data "huaweicloud_hss_setting_dictionaries" "code_filter" {
+  group_code = "featureSwitch"
+  code       = local.code
+}
+
+output "code_filter_useful" {
+  value = length(data.huaweicloud_hss_setting_dictionaries.code_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_setting_dictionaries.code_filter.data_list[*].code : v == local.code]
+  )
+}
+
+data "huaweicloud_hss_setting_dictionaries" "scene_filter" {
+  group_code = "featureSwitch"
+  scene      = "hws"
+}
+
+output "scene_filter_useful" {
+  value = length(data.huaweicloud_hss_setting_dictionaries.scene_filter.data_list) > 0
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_setting_dictionaries.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_setting_dictionaries.go
@@ -1,0 +1,153 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/setting/dictionaries
+func DataSourceSettingDictionaries() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSettingDictionariesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"group_code": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"scene": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"code": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSettingDictionariesQueryParams(d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("?group_code=%v&limit=200", d.Get("group_code"))
+
+	if v, ok := d.GetOk("scene"); ok {
+		queryParams = fmt.Sprintf("%s&scene=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("code"); ok {
+		queryParams = fmt.Sprintf("%s&code=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceSettingDictionariesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/setting/dictionaries"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildSettingDictionariesQueryParams(d)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", getPath, offset)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving dictionaries: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataResp := utils.PathSearch("data_list", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(dataResp) == 0 {
+			break
+		}
+
+		result = append(result, dataResp...)
+		offset += len(dataResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenSettingDictionaries(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSettingDictionaries(dataList []interface{}) []interface{} {
+	if len(dataList) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(dataList))
+	for _, v := range dataList {
+		rst = append(rst, map[string]interface{}{
+			"code":   utils.PathSearch("code", v, nil),
+			"value":  utils.PathSearch("value", v, nil),
+			"values": utils.PathSearch("values", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get the list of dictionaries.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceSettingDictionaries_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceSettingDictionaries_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSettingDictionaries_basic
=== PAUSE TestAccDataSourceSettingDictionaries_basic
=== CONT  TestAccDataSourceSettingDictionaries_basic
--- PASS: TestAccDataSourceSettingDictionaries_basic (22.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       22.506s
```
<img width="1208" height="20" alt="image" src="https://github.com/user-attachments/assets/fed7b1fb-79be-47ec-ad34-f110d304d7ce" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
