### PR TITLE
feat(DNS): support to manage zone retrieval

### DIFF
--- a/docs/resources/dns_zone_retrieval.md
+++ b/docs/resources/dns_zone_retrieval.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Domain Name Service (DNS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dns_zone_retrieval"
+description: |-
+  Manages a DNS zone retrieval resource within HuaweiCloud.
+---
+
+# huaweicloud_dns_zone_retrieval
+
+Manages a DNS zone retrieval resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "zone_name" {}
+
+resource "huaweicloud_dns_zone_retrieval" "test" {
+  zone_name = var.zone_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `zone_name` - (Required, String, NonUpdatable) Specifies the zone name.
+  Note the `.` at the end of the name is available.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `retrieval_id` - Indicates the retrieval ID
+
+* `record` - Indicates the record detail.
+  The [record](#attrblock--record) structure is documented below.
+
+* `status` - Indicates the status.
+
+* `created_at` - Indicates the create time.
+
+* `updated_at` - Indicates the last update time.
+
+<a name="attrblock--record"></a>
+The `record` block supports:
+
+* `host` - Indicates the record host.
+
+* `value` - Indicates the record value.
+
+## Import
+
+The zone retrieval can be imported using `zone_name`, e.g.
+
+```bash
+$ terraform import huaweicloud_dns_zone_retrieval.test <zone_name>
+```

--- a/docs/resources/dns_zone_retrieval_verify.md
+++ b/docs/resources/dns_zone_retrieval_verify.md
@@ -1,0 +1,39 @@
+---
+subcategory: "Domain Name Service (DNS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dns_zone_retrieval_verify"
+description: |-
+  Manages a DNS zone retrieval verify resource within HuaweiCloud.
+---
+
+# huaweicloud_dns_zone_retrieval_verify
+
+Manages a DNS zone retrieval verify resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "retrieval_id" {}
+
+resource "huaweicloud_dns_zone_retrieval_verify" "test" {
+  retrieval_id = var.retrieval_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `retrieval_id` - (Required, String, NonUpdatable) Specifies the retrieval ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `message` - Indicates the message.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2969,6 +2969,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_line_group":                dns.ResourceLineGroup(),
 			"huaweicloud_dns_zone_authorization":        dns.ResourceZoneAuthorization(),
 			"huaweicloud_dns_zone_authorization_verify": dns.ResourceZoneAuthorizationVerify(),
+			"huaweicloud_dns_zone_retrieval":            dns.ResourceDNSZoneRetrieval(),
+			"huaweicloud_dns_zone_retrieval_verify":     dns.ResourceDNSZoneRetrievalVerify(),
 
 			"huaweicloud_drs_job":                        drs.ResourceDrsJob(),
 			"huaweicloud_drs_job_primary_standby_switch": drs.ResourceDRSPrimaryStandbySwitch(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -800,7 +800,8 @@ var (
 	HW_SERVICESTAGE_JAR_PKG_STORAGE_URLS = os.Getenv("HW_SERVICESTAGE_JAR_PKG_STORAGE_URLS")
 	HW_SERVICESTAGE_ZIP_STORAGE_URLS     = os.Getenv("HW_SERVICESTAGE_ZIP_STORAGE_URLS")
 
-	HW_DNS_ZONE_NAMES = os.Getenv("HW_DNS_ZONE_NAMES")
+	HW_DNS_ZONE_NAMES          = os.Getenv("HW_DNS_ZONE_NAMES")
+	HW_DNS_ZONE_RETRIEVAL_NAME = os.Getenv("HW_DNS_ZONE_RETRIEVAL_NAME")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -4590,5 +4591,12 @@ func TestAccPreCheckServiceStageZipStorageURLs(t *testing.T, n int) {
 func TestAccPreCheckDnsZoneNames(t *testing.T, min int) {
 	if HW_DNS_ZONE_NAMES == "" || len(strings.Split(HW_DNS_ZONE_NAMES, ",")) < min {
 		t.Skipf("At least %d DNS zone name(s) must be supported during the HW_DNS_ZONE_NAMES, separated by commas (,)", min)
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDnsZoneRetrievalName(t *testing.T) {
+	if HW_DNS_ZONE_RETRIEVAL_NAME == "" {
+		t.Skipf("HW_DNS_ZONE_RETRIEVAL_NAME must be set for the acceptance test")
 	}
 }

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_retrieval_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_retrieval_test.go
@@ -1,0 +1,88 @@
+package dns
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getResourceDNSRetrieval(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dns", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DNS client: %s", err)
+	}
+
+	getHttpUrl := "v2/retrieval?name={name}"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{name}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccDNSRetrieval_basic(t *testing.T) {
+	var obj interface{}
+	resourceName := "huaweicloud_dns_zone_retrieval.test"
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getResourceDNSRetrieval,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDnsZoneRetrievalName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSRetrieval_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "retrieval_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "record.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "record.0.host"),
+					resource.TestCheckResourceAttrSet(resourceName, "record.0.value"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDNSRetrieval_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dns_zone_retrieval" "test" {
+  zone_name = "%[1]s"
+}
+`, acceptance.HW_DNS_ZONE_RETRIEVAL_NAME)
+}

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_retrieval_verify_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_retrieval_verify_test.go
@@ -1,0 +1,42 @@
+package dns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDNSRetrievalVerify_basic(t *testing.T) {
+	resourceName := "huaweicloud_dns_zone_retrieval_verify.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDnsZoneRetrievalName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSRetrievalVerify_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "message"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDNSRetrievalVerify_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dns_zone_retrieval" "test" {
+  zone_name = "%[1]s"
+}
+
+resource "huaweicloud_dns_zone_retrieval_verify" "test" {
+  retrieval_id = huaweicloud_dns_zone_retrieval.test.retrieval_id
+}
+`, acceptance.HW_DNS_ZONE_RETRIEVAL_NAME)
+}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_zone_retrieval.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_zone_retrieval.go
@@ -1,0 +1,194 @@
+package dns
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var zoneRetrievalNonUpdatableParams = []string{
+	"zone_name",
+}
+
+var dnsZoneRetrievalSchema = map[string]*schema.Schema{
+	"region": {
+		Type:        schema.TypeString,
+		ForceNew:    true,
+		Optional:    true,
+		Computed:    true,
+		Description: `The region in which to create the resource. If omitted, the provider-level region will be used.`,
+	},
+	"zone_name": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: `Specifies the zone name.`,
+		DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+			return strings.TrimSuffix(oldVal, ".") == strings.TrimSuffix(newVal, ".")
+		},
+	},
+	"enable_force_new": {
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+		Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+	},
+	"retrieval_id": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: `Indicates the retrieval ID`,
+	},
+	"status": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: `Indicates the status.`,
+	},
+	"created_at": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: `Indicates the create time.`,
+	},
+	"updated_at": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: `Indicates the last update time.`,
+	},
+	"record": {
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: `Indicates the record detail.`,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"host": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: `Indicates the record host.`,
+				},
+				"value": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: `Indicates the record value.`,
+				},
+			},
+		},
+	},
+}
+
+// @API DNS POST /v2/retrieval
+// @API DNS GET /v2/retrieval
+func ResourceDNSZoneRetrieval() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDNSZoneRetrievalCreate,
+		UpdateContext: resourceDNSZoneRetrievalUpdate,
+		ReadContext:   resourceDNSZoneRetrievalRead,
+		DeleteContext: resourceDNSZoneRetrievalDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(zoneRetrievalNonUpdatableParams, dnsZoneRetrievalSchema),
+
+		Schema: dnsZoneRetrievalSchema,
+	}
+}
+
+func resourceDNSZoneRetrievalCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dns", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	zoneName := d.Get("zone_name").(string)
+	createHttpUrl := "v2/retrieval"
+	createPath := client.Endpoint + createHttpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"zone_name": zoneName,
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DNS retrieval: %s", err)
+	}
+
+	d.SetId(zoneName)
+
+	return resourceDNSZoneRetrievalRead(ctx, d, meta)
+}
+
+func resourceDNSZoneRetrievalRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dns", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	getHttpUrl := "v2/retrieval?name={name}"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{name}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DNS zone retrieval.")
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("zone_name", utils.PathSearch("zone_name", getRespBody, nil)),
+		d.Set("retrieval_id", utils.PathSearch("id", getRespBody, nil)),
+		d.Set("status", utils.PathSearch("status", getRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", getRespBody, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", getRespBody, nil)),
+		d.Set("record", flattenDNSZoneRetrievalRecord(getRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDNSZoneRetrievalRecord(resp interface{}) []interface{} {
+	rawParams := utils.PathSearch("record", resp, nil)
+	if param, ok := rawParams.(map[string]interface{}); ok {
+		m := map[string]interface{}{
+			"host":  utils.PathSearch("host", param, nil),
+			"value": utils.PathSearch("value", param, nil),
+		}
+		return []interface{}{m}
+	}
+
+	return nil
+}
+
+func resourceDNSZoneRetrievalUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDNSZoneRetrievalDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting DNS zone retrieval resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_zone_retrieval_verify.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_zone_retrieval_verify.go
@@ -1,0 +1,115 @@
+package dns
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var zoneRetrievalVerifyNonUpdatableParams = []string{
+	"retrieval_id",
+}
+
+// @API DNS POST /v2/retrieval/verification/{id}
+func ResourceDNSZoneRetrievalVerify() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDNSZoneRetrievalVerifyCreate,
+		UpdateContext: resourceDNSZoneRetrievalVerifyUpdate,
+		ReadContext:   resourceDNSZoneRetrievalVerifyRead,
+		DeleteContext: resourceDNSZoneRetrievalVerifyDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(zoneRetrievalVerifyNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"retrieval_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the retrieval ID.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"message": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the message.`,
+			},
+		},
+	}
+}
+
+func resourceDNSZoneRetrievalVerifyCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dns", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	createHttpUrl := "v2/retrieval/verification/{id}"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{id}", d.Get("retrieval_id").(string))
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes:          []int{202},
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DNS retrieval verify: %s", err)
+	}
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("message", utils.PathSearch("message", createRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDNSZoneRetrievalVerifyRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDNSZoneRetrievalVerifyUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDNSZoneRetrievalVerifyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting DNS zone retrieval verify resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDNSRetrieval_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSRetrieval_basic -timeout 360m -parallel 4
=== RUN   TestAccDNSRetrieval_basic
=== PAUSE TestAccDNSRetrieval_basic
=== CONT  TestAccDNSRetrieval_basic
--- PASS: TestAccDNSRetrieval_basic (15.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       15.793s

make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDNSRetrievalVerify_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSRetrievalVerify_basic -timeout 360m -parallel 4
=== RUN   TestAccDNSRetrievalVerify_basic
=== PAUSE TestAccDNSRetrievalVerify_basic
=== CONT  TestAccDNSRetrievalVerify_basic
--- PASS: TestAccDNSRetrievalVerify_basic (12.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       12.615s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
