### PR TITLE
feat(workspace): add new resource for assign shared folder user

### DIFF
--- a/docs/resources/workspace_app_shared_folder_assign.md
+++ b/docs/resources/workspace_app_shared_folder_assign.md
@@ -1,0 +1,105 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_shared_folder_assign"
+description: |-
+  Use this resource to assign user access to the shared folder within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_shared_folder_assign
+
+Use this resource to assign user access to the shared folder within HuaweiCloud.
+
+-> This resource is only a one-time action resource for assignment of user access to a shared folder.
+   Deleting this resource will not clear the corresponding request record, but will only remove
+   the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "storage_id" {}
+variable "storage_claim_id" {}
+variable "add_items" {
+  type = list(object({
+    policy_statement_id = string
+    attach              = string
+    attach_type         = string
+  }))
+}
+variable "del_items" {
+  type = list(object({
+    attach      = string
+    attach_type = string
+  }))
+}
+
+resource "huaweicloud_workspace_app_shared_folder_assign" "test" {
+  storage_id       = var.storage_id
+  storage_claim_id = var.storage_claim_id
+
+  dynamic "add_items" {
+    for_each = var.add_items
+
+    content {
+      policy_statement_id = add_items.value.policy_statement_id
+      attach              = add_items.value.attach
+      attach_type         = add_items.value.attach_type
+    }
+  }
+
+  dynamic "del_items" {
+    for_each = var.del_items
+
+    content {
+      attach      = del_items.value.attach
+      attach_type = del_items.value.attach_type
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the WKS storage is located.  
+  If omitted, the provider-level region will be used.  
+  Change this parameter will create a new resource.
+
+* `storage_id` - (Required, String, NonUpdatable) Specifies the WKS storage ID to which the shared folder belongs.
+
+* `storage_claim_id` - (Required, String, NonUpdatable) Specifies the WKS storage directory claim ID.
+
+* `add_items` - (Optional, List, NonUpdatable) Specifies the list of members to be added.  
+  The [add_items](#workspace_shared_folders_access_add_items) structure is documented below.
+
+* `del_items` - (Optional, List, NonUpdatable) Specifies the list of members to be removed.  
+  The [del_items](#workspace_shared_folders_access_del_items) structure is documented below.
+
+<a name="workspace_shared_folders_access_add_items"></a>
+The `add_items` block supports:
+
+* `policy_statement_id` - (Required, String) Specifies the policy ID.
+
+* `attach` - (Required, String) Specifies the target.
+
+* `attach_type` - (Required, String) Specifies the associated object type.  
+  The valid values are as follows:
+  + **USER** - User
+  + **USER_GROUP** - User group
+
+<a name="workspace_shared_folders_access_del_items"></a>
+The `del_items` block supports:
+
+* `attach` - (Required, String) Specifies the target.
+
+* `attach_type` - (Required, String) Specifies the associated object type.  
+  The valid values are as follows:
+  + **USER** - User
+  + **USER_GROUP** - User group
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3824,6 +3824,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_server_group_scaling_policy":             workspace.ResourceAppServerGroupScalingPolicy(),
 			"huaweicloud_workspace_app_service_action":                          workspace.ResourceAppServiceAction(),
 			"huaweicloud_workspace_app_shared_folder":                           workspace.ResourceAppSharedFolder(),
+			"huaweicloud_workspace_app_shared_folder_assign":                    workspace.ResourceAppSharedFolderAssign(),
 			"huaweicloud_workspace_app_storage_policy":                          workspace.ResourceAppStoragePolicy(),
 			"huaweicloud_workspace_app_warehouse_application":                   workspace.ResourceAppWarehouseApplication(),
 

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_shared_folder_assign_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_shared_folder_assign_test.go
@@ -1,0 +1,87 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceAppSharedFolderAssign_basic(t *testing.T) {
+	var name = acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckSfsFileSystemNames(t, 1)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppSharedFolderAssign_step1(name),
+			},
+			{
+				Config: testAccAppSharedFolderAssign_step2(name),
+			},
+		},
+	})
+}
+
+func testAccAppSharedFolderAssign_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_workspace_app_nas_storage" "test" {
+  name = "%[1]s"
+
+  storage_metadata {
+    storage_handle = element(split(",", "%[2]s"), 0)
+    storage_class  = "sfs"
+  }
+}
+
+resource "huaweicloud_workspace_app_shared_folder" "test" {
+  storage_id = huaweicloud_workspace_app_nas_storage.test.id
+  name       = "%[1]s"
+}
+
+resource "huaweicloud_workspace_user" "test" {
+  name  = "%[1]s"
+  email = "tf@example.com"
+}
+`, name, acceptance.HW_SFS_FILE_SYSTEM_NAMES)
+}
+
+func testAccAppSharedFolderAssign_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_shared_folder_assign" "test_with_add_items" {
+  storage_id       = huaweicloud_workspace_app_nas_storage.test.id
+  storage_claim_id = huaweicloud_workspace_app_shared_folder.test.id
+
+  add_items {
+    policy_statement_id = "DEFAULT_1"
+    attach              = huaweicloud_workspace_user.test.name
+    attach_type         = "USER"
+  }
+}
+`, testAccAppSharedFolderAssign_base(name))
+}
+
+func testAccAppSharedFolderAssign_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_shared_folder_assign" "test_with_del_items" {
+  storage_id       = huaweicloud_workspace_app_nas_storage.test.id
+  storage_claim_id = huaweicloud_workspace_app_shared_folder.test.id
+
+  del_items {
+    attach      = huaweicloud_workspace_user.test.name
+    attach_type = "USER"
+  }
+}
+`, testAccAppSharedFolderAssign_base(name))
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_shared_folder_assign.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_shared_folder_assign.go
@@ -1,0 +1,209 @@
+package workspace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var appSharedFolderAssignNonUpdatableParams = []string{"storage_id", "storage_claim_id", "add_items", "del_items"}
+
+// @API Workspace POST /v1/{project_id}/persistent-storages/{storage_id}/actions/assign-share-folder
+func ResourceAppSharedFolderAssign() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppSharedFolderAssignCreate,
+		ReadContext:   resourceAppSharedFolderAssignRead,
+		UpdateContext: resourceAppSharedFolderAssignUpdate,
+		DeleteContext: resourceAppSharedFolderAssignDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(appSharedFolderAssignNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the WKS storage is located.`,
+			},
+
+			// Required parameters.
+			"storage_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The WKS storage ID to which the shared folder belongs.`,
+			},
+			"storage_claim_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The WKS storage directory claim ID.`,
+			},
+
+			// Optional parameters.
+			"add_items": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        addItemSchema(),
+				Description: `The list of members to be added.`,
+			},
+			"del_items": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        delItemSchema(),
+				Description: `The list of members to be removed.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func addItemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"policy_statement_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The policy ID.`,
+			},
+			"attach": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The target.`,
+			},
+			"attach_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The associated object type.`,
+			},
+		},
+	}
+}
+
+func delItemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"attach": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The target.`,
+			},
+			"attach_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The associated object type.`,
+			},
+		},
+	}
+}
+
+func buildAppSharedFolderAddItems(addItems []interface{}) []map[string]interface{} {
+	if len(addItems) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(addItems))
+	for _, item := range addItems {
+		result = append(result, map[string]interface{}{
+			"policy_statement_id": utils.PathSearch("policy_statement_id", item, ""),
+			"attach":              utils.PathSearch("attach", item, ""),
+			"attach_type":         utils.PathSearch("attach_type", item, ""),
+		})
+	}
+
+	return result
+}
+
+func buildAppSharedFolderDelItems(delItems []interface{}) []map[string]interface{} {
+	if len(delItems) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(delItems))
+	for _, item := range delItems {
+		result = append(result, map[string]interface{}{
+			"attach":      utils.PathSearch("attach", item, ""),
+			"attach_type": utils.PathSearch("attach_type", item, ""),
+		})
+	}
+
+	return result
+}
+
+func buildAppSharedFolderAssignBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"storage_claim_id": d.Get("storage_claim_id").(string),
+		"add_items":        buildAppSharedFolderAddItems(d.Get("add_items").([]interface{})),
+		"del_items":        buildAppSharedFolderDelItems(d.Get("del_items").([]interface{})),
+	}
+}
+
+func resourceAppSharedFolderAssignCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		httpUrl   = "v1/{project_id}/persistent-storages/{storage_id}/actions/assign-share-folder"
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		storageId = d.Get("storage_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{storage_id}", storageId)
+
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAppSharedFolderAssignBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("error assigning shared folder members: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceAppSharedFolderAssignRead(ctx, d, meta)
+}
+
+func resourceAppSharedFolderAssignRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppSharedFolderAssignUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAppSharedFolderAssignDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for assignment of user access to a shared folder. Deleting
+this resource will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(workspace): add new resource for assign shared folder user

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add provider implement
2. add test case
3. add document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccResourceAppSharedFolderAssign_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceAppSharedFolderAssign_basic
=== PAUSE TestAccResourceAppSharedFolderAssign_basic
=== CONT  TestAccResourceAppSharedFolderAssign_basic
--- PASS: TestAccResourceAppSharedFolderAssign_basic (144.54s)
PASS
coverage: 5.6% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 144.682s        coverage: 5.6% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.