### PR TITLE
fix(kafka/consumer_groups): fix some filtering parameters are invalid

### DIFF
--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_consumer_groups_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_consumer_groups_test.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,107 +10,195 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceDmsKafkaConsumerGroups_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_dms_kafka_consumer_groups.all"
-	rName := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(dataSource)
+// Before running this test, make sure that the `HW_DMS_KAFKA_CONSUMER_GROUP_NAME` is online (status is online).
+func TestAccDataConsumerGroups_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testDataSourceDataSourceDmsKafkaConsumerGroups_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "groups.#"),
-					resource.TestCheckOutput("name_validation", "true"),
-					resource.TestCheckOutput("state_validation", "true"),
-					resource.TestCheckOutput("description_validation", "true"),
-					resource.TestCheckOutput("lag_validation", "true"),
-					resource.TestCheckOutput("coordinator_id_validation", "true"),
-				),
-			},
-		},
-	})
-}
+		all = "data.huaweicloud_dms_kafka_consumer_groups.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
-func testDataSourceDataSourceDmsKafkaConsumerGroups_basic(name string) string {
-	return fmt.Sprintf(`
-%s
+		filterByName   = "data.huaweicloud_dms_kafka_consumer_groups.filter_by_name"
+		dcFilterByName = acceptance.InitDataSourceCheck(filterByName)
 
-data "huaweicloud_dms_kafka_consumer_groups" "all" {
-  depends_on = [huaweicloud_dms_kafka_consumer_group.test]
+		filterByDescription   = "data.huaweicloud_dms_kafka_consumer_groups.filter_by_description"
+		dcFilterByDescription = acceptance.InitDataSourceCheck(filterByDescription)
 
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-}
+		filterByLag   = "data.huaweicloud_dms_kafka_consumer_groups.filter_by_lag"
+		dcFilterByLag = acceptance.InitDataSourceCheck(filterByLag)
 
-data "huaweicloud_dms_kafka_consumer_groups" "test" {
-  instance_id    = huaweicloud_dms_kafka_instance.test.id
-  name           = local.test_refer.name
-  description    = local.test_refer.description
-  lag            = local.test_refer.lag
-  coordinator_id = local.test_refer.coordinator_id
-  state          = local.test_refer.state
-}
+		filterByCoordinatorId   = "data.huaweicloud_dms_kafka_consumer_groups.filter_by_coordinator_id"
+		dcFilterByCoordinatorId = acceptance.InitDataSourceCheck(filterByCoordinatorId)
 
-locals {
-  test_refer   = huaweicloud_dms_kafka_consumer_group.test
-  test_results = data.huaweicloud_dms_kafka_consumer_groups.test
-}
+		filterByState   = "data.huaweicloud_dms_kafka_consumer_groups.filter_by_state"
+		dcFilterByState = acceptance.InitDataSourceCheck(filterByState)
 
-output "name_validation" {
-  value = alltrue([for v in local.test_results.groups[*].name : strcontains(v, local.test_refer.name)])
-}
-
-output "description_validation" {
-  value = alltrue([for v in local.test_results.groups[*].description : strcontains(v, local.test_refer.description)])
-}
-
-output "lag_validation" {
-  value = alltrue([for v in local.test_results.groups[*].lag : v == local.test_refer.lag])
-}
-
-output "coordinator_id_validation" {
-  value = alltrue([for v in local.test_results.groups[*].coordinator_id : v == local.test_refer.coordinator_id])
-}
-
-output "state_validation" {
-  value = alltrue([for v in local.test_results.groups[*].state : v == local.test_refer.state])
-}
-`, testDmsKafkaConsumerGroup_basic(name))
-}
-
-func TestAccDataSourceDmsKafkaConsumerGroups_consumers(t *testing.T) {
-	dataSource := "data.huaweicloud_dms_kafka_consumer_groups.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+		online   = "data.huaweicloud_dms_kafka_consumer_groups.online"
+		dcOnline = acceptance.InitDataSourceCheck(online)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckDMSKafkaInstanceID(t)
+			acceptance.TestAccPreCheckDMSKafkaConsumerGroupName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDmsKafkaConsumerGroups_consumers(),
+				Config: testAccDataConsumerGroups_basic(name),
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "groups.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "groups.0.members.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "groups.0.group_message_offsets.#"),
+					resource.TestMatchResourceAttr(all, "groups.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'name' parameter.
+					dcFilterByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					// Filter by 'description' parameter.
+					dcFilterByDescription.CheckResourceExists(),
+					resource.TestCheckOutput("is_description_filter_useful", "true"),
+					// Filter by 'lag' parameter.
+					dcFilterByLag.CheckResourceExists(),
+					resource.TestCheckOutput("is_lag_filter_useful", "true"),
+					// Filter by 'coordinator_id' parameter.
+					dcFilterByCoordinatorId.CheckResourceExists(),
+					resource.TestCheckOutput("is_coordinator_id_filter_useful", "true"),
+					// Filter by 'state' parameter.
+					dcFilterByState.CheckResourceExists(),
+					resource.TestCheckOutput("is_state_filter_useful", "true"),
+					// Use the online consumer group to filter.
+					dcOnline.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(online, "groups.0.assignment_strategy"),
+					resource.TestMatchResourceAttr(online, "groups.0.members.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceDmsKafkaConsumerGroups_consumers() string {
+func testAccDataConsumerGroups_basic(name string) string {
 	return fmt.Sprintf(`
-data "huaweicloud_dms_kafka_consumer_groups" "test" {
+resource "huaweicloud_dms_kafka_consumer_group" "test" {
   instance_id = "%[1]s"
+  name        = "%[2]s"
+  description = "Created by Terraform script"
 }
-`, acceptance.HW_DMS_KAFKA_INSTANCE_ID)
+
+# Without any filter parameters.
+data "huaweicloud_dms_kafka_consumer_groups" "all" {
+  instance_id = "%[1]s"
+  depends_on  = [huaweicloud_dms_kafka_consumer_group.test]
+}
+
+# Filter by 'name' parameter.
+locals {
+  name = huaweicloud_dms_kafka_consumer_group.test.name
+}
+
+data "huaweicloud_dms_kafka_consumer_groups" "filter_by_name" {
+  instance_id = "%[1]s"
+  name        = local.name
+  depends_on  = [huaweicloud_dms_kafka_consumer_group.test]
+}
+
+locals {
+  name_filter_result = [for v in data.huaweicloud_dms_kafka_consumer_groups.filter_by_name.groups[*].name :
+    strcontains(v, local.name)
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by 'description' parameter.
+locals {
+  description = huaweicloud_dms_kafka_consumer_group.test.description
+}
+
+data "huaweicloud_dms_kafka_consumer_groups" "filter_by_description" {
+  instance_id = "%[1]s"
+  description = local.description
+  depends_on  = [huaweicloud_dms_kafka_consumer_group.test]
+}
+
+locals {
+  description_filter_result = [
+    for v in data.huaweicloud_dms_kafka_consumer_groups.filter_by_description.groups[*].description :
+    v == local.description
+  ]
+}
+
+output "is_description_filter_useful" {
+  value = length(local.description_filter_result) > 0 && alltrue(local.description_filter_result)
+}
+
+# Filter by 'lag' parameter.
+locals {
+  lag = try(data.huaweicloud_dms_kafka_consumer_groups.all.groups[0].lag, null)
+}
+
+data "huaweicloud_dms_kafka_consumer_groups" "filter_by_lag" {
+  instance_id = "%[1]s"
+  lag         = local.lag
+}
+
+locals {
+  lag_filter_result = [for v in data.huaweicloud_dms_kafka_consumer_groups.filter_by_lag.groups[*].lag :
+    v == local.lag
+  ]
+}
+
+output "is_lag_filter_useful" {
+  value = length(local.lag_filter_result) > 0 && alltrue(local.lag_filter_result)
+}
+
+# Filter by 'coordinator_id' parameter.
+locals {
+  coordinator_id = huaweicloud_dms_kafka_consumer_group.test.coordinator_id
+}
+
+data "huaweicloud_dms_kafka_consumer_groups" "filter_by_coordinator_id" {
+  instance_id    = "%[1]s"
+  coordinator_id = local.coordinator_id
+}
+
+locals {
+  coordinator_id_filter_result = [
+    for v in data.huaweicloud_dms_kafka_consumer_groups.filter_by_coordinator_id.groups[*].coordinator_id :
+    v == local.coordinator_id
+  ]
+}
+
+output "is_coordinator_id_filter_useful" {
+  value = length(local.coordinator_id_filter_result) > 0 && alltrue(local.coordinator_id_filter_result)
+}
+
+# Filter by 'state' parameter.
+locals {
+  state = huaweicloud_dms_kafka_consumer_group.test.state
+}
+
+data "huaweicloud_dms_kafka_consumer_groups" "filter_by_state" {
+  instance_id = "%[1]s"
+  state       = local.state
+}
+
+locals {
+  state_filter_result = [
+    for v in data.huaweicloud_dms_kafka_consumer_groups.filter_by_state.groups[*].state :
+    v == local.state
+  ]
+}
+
+output "is_state_filter_useful" {
+  value = length(local.state_filter_result) > 0 && alltrue(local.state_filter_result)
+}
+
+# Use the online consumer group to filter.
+data "huaweicloud_dms_kafka_consumer_groups" "online" {
+  instance_id = "%[1]s"
+  name        = "%[3]s"
+}
+`, acceptance.HW_DMS_KAFKA_INSTANCE_ID, name, acceptance.HW_DMS_KAFKA_CONSUMER_GROUP_NAME)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix some filtering parameters are invalid and adjust acceptance test.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o kafka -f TestAccDataConsumerGroups_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataConsumerGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccDataConsumerGroups_basic
=== PAUSE TestAccDataConsumerGroups_basic
=== CONT  TestAccDataConsumerGroups_basic
--- PASS: TestAccDataConsumerGroups_basic (20.55s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     20.652s coverage: 5.2% of statements in ./huaweicloud/services/kafka
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
