### PR TITLE
feat(secmaster): new datasource to query pipes

### DIFF
--- a/docs/data-sources/secmaster_pipes.md
+++ b/docs/data-sources/secmaster_pipes.md
@@ -1,0 +1,81 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_pipes"
+description: |-
+  Use this data source to query the SecMaster pipes within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_pipes
+
+Use this data source to query the SecMaster pipes within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_pipes" "example" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the pipes.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to query pipes.
+
+* `dataspace_id` - (Optional, String) Specifies the dataspace ID to filter pipes.
+
+* `pipe_id` - (Optional, String) Specifies the pipe ID to filter pipes.
+
+* `pipe_name` - (Optional, String) Specifies the pipe name to filter pipes.
+
+* `sort_dir` - (Optional, String) Specifies the sort direction.
+
+* `sort_key` - (Optional, String) Specifies the field to sort the results by.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The list of pipes that match the query criteria.
+
+  The [records](#records_struct) structure is documented below.
+
+<a name="records_struct"></a>
+The `records` block supports:
+
+* `create_by` - The creator of the pipe.
+
+* `create_time` - The creation timestamp of the pipe.
+
+* `dataspace_id` - The ID of the associated dataspace.
+
+* `dataspace_name` - The name of the associated dataspace.
+
+* `description` - The description of the pipe.
+
+* `domain_id` - The domain ID of the pipe.
+
+* `pipe_id` - The unique identifier of the pipe.
+
+* `pipe_name` - The name of the pipe.
+
+* `pipe_type` - The type of the pipe. Valid values are **system-defined** and **user-defined**.
+
+* `project_id` - The project ID of the pipe.
+
+* `shards` - The number of shards for the pipe.
+
+* `storage_period` - The storage period in days for the pipe. The unit is day.
+
+* `update_by` - The last updater of the pipe.
+
+* `update_time` - The last update timestamp of the pipe.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1964,6 +1964,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_retrieve_scripts":             secmaster.DataSourceRetrieveScripts(),
 			"huaweicloud_secmaster_tables":                       secmaster.DataSourceTables(),
 			"huaweicloud_secmaster_operation_connections":        secmaster.DataSourceOperationConnections(),
+			"huaweicloud_secmaster_pipes":                        secmaster.DataSourceSecmasterPipes(),
 			"huaweicloud_secmaster_mappings_functions":           secmaster.DataSourceMappingsFunctions(),
 			"huaweicloud_secmaster_vulnerabilities":              secmaster.DataSourceVulnerabilities(),
 			"huaweicloud_secmasterv2_alert_rule_template_detail": secmaster.DataSourceAlertRuleTemplateDetailV2(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_pipes_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_pipes_test.go
@@ -1,0 +1,116 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSecmasterPipes_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_secmaster_pipes.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSecmasterPipes_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "records.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.create_by"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.dataspace_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.dataspace_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.domain_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.pipe_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.pipe_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.pipe_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.project_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.shards"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.storage_period"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.update_by"),
+
+					resource.TestCheckOutput("is_dataspace_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_pipe_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_pipe_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSecmasterPipes_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_pipes" "test" {
+  workspace_id = "%[1]s"
+}
+
+# Filter by dataspace_id
+locals {
+  dataspace_id = data.huaweicloud_secmaster_pipes.test.records[0].dataspace_id
+}
+
+data "huaweicloud_secmaster_pipes" "filter_by_dataspace_id" {
+  workspace_id = "%[1]s"
+  dataspace_id = local.dataspace_id
+}
+
+locals {
+  list_by_dataspace_id = data.huaweicloud_secmaster_pipes.filter_by_dataspace_id.records
+}
+
+output "is_dataspace_id_filter_useful" {
+  value = length(local.list_by_dataspace_id) > 0 && alltrue(
+    [for v in local.list_by_dataspace_id[*].dataspace_id : v == local.dataspace_id]
+  )
+}
+
+# Filter by pipe_id
+locals {
+  pipe_id = data.huaweicloud_secmaster_pipes.test.records[0].pipe_id
+}
+
+data "huaweicloud_secmaster_pipes" "filter_by_pipe_id" {
+  workspace_id = "%[1]s"
+  pipe_id      = local.pipe_id
+}
+
+locals {
+  list_by_pipe_id = data.huaweicloud_secmaster_pipes.filter_by_pipe_id.records
+}
+
+output "is_pipe_id_filter_useful" {
+  value = length(local.list_by_pipe_id) > 0 && alltrue(
+    [for v in local.list_by_pipe_id[*].pipe_id : v == local.pipe_id]
+  )
+}
+
+# Filter by pipe_name
+locals {
+  pipe_name = data.huaweicloud_secmaster_pipes.test.records[0].pipe_name
+}
+
+data "huaweicloud_secmaster_pipes" "filter_by_pipe_name" {
+  workspace_id = "%[1]s"
+  pipe_name    = local.pipe_name
+}
+
+locals {
+  list_by_pipe_name = data.huaweicloud_secmaster_pipes.filter_by_pipe_name.records
+}
+
+output "is_pipe_name_filter_useful" {
+  value = length(local.list_by_pipe_name) > 0 && alltrue(
+    [for v in local.list_by_pipe_name[*].pipe_name : v == local.pipe_name]
+  )
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_pipes.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_pipes.go
@@ -1,0 +1,249 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v1/{project_id}/workspaces/{workspace_id}/siem/pipes
+func DataSourceSecmasterPipes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecmasterPipesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"dataspace_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"pipe_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"pipe_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// There's a problem with the API; passing this field `pipe_type` will cause an error.
+			"pipe_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"create_by": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"dataspace_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dataspace_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"pipe_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"pipe_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"pipe_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"shards": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"storage_period": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"update_by": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildPipesQueryParams(d *schema.ResourceData, offset int) string {
+	rst := ""
+
+	if v, ok := d.GetOk("dataspace_id"); ok {
+		rst += fmt.Sprintf("&dataspace_id=%v", v)
+	}
+
+	if v, ok := d.GetOk("pipe_id"); ok {
+		rst += fmt.Sprintf("&pipe_id=%v", v)
+	}
+
+	if v, ok := d.GetOk("pipe_name"); ok {
+		rst += fmt.Sprintf("&pipe_name=%v", v)
+	}
+
+	if v, ok := d.GetOk("pipe_type"); ok {
+		rst += fmt.Sprintf("&pipe_type=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%v", v)
+	}
+
+	if offset > 0 {
+		rst += fmt.Sprintf("&offset=%d", offset)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourceSecmasterPipesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/siem/pipes"
+		offset  = 0
+		allData = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestCurrentPath := requestPath + buildPipesQueryParams(d, offset)
+		resp, err := client.Request("GET", requestCurrentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving SecMaster pipes: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		records := utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{})
+		if len(records) == 0 {
+			break
+		}
+
+		allData = append(allData, records...)
+		offset += len(records)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("records", flattenPipesAttribute(allData)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPipesAttribute(allData []interface{}) []interface{} {
+	if len(allData) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(allData))
+	for _, v := range allData {
+		rst = append(rst, map[string]interface{}{
+			"create_by":      utils.PathSearch("create_by", v, nil),
+			"create_time":    utils.PathSearch("create_time", v, nil),
+			"dataspace_id":   utils.PathSearch("dataspace_id", v, nil),
+			"dataspace_name": utils.PathSearch("dataspace_name", v, nil),
+			"description":    utils.PathSearch("description", v, nil),
+			"domain_id":      utils.PathSearch("domain_id", v, nil),
+			"pipe_id":        utils.PathSearch("pipe_id", v, nil),
+			"pipe_name":      utils.PathSearch("pipe_name", v, nil),
+			"pipe_type":      utils.PathSearch("pipe_type", v, nil),
+			"project_id":     utils.PathSearch("project_id", v, nil),
+			"shards":         utils.PathSearch("shards", v, nil),
+			"storage_period": utils.PathSearch("storage_period", v, nil),
+			"update_by":      utils.PathSearch("update_by", v, nil),
+			"update_time":    utils.PathSearch("update_time", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query pipes

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourceSecmasterPipes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceSecmasterPipes_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSecmasterPipes_basic
=== PAUSE TestAccDataSourceSecmasterPipes_basic
=== CONT  TestAccDataSourceSecmasterPipes_basic
--- PASS: TestAccDataSourceSecmasterPipes_basic (17.16s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 17.261s coverage: 4.7% of statements in ./huaweicloud/services/secmaster
```
<img width="1380" height="78" alt="image" src="https://github.com/user-attachments/assets/678cf5ff-63ed-4500-9d79-af2ce34ffda2" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
