### PR TITLE
feat(workspace): add data source to query ous

### DIFF
--- a/docs/data-sources/workspace_ous.md
+++ b/docs/data-sources/workspace_ous.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_ous"
+description: |-
+  Use this data source to get the list of organizational units (OUs) within HuaweiCloud.
+---
+
+# huaweicloud_workspace_ous
+
+Use this data source to get the list of organizational units (OUs) within HuaweiCloud.
+
+## Example Usage
+
+### Query all OUs
+
+```hcl
+data "huaweicloud_workspace_ous" "test" {}
+```
+
+### Filter OUs by name
+
+```hcl
+variable "ou_name" {}
+
+data "huaweicloud_workspace_ous" "test" {
+  ou_name = var.ou_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the OUs are located.  
+  If omitted, the provider-level region will be used.
+
+* `ou_name` - (Optional, String) Specifies the name of the OU.  
+  Fuzzy match is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `ous` - The list of OUs that match the filter parameters.  
+  The [ous](#workspace_ous) structure is documented below.
+
+<a name="workspace_ous"></a>
+The `ous` block supports:
+
+* `id` - The ID of the OU.
+
+* `name` - The name of the OU.
+
+* `domain_id` - The ID of the AD domain.
+
+* `domain` - The AD domain name to which the OU belongs.
+
+* `ou_dn` - The distinguished name (DN) of the OU.
+
+* `description` - The description of the OU.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2270,6 +2270,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_desktop_tags_filter":                  workspace.DataSourceDesktopTagsFilter(),
 			"huaweicloud_workspace_flavors":                              workspace.DataSourceWorkspaceFlavors(),
 			"huaweicloud_workspace_hour_packages":                        workspace.DataSourceHourPackages(),
+			"huaweicloud_workspace_ous":                                  workspace.DataSourceOus(),
 			"huaweicloud_workspace_policy_groups":                        workspace.DataSourcePolicyGroups(),
 			"huaweicloud_workspace_quotas":                               workspace.DataSourceQuotas(),
 			"huaweicloud_workspace_scheduled_tasks":                      workspace.DataSourceScheduledTasks(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_ous_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_ous_test.go
@@ -1,0 +1,70 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataOus_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_workspace_ous.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		filterByOuName   = "data.huaweicloud_workspace_ous.filter_by_ou_name"
+		dcFilterByOuName = acceptance.InitDataSourceCheck(filterByOuName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceOUName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataOus_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					// Without any filter parameter.
+					resource.TestMatchResourceAttr(all, "ous.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "ous.0.id"),
+					resource.TestCheckResourceAttrSet(all, "ous.0.name"),
+					resource.TestCheckResourceAttrSet(all, "ous.0.domain_id"),
+					resource.TestCheckResourceAttrSet(all, "ous.0.domain"),
+					resource.TestCheckResourceAttrSet(all, "ous.0.ou_dn"),
+					// Filter by 'ou_name' parameter.
+					dcFilterByOuName.CheckResourceExists(),
+					resource.TestCheckOutput("is_ou_name_filter_useful", "true"),
+					// `description` may be empty, so we don't check it.
+				),
+			},
+		},
+	})
+}
+
+func testAccDataOus_basic() string {
+	return fmt.Sprintf(`
+# Without any filter parameter.
+data "huaweicloud_workspace_ous" "all" {}
+
+# Filter by 'ou_name' parameter.
+data "huaweicloud_workspace_ous" "filter_by_ou_name" {
+  ou_name = "%[1]s"
+}
+
+locals {
+  ou_name_filter_result = [for v in data.huaweicloud_workspace_ous.filter_by_ou_name.ous[*].name :
+    strcontains(v, "%[1]s")
+  ]
+}
+
+output "is_ou_name_filter_useful" {
+  value = length(local.ou_name_filter_result) > 0 && alltrue(local.ou_name_filter_result)
+}
+`, acceptance.HW_WORKSPACE_OU_NAME)
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_ous.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_ous.go
@@ -1,0 +1,130 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v2/{project_id}/ous
+func DataSourceOus() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceOusRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the OUs are located.`,
+			},
+			"ou_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the OU.`,
+			},
+			"ous": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the OU.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the OU.`,
+						},
+						"domain_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the AD domain.`,
+						},
+						"domain": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The AD domain name to which the OU belongs.`,
+						},
+						"ou_dn": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The distinguished name (DN) of the OU.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the OU.`,
+						},
+					},
+				},
+				Description: `The list of OUs that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildOusQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("ou_name"); ok {
+		res = fmt.Sprintf("%s&ou_name=%v", res, v)
+	}
+	return res
+}
+
+func dataSourceOusRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	ous, err := listOus(client, buildOusQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error querying OUs: %s", err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(randomId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("ous", flattenOus(ous)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenOus(ous []interface{}) []interface{} {
+	if len(ous) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(ous))
+	for _, ou := range ous {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("id", ou, nil),
+			"name":        utils.PathSearch("ou_name", ou, nil),
+			"domain_id":   utils.PathSearch("domain_id", ou, nil),
+			"domain":      utils.PathSearch("domain", ou, nil),
+			"ou_dn":       utils.PathSearch("ou_dn", ou, nil),
+			"description": utils.PathSearch("description", ou, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_workspace_ous`) to query OUs of the Workspace.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataOus_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataOus_basic -timeout 360m -parallel 10
=== RUN   TestAccDataOus_basic
=== PAUSE TestAccDataOus_basic
=== CONT  TestAccDataOus_basic
--- PASS: TestAccDataOus_basic (20.36s)
PASS
coverage: 3.3% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 20.472s coverage: 3.3% of statements in ./huaweicloud/services/workspace
```
<img width="1112" height="514" alt="image" src="https://github.com/user-attachments/assets/5a6c32ab-d5be-42c3-897f-54b95d62f741" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
