### PR TITLE
feat: fix: test(workspace): desktop supports udpate feature of name parameter

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -319,6 +319,7 @@ var (
 	// HW_WORKSPACE_AD_SERVER_OU_NAMES indicates OUs that do not exist in the Workspace service but only in the Active Directory server.
 	HW_WORKSPACE_AD_SERVER_OU_NAMES    = os.Getenv("HW_WORKSPACE_AD_SERVER_OU_NAMES")
 	HW_WORKSPACE_DESKTOP_IDS           = os.Getenv("HW_WORKSPACE_DESKTOP_IDS")
+	HW_WORKSPACE_DESKTOP_IMAGE_ID      = os.Getenv("HW_WORKSPACE_DESKTOP_IMAGE_ID")
 	HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID = os.Getenv("HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID")
 	HW_WORKSPACE_SCHEDULED_TASK_ID     = os.Getenv("HW_WORKSPACE_SCHEDULED_TASK_ID")
 
@@ -2514,6 +2515,13 @@ func TestAccPreCheckWorkspaceOUName(t *testing.T) {
 func TestAccPreCheckWorkspaceOUNames(t *testing.T, min int) {
 	if HW_WORKSPACE_AD_SERVER_OU_NAMES == "" || len(strings.Split(HW_WORKSPACE_AD_SERVER_OU_NAMES, ",")) < min {
 		t.Skipf("At least %d OU must be configured in the HW_WORKSPACE_AD_SERVER_OU_NAMES, and separated by commas (,).", min)
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckWorkspaceDesktopImageId(t *testing.T) {
+	if HW_WORKSPACE_DESKTOP_IMAGE_ID == "" {
+		t.Skip("HW_WORKSPACE_DESKTOP_IMAGE_ID must be set for the acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_remote_console_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_remote_console_test.go
@@ -22,6 +22,7 @@ func TestAccDataDesktopRemoteConsole_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceDesktopImageId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_sysprep_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_sysprep_test.go
@@ -21,6 +21,7 @@ func TestAccDataDesktopSysprep_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceDesktopImageId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
@@ -81,6 +81,7 @@ func desktopVolumeSchemaResource() *schema.Resource {
 // @API Workspace POST /v2/{project_id}/volumes
 // @API Workspace GET /v2/{project_id}/desktops/{desktop_id}/networks
 // @API Workspace PUT /v2/{project_id}/desktops/{desktop_id}/networks
+// @API Workspace POST /v2/{project_id}/desktops/action
 // @API Workspace POST /v2/{project_id}/desktops
 // @API Workspace POST /v2/{project_id}/volumes/expand
 // @API Workspace GET /v2/{project_id}/workspace-sub-jobs

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
@@ -76,6 +76,7 @@ func desktopVolumeSchemaResource() *schema.Resource {
 // @API Workspace POST /v2/{project_id}/desktops/rebuild
 // @API Workspace POST /v2/{project_id}/desktops/resize
 // @API Workspace GET /v2/{project_id}/desktops/{desktop_id}
+// @API Workspace PUT /v2/{project_id}/desktops/{desktop_id}
 // @API Workspace DELETE /v2/{project_id}/desktops/{desktop_id}
 // @API Workspace POST /v2/{project_id}/desktops/{id}/tags/action
 // @API Workspace POST /v2/{project_id}/volumes
@@ -191,7 +192,6 @@ func ResourceDesktop() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
-				ForceNew:         true,
 				DiffSuppressFunc: utils.SuppressCaseDiffs(),
 			},
 			"email_notification": {
@@ -1133,6 +1133,38 @@ func updateDesktopImage(ctx context.Context, client *golangsdk.ServiceClient, d 
 	return nil
 }
 
+func updateDesktopAttributes(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl   = "v2/{project_id}/desktops/{desktop_id}"
+		desktopId = d.Id()
+		opts      = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: map[string]interface{}{
+				"desktop": map[string]interface{}{
+					"computer_name": utils.ValueIgnoreEmpty(d.Get("name").(string)),
+				},
+			},
+		}
+	)
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{desktop_id}", desktopId)
+	_, err := client.Request("PUT", updatePath, &opts)
+	if err != nil {
+		return fmt.Errorf("error updating desktop attributes: %s", err)
+	}
+
+	err = waitForWorkspaceStatusCompleted(ctx, client, desktopId, "os-start", d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return fmt.Errorf("error waiting for power action (os-start) for desktop (%s) failed: %s", desktopId, err)
+	}
+	return nil
+}
+
 func resourceDesktopUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
@@ -1150,6 +1182,12 @@ func resourceDesktopUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 	if d.HasChanges("image_type", "image_id") {
 		if err = updateDesktopImage(ctx, client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("name") {
+		if err = updateDesktopAttributes(ctx, client, d); err != nil {
 			return diag.FromErr(err)
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The name parameter of Workspace desktop resource supports update feature now.
The current acceptance tests are both have some problems and cannot be worked, so refactor them.
Also the desktop resource is missing an API reference of desktop action operation.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supplement the missing reference of action API
2. desktop resource supports update name
3. format and update the acceptance tests for desktop
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDesktop_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktop_basic -timeout 360m -parallel 10
=== RUN   TestAccDesktop_basic
--- PASS: TestAccDesktop_basic (796.02s)
PASS
coverage: 6.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 796.125s        coverage: 6.8% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDesktop_withEpsId
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktop_withEpsId -timeout 360m -parallel 10
=== RUN   TestAccDesktop_withEpsId
--- PASS: TestAccDesktop_withEpsId (470.60s)
PASS
coverage: 7.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 470.675s        coverage: 7.0% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDesktop_powerAction
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktop_powerAction -timeout 360m -parallel 10
=== RUN   TestAccDesktop_powerAction
--- PASS: TestAccDesktop_powerAction (688.08s)
PASS
coverage: 7.4% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 688.168s        coverage: 7.4% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataDesktops_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataDesktops_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDesktops_basic
--- PASS: TestAccDataDesktops_basic (398.86s)
PASS
coverage: 7.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 398.958s        coverage: 7.9% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
