### PR TITLE
feat(workspace): add new data source for query shared folders

### DIFF
--- a/docs/data-sources/workspace_app_shared_folders.md
+++ b/docs/data-sources/workspace_app_shared_folders.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_shared_folders"
+description: |-
+  Use this data source to get the list of application shared folders within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_shared_folders
+
+Use this data source to get the list of application shared folders within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "storage_id" {}
+
+data "huaweicloud_workspace_app_shared_folders" "test" {
+  storage_id = var.storage_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the WKS storage is located.  
+  If omitted, the provider-level region will be used.
+
+* `storage_id` - (Required, String) Specifies the WKS storage ID.
+
+* `storage_claim_id` - (Optional, String) Specifies the WKS storage directory claim ID.
+
+* `path` - (Optional, String) Specifies the shared folder path for query.  
+  Only visible characters and space(` `) are allowed, must start with a visible character.  
+  The valid length is limited from `0` to `128` characters.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `shared_folders` - The list of the shared folders that matched filter parameters.  
+  The [shared_folders](#workspace_shared_folders) structure is documented below.
+
+<a name="workspace_shared_folders"></a>
+The `shared_folders` block supports:
+
+* `storage_claim_id` - The WKS storage directory claim ID.
+
+* `folder_path` - The storage object path.  
+
+  -> This path is the complete path of the object in the system.
+
+* `delimiter` - The path delimiter.
+
+* `claim_mode` - The storage claim type.
+  + **USER**: user directory
+  + **SHARE**: shared directory.
+
+* `count` - The number of associated users and user groups of the shared folder.  
+  It is a map with keys like `USER` and `USER_GROUP`, and values are integers representing the counts.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2305,6 +2305,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_server_metric_data":                       workspace.DataSourceAppServerMetricData(),
 			"huaweicloud_workspace_app_server_quotas":                            workspace.DataSourceAppServerQuotas(),
 			"huaweicloud_workspace_app_session_types":                            workspace.DataSourceSessionTypes(),
+			"huaweicloud_workspace_app_shared_folders":                           workspace.DataSourceAppSharedFolders(),
 			"huaweicloud_workspace_app_storage_policies":                         workspace.DataSourceAppStoragePolicies(),
 			"huaweicloud_workspace_app_vnc_remote":                               workspace.DataSourceAppVncRemote(),
 			"huaweicloud_workspace_app_warehouse_applications":                   workspace.DataSourceAppWarehouseApplications(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_shared_folders_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_shared_folders_test.go
@@ -1,0 +1,129 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAppSharedFolders_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_workspace_app_shared_folders.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		filterByStorageClaimId   = "data.huaweicloud_workspace_app_shared_folders.filter_by_storage_claim_id"
+		dcFilterByStorageClaimId = acceptance.InitDataSourceCheck(filterByStorageClaimId)
+
+		filterByPath   = "data.huaweicloud_workspace_app_shared_folders.filter_by_path"
+		dcFilterByPath = acceptance.InitDataSourceCheck(filterByPath)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckSfsFileSystemNames(t, 1)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppSharedFolders_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "shared_folders.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'storage_claim_id' parameter.
+					dcFilterByStorageClaimId.CheckResourceExists(),
+					resource.TestCheckOutput("is_storage_claim_id_filter_useful", "true"),
+					// Filter by 'path' parameter.
+					dcFilterByPath.CheckResourceExists(),
+					resource.TestCheckOutput("is_path_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAppSharedFolders_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_nas_storage" "test" {
+  name = "%[1]s"
+
+  storage_metadata {
+    storage_handle = element(split(",", "%[2]s"), 0)
+    storage_class  = "sfs"
+  }
+}
+
+resource "huaweicloud_workspace_app_shared_folder" "test" {
+  storage_id = huaweicloud_workspace_app_nas_storage.test.id
+  name       = "%[1]s"
+}`, name, acceptance.HW_SFS_FILE_SYSTEM_NAMES)
+}
+
+func testAccDataSourceAppSharedFolders_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameter
+data "huaweicloud_workspace_app_shared_folders" "test" {
+  storage_id = huaweicloud_workspace_app_nas_storage.test.id
+
+  depends_on = [
+    huaweicloud_workspace_app_shared_folder.test,
+  ]
+}
+
+# Filter by 'storage_claim_id' parameter
+locals {
+  storage_claim_id = huaweicloud_workspace_app_shared_folder.test.id
+}
+
+data "huaweicloud_workspace_app_shared_folders" "filter_by_storage_claim_id" {
+  storage_id       = huaweicloud_workspace_app_nas_storage.test.id
+  storage_claim_id = local.storage_claim_id
+
+  depends_on = [
+    huaweicloud_workspace_app_shared_folder.test,
+  ]
+}
+
+locals {
+  storage_claim_id_filter_result = [
+    for o in data.huaweicloud_workspace_app_shared_folders.filter_by_storage_claim_id.shared_folders:
+    o.storage_claim_id == local.storage_claim_id
+  ]
+}
+
+output "is_storage_claim_id_filter_useful" {
+  value = length(local.storage_claim_id_filter_result) == 1 && alltrue(local.storage_claim_id_filter_result)
+}
+
+# Filter by 'path' parameter
+locals {
+  folder_path = "shares/%[2]s/"
+}
+
+data "huaweicloud_workspace_app_shared_folders" "filter_by_path" {
+  storage_id = huaweicloud_workspace_app_nas_storage.test.id
+  path       = local.folder_path
+
+  depends_on = [
+    huaweicloud_workspace_app_shared_folder.test,
+  ]
+}
+
+locals {
+  path_filter_result = [for o in data.huaweicloud_workspace_app_shared_folders.filter_by_path.shared_folders: o.folder_path == local.folder_path]
+}
+
+output "is_path_filter_useful" {
+  value = length(local.path_filter_result) >= 1 && alltrue(local.path_filter_result)
+}
+`, testAccDataSourceAppSharedFolders_base(name), name)
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_shared_folders.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_shared_folders.go
@@ -1,0 +1,201 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v1/{project_id}/persistent-storages/actions/list-share-folders
+func DataSourceAppSharedFolders() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppSharedFoldersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the WKS storage is located.`,
+			},
+
+			// Required parameters.
+			"storage_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The WKS storage ID.`,
+			},
+
+			// Optional parameters.
+			"storage_claim_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The WKS storage directory claim ID.`,
+			},
+			"path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The shared folder path for query.`,
+			},
+
+			// Attributes.
+			"shared_folders": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        appSharedFoldersSchema(),
+				Description: `The list of the shared folders that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func appSharedFoldersSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"storage_claim_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The WKS storage directory claim ID.`,
+			},
+			"folder_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The storage object path.`,
+			},
+			"delimiter": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The path delimiter.`,
+			},
+			"claim_mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The storage claim type.`,
+			},
+			"count": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+				Description: `The number of associated users and user groups of the shared folder.`,
+			},
+		},
+	}
+}
+
+func buildSharedFoldersQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	res = fmt.Sprintf("%s&storage_id=%v", res, d.Get("storage_id"))
+
+	if v, ok := d.GetOk("storage_claim_id"); ok {
+		res = fmt.Sprintf("%s&storage_claim_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("path"); ok {
+		res = fmt.Sprintf("%s&path=%v", res, v)
+	}
+
+	return res
+}
+
+func listSharedFolders(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/persistent-storages/actions/list-share-folders?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+	listPathWithLimit += buildSharedFoldersQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPathWithLimit + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		items := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, items...)
+		if len(items) < limit {
+			break
+		}
+
+		offset += len(items)
+	}
+
+	return result, nil
+}
+
+func flattenSharedFolders(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"storage_claim_id": utils.PathSearch("storage_claim_id", item, nil),
+			"folder_path":      utils.PathSearch("folder_path", item, nil),
+			"delimiter":        utils.PathSearch("delimiter", item, nil),
+			"claim_mode":       utils.PathSearch("claim_mode", item, nil),
+			"count":            utils.PathSearch("count", item, make(map[string]interface{})),
+		})
+	}
+
+	return result
+}
+
+func dataSourceAppSharedFoldersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	resp, err := listSharedFolders(client, d)
+	if err != nil {
+		return diag.Errorf("error querying shared folders: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("shared_folders", flattenSharedFolders(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(workspace): add new data source for query shared folders

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataSourceAppSharedFolders_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAppSharedFolders_basic
=== PAUSE TestAccDataSourceAppSharedFolders_basic
=== CONT  TestAccDataSourceAppSharedFolders_basic
--- PASS: TestAccDataSourceAppSharedFolders_basic (102.24s)
PASS
coverage: 5.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 102.403s        coverage: 5.0% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.