### PR TITLE
feat(workspace): add action resource for batch delete desktop volumes

### DIFF
--- a/docs/resources/workspace_desktop_volume_batch_delete.md
+++ b/docs/resources/workspace_desktop_volume_batch_delete.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_desktop_volume_batch_delete"
+description: |-
+  Use this resource to batch delete desktop data volumes within HuaweiCloud.
+---
+
+# huaweicloud_workspace_desktop_volume_batch_delete
+
+Use this resource to batch delete desktop data volumes within HuaweiCloud.
+
+-> This resource is only a one-time action resource for batch deleting desktop data volumes. Deleting this
+  resource will not clear the corresponding request record, but will only remove the resource information from the
+  tfstate file.
+
+## Example Usage
+
+```hcl
+variable "desktop_id" {}
+variable "volume_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_workspace_desktop_volume_batch_delete" "test" {
+  desktop_id = var.desktop_id
+  volume_ids = var.volume_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the desktop is located.  
+  If omitted, the provider-level region will be used.  
+  Changing this parameter will create a new resource.
+
+* `desktop_id` - (Required, String, NonUpdatable) Specifies the ID of the desktop to which the data volumes to
+  be deleted belongs.
+
+* `volume_ids` - (Required, List, NonUpdatable) Specifies the list of desktop data volume IDs to be deleted.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is `10` minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3790,6 +3790,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_desktop_pool":                         workspace.ResourceDesktopPool(),
 			"huaweicloud_workspace_desktop_pool_action":                  workspace.ResourceDesktopPoolAction(),
 			"huaweicloud_workspace_desktop_pool_notification":            workspace.ResourceDesktopPoolNotification(),
+			"huaweicloud_workspace_desktop_volume_batch_delete":          workspace.ResourceDesktopVolumeBatchDelete(),
 			"huaweicloud_workspace_eip_associate":                        workspace.ResourceEipAssociate(),
 			"huaweicloud_workspace_log_configuration":                    workspace.ResourceLogConfiguration(),
 			"huaweicloud_workspace_notification_rule":                    workspace.ResourceNotificationRule(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_volume_batch_delete_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_volume_batch_delete_test.go
@@ -1,0 +1,146 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDesktopVolumeBatchDelete_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		desktop      interface{}
+		resourceName = "huaweicloud_workspace_desktop.test"
+		rc           = acceptance.InitResourceCheck(
+			resourceName,
+			&desktop,
+			getDesktopFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDesktopVolumeBatchDelete_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckOutput("is_desktop_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDesktopVolumeBatchDelete_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
+data "huaweicloud_workspace_flavors" "test" {
+  os_type = "Windows"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_images_images" "test" {
+  image_id = "%[2]s"
+  visibility = "market"
+}
+
+variable "data_volumes" {
+  type = list(object({
+    type       = string
+    size       = number
+  }))
+
+  default = [
+    { type = "SSD", size = 80 },
+    { type = "SSD", size = 100 },
+  ]
+}
+
+resource "huaweicloud_workspace_desktop" "test" {
+  flavor_id         = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "NOT_FOUND")
+  image_type        = "market"
+  image_id          = try(data.huaweicloud_images_images.test.images[0].id, "NOT_FOUND")
+  availability_zone = try(data.huaweicloud_availability_zones.test.names[0], "NOT_FOUND")
+  vpc_id            = data.huaweicloud_workspace_service.test.vpc_id
+  security_groups   = [
+    try(data.huaweicloud_workspace_service.test.desktop_security_group[0].id, "NOT_FOUND"), 
+    try(data.huaweicloud_workspace_service.test.infrastructure_security_group[0].id, "NOT_FOUND")
+  ]
+
+  nic {
+    network_id = try(data.huaweicloud_workspace_service.test.network_ids[0], "NOT_FOUND")
+  }
+
+  name       = "%[1]s"
+  user_name  = "user-%[1]s"
+  user_email = "terraform@example.com"
+  user_group = "administrators"
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  dynamic "data_volume" {
+    for_each = var.data_volumes
+
+    content {
+      type = data_volume.value.type
+      size = data_volume.value.size
+    }
+  }
+
+  lifecycle {
+    ignore_changes = ["data_volume"]
+  }
+}
+`, name, acceptance.HW_IMAGE_ID)
+}
+
+func testAccDesktopVolumeBatchDelete_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_desktop_volume_batch_delete" "test" {
+  desktop_id = huaweicloud_workspace_desktop.test.id
+  volume_ids = [
+    huaweicloud_workspace_desktop.test.data_volume.0.id
+  ]
+
+  lifecycle {
+    ignore_changes = ["volume_ids"]
+  }
+
+  depends_on = [
+    huaweicloud_workspace_desktop.test
+  ]
+}
+
+# By desktop ID filter
+data "huaweicloud_workspace_desktops" "filter_by_desktop_id" {
+  desktop_id = huaweicloud_workspace_desktop.test.id
+
+  depends_on = [
+    huaweicloud_workspace_desktop_volume_batch_delete.test
+  ]
+}
+
+output "is_desktop_id_filter_useful" {
+  value = (
+    length(data.huaweicloud_workspace_desktops.filter_by_desktop_id.desktops) == 1 &&
+    length(data.huaweicloud_workspace_desktops.filter_by_desktop_id.desktops[0].data_volume) == 1
+  )
+}
+`, testAccDesktopVolumeBatchDelete_base(name))
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop_volume_batch_delete.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop_volume_batch_delete.go
@@ -1,0 +1,143 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var desktopVolumeBatchDeleteNonUpdatableParams = []string{"desktop_id", "volume_ids"}
+
+// @API Workspace POST /v2/{project_id}/desktops/{desktop_id}/volumes/batch-delete
+// @API Workspace GET /v2/{project_id}/workspace-jobs/{job_id}
+func ResourceDesktopVolumeBatchDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDesktopVolumeBatchDeleteCreate,
+		ReadContext:   resourceDesktopVolumeBatchDeleteRead,
+		UpdateContext: resourceDesktopVolumeBatchDeleteUpdate,
+		DeleteContext: resourceDesktopVolumeBatchDeleteDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(desktopVolumeBatchDeleteNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the desktop is located.`,
+			},
+
+			// Required parameters.
+			"desktop_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the desktop to which the data volumes to be deleted belongs.`,
+			},
+			"volume_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of desktop data volume IDs to be deleted.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildDesktopVolumeBatchDeleteBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"volume_ids": d.Get("volume_ids"),
+	}
+}
+
+func resourceDesktopVolumeBatchDeleteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v2/{project_id}/desktops/{desktop_id}/volumes/batch-delete"
+		desktopId = d.Get("desktop_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{desktop_id}", desktopId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildDesktopVolumeBatchDeleteBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error deleting desktop data volumes: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find job ID from API response")
+	}
+	d.SetId(jobId)
+
+	status, err := waitForJobCompleted(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the job (%s) to complete: %s", jobId, err)
+	}
+	if status == "FAIL" {
+		return diag.Errorf("the job (%s) of delete desktop data volume has failed.", jobId)
+	}
+
+	return resourceDesktopVolumeBatchDeleteRead(ctx, d, meta)
+}
+
+func resourceDesktopVolumeBatchDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDesktopVolumeBatchDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDesktopVolumeBatchDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for batch deleting desktop data volumes. Deleting this
+resource will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(workspace): add action resource for batch delete desktop volumes

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktopVolumeBatchDelete_basic -timeout 360m -parallel 10
=== RUN   TestAccDesktopVolumeBatchDelete_basic
=== PAUSE TestAccDesktopVolumeBatchDelete_basic
=== CONT  TestAccDesktopVolumeBatchDelete_basic
--- PASS: TestAccDesktopVolumeBatchDelete_basic (732.27s)
PASS
coverage: 8.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 732.403s        coverage: 8.1% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.