### PR TITLE
feat(hss): support `hss_agent_auto_upgrade_config` data source

### DIFF
--- a/docs/data-sources/hss_agent_auto_upgrade_config.md
+++ b/docs/data-sources/hss_agent_auto_upgrade_config.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_agent_auto_upgrade_config"
+description: |-
+  Use this data source to get the agent auto upgrade configuration of HSS within HuaweiCloud.
+---
+
+# huaweicloud_hss_agent_auto_upgrade_config
+
+Use this data source to get the agent auto upgrade configuration of HSS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_agent_auto_upgrade_config" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `enabled` - The agent auto upgrade configuration switch status.  
+  The valid values are as follows:
+  + **true**: Enabled.
+  + **false**: Disabled.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1494,6 +1494,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_cicd_configurations":                        hss.DataSourceCiCdConfigurations(),
 			"huaweicloud_hss_page_notices":                               hss.DataSourcePageNotices(),
 			"huaweicloud_hss_change_files":                               hss.DataSourceChangeFiles(),
+			"huaweicloud_hss_agent_auto_upgrade_config":                  hss.DataSourceAgentAutoUpgradeConfig(),
 			"huaweicloud_hss_billing_version":                            hss.DataSourceBillingVersion(),
 			"huaweicloud_hss_security_check_config":                      hss.DataSourceSecurityCheckConfig(),
 			"huaweicloud_hss_baseline_security_checks_directories":       hss.DataSourceBaselineSecurityChecksDirectories(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_agent_auto_upgrade_config_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_agent_auto_upgrade_config_test.go
@@ -1,0 +1,40 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAgentAutoUpgradeConfig_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_agent_auto_upgrade_config.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAgentAutoUpgradeConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "enabled"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAgentAutoUpgradeConfig_basic() string {
+	return `
+data "huaweicloud_hss_agent_auto_upgrade_config" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_agent_auto_upgrade_config.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_agent_auto_upgrade_config.go
@@ -1,0 +1,94 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/setting/config/agent-auto-upgrade
+func DataSourceAgentAutoUpgradeConfig() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAgentAutoUpgradeConfigRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildAgentAutoUpgradeConfigQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func dataSourceAgentAutoUpgradeConfigRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/setting/config/agent-auto-upgrade"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAgentAutoUpgradeConfigQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS agent auto upgrade config: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("enabled", utils.PathSearch("enabled", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_agent_auto_upgrade_config` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_agent_auto_upgrade_config` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceAgentAutoUpgradeConfig_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceAgentAutoUpgradeConfig_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAgentAutoUpgradeConfig_basic
=== PAUSE TestAccDataSourceAgentAutoUpgradeConfig_basic
=== CONT  TestAccDataSourceAgentAutoUpgradeConfig_basic
--- PASS: TestAccDataSourceAgentAutoUpgradeConfig_basic (11.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.281s

```
<img width="940" height="24" alt="image" src="https://github.com/user-attachments/assets/8f3cfee0-dede-4d4c-975f-a0debbe91760" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
