### PR TITLE
feat(workspace): add new data source to query users of the OU

### DIFF
--- a/docs/data-sources/workspace_ou_users.md
+++ b/docs/data-sources/workspace_ou_users.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_ou_users"
+description: |-
+  Use this data source to query the user list under the specified OU within HuaweiCloud.
+---
+
+# huaweicloud_workspace_ou_users
+
+Use this data source to query the user list under the specified OU within HuaweiCloud.
+
+## Example Usage
+
+### Query all users under the specified OU
+
+```hcl
+variable "ou_dn" {}
+
+data "huaweicloud_workspace_ou_users" "test" {
+  ou_dn = var.ou_dn
+}
+```
+
+### Query users by user name
+
+```hcl
+variable "ou_dn" {}
+variable "user_name" {}
+
+data "huaweicloud_workspace_ou_users" "test" {
+  ou_dn     = var.ou_dn
+  user_name = var.user_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the OU users are located.  
+  If omitted, the provider-level region will be used.
+
+* `ou_dn` - (Required, String) Specifies the distinguished name (DN) of the OU.
+
+* `user_name` - (Optional, String) Specifies the name of the user to which the OU belongs.
+  Fuzzy matching is supported.
+
+* `has_existed` - (Optional, Bool) Specifies whether the user already exists in the user list.  
+  If omitted, all users under the OU will be returned.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `users` - The list of users that match the filter parameters.  
+  The [users](#workspace_ou_users) structure is documented below.
+
+* `enable_create_count` - The number of users that can be created.
+
+<a name="workspace_ou_users"></a>
+The `users` block supports:
+
+* `name` - The name of the user.
+
+* `expired_time` - The expiration time of the user.  
+  `-1` indicates that the user never expires.
+
+* `has_existed` - Whether the user already exists in the user list.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2271,6 +2271,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_desktop_tags_filter":                  workspace.DataSourceDesktopTagsFilter(),
 			"huaweicloud_workspace_flavors":                              workspace.DataSourceWorkspaceFlavors(),
 			"huaweicloud_workspace_hour_packages":                        workspace.DataSourceHourPackages(),
+			"huaweicloud_workspace_ou_users":                             workspace.DataSourceOuUsers(),
 			"huaweicloud_workspace_ous":                                  workspace.DataSourceOus(),
 			"huaweicloud_workspace_policy_groups":                        workspace.DataSourcePolicyGroups(),
 			"huaweicloud_workspace_quotas":                               workspace.DataSourceQuotas(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_ou_users_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_ou_users_test.go
@@ -1,0 +1,109 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running the test, ensure that there is at least one user under this OU.
+func TestAccDataOuUsers_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_workspace_ou_users.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		filterByUserName   = "data.huaweicloud_workspace_ou_users.filter_by_user_name"
+		dcFilterByUserName = acceptance.InitDataSourceCheck(filterByUserName)
+
+		filterByHasExisted   = "data.huaweicloud_workspace_ou_users.filter_by_has_existed"
+		dcFilterByHasExisted = acceptance.InitDataSourceCheck(filterByHasExisted)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceOUName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataOuUsers_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "users.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "enable_create_count"),
+					resource.TestCheckResourceAttrSet(all, "users.0.name"),
+					resource.TestCheckResourceAttrSet(all, "users.0.expired_time"),
+					// Filter by 'user_name' parameter.
+					dcFilterByUserName.CheckResourceExists(),
+					resource.TestCheckOutput("is_user_name_filter_useful", "true"),
+					// Filter by 'has_existed' parameter.
+					dcFilterByHasExisted.CheckResourceExists(),
+					resource.TestCheckOutput("is_has_existed_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataOuUsers_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_ous" "test" {
+  ou_name = "%[1]s"
+}
+
+locals {
+  ou_dn = try(data.huaweicloud_workspace_ous.test.ous[0].ou_dn, "NOT_FOUND")
+}
+
+# Without any filter parameter.
+data "huaweicloud_workspace_ou_users" "all" {
+  ou_dn = local.ou_dn
+}
+
+# Filter by 'user_name' parameter.
+locals {
+  user_name = try(data.huaweicloud_workspace_ou_users.all.users[0].name, "NOT_FOUND")
+}
+
+data "huaweicloud_workspace_ou_users" "filter_by_user_name" {
+  ou_dn     = local.ou_dn
+  user_name = local.user_name
+}
+
+locals {
+  user_name_filter_result = [for v in data.huaweicloud_workspace_ou_users.filter_by_user_name.users[*].name :
+    strcontains(v, local.user_name)
+  ]
+}
+
+output "is_user_name_filter_useful" {
+  value = length(local.user_name_filter_result) > 0 && alltrue(local.user_name_filter_result)
+}
+
+# Filter by 'has_existed' parameter.
+locals {
+  has_existed = try(data.huaweicloud_workspace_ou_users.all.users[0].has_existed, null)
+}
+
+data "huaweicloud_workspace_ou_users" "filter_by_has_existed" {
+  ou_dn       = local.ou_dn
+  has_existed = local.has_existed
+}
+
+locals {
+  has_existed_filter_result = [for v in data.huaweicloud_workspace_ou_users.filter_by_has_existed.users[*].has_existed :
+    v == local.has_existed
+  ]
+}
+
+output "is_has_existed_filter_useful" {
+  value = length(local.has_existed_filter_result) > 0 && alltrue(local.has_existed_filter_result)
+}
+`, acceptance.HW_WORKSPACE_OU_NAME)
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_ou_users.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_ou_users.go
@@ -1,0 +1,182 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v2/{project_id}/ou-users
+func DataSourceOuUsers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceOuUsersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the OU users are located.`,
+			},
+			"ou_dn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The distinguished name (DN) of the OU.`,
+			},
+			"user_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the user to which the OU belongs.`,
+			},
+			"has_existed": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether the user already exists in the user list.`,
+			},
+			"users": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the user.`,
+						},
+						"expired_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The expiration time of the user.`,
+						},
+						"has_existed": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the user already exists in the user list.`,
+						},
+					},
+				},
+				Description: `The list of users that match the filter parameters.`,
+			},
+			"enable_create_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of users that can be created.`,
+			},
+		},
+	}
+}
+
+func buildListOuUsersQueryParams(d *schema.ResourceData) string {
+	res := fmt.Sprintf("&ou_dn=%v", d.Get("ou_dn"))
+
+	if v, ok := d.GetOk("user_name"); ok {
+		res = fmt.Sprintf("%s&user_name=%v", res, v)
+	}
+
+	// If the 'has_existed' parameter is not specified, query all users.
+	rawConfig := d.GetRawConfig()
+	if v := utils.GetNestedObjectFromRawConfig(rawConfig, "has_existed"); v != nil {
+		res = fmt.Sprintf("%s&has_existed=%v", res, v)
+	}
+
+	return res
+}
+
+func listOuUsers(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/ou-users"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = fmt.Sprintf("%s?limit=%v", listPath, limit)
+	listPath += buildListOuUsersQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=utf-8"},
+	}
+
+	var enableCreateCount interface{}
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		users := utils.PathSearch("user_infos", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, users...)
+		if len(users) < limit {
+			enableCreateCount = utils.PathSearch("enable_create_count", respBody, nil)
+			break
+		}
+		offset += len(users)
+	}
+
+	return result, enableCreateCount, nil
+}
+
+func dataSourceOuUsersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	users, enableCreateCount, err := listOuUsers(client, d)
+	if err != nil {
+		return diag.Errorf("error querying users under the OU: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("users", flattenOuUsers(users)),
+		d.Set("enable_create_count", enableCreateCount),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenOuUsers(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"name":         utils.PathSearch("user_name", item, nil),
+			"expired_time": utils.PathSearch("expired_time", item, nil),
+			"has_existed":  utils.PathSearch("has_existed", item, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_workspace_ou_users`) to query users under the specified OU.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataOuUsers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataOuUsers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataOuUsers_basic
=== PAUSE TestAccDataOuUsers_basic
=== CONT  TestAccDataOuUsers_basic
--- PASS: TestAccDataOuUsers_basic (20.05s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 20.358s coverage: 3.9% of statements in ./huaweicloud/services/workspace
```
<img width="1122" height="513" alt="image" src="https://github.com/user-attachments/assets/67a6f374-929f-4e79-9922-d26ee162ac08" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
