### PR TITLE
feat(hss): add new data source to query the configuration switch status

### DIFF
--- a/docs/data-sources/hss_setting_switches_status.md
+++ b/docs/data-sources/hss_setting_switches_status.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_setting_switches_status"
+description: |-
+  Use this data source to query the configuration switch status.
+---
+
+# huaweicloud_hss_setting_switches_status
+
+Use this data source to query the configuration switch status.
+
+## Example Usage
+
+```hcl
+variable "code" {}
+
+data "huaweicloud_hss_setting_switches_status" "test" {
+  code = var.code
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `code` - (Required, String) Specifies the configuration type.
+  The valid values are as follows:
+  + **malware_sample_high_detect**: Sensitive malware detection mode.
+  + **image_pay_per_scan**: Pay-per-use image scan switch.
+  + **image_popup**: Pay-per-use image scan pop-up window switch.
+  + **image_free_to_pay_popup**: Switch of the pop-up window for transferring from free to paid image scan.
+  + **display_unprotected_host**: Show unprotected servers.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `enabled` - Whether the switch enabled.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1473,6 +1473,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_setting_login_common_locations":             hss.DataSourceSettingLoginCommonLocations(),
 			"huaweicloud_hss_setting_login_white_ips":                    hss.DataSourceSettingLoginWhiteIps(),
 			"huaweicloud_hss_setting_malware_reminders":                  hss.DataSourceSettingMalwareReminders(),
+			"huaweicloud_hss_setting_switches_status":                    hss.DataSourceSettingSwitchesStatus(),
 			"huaweicloud_hss_setting_two_factor_login_hosts":             hss.DataSourceSettingTwoFactorLoginHosts(),
 			"huaweicloud_hss_setting_virus_kill":                         hss.DataSourceSettingVirusKill(),
 			"huaweicloud_hss_tags":                                       hss.DataSourceHssTags(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_setting_switches_status_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_setting_switches_status_test.go
@@ -1,0 +1,40 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSettingSwitchesStatus_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_setting_switches_status.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSettingSwitchesStatus_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "enabled"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceSettingSwitchesStatus_basic = `
+data "huaweicloud_hss_setting_switches_status" "test" {
+  code                  = "image_pay_per_scan"
+  enterprise_project_id = "0"
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_setting_switches_status.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_setting_switches_status.go
@@ -1,0 +1,94 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/setting/switches/{code}
+func DataSourceSettingSwitchesStatus() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSettingSwitchesStatusRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"code": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceSettingSwitchesStatusRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v5/{project_id}/setting/switches/{code}"
+		switchCode = d.Get("code").(string)
+		epsId      = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{code}", switchCode)
+	if epsId != "" {
+		getPath = fmt.Sprintf("%s?enterprise_project_id=%s", getPath, epsId)
+	}
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the configuration switch status: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("enabled", utils.PathSearch("enabled", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query the configuration switch status.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceSettingSwitchesStatus_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceSettingSwitchesStatus_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSettingSwitchesStatus_basic
--- PASS: TestAccDataSourceSettingSwitchesStatus_basic (18.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       18.208s
```
<img width="1208" height="20" alt="image" src="https://github.com/user-attachments/assets/d3f21730-7b0f-4b28-84ea-4d9a38bb3346" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
