### PR TITLE
feat(workspace): add new data source to get OUs in AD

### DIFF
--- a/docs/data-sources/workspace_ad_ous.md
+++ b/docs/data-sources/workspace_ad_ous.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_ad_ous"
+description: |-
+  Use this data source to get organizational units (OUs) list in Active Directory (AD) within HuaweiCloud.
+---
+
+# huaweicloud_workspace_ad_ous
+
+Use this data source to get organizational units (OUs) list in Active Directory (AD) within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_workspace_ad_ous" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the OUs are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `ous` - The list of OUs.  
+  The [ous](#workspace_ad_ous) structure is documented below.
+
+<a name="workspace_ad_ous"></a>
+The `ous` block supports:
+
+* `name` - The name of the OU.
+
+* `ou_dn` - The distinguished name (DN) of the OU.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2255,6 +2255,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_workload_queues":                 dws.DataSourceWorkloadQueues(),
 
 			// Workspace
+			"huaweicloud_workspace_ad_ous":                               workspace.DataSourceAdOus(),
 			"huaweicloud_workspace_applications":                         workspace.DataSourceApplications(),
 			"huaweicloud_workspace_application_authorizations":           workspace.DataSourceApplicationAuthorizations(),
 			"huaweicloud_workspace_application_catalogs":                 workspace.DataSourceApplicationCatalogs(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_ad_ous_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_ad_ous_test.go
@@ -1,0 +1,42 @@
+package workspace
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this test, please ensure the Workspace service is connected to the AD.
+func TestAccDataAdOus_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_workspace_ad_ous.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAdOus_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					// Without any filter parameter.
+					resource.TestMatchResourceAttr(all, "ous.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "ous.0.name"),
+					resource.TestCheckResourceAttrSet(all, "ous.0.ou_dn"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataAdOus_basic = `
+# Without any filter parameter.
+data "huaweicloud_workspace_ad_ous" "all" {}
+`

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_ad_ous.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_ad_ous.go
@@ -1,0 +1,120 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v2/{project_id}/ad-ous
+func DataSourceAdOus() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAdOusRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the OUs are located.`,
+			},
+			"ous": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the OU.`,
+						},
+						"ou_dn": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The distinguished name (DN) of the OU.`,
+						},
+					},
+				},
+				Description: `The list of OUs.`,
+			},
+		},
+	}
+}
+
+func dataSourceAdOusRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	ous, err := listAdOus(client)
+	if err != nil {
+		return diag.Errorf("error querying OUs in AD service: %s", err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(randomId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("ous", flattenAdOus(ous)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func listAdOus(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/ad-ous"
+		listOpt = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json;charset=UTF-8",
+			},
+		}
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	resp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("ou_infos", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenAdOus(ouInfos []interface{}) []interface{} {
+	if len(ouInfos) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(ouInfos))
+	for _, ouInfo := range ouInfos {
+		result = append(result, map[string]interface{}{
+			"name":  utils.PathSearch("ou_name", ouInfo, nil),
+			"ou_dn": utils.PathSearch("ou_dn", ouInfo, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_workspace_ad_ous`) to OUs in AD service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataAdOus_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAdOus_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAdOus_basic
=== PAUSE TestAccDataAdOus_basic
=== CONT  TestAccDataAdOus_basic
--- PASS: TestAccDataAdOus_basic (16.59s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 16.746s coverage: 3.1% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

<img width="1149" height="87" alt="image" src="https://github.com/user-attachments/assets/dae7752e-58e3-4b33-9660-15f01ca01186" />

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
