### PR TITLE
feat(hss): new resource to switch policy status

### DIFF
--- a/docs/resources/hss_policy_switch_status.md
+++ b/docs/resources/hss_policy_switch_status.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_policy_switch_status"
+description: |-
+  Manages an HSS policy switch status resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_policy_switch_status
+
+Manages an HSS policy switch status resource within HuaweiCloud.
+
+-> This resource is a one-time action resource using to switch HSS policy status. Deleting this resource will
+  not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_hss_policy_switch_status" "test" {
+  enterprise_project_id = "all_granted_eps"
+  policy_name           = "sp_feature"
+  enable                = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `enterprise_project_id` - (Required, String, NonUpdatable) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `policy_name` - (Required, String, NonUpdatable) Specifies the policy name. Only support **sp_feature**.
+
+* `enable` - (Required, Bool) Specifies the policy switch status.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3152,6 +3152,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_quota":                                          hss.ResourceQuota(),
 			"huaweicloud_hss_ransomware_protection_policy":                   hss.ResourceRansomwareProtectionPolicy(),
 			"huaweicloud_hss_policy_group_deploy":                            hss.ResourcePolicyGroupDeploy(),
+			"huaweicloud_hss_policy_switch_status":                           hss.ResourcePolicySwitchStatus(),
 			"huaweicloud_hss_event_unblock_ip":                               hss.ResourceEventUnblockIp(),
 			"huaweicloud_hss_event_delete_isolated_file":                     hss.ResourceEventDeleteIsolatedFile(),
 			"huaweicloud_hss_event_system_user_white_list":                   hss.ResourceEventSystemUserWhiteList(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_policy_switch_status_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_policy_switch_status_test.go
@@ -1,0 +1,43 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccPolicySwitchStatus_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testPolicySwitchStatus_basic,
+			},
+			{
+				Config: testPolicySwitchStatus_basic_update,
+			},
+		},
+	})
+}
+
+const testPolicySwitchStatus_basic = `
+resource "huaweicloud_hss_policy_switch_status" "test" {
+  enterprise_project_id = "all_granted_eps"
+  policy_name           = "sp_feature"
+  enable                = true
+}
+`
+
+const testPolicySwitchStatus_basic_update = `
+resource "huaweicloud_hss_policy_switch_status" "test" {
+  enterprise_project_id = "all_granted_eps"
+  policy_name           = "sp_feature"
+  enable                = false
+}
+`

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_policy_switch_status.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_policy_switch_status.go
@@ -1,0 +1,139 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS POST /v5/{project_id}/policy/switch
+func ResourcePolicySwitchStatus() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePolicySwitchStatusCreate,
+		ReadContext:   resourcePolicySwitchStatusRead,
+		UpdateContext: resourcePolicySwitchStatusUpdate,
+		DeleteContext: resourcePolicySwitchStatusDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"enterprise_project_id",
+			"policy_name",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"policy_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func updatePolicySwitchStatus(client *golangsdk.ServiceClient, d *schema.ResourceData, epsId string) error {
+	requestPath := client.Endpoint + "v5/{project_id}/policy/switch"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"policy_name": d.Get("policy_name"),
+			"enable":      d.Get("enable"),
+		},
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	return err
+}
+
+func resourcePolicySwitchStatusCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d, QueryAllEpsValue)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	if err := updatePolicySwitchStatus(client, d, epsId); err != nil {
+		return diag.Errorf("error changing HSS policy status in create operation: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return resourcePolicySwitchStatusRead(ctx, d, meta)
+}
+
+func resourcePolicySwitchStatusRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourcePolicySwitchStatusUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d, QueryAllEpsValue)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	if err := updatePolicySwitchStatus(client, d, epsId); err != nil {
+		return diag.Errorf("error changing HSS policy status in update operation: %s", err)
+	}
+
+	return resourcePolicySwitchStatusRead(ctx, d, meta)
+}
+
+func resourcePolicySwitchStatusDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to switch HSS policy status. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from the
+    tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to switch policy status

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccPolicySwitchStatus_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccPolicySwitchStatus_basic -timeout 360m -parallel 10
=== RUN   TestAccPolicySwitchStatus_basic
=== PAUSE TestAccPolicySwitchStatus_basic
=== CONT  TestAccPolicySwitchStatus_basic
--- PASS: TestAccPolicySwitchStatus_basic (25.85s)
PASS
coverage: 2.8% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       25.975s coverage: 2.8% of statements in ./huaweicloud/services/hss
```
<img width="1381" height="83" alt="image" src="https://github.com/user-attachments/assets/840ebb8f-0fde-4c05-8165-5eb0915930b3" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
