### PR TITLE
feat(secmaster): new datasource to query collector parser templates

### DIFF
--- a/docs/data-sources/secmaster_collector_parser_templates.md
+++ b/docs/data-sources/secmaster_collector_parser_templates.md
@@ -1,0 +1,58 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_collector_parser_templates"
+description: |-
+  Use this data source to query the SecMaster collector parser templates within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_collector_parser_templates
+
+Use this data source to query the SecMaster collector parser templates within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_collector_parser_templates" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the parser templates.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to query parser templates.
+
+* `title` - (Optional, String) Specifies the title of the parser template to filter the results.
+
+* `description` - (Optional, String) Specifies the description to filter the parser templates.
+
+* `sort_key` - (Optional, String) Specifies the key for sorting the results.
+
+* `sort_dir` - (Optional, String) Specifies the sort direction.
+  Valid values are `asc` (ascending) and `desc` (descending).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The list of parser templates that match the query criteria.
+
+  The [records](#records_struct) structure is documented below.
+
+<a name="records_struct"></a>
+The `records` block supports:
+
+* `title` - The title of the parser template.
+
+* `description` - The description of the parser template.
+
+* `parser_id` - The unique identifier of the parser template.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1959,6 +1959,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_catalogues_search":            secmaster.DataSourceSecmasterCataloguesSearch(),
 			"huaweicloud_secmaster_collector_channel_groups":     secmaster.DataSourceCollectorChannelGroups(),
 			"huaweicloud_secmaster_collector_logstash_parsers":   secmaster.DataSourceCollectorLogstashParsers(),
+			"huaweicloud_secmaster_collector_parser_templates":   secmaster.DataSourceSecmasterCollectorParserTemplates(),
 			"huaweicloud_secmaster_collector_channel_instances":  secmaster.DataSourceCollectorChannelInstances(),
 			"huaweicloud_secmaster_installation_scripts":         secmaster.DataSourceSecmasterInstallationScripts(),
 			"huaweicloud_secmaster_retrieve_scripts":             secmaster.DataSourceRetrieveScripts(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_collector_parser_templates_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_collector_parser_templates_test.go
@@ -1,0 +1,85 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSecmasterCollectorParserTemplates_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_secmaster_collector_parser_templates.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSecmasterCollectorParserTemplates_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.description"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.parser_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.title"),
+
+					resource.TestCheckOutput("is_title_filter_useful", "true"),
+					resource.TestCheckOutput("is_description_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSecmasterCollectorParserTemplates_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_collector_parser_templates" "test" {
+  workspace_id = "%[1]s"
+}
+
+# Filter by title
+locals {
+  title = data.huaweicloud_secmaster_collector_parser_templates.test.records[0].title
+}
+
+data "huaweicloud_secmaster_collector_parser_templates" "filter_by_title" {
+  workspace_id = "%[1]s"
+  title        = local.title
+}
+
+locals {
+  list_by_title = data.huaweicloud_secmaster_collector_parser_templates.filter_by_title.records
+}
+
+output "is_title_filter_useful" {
+  value = length(local.list_by_title) > 0 && alltrue(
+    [for v in local.list_by_title[*].title : v == local.title]
+  )
+}
+
+# Filter by description
+locals {
+  description = data.huaweicloud_secmaster_collector_parser_templates.test.records[0].description
+}
+
+data "huaweicloud_secmaster_collector_parser_templates" "filter_by_description" {
+  workspace_id   = "%[1]s"
+  description    = local.description
+}
+
+locals {
+  list_by_description = data.huaweicloud_secmaster_collector_parser_templates.filter_by_description.records
+}
+
+output "is_description_filter_useful" {
+  value = length(local.list_by_description) > 0 && alltrue(
+    [for v in local.list_by_description[*].description : v == local.description]
+  )
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_collector_parser_templates.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_collector_parser_templates.go
@@ -1,0 +1,176 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v1/{project_id}/workspaces/{workspace_id}/collector/logstash/parsers/templates
+func DataSourceSecmasterCollectorParserTemplates() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecmasterCollectorParserTemplatesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"title": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"parser_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"title": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildCollectorParserTemplatesQueryParams(d *schema.ResourceData, offset int) string {
+	rst := ""
+
+	if v, ok := d.GetOk("title"); ok {
+		rst += fmt.Sprintf("&title=%v", v)
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		rst += fmt.Sprintf("&description=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%v", v)
+	}
+
+	if offset > 0 {
+		rst += fmt.Sprintf("&offset=%d", offset)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourceSecmasterCollectorParserTemplatesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/collector/logstash/parsers/templates"
+		offset  = 0
+		allData = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestCurrentPath := requestPath + buildCollectorParserTemplatesQueryParams(d, offset)
+		resp, err := client.Request("GET", requestCurrentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving SecMaster collector parser templates: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		records := utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{})
+		if len(records) == 0 {
+			break
+		}
+
+		allData = append(allData, records...)
+		offset += len(records)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("records", flattenCollectorParserTemplates(allData)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCollectorParserTemplates(allData []interface{}) []interface{} {
+	if len(allData) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(allData))
+	for _, v := range allData {
+		rst = append(rst, map[string]interface{}{
+			"description": utils.PathSearch("description", v, nil),
+			"parser_id":   utils.PathSearch("parser_id", v, nil),
+			"title":       utils.PathSearch("title", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query collector parser templates

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourceSecmasterCollectorParserTemplates_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceSecmasterCollectorParserTemplates_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSecmasterCollectorParserTemplates_basic
=== PAUSE TestAccDataSourceSecmasterCollectorParserTemplates_basic
=== CONT  TestAccDataSourceSecmasterCollectorParserTemplates_basic
--- PASS: TestAccDataSourceSecmasterCollectorParserTemplates_basic (15.72s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 15.831s coverage: 4.6% of statements in ./huaweicloud/services/secmaster
```
<img width="1391" height="83" alt="image" src="https://github.com/user-attachments/assets/f6d2716b-f9d6-47fe-b7cd-5a610544431b" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
