### PR TITLE
feat(workspace/app): add one-time resources to batch publish or unpublish applications

### DIFF
--- a/docs/resources/workspace_app_application_batch_publish.md
+++ b/docs/resources/workspace_app_application_batch_publish.md
@@ -1,0 +1,133 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_application_batch_publish"
+description: |-
+  Use this resource to batch publish applications of the Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_application_batch_publish
+
+Use this resource to batch publish applications of the Workspace APP within HuaweiCloud.
+
+-> This resource is a one-time action resource used to batch publish applications. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "application_group_id" {}
+variable "applications" {
+  type = list(object({
+    name              = string
+    execute_path      = string
+    source_type       = number
+    sandbox_enable    = optional(bool)
+    version           = optional(string)
+    publisher         = optional(string)
+    work_path         = optional(string)
+    command_param     = optional(string)
+    description       = optional(string)
+    icon_path         = optional(string)
+    icon_index        = optional(number)
+    source_image_ids  = optional(list(string))
+    is_pre_boot       = optional(bool)
+    app_extended_info = optional(map(string))
+  }))
+}
+
+resource "huaweicloud_workspace_app_application_batch_publish" "test" {
+  app_group_id = var.application_group_id
+
+  dynamic "applications" {
+    for_each = var.applications
+    content {
+      name              = applications.value["name"]
+      execute_path      = applications.value["execute_path"]
+      source_type       = applications.value["source_type"]
+      sandbox_enable    = applications.value["sandbox_enable"]
+      version           = applications.value["version"]
+      publisher         = applications.value["publisher"]
+      work_path         = applications.value["work_path"]
+      command_param     = applications.value["command_param"]
+      description       = applications.value["description"]
+      icon_path         = applications.value["icon_path"]
+      icon_index        = applications.value["icon_index"]
+      source_image_ids  = applications.value["source_image_ids"]
+      is_pre_boot       = applications.value["is_pre_boot"]
+      app_extended_info = applications.value["app_extended_info"]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the applications to be published are located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `app_group_id` - (Required, String, NonUpdatable) Specifies the ID of the application group.
+
+* `applications` - (Required, List, NonUpdatable) Specifies the list of applications to be published.  
+  The [applications](#app_application_batch_publish_applications) structure is documented below.
+
+<a name="app_application_batch_publish_applications"></a>
+The `applications` block supports:
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the application.  
+  The application name allows visible characters or spaces, but cannot be all spaces.  
+  The length range is `1` to `64` characters.
+
+* `execute_path` - (Required, String, NonUpdatable) Specifies the execution path of the application.
+
+* `source_type` - (Required, Int, NonUpdatable) Specifies the type of the application.  
+  The valid values are as follows:
+  + **2**: Private image APP.
+  + **3**: Custom APP.
+
+* `version` - (Optional, String, NonUpdatable) Specifies the version of the application.  
+
+* `command_param` - (Optional, String, NonUpdatable) Specifies the command line parameters used to start
+  the application.  
+  If the `sandbox_enable` is set to **true**, the path of the application to be started must be enclosed in
+  double quotation marks (""), e.g. `/box:DefaultBox "C:\Program Files\Internet Explorer\iexplore.exe"`.
+
+* `work_path` - (Optional, String, NonUpdatable) Specifies the working directory of the application.
+
+* `icon_path` - (Optional, String, NonUpdatable) Specifies the path where the application icon is located.
+
+* `icon_index` - (Optional, Int, NonUpdatable) Specifies the icon index of the application.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the application.
+
+* `publisher` - (Optional, String, NonUpdatable) Specifies the publisher of the application.  
+    If the `sandbox_enable` is set to **true**, this parameter value is the publisher of the sandboxed application.
+
+* `source_image_ids` - (Optional, List, NonUpdatable) Specifies the list of image IDs to which the application
+  belongs.  
+  The maximum length is `20`.  
+  This parameter is required and available only when the `source_type` is `2`.
+
+* `sandbox_enable` - (Optional, Bool, NonUpdatable) Specifies whether to run in sandbox mode.
+  Defaults to **false**.
+
+* `is_pre_boot` - (Optional, Bool, NonUpdatable) Specifies whether to enable application pre-boot.  
+  Defaults to **false**.
+
+* `app_extended_info` - (Optional, Map, NonUpdatable) Specifies the extended information of the custom application.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `applications` - The list of published applications.  
+  The [applications](#app_application_batch_publish_applications_attr) structure is documented below.
+
+<a name="app_application_batch_publish_applications_attr"></a>
+The `applications` block supports:
+
+* `id` - The ID of the published application.

--- a/docs/resources/workspace_app_application_batch_unpublish.md
+++ b/docs/resources/workspace_app_application_batch_unpublish.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_application_batch_unpublish"
+description: |-
+  Use this resource to batch unpublish applications of the Workspace APP within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_application_batch_unpublish
+
+Use this resource to batch unpublish applications of the Workspace APP within HuaweiCloud.
+
+-> This resource is a one-time action resource used to batch unpublish applications. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "app_group_id" {}
+variable "application_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_app_application_batch_unpublish" "test" {
+  app_group_id    = var.app_group_id
+  application_ids = var.application_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the applications to be unpublished are located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `app_group_id` - (Required, String, NonUpdatable) Specifies the ID of the application group.  
+
+* `application_ids` - (Required, List, NonUpdatable) Specifies the list of application IDs to be unpublished.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3766,6 +3766,8 @@ func Provider() *schema.Provider {
 			// Workspace APP
 			"huaweicloud_workspace_app_application_batch_action":                workspace.ResourceAppApplicationBatchAction(),
 			"huaweicloud_workspace_app_application_batch_attach":                workspace.ResourceAppApplicationBatchAttach(),
+			"huaweicloud_workspace_app_application_batch_publish":               workspace.ResourceAppApplicationBatchPublish(),
+			"huaweicloud_workspace_app_application_batch_unpublish":             workspace.ResourceAppApplicationBatchUnpublish(),
 			"huaweicloud_workspace_app_application_publishment":                 workspace.ResourceAppApplicationPublishment(),
 			"huaweicloud_workspace_app_bucket_authorize":                        workspace.ResourceAppBucketAuthorize(),
 			"huaweicloud_workspace_app_group_authorization":                     workspace.ResourceAppGroupAuthorization(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_application_batch_unpublish_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_application_batch_unpublish_test.go
@@ -1,0 +1,118 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAppApplicationBatchUnpublish_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		rName          = "huaweicloud_workspace_app_application_batch_publish.test"
+		unpublishRName = "huaweicloud_workspace_app_application_batch_unpublish.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroup(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppApplicationBatchUnpublish_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rName, "app_group_id"),
+					resource.TestCheckResourceAttr(rName, "applications.#", "2"),
+					// Check attribute(s).
+					resource.TestCheckResourceAttrSet(rName, "applications.0.id"),
+				),
+			},
+			{
+				Config: testAccAppApplicationBatchUnpublish_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(unpublishRName, "app_group_id"),
+					resource.TestCheckResourceAttr(unpublishRName, "application_ids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAppApplicationBatchUnpublish_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
+resource "huaweicloud_workspace_app_server_group" "test" {
+  name             = "%[1]s"
+  os_type          = "Windows"
+  app_type         = "COMMON_APP"
+  flavor_id        = "%[2]s"
+  vpc_id           = data.huaweicloud_workspace_service.test.vpc_id
+  subnet_id        = data.huaweicloud_workspace_service.test.network_ids[0]
+  system_disk_type = "SAS"
+  system_disk_size = 90
+  is_vdi           = true
+  image_id         = "%[3]s"
+  image_type       = "gold"
+  image_product_id = "%[4]s"
+}
+
+# A server group can only be associated with one application group.
+resource "huaweicloud_workspace_app_group" "test" {
+  server_group_id = huaweicloud_workspace_app_server_group.test.id
+  name            = "%[1]s"
+}
+`, name,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
+}
+
+func testAccAppApplicationBatchUnpublish_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_application_batch_publish" "test" {
+  app_group_id = huaweicloud_workspace_app_group.test.id
+
+  applications {
+    name           = "%[2]s-1"
+    execute_path   = "C:\\Program Files\\7-Zip\\7zFM.exe"
+    source_type    = 3
+    sandbox_enable = true
+    version        = "1.0.0"
+    publisher      = "terraform"
+    work_path      = "C:\\Program Files\\Sandboxie"
+    command_param  = "/box:DefaultBox \"7567\""
+    description    = "Created APP by script"
+    icon_path      = "C:\\Program Files\\7-Zip\\7zFM.exe"
+    icon_index     = 0
+  }
+  applications {
+    name         = "%[2]s-2"
+    execute_path = "C:\\Program Files\\7-Zip\\7zFM.exe"
+    source_type  = 3
+  }
+}
+`, testAccAppApplicationBatchUnpublish_base(name), name)
+}
+
+func testAccAppApplicationBatchUnpublish_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_application_batch_unpublish" "test" {
+  app_group_id = huaweicloud_workspace_app_group.test.id
+
+  application_ids = huaweicloud_workspace_app_application_batch_publish.test.applications[*].id
+}
+`, testAccAppApplicationBatchUnpublish_basic_step1(name))
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_application_batch_publish.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_application_batch_publish.go
@@ -1,0 +1,253 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var appApplicationBatchPublishNonUpdatableParams = []string{
+	"app_group_id",
+	"applications",
+	"applications.*.name",
+	"applications.*.execute_path",
+	"applications.*.source_type",
+	"applications.*.version",
+	"applications.*.command_param",
+	"applications.*.work_path",
+	"applications.*.icon_path",
+	"applications.*.icon_index",
+	"applications.*.description",
+	"applications.*.publisher",
+	"applications.*.source_image_ids",
+	"applications.*.sandbox_enable",
+	"applications.*.is_pre_boot",
+	"applications.*.app_extended_info",
+}
+
+// @API Workspace POST /v1/{project_id}/app-groups/{app_group_id}/apps
+func ResourceAppApplicationBatchPublish() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppApplicationBatchPublishCreate,
+		ReadContext:   resourceAppApplicationBatchPublishRead,
+		UpdateContext: resourceAppApplicationBatchPublishUpdate,
+		DeleteContext: resourceAppApplicationBatchPublishDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(appApplicationBatchPublishNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the applications to be published are located.`,
+			},
+			"app_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the application group.`,
+			},
+			"applications": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the application.`,
+						},
+						"execute_path": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The execution path of the application.`,
+						},
+						"source_type": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: `The type of the application.`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The version of the application.`,
+						},
+						"command_param": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The command line parameters used to start the application.`,
+						},
+						"work_path": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The working directory of the application.`,
+						},
+						"icon_path": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The path where the application icon is located.`,
+						},
+						"icon_index": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `The icon index of the application.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The description of the application.`,
+						},
+						"publisher": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The publisher of the application.`,
+						},
+						"source_image_ids": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of image IDs to which the application belongs.`,
+						},
+						"sandbox_enable": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: `Whether to run in sandbox mode.`,
+						},
+						"is_pre_boot": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: `Whether to enable application pre-boot.`,
+						},
+						"app_extended_info": {
+							Type:        schema.TypeMap,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The extended information of the custom application.`,
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the published application.`,
+						},
+					},
+				},
+				Description: `The list of applications to be published.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceAppApplicationBatchPublishCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                = meta.(*config.Config)
+		applicationGroupId = d.Get("app_group_id").(string)
+		httpUrl            = "v1/{project_id}/app-groups/{app_group_id}/apps"
+		applications       = d.Get("applications").([]interface{})
+	)
+
+	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{app_group_id}", applicationGroupId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+		JSONBody:         utils.RemoveNil(buildApplicationBatchPublishBodyParams(applications)),
+	}
+
+	resp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error batch publishing applications under application group (%s): %s", applicationGroupId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	result := make([]map[string]interface{}, 0, len(applications))
+	for _, v := range applications {
+		item := v.(map[string]interface{})
+		// Set the ID of the published application.
+		item["id"] = utils.PathSearch(fmt.Sprintf("items[?name=='%s']|[0].id", utils.PathSearch("name", v, "").(string)),
+			respBody, nil)
+		result = append(result, item)
+	}
+
+	return diag.FromErr(d.Set("applications", result))
+}
+
+func buildApplicationBatchPublishBodyParams(applications []interface{}) map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(applications))
+	for _, item := range applications {
+		result = append(result, map[string]interface{}{
+			"name":              utils.PathSearch("name", item, nil),
+			"execute_path":      utils.PathSearch("execute_path", item, nil),
+			"source_type":       utils.PathSearch("source_type", item, nil),
+			"version":           utils.ValueIgnoreEmpty(utils.PathSearch("version", item, nil)),
+			"command_param":     utils.ValueIgnoreEmpty(utils.PathSearch("command_param", item, nil)),
+			"icon_uri":          utils.ValueIgnoreEmpty(utils.PathSearch("icon_uri", item, nil)),
+			"work_path":         utils.ValueIgnoreEmpty(utils.PathSearch("work_path", item, nil)),
+			"icon_path":         utils.ValueIgnoreEmpty(utils.PathSearch("icon_path", item, nil)),
+			"icon_index":        utils.ValueIgnoreEmpty(utils.PathSearch("icon_index", item, nil)),
+			"description":       utils.ValueIgnoreEmpty(utils.PathSearch("description", item, nil)),
+			"publisher":         utils.ValueIgnoreEmpty(utils.PathSearch("publisher", item, nil)),
+			"source_image_ids":  utils.ValueIgnoreEmpty(utils.PathSearch("source_image_ids", item, nil)),
+			"sandbox_enable":    utils.ValueIgnoreEmpty(utils.PathSearch("sandbox_enable", item, nil)),
+			"is_pre_boot":       utils.ValueIgnoreEmpty(utils.PathSearch("is_pre_boot", item, nil)),
+			"app_extended_info": utils.ValueIgnoreEmpty(utils.PathSearch("app_extended_info", item, nil)),
+		})
+	}
+
+	return map[string]interface{}{
+		"items": result,
+	}
+}
+
+func resourceAppApplicationBatchPublishRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppApplicationBatchPublishUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppApplicationBatchPublishDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch publish applications. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_application_batch_unpublish.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_application_batch_unpublish.go
@@ -1,0 +1,110 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+var appApplicationBatchUnpublishNonUpdatableParams = []string{
+	"app_group_id",
+	"application_ids",
+}
+
+// @API Workspace POST /v1/{project_id}/app-groups/{app_group_id}/apps/batch-unpublish
+func ResourceAppApplicationBatchUnpublish() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppApplicationBatchUnpublishCreate,
+		ReadContext:   resourceAppApplicationBatchUnpublishRead,
+		UpdateContext: resourceAppApplicationBatchUnpublishUpdate,
+		DeleteContext: resourceAppApplicationBatchUnpublishDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(appApplicationBatchUnpublishNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the applications to be unpublished are located.`,
+			},
+			"app_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the application group.`,
+			},
+			"application_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: `The list of application IDs to be unpublished.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceAppApplicationBatchUnpublishCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                = meta.(*config.Config)
+		region             = cfg.GetRegion(d)
+		applicationGroupId = d.Get("app_group_id").(string)
+		httpUrl            = "v1/{project_id}/app-groups/{app_group_id}/apps/batch-unpublish"
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{app_group_id}", applicationGroupId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+		JSONBody: map[string]interface{}{
+			"ids": d.Get("application_ids"),
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error batch unpublishing applications under application group (%s): %s", applicationGroupId, err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	return nil
+}
+
+func resourceAppApplicationBatchUnpublishRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppApplicationBatchUnpublishUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppApplicationBatchUnpublishDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch unpublish applications. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add one-time resources to batch publish or unpublish applications.
+ **huaweicloud_workspace_app_application_batch_publish**
+ **huaweicloud_workspace_app_application_batch_unpublish**

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add two one-time resources.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
./scripts/coverage.sh -o workspace -f TestAccAppApplicationBatchUnpublish_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppApplicationBatchUnpublish_basic -timeout 360m -parallel 10
=== RUN   TestAccAppApplicationBatchUnpublish_basic
=== PAUSE TestAccAppApplicationBatchUnpublish_basic
=== CONT  TestAccAppApplicationBatchUnpublish_basic
--- PASS: TestAccAppApplicationBatchUnpublish_basic (38.51s)
PASS
coverage: 5.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 38.625s coverage: 5.7% of statements in ./huaweicloud/services/workspace
```
<img width="1125" height="511" alt="image" src="https://github.com/user-attachments/assets/6524d6b9-3fb2-4acd-a264-a455c47b6554" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
