### PR TITLE
test(workspace): keep all acceptance tests' coding format be same

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -2437,7 +2437,7 @@ func TestAccPreCheckWorkspaceAppServerGroup(t *testing.T) {
 	if HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID == "" {
 		t.Skip("HW_WORKSPACE_APP_SERVER_GROUP_FLAVOR_ID must be set for Workspace APP acceptance tests.")
 	}
-	TestAccPreCheckWorkspaceAppServerImageInfo(t)
+	TestAccPreCheckWorkspaceAppServerImageId(t)
 }
 
 // lintignore:AT003
@@ -2455,9 +2455,10 @@ func TestAccPreCheckWorkspaceDesktopIds(t *testing.T, min int) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckWorkspaceAppServerImageInfo(t *testing.T) {
-	if HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID == "" || HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID == "" {
-		t.Skip("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID and HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID must be set for Workspace APP acceptance tests.")
+func TestAccPreCheckWorkspaceAppServerImageId(t *testing.T) {
+	// HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID is not required for acceptance tests.
+	if HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID == "" {
+		t.Skip("HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID must be set for Workspace APP acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_server_groups_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_server_groups_test.go
@@ -13,7 +13,7 @@ func TestAccDataAppServerGroups_basic(t *testing.T) {
 	var (
 		name = acceptance.RandomAccResourceName()
 
-		all = "data.huaweicloud_workspace_app_server_groups.test"
+		all = "data.huaweicloud_workspace_app_server_groups.all"
 		dc  = acceptance.InitDataSourceCheck(all)
 
 		byId   = "data.huaweicloud_workspace_app_server_groups.filter_by_id"
@@ -40,7 +40,7 @@ func TestAccDataAppServerGroups_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataAppServerGroups_basic_step2(name),
+				Config: testAccDataAppServerGroups_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					dcById.CheckResourceExists(),
@@ -131,63 +131,64 @@ resource "huaweicloud_workspace_app_server_group" "test" {
 		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
 }
 
-func testAccDataAppServerGroups_basic_step2(name string) string {
+func testAccDataAppServerGroups_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-data "huaweicloud_workspace_app_server_groups" "test" {
+# Without any filter parameter.
+data "huaweicloud_workspace_app_server_groups" "all" {
   depends_on = [
     huaweicloud_workspace_app_server_group.test
   ]
 }
 
-# Filter by ID
+# Filter by 'server_group_id' parameter.
 locals {
-  group_id = huaweicloud_workspace_app_server_group.test.id
+  server_group_id = huaweicloud_workspace_app_server_group.test.id
 }
 
-data "huaweicloud_workspace_app_server_groups" "filter_by_id" {
+data "huaweicloud_workspace_app_server_groups" "filter_by_server_group_id" {
   depends_on = [
     huaweicloud_workspace_app_server_group.test
   ]
 
-  server_group_id = local.group_id
+  server_group_id = local.server_group_id
 }
 
 locals {
-  id_filter_result = [
-    for v in data.huaweicloud_workspace_app_server_groups.filter_by_id.server_groups[*].id : v == local.group_id
+  server_group_id_filter_result = [
+    for v in data.huaweicloud_workspace_app_server_groups.filter_by_server_group_id.server_groups[*].id : v == local.server_group_id
   ]
 }
 
-output "is_id_filter_useful" {
-  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)
+output "is_server_group_id_filter_useful" {
+  value = length(local.server_group_id_filter_result) > 0 && alltrue(local.server_group_id_filter_result)
 }
 
-# Filter by name
+# Filter by 'server_group_name' parameter.
 locals {
-  group_name = huaweicloud_workspace_app_server_group.test.name
+  server_group_name = huaweicloud_workspace_app_server_group.test.name
 }
 
-data "huaweicloud_workspace_app_server_groups" "filter_by_name" {
+data "huaweicloud_workspace_app_server_groups" "filter_by_server_group_name" {
   depends_on = [
     huaweicloud_workspace_app_server_group.test
   ]
 
-  server_group_name = local.group_name
+  server_group_name = local.server_group_name
 }
 
 locals {
-  name_filter_result = [
-    for v in data.huaweicloud_workspace_app_server_groups.filter_by_name.server_groups[*].name : v == local.group_name
+  server_group_name_filter_result = [
+    for v in data.huaweicloud_workspace_app_server_groups.filter_by_server_group_name.server_groups[*].name : v == local.server_group_name
   ]
 }
 
-output "is_name_filter_useful" {
-  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+output "is_server_group_name_filter_useful" {
+  value = length(local.server_group_name_filter_result) > 0 && alltrue(local.server_group_name_filter_result)
 }
 
-# Filter by app_type
+# Filter by 'app_type' parameter.
 locals {
   app_type = huaweicloud_workspace_app_server_group.test.app_type
 }
@@ -210,7 +211,7 @@ output "is_app_type_filter_useful" {
   value = length(local.app_type_filter_result) > 0 && alltrue(local.app_type_filter_result)
 }
 
-# Filter by tags
+# Filter by 'tags' parameter.
 locals {
   tags_str = "key1=value1"
 }
@@ -234,7 +235,7 @@ output "is_tags_filter_useful" {
   value = length(local.tags_filter_result) > 0 && alltrue(local.tags_filter_result)
 }
 
-# Filter by enterprise_project_id
+# Filter by 'enterprise_project_id' parameter.
 locals {
   eps_id = huaweicloud_workspace_app_server_group.test.enterprise_project_id
 }

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_server_metric_data_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_server_metric_data_test.go
@@ -43,8 +43,8 @@ func TestAccDataAppServerMetricData_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataAppServerMetricData_serverIdNotFound(startTime, endTime),
-				ExpectError: regexp.MustCompile("The cloud application server requested by the client was not found, and '" +
-					".+" + "' is a non-existing cloud application server."),
+				ExpectError: regexp.MustCompile(
+					`The cloud application server requested by the client was not found, and '.*' is a non-existing cloud application server.`),
 			},
 			{
 				Config: testAccDataAppServerMetricData_basic(startTime, endTime),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_server_quotas_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_server_quotas_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceAppServerQuotas_basic(t *testing.T) {
+func TestAccDataAppServerQuotas_basic(t *testing.T) {
 	var (
-		dataSourceName = "data.huaweicloud_workspace_app_server_quotas.test"
-		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		all = "data.huaweicloud_workspace_app_server_quotas.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
 		byFlavorId   = "data.huaweicloud_workspace_app_server_quotas.filter_by_flavor_id"
 		dcByFlavorId = acceptance.InitDataSourceCheck(byFlavorId)
@@ -27,18 +27,21 @@ func TestAccDataSourceAppServerQuotas_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDataSourceAppServerQuotas_notFound,
+				Config:      testAccDataAppServerQuotas_notFound,
 				ExpectError: regexp.MustCompile("The product 'not_exist' not find"),
 			},
 			{
-				Config: testAccDataSourceAppServerQuotas_basic,
+				Config: testAccDataAppServerQuotas_basic,
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dataSourceName, "quotas.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestCheckResourceAttr(dataSourceName, "is_enough", "true"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.type"),
+					resource.TestMatchResourceAttr(all, "quotas.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(all, "is_enough", "true"),
+					resource.TestCheckResourceAttrSet(all, "quotas.0.type"),
+					// Filter by 'flavor_id' parameter.
 					dcByFlavorId.CheckResourceExists(),
 					resource.TestCheckOutput("is_flavor_id_filter_useful", "true"),
+					// Filter by 'is_period' parameter.
 					dcByIsPeriod.CheckResourceExists(),
 					resource.TestMatchResourceAttr(byIsPeriod, "quotas.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
 				),
@@ -47,7 +50,7 @@ func TestAccDataSourceAppServerQuotas_basic(t *testing.T) {
 	})
 }
 
-const testAccDataSourceAppServerQuotas_notFound = `
+const testAccDataAppServerQuotas_notFound = `
 data "huaweicloud_workspace_app_server_quotas" "test" {
   product_id       = "not_exist"
   subscription_num = 1
@@ -56,7 +59,7 @@ data "huaweicloud_workspace_app_server_quotas" "test" {
 }
 `
 
-const testAccDataSourceAppServerQuotas_basic = `
+const testAccDataAppServerQuotas_basic = `
 data "huaweicloud_workspace_app_flavors" "test" {}
 
 locals {
@@ -64,7 +67,7 @@ locals {
   disk_size  = try(data.huaweicloud_workspace_app_flavors.test.flavors[0].system_disk_size, null)
 }
 
-data "huaweicloud_workspace_app_server_quotas" "test" {
+data "huaweicloud_workspace_app_server_quotas" "all" {
   product_id       = local.product_id
   subscription_num = 1
   disk_size        = local.disk_size

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_servers_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_servers_test.go
@@ -12,9 +12,8 @@ import (
 
 func TestAccAppServers_basic(t *testing.T) {
 	var (
-		all  = "data.huaweicloud_workspace_app_servers.test"
-		dc   = acceptance.InitDataSourceCheck(all)
-		name = acceptance.RandomAccResourceName()
+		all = "data.huaweicloud_workspace_app_servers.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
 		byServerName   = "data.huaweicloud_workspace_app_servers.filter_by_server_name"
 		dcByServerName = acceptance.InitDataSourceCheck(byServerName)
@@ -30,6 +29,8 @@ func TestAccAppServers_basic(t *testing.T) {
 
 		byScalingAutoCreate   = "data.huaweicloud_workspace_app_servers.filter_by_scaling_auto_create"
 		dcByScalingAutoCreate = acceptance.InitDataSourceCheck(byScalingAutoCreate)
+
+		name = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -42,6 +43,7 @@ func TestAccAppServers_basic(t *testing.T) {
 			{
 				Config: testDataSourceAppServers_basic(name),
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
 					resource.TestMatchResourceAttr(all, "servers.#", regexp.MustCompile(`[1-9]\d*`)),
 					resource.TestCheckResourceAttrSet(all, "servers.0.id"),
@@ -53,14 +55,19 @@ func TestAccAppServers_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(all, "servers.0.product_info.#"),
 					resource.TestCheckResourceAttrSet(all, "servers.0.host_address.#"),
 					resource.TestCheckResourceAttrSet(all, "servers.0.tags.#"),
+					// Filter by 'server_name' parameter.
 					dcByServerName.CheckResourceExists(),
 					resource.TestCheckOutput("is_server_name_filter_useful", "true"),
+					// Filter by 'machine_name' parameter.
 					dcByMachineName.CheckResourceExists(),
 					resource.TestCheckOutput("is_machine_name_filter_useful", "true"),
+					// Filter by 'server_group_id' parameter.
 					dcByServerGroupId.CheckResourceExists(),
 					resource.TestCheckOutput("is_server_group_id_filter_useful", "true"),
+					// Filter by 'maintain_status' parameter.
 					dcByMaintainStatus.CheckResourceExists(),
 					resource.TestCheckOutput("is_maintain_status_filter_useful", "true"),
+					// Filter by 'scaling_auto_create' parameter.
 					dcByScalingAutoCreate.CheckResourceExists(),
 					resource.TestCheckOutput("is_scaling_auto_create_filter_useful", "true"),
 				),
@@ -100,18 +107,19 @@ func testDataSourceAppServers_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
-data "huaweicloud_workspace_app_servers" "test" {
+# Without any filter parameter.
+data "huaweicloud_workspace_app_servers" "all" {
   server_id = huaweicloud_workspace_app_server.test.id
 }
 
-# Filter by server name
+# Filter by 'server_name' parameter.
 locals {
-  server_name = data.huaweicloud_workspace_app_servers.test.servers[0].name
+  server_name = data.huaweicloud_workspace_app_servers.all.servers[0].name
 }
 
 data "huaweicloud_workspace_app_servers" "filter_by_server_name" {
   depends_on = [
-    data.huaweicloud_workspace_app_servers.test
+    data.huaweicloud_workspace_app_servers.all
   ]
 
   server_name = local.server_name
@@ -127,14 +135,14 @@ output "is_server_name_filter_useful" {
   value = length(local.server_name_filter_result) > 0 && alltrue(local.server_name_filter_result)
 }
 
-# Filter by machine name
+# Filter by 'machine_name' parameter.
 locals {
-  machine_name = data.huaweicloud_workspace_app_servers.test.servers[0].machine_name
+  machine_name = data.huaweicloud_workspace_app_servers.all.servers[0].machine_name
 }
 
 data "huaweicloud_workspace_app_servers" "filter_by_machine_name" {
   depends_on = [
-    data.huaweicloud_workspace_app_servers.test
+    data.huaweicloud_workspace_app_servers.all
   ]
 
   machine_name = local.machine_name
@@ -150,14 +158,14 @@ output "is_machine_name_filter_useful" {
   value = length(local.machine_name_filter_result) > 0 && alltrue(local.machine_name_filter_result)
 }
 
-# Filter by server group ID
+# Filter by 'server_group_id' parameter.
 locals {
-  server_group_id = data.huaweicloud_workspace_app_servers.test.servers[0].server_group_id
+  server_group_id = data.huaweicloud_workspace_app_servers.all.servers[0].server_group_id
 }
 
 data "huaweicloud_workspace_app_servers" "filter_by_server_group_id" {
   depends_on = [
-    data.huaweicloud_workspace_app_servers.test
+    data.huaweicloud_workspace_app_servers.all
   ]
 
   server_group_id = local.server_group_id
@@ -173,17 +181,17 @@ output "is_server_group_id_filter_useful" {
   value = length(local.server_group_id_filter_result) > 0 && alltrue(local.server_group_id_filter_result)
 }
 
-# Filter by maintain status
+# Filter by 'maintain_status' parameter.
 data "huaweicloud_workspace_app_servers" "filter_by_maintain_status" {
   depends_on = [
-    data.huaweicloud_workspace_app_servers.test
+    data.huaweicloud_workspace_app_servers.all
   ]
 
   maintain_status = false
 }
 
 locals {
-  maintain_status = data.huaweicloud_workspace_app_servers.test.servers[0].maintain_status
+  maintain_status = data.huaweicloud_workspace_app_servers.all.servers[0].maintain_status
 
   maintain_status_filter_result = [
     for v in data.huaweicloud_workspace_app_servers.filter_by_maintain_status.servers[*].maintain_status : v == false
@@ -194,17 +202,17 @@ output "is_maintain_status_filter_useful" {
   value = length(local.maintain_status_filter_result) > 0 && alltrue(local.maintain_status_filter_result)
 }
 
-# Filter by scaling auto create
+# Filter by 'scaling_auto_create' parameter.
 data "huaweicloud_workspace_app_servers" "filter_by_scaling_auto_create" {
   depends_on = [
-    data.huaweicloud_workspace_app_servers.test
+    data.huaweicloud_workspace_app_servers.all
   ]
 
   scaling_auto_create = false
 }
 
 locals {
-  scaling_auto_create = data.huaweicloud_workspace_app_servers.test.servers[0].scaling_auto_create
+  scaling_auto_create = data.huaweicloud_workspace_app_servers.all.servers[0].scaling_auto_create
 
   scaling_auto_create_filter_result = [
     for v in data.huaweicloud_workspace_app_servers.filter_by_scaling_auto_create.servers[*].scaling_auto_create : v == false

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_service_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_service_test.go
@@ -9,23 +9,25 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceAppService_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_workspace_app_service.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataAppService_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_workspace_app_service.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAppService_basic,
+				Config: testAccDataAppService_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckOutput("is_open_with_ad_set_and_valid", "true"),
-					resource.TestCheckResourceAttrSet(dataSource, "service_status"),
-					resource.TestCheckResourceAttrSet(dataSource, "tenant_domain_id"),
-					resource.TestCheckResourceAttrSet(dataSource, "tenant_domain_name"),
-					resource.TestMatchResourceAttr(dataSource, "created_at",
+					resource.TestCheckResourceAttrSet(dcName, "service_status"),
+					resource.TestCheckResourceAttrSet(dcName, "tenant_domain_id"),
+					resource.TestCheckResourceAttrSet(dcName, "tenant_domain_name"),
+					resource.TestMatchResourceAttr(dcName, "created_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
@@ -33,7 +35,7 @@ func TestAccDataSourceAppService_basic(t *testing.T) {
 	})
 }
 
-const testAccDataSourceAppService_basic = `
+const testAccDataAppService_basic string = `
 data "huaweicloud_workspace_app_service" "test" {}
 
 output "is_open_with_ad_set_and_valid" {

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_session_types_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_session_types_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourceWorkspaceAppSessionTypes_basic(t *testing.T) {
-	rName := "data.huaweicloud_workspace_app_session_types.test"
+func TestAccDataAppSessionTypes_basic(t *testing.T) {
+	rName := "data.huaweicloud_workspace_app_session_types.all"
 	dc := acceptance.InitDataSourceCheck(rName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -19,8 +19,9 @@ func TestAccDatasourceWorkspaceAppSessionTypes_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceWorkspaceAppSessionTypes_basic(),
+				Config: testAccDataAppSessionTypes_basic,
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
 					resource.TestCheckOutput("is_resource_spec_code_set", "true"),
 					resource.TestCheckOutput("is_session_type_set", "true"),
@@ -32,12 +33,11 @@ func TestAccDatasourceWorkspaceAppSessionTypes_basic(t *testing.T) {
 	})
 }
 
-func testAccDatasourceWorkspaceAppSessionTypes_basic() string {
-	return `
-data "huaweicloud_workspace_app_session_types" "test" {}
+const testAccDataAppSessionTypes_basic string = `
+data "huaweicloud_workspace_app_session_types" "all" {}
 
 locals {
-  session_types      = data.huaweicloud_workspace_app_session_types.test.session_types
+  session_types      = data.huaweicloud_workspace_app_session_types.all.session_types
   first_session_type = try(local.session_types[0], {})
 }
 
@@ -57,4 +57,3 @@ output "is_cloud_service_type_set" {
   value = length(local.session_types) != 0 ? try(local.first_session_type.cloud_service_type != "", false) : true 
 }
 `
-}

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_storage_policies_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_storage_policies_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceAppStoragePolicies_basic(t *testing.T) {
+func TestAccDataAppStoragePolicies_basic(t *testing.T) {
 	var (
-		all = "data.huaweicloud_workspace_app_storage_policies.test"
+		all = "data.huaweicloud_workspace_app_storage_policies.all"
 		dc  = acceptance.InitDataSourceCheck(all)
 	)
 
@@ -22,8 +22,9 @@ func TestAccDataSourceAppStoragePolicies_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAppStoragePolicies_basic,
+				Config: testAccDataAppStoragePolicies_basic,
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
 					resource.TestCheckOutput("is_system_policy_exist", "true"),
 					resource.TestCheckOutput("is_policy_id_filter_useful", "true"),
@@ -33,29 +34,29 @@ func TestAccDataSourceAppStoragePolicies_basic(t *testing.T) {
 	})
 }
 
-const testAccDataSourceAppStoragePolicies_basic string = `
+const testAccDataAppStoragePolicies_basic string = `
 resource "huaweicloud_workspace_app_storage_policy" "test" {
   server_actions = ["GetObject"]
 }
 
-data "huaweicloud_workspace_app_storage_policies" "test" {
+data "huaweicloud_workspace_app_storage_policies" "all" {
   depends_on = [huaweicloud_workspace_app_storage_policy.test]
 }
 
-// Filter all system policies
+# Filter all system policies
 locals {
-  system_policies = [for o in data.huaweicloud_workspace_app_storage_policies.test.policies: o if strcontains(o.id, "DEFAULT")]
+  system_policies = [for o in data.huaweicloud_workspace_app_storage_policies.all.policies: o if strcontains(o.id, "DEFAULT")]
 }
 
 output "is_system_policy_exist" {
   value = length(local.system_policies) > 0
 }
 
-// Filter by storage permission policy ID, in manual
+# Filter by storage permission policy ID, in manual
 locals {
   policy_id = huaweicloud_workspace_app_storage_policy.test.id
 
-  policy_id_filter_result = [for o in data.huaweicloud_workspace_app_storage_policies.test.policies: o if o.id == local.policy_id]
+  policy_id_filter_result = [for o in data.huaweicloud_workspace_app_storage_policies.all.policies: o if o.id == local.policy_id]
 }
 
 output "is_policy_id_filter_useful" {

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_vnc_remote_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_vnc_remote_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceAppVncRemote_basic(t *testing.T) {
+func TestAccDataAppVncRemote_basic(t *testing.T) {
 	var (
-		dataSourceName = "data.huaweicloud_workspace_app_vnc_remote.test"
-		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		dcName = "data.huaweicloud_workspace_app_vnc_remote.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -24,10 +24,10 @@ func TestAccDataSourceAppVncRemote_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAppVncRemote_basic(),
+				Config: testAccDataAppVncRemote_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dataSourceName, "url", regexp.MustCompile(`^https?://.*$`)),
+					resource.TestMatchResourceAttr(dcName, "url", regexp.MustCompile(`^https?://.*$`)),
 					resource.TestCheckOutput("is_type_valid", "true"),
 				),
 			},
@@ -35,7 +35,7 @@ func TestAccDataSourceAppVncRemote_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAppVncRemote_basic() string {
+func testAccDataAppVncRemote_basic() string {
 	return fmt.Sprintf(`
 data "huaweicloud_workspace_app_vnc_remote" "test" {
   server_id = "%[1]s"

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_warehouse_applications_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_app_warehouse_applications_test.go
@@ -10,26 +10,24 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceAppWarehouseApplications_basic(t *testing.T) {
+func TestAccDataAppWarehouseApplications_basic(t *testing.T) {
 	var (
-		name       = acceptance.RandomAccResourceName()
-		dataSource = "data.huaweicloud_workspace_app_warehouse_applications.test"
-		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name = acceptance.RandomAccResourceName()
 
-		byAppId   = "data.huaweicloud_workspace_app_warehouse_applications.filter_by_app_id"
-		dcByAppId = acceptance.InitDataSourceCheck(byAppId)
+		all = "data.huaweicloud_workspace_app_warehouse_applications.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
-		exactByName   = "data.huaweicloud_workspace_app_warehouse_applications.exact_filter_by_name"
-		dcExactByName = acceptance.InitDataSourceCheck(exactByName)
+		filterByAppId   = "data.huaweicloud_workspace_app_warehouse_applications.filter_by_app_id"
+		dcFilterByAppId = acceptance.InitDataSourceCheck(filterByAppId)
 
-		byName   = "data.huaweicloud_workspace_app_warehouse_applications.filter_by_name"
-		dcByName = acceptance.InitDataSourceCheck(byName)
+		filterByName   = "data.huaweicloud_workspace_app_warehouse_applications.filter_by_name"
+		dcFilterByName = acceptance.InitDataSourceCheck(filterByName)
 
-		byCategory   = "data.huaweicloud_workspace_app_warehouse_applications.filter_by_category"
-		dcByCategory = acceptance.InitDataSourceCheck(byCategory)
+		filterByCategory   = "data.huaweicloud_workspace_app_warehouse_applications.filter_by_category"
+		dcFilterByCategory = acceptance.InitDataSourceCheck(filterByCategory)
 
-		byVerifyStatus   = "data.huaweicloud_workspace_app_warehouse_applications.filter_by_verify_status"
-		dcByVerifyStatus = acceptance.InitDataSourceCheck(byVerifyStatus)
+		filterByVerifyStatus   = "data.huaweicloud_workspace_app_warehouse_applications.filter_by_verify_status"
+		dcFilterByVerifyStatus = acceptance.InitDataSourceCheck(filterByVerifyStatus)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -46,34 +44,37 @@ func TestAccDataSourceAppWarehouseApplications_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAppWarehouseApplications_basic(name),
+				Config: testAccDataAppWarehouseApplications_basic(name),
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dataSource, "applications.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					dcByAppId.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "applications.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'app_id' parameter.
+					dcFilterByAppId.CheckResourceExists(),
 					resource.TestCheckOutput("is_app_id_filter_useful", "true"),
-					resource.TestCheckResourceAttrSet(byAppId, "applications.0.id"),
-					resource.TestCheckResourceAttrSet(byAppId, "applications.0.app_id"),
-					resource.TestCheckResourceAttrSet(byAppId, "applications.0.name"),
-					resource.TestCheckResourceAttrSet(byAppId, "applications.0.category"),
-					resource.TestCheckResourceAttrSet(byAppId, "applications.0.os_type"),
-					resource.TestCheckResourceAttrSet(byAppId, "applications.0.version"),
-					resource.TestCheckResourceAttrSet(byAppId, "applications.0.version_name"),
-					resource.TestCheckResourceAttr(byAppId, "applications.0.file_store_path", acceptance.HW_WORKSPACE_APP_FILE_NAME),
-					resource.TestCheckResourceAttrSet(byAppId, "applications.0.app_file_size"),
-					resource.TestCheckResourceAttrSet(byAppId, "applications.0.description"),
-					resource.TestCheckResourceAttrSet(byAppId, "applications.0.verify_status"),
-					resource.TestMatchResourceAttr(byAppId, "applications.0.created_at",
+					resource.TestCheckResourceAttrSet(filterByAppId, "applications.0.id"),
+					resource.TestCheckResourceAttrSet(filterByAppId, "applications.0.app_id"),
+					resource.TestCheckResourceAttrSet(filterByAppId, "applications.0.name"),
+					resource.TestCheckResourceAttrSet(filterByAppId, "applications.0.category"),
+					resource.TestCheckResourceAttrSet(filterByAppId, "applications.0.os_type"),
+					resource.TestCheckResourceAttrSet(filterByAppId, "applications.0.version"),
+					resource.TestCheckResourceAttrSet(filterByAppId, "applications.0.version_name"),
+					resource.TestCheckResourceAttr(filterByAppId, "applications.0.file_store_path", acceptance.HW_WORKSPACE_APP_FILE_NAME),
+					resource.TestCheckResourceAttrSet(filterByAppId, "applications.0.app_file_size"),
+					resource.TestCheckResourceAttrSet(filterByAppId, "applications.0.description"),
+					resource.TestCheckResourceAttrSet(filterByAppId, "applications.0.verify_status"),
+					resource.TestMatchResourceAttr(filterByAppId, "applications.0.created_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
-					resource.TestMatchResourceAttr(byAppId, "applications.0.updated_at",
+					resource.TestMatchResourceAttr(filterByAppId, "applications.0.updated_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
-					dcExactByName.CheckResourceExists(),
-					resource.TestCheckOutput("is_name_exact_filter_useful", "true"),
-					dcByName.CheckResourceExists(),
+					// Filter by 'name' parameter (Fuzzy search).
+					dcFilterByName.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
-					dcByCategory.CheckResourceExists(),
+					// Filter by 'category' parameter.
+					dcFilterByCategory.CheckResourceExists(),
 					resource.TestCheckOutput("is_category_filter_useful", "true"),
-					dcByVerifyStatus.CheckResourceExists(),
+					// Filter by 'verify_status' parameter.
+					dcFilterByVerifyStatus.CheckResourceExists(),
 					resource.TestCheckOutput("is_verify_status_filter_useful", "true"),
 				),
 			},
@@ -81,22 +82,23 @@ func TestAccDataSourceAppWarehouseApplications_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAppWarehouseApplications_basic(name string) string {
+func testAccDataAppWarehouseApplications_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-data "huaweicloud_workspace_app_warehouse_applications" "test" {
-  depends_on = [huaweicloud_workspace_app_warehouse_app.test]
+# Without any filter parameter.
+data "huaweicloud_workspace_app_warehouse_applications" "all" {
+  depends_on = [huaweicloud_workspace_app_warehouse_application.test]
 }
 
 locals {
-  application_id = huaweicloud_workspace_app_warehouse_app.test.id
-  name           = huaweicloud_workspace_app_warehouse_app.test.name
-  category       = huaweicloud_workspace_app_warehouse_app.test.category
-  verify_status  = try(data.huaweicloud_workspace_app_warehouse_applications.test.applications[0].verify_status, null)
+  application_id = huaweicloud_workspace_app_warehouse_application.test.id
+  name           = huaweicloud_workspace_app_warehouse_application.test.name
+  category       = huaweicloud_workspace_app_warehouse_application.test.category
+  verify_status  = try(data.huaweicloud_workspace_app_warehouse_applications.all.applications[0].verify_status, null)
 }
 
-# Filter by application ID.
+# Filter by 'app_id' parameter.
 data "huaweicloud_workspace_app_warehouse_applications" "filter_by_app_id" {
   app_id = local.application_id
 }
@@ -110,24 +112,10 @@ output "is_app_id_filter_useful" {
   value = length(local.app_id_filter_result) > 0 && alltrue(local.app_id_filter_result)
 }
 
-# Filter by application name (Exact match).
-data "huaweicloud_workspace_app_warehouse_applications" "exact_filter_by_name" {
-  name       = local.name
-  depends_on = [huaweicloud_workspace_app_warehouse_app.test]
-}
-
-locals {
-  name_exact_filter_result = [for v in data.huaweicloud_workspace_app_warehouse_applications.exact_filter_by_name.applications : v.name == local.name]
-}
-
-output "is_name_exact_filter_useful" {
-  value = length(local.name_exact_filter_result) > 0 && alltrue(local.name_exact_filter_result)
-}
-
-# Filter by application name (Fuzzy search).
+# Filter by 'name' parameter (Fuzzy search).
 data "huaweicloud_workspace_app_warehouse_applications" "filter_by_name" {
   name       = "tf_test"
-  depends_on = [huaweicloud_workspace_app_warehouse_app.test]
+  depends_on = [huaweicloud_workspace_app_warehouse_application.test]
 }
 
 locals {
@@ -139,10 +127,10 @@ output "is_name_filter_useful" {
   value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
 }
 
-# Filter by application category.
+# Filter by 'category' parameter.
 data "huaweicloud_workspace_app_warehouse_applications" "filter_by_category" {
   category   = local.category
-  depends_on = [huaweicloud_workspace_app_warehouse_app.test]
+  depends_on = [huaweicloud_workspace_app_warehouse_application.test]
 }
 
 locals {
@@ -154,10 +142,10 @@ output "is_category_filter_useful" {
   value = length(local.category_filter_result) > 0 && alltrue(local.category_filter_result)
 }
 
-# Filter by application verify status.
+# Filter by 'verify_status' parameter.
 data "huaweicloud_workspace_app_warehouse_applications" "filter_by_verify_status" {
   verify_status = local.verify_status
-  depends_on    = [huaweicloud_workspace_app_warehouse_app.test]
+  depends_on    = [huaweicloud_workspace_app_warehouse_application.test]
 }
 
 locals {
@@ -168,5 +156,5 @@ locals {
 output "is_verify_status_filter_useful" {
   value = length(local.verify_status_filter_result) > 0 && alltrue(local.verify_status_filter_result)
 }
-`, testAccResourceWarehouseApplication_basic_step1(name))
+`, testAccAppWarehouseApplication_basic_step1(name))
 }

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_application_catalogs_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_application_catalogs_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestAccDataApplicationCatalogs_basic(t *testing.T) {
 	var (
-		dcName = "data.huaweicloud_workspace_application_catalogs.test"
-		dc     = acceptance.InitDataSourceCheck(dcName)
+		all = "data.huaweicloud_workspace_application_catalogs.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -22,11 +22,12 @@ func TestAccDataApplicationCatalogs_basic(t *testing.T) {
 			{
 				Config: testAccDataApplicationCatalogs_basic,
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dcName, "catalogs.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestCheckResourceAttrSet(dcName, "catalogs.0.id"),
-					resource.TestCheckResourceAttrSet(dcName, "catalogs.0.zh"),
-					resource.TestCheckResourceAttrSet(dcName, "catalogs.0.en"),
+					resource.TestMatchResourceAttr(all, "catalogs.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "catalogs.0.id"),
+					resource.TestCheckResourceAttrSet(all, "catalogs.0.zh"),
+					resource.TestCheckResourceAttrSet(all, "catalogs.0.en"),
 				),
 			},
 		},
@@ -34,5 +35,5 @@ func TestAccDataApplicationCatalogs_basic(t *testing.T) {
 }
 
 const testAccDataApplicationCatalogs_basic = `
-data "huaweicloud_workspace_application_catalogs" "test" {}
+data "huaweicloud_workspace_application_catalogs" "all" {}
 `

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_application_rule_restriction_setting_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_application_rule_restriction_setting_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestAccDataApplicationRuleRestrictionSetting_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_workspace_application_rule_restriction_setting.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+	dcName := "data.huaweicloud_workspace_application_rule_restriction_setting.test"
+	dc := acceptance.InitDataSourceCheck(dcName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -20,11 +20,11 @@ func TestAccDataApplicationRuleRestrictionSetting_basic(t *testing.T) {
 				Config: testAccDataApplicationRuleRestrictionSetting_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSource, "app_restrict_rule_switch", "true"),
-					resource.TestCheckResourceAttr(dataSource, "app_control_mode", "0"),
-					resource.TestCheckResourceAttr(dataSource, "app_periodic_switch", "true"),
-					resource.TestCheckResourceAttr(dataSource, "app_periodic_interval", "10"),
-					resource.TestCheckResourceAttr(dataSource, "app_force_kill_proc_switch", "true"),
+					resource.TestCheckResourceAttr(dcName, "app_restrict_rule_switch", "true"),
+					resource.TestCheckResourceAttr(dcName, "app_control_mode", "0"),
+					resource.TestCheckResourceAttr(dcName, "app_periodic_switch", "true"),
+					resource.TestCheckResourceAttr(dcName, "app_periodic_interval", "10"),
+					resource.TestCheckResourceAttr(dcName, "app_force_kill_proc_switch", "true"),
 				),
 			},
 		},

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_available_ip_number_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_available_ip_number_test.go
@@ -9,13 +9,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccAvailableIpNumberDataSource_basic(t *testing.T) {
+func TestAccDataAvailableIpNumber_basic(t *testing.T) {
 	var (
 		dcName = "data.huaweicloud_workspace_available_ip_number.test"
 		dc     = acceptance.InitDataSourceCheck(dcName)
-
-		notExistSubnetName = "data.huaweicloud_workspace_available_ip_number.test_non_exist_subnet"
-		dcNonExistSubnet   = acceptance.InitDataSourceCheck(notExistSubnetName)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -25,33 +22,33 @@ func TestAccAvailableIpNumberDataSource_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAvailableIpNumberDataSource_step1,
+				Config: testAccDataAvailableIpNumber_basic_step1,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dcName, "available_ip", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(dcName, "available_ip", "0"),
 				),
 			},
 			{
-				Config: testAccAvailableIpNumberDataSource_step2,
+				Config: testAccDataAvailableIpNumber_basic_step2,
 				Check: resource.ComposeTestCheckFunc(
-					dcNonExistSubnet.CheckResourceExists(),
-					resource.TestCheckResourceAttr(notExistSubnetName, "available_ip", "0"),
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dcName, "available_ip", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
 				),
 			},
 		},
 	})
 }
 
-const testAccAvailableIpNumberDataSource_step1 = `
+const testAccDataAvailableIpNumber_basic_step1 = `
+data "huaweicloud_workspace_available_ip_number" "test" {
+  subnet_id = "NOT_FOUND"
+}
+`
+
+const testAccDataAvailableIpNumber_basic_step2 = `
 data "huaweicloud_workspace_service" "test" {}
 
 data "huaweicloud_workspace_available_ip_number" "test" {
   subnet_id = try(data.huaweicloud_workspace_service.test.network_ids[0], "NOT_FOUND")
-}
-`
-
-const testAccAvailableIpNumberDataSource_step2 = `
-data "huaweicloud_workspace_available_ip_number" "test_non_exist_subnet" {
-  subnet_id = "NOT_FOUND"
 }
 `

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_connections_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_connections_test.go
@@ -10,13 +10,12 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDesktopConnectionsDataSource_basic(t *testing.T) {
+func TestAccDataDesktopConnections_basic(t *testing.T) {
 	var (
-		name      = acceptance.RandomAccResourceNameWithDash()
-		otherName = acceptance.RandomAccResourceNameWithDash()
+		name = acceptance.RandomAccResourceNameWithDash()
 
-		dcName = "data.huaweicloud_workspace_desktop_connections.all"
-		dc     = acceptance.InitDataSourceCheck(dcName)
+		all = "data.huaweicloud_workspace_desktop_connections.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
 		filterByUserName   = "data.huaweicloud_workspace_desktop_connections.filter_by_user_name"
 		dcFilterByUserName = acceptance.InitDataSourceCheck(filterByUserName)
@@ -28,25 +27,27 @@ func TestAccDesktopConnectionsDataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceDesktopPoolImageId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDesktopConnectionsDataSource_basic(name, otherName),
+				Config: testAccDataDesktopConnections_basic(name),
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dcName, "desktop_connections.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_connections.0.id"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_connections.0.name"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_connections.0.connect_status"),
-					resource.TestMatchResourceAttr(dcName, "desktop_connections.0.attach_users.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_connections.0.attach_users.0.name"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_connections.0.attach_users.0.user_group"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_connections.0.attach_users.0.type"),
-					// filter by user name
+					resource.TestMatchResourceAttr(all, "desktop_connections.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "desktop_connections.0.id"),
+					resource.TestCheckResourceAttrSet(all, "desktop_connections.0.name"),
+					resource.TestCheckResourceAttrSet(all, "desktop_connections.0.connect_status"),
+					resource.TestMatchResourceAttr(all, "desktop_connections.0.attach_users.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "desktop_connections.0.attach_users.0.name"),
+					resource.TestCheckResourceAttrSet(all, "desktop_connections.0.attach_users.0.user_group"),
+					resource.TestCheckResourceAttrSet(all, "desktop_connections.0.attach_users.0.type"),
+					// Filter by 'user_names' parameter.
 					dcFilterByUserName.CheckResourceExists(),
 					resource.TestCheckOutput("is_user_name_filter_useful", "true"),
-					// filter by status
+					// Filter by 'connect_status' parameter.
 					dcFilterByStatus.CheckResourceExists(),
 					resource.TestCheckOutput("is_status_filter_useful", "true"),
 				),
@@ -55,30 +56,75 @@ func TestAccDesktopConnectionsDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccDesktopConnectionsDataSource_basic(name string, otherName string) string {
+func testAccDataDesktopConnections_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_workspace_service" "test" {}
+
+data "huaweicloud_workspace_flavors" "test" {
+  os_type = "Windows"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_workspace_desktop" "test" {
+  count = 2
+
+  flavor_id         = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "NOT_FOUND")
+  image_type        = "market"
+  image_id          = "%[1]s"
+  availability_zone = try(data.huaweicloud_availability_zones.test.names[0], "NOT_FOUND")
+  vpc_id            = data.huaweicloud_workspace_service.test.vpc_id
+  security_groups   = [
+    try(data.huaweicloud_workspace_service.test.desktop_security_group[0].id, "NOT_FOUND"),
+    try(data.huaweicloud_workspace_service.test.infrastructure_security_group[0].id, "NOT_FOUND")
+  ]
+
+  nic {
+    network_id = try(data.huaweicloud_workspace_service.test.network_ids[0], "NOT_FOUND")
+  }
+
+  name       = "%[2]s-${count.index}"
+  user_name  = "user-%[2]s-${count.index}"
+  user_email = "terraform@example.com"
+  user_group = "administrators"
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  data_volume {
+    type = "SAS"
+    size = 10
+  }
+
+  email_notification = true
+  delete_user        = true
+}
+`, acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID, name)
+}
+
+func testAccDataDesktopConnections_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-# All
+# Without any filter parameter.
 data "huaweicloud_workspace_desktop_connections" "all" {
   depends_on = [
-    huaweicloud_workspace_desktop.test,
-    huaweicloud_workspace_desktop.test2
+    huaweicloud_workspace_desktop.test
   ]
 }
 
 locals {
   user_name      = data.huaweicloud_workspace_desktop_connections.all.desktop_connections[0].attach_users[0].name
-  connect_status = data.huaweicloud_workspace_desktop_connections.all.desktop_connections[0].connect_status
 }
 
-# Filter by user name
+# Filter by 'user_names' parameter.
 data "huaweicloud_workspace_desktop_connections" "filter_by_user_name" {
   user_names = [local.user_name]
 
   depends_on = [
-    huaweicloud_workspace_desktop.test,
-    huaweicloud_workspace_desktop.test2
+    huaweicloud_workspace_desktop.test
   ]
 }
 
@@ -94,13 +140,16 @@ output "is_user_name_filter_useful" {
   value = alltrue(local.user_name_filter_result)
 }
 
-# Filter by status
+# Filter by 'connect_status' parameter.
+locals {
+  connect_status = data.huaweicloud_workspace_desktop_connections.all.desktop_connections[0].connect_status
+}
+
 data "huaweicloud_workspace_desktop_connections" "filter_by_status" {
   connect_status = local.connect_status
 
   depends_on = [
     huaweicloud_workspace_desktop.test,
-    huaweicloud_workspace_desktop.test2
   ]
 }
 
@@ -114,90 +163,5 @@ locals {
 output "is_status_filter_useful" {
   value = alltrue(local.status_filter_result)
 }
-`, testAccDesktopConnectionsDataSource_base(name, otherName))
-}
-
-func testAccDesktopConnectionsDataSource_base(name string, otherName string) string {
-	return fmt.Sprintf(`
-data "huaweicloud_workspace_service" "test" {}
-
-data "huaweicloud_workspace_flavors" "test" {
-  os_type = "Windows"
-}
-
-data "huaweicloud_availability_zones" "test" {}
-
-data "huaweicloud_images_images" "test" {
-  name_regex = "WORKSPACE"
-  visibility = "market"
-}
-
-resource "huaweicloud_workspace_desktop" "test" {
-  flavor_id         = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "NOT_FOUND")
-  image_type        = "market"
-  image_id          = try(data.huaweicloud_images_images.test.images[0].id, "NOT_FOUND")
-  availability_zone = try(data.huaweicloud_availability_zones.test.names[0], "NOT_FOUND")
-  vpc_id            = data.huaweicloud_workspace_service.test.vpc_id
-  security_groups   = [
-    try(data.huaweicloud_workspace_service.test.desktop_security_group[0].id, "NOT_FOUND"),
-    try(data.huaweicloud_workspace_service.test.infrastructure_security_group[0].id, "NOT_FOUND")
-  ]
-
-  nic {
-    network_id = try(data.huaweicloud_workspace_service.test.network_ids[0], "NOT_FOUND")
-  }
-
-  name       = "%[1]s"
-  user_name  = "user-%[1]s"
-  user_email = "terraform@example.com"
-  user_group = "administrators"
-
-  root_volume {
-    type = "SAS"
-    size = 80
-  }
-
-  data_volume {
-    type = "SAS"
-    size = 10
-  }
-
-  email_notification = true
-  delete_user        = true
-}
-
-resource "huaweicloud_workspace_desktop" "test2" {
-  flavor_id         = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "NOT_FOUND")
-  image_type        = "market"
-  image_id          = try(data.huaweicloud_images_images.test.images[0].id, "NOT_FOUND")
-  availability_zone = try(data.huaweicloud_availability_zones.test.names[0], "NOT_FOUND")
-  vpc_id            = data.huaweicloud_workspace_service.test.vpc_id
-  security_groups   = [
-    try(data.huaweicloud_workspace_service.test.desktop_security_group[0].id, "NOT_FOUND"),
-    try(data.huaweicloud_workspace_service.test.infrastructure_security_group[0].id, "NOT_FOUND")
-  ]
-
-  nic {
-    network_id = try(data.huaweicloud_workspace_service.test.network_ids[0], "NOT_FOUND")
-  }
-
-  name       = "%[2]s"
-  user_name  = "user-%[2]s"
-  user_email = "terraform@example.com"
-  user_group = "administrators"
-
-  root_volume {
-    type = "SAS"
-    size = 80
-  }
-
-  data_volume {
-    type = "SAS"
-    size = 10
-  }
-
-  email_notification = true
-  delete_user        = true
-}
-`, name, otherName)
+`, testAccDataDesktopConnections_base(name))
 }

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_pools_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_pools_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceDesktopPools_basic(t *testing.T) {
+func TestAccDataDesktopPools_basic(t *testing.T) {
 	var (
 		name = acceptance.RandomAccResourceNameWithDash()
 
-		dcName = "data.huaweicloud_workspace_desktop_pools.all"
-		dc     = acceptance.InitDataSourceCheck(dcName)
+		all = "data.huaweicloud_workspace_desktop_pools.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
 		filterByName   = "data.huaweicloud_workspace_desktop_pools.filter_by_name"
 		dcFilterByName = acceptance.InitDataSourceCheck(filterByName)
@@ -31,53 +31,56 @@ func TestAccDataSourceDesktopPools_basic(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceDesktopPoolImageId(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDesktopPools_basic(name),
+				Config: testAccDataDesktopPools_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					// all
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dcName, "desktop_pools.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.id"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.name"),
-					resource.TestMatchResourceAttr(dcName, "desktop_pools.0.autoscale_policy.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.autoscale_policy.0.autoscale_type"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.autoscale_policy.0.max_auto_created"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.autoscale_policy.0.min_idle"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.autoscale_policy.0.once_auto_created"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.availability_zone"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.charging_mode"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.created_time"),
-					resource.TestMatchResourceAttr(dcName, "desktop_pools.0.data_volumes.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.desktop_count"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.desktop_used"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.disconnected_retention_period"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.enable_autoscale"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.enterprise_project_id"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.image_id"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.image_name"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.image_os_platform"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.image_os_type"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.image_os_version"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.in_maintenance_mode"),
-					resource.TestMatchResourceAttr(dcName, "desktop_pools.0.product.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestMatchResourceAttr(dcName, "desktop_pools.0.root_volume.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestMatchResourceAttr(dcName, "desktop_pools.0.security_groups.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.status"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.subnet_id"),
-					resource.TestCheckResourceAttrSet(dcName, "desktop_pools.0.type"),
-					// filter by name
+					resource.TestMatchResourceAttr(all, "desktop_pools.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.id"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.name"),
+					resource.TestMatchResourceAttr(all, "desktop_pools.0.autoscale_policy.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.autoscale_policy.0.autoscale_type"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.autoscale_policy.0.max_auto_created"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.autoscale_policy.0.min_idle"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.autoscale_policy.0.once_auto_created"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.availability_zone"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.charging_mode"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.created_time"),
+					resource.TestMatchResourceAttr(all, "desktop_pools.0.data_volumes.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.desktop_count"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.desktop_used"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.disconnected_retention_period"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.enable_autoscale"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.image_id"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.image_name"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.image_os_platform"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.image_os_type"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.image_os_version"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.in_maintenance_mode"),
+					resource.TestMatchResourceAttr(all, "desktop_pools.0.product.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(all, "desktop_pools.0.root_volume.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(all, "desktop_pools.0.security_groups.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.status"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(all, "desktop_pools.0.type"),
+					// Filter by 'name' parameter.
 					dcFilterByName.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
-					// filter by type
+					// Filter by 'type' parameter.
 					dcFilterByType.CheckResourceExists(),
 					resource.TestCheckOutput("is_type_filter_useful", "true"),
-					// filter by enterprise project id
+					// Filter by 'enterprise_project_id' parameter.
 					dcFilterByEnterpriseProjectId.CheckResourceExists(),
 					resource.TestCheckOutput("is_enterprise_project_id_filter_useful", "true"),
-					// filter by maintenance mode
+					// Filter by 'in_maintenance_mode' parameter.
 					dcFilterByMaintenanceMode.CheckResourceExists(),
 					resource.TestCheckOutput("is_in_maintenance_mode_filter_useful", "true"),
 				),
@@ -86,105 +89,7 @@ func TestAccDataSourceDesktopPools_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceDesktopPools_basic(name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-locals {
-  name                  = huaweicloud_workspace_desktop_pool.test.name
-  type                  = huaweicloud_workspace_desktop_pool.test.type
-  enterprise_project_id = huaweicloud_workspace_desktop_pool.test.enterprise_project_id
-  in_maintenance_mode 	= huaweicloud_workspace_desktop_pool.test.in_maintenance_mode
-}
-
-# all
-data "huaweicloud_workspace_desktop_pools" "all" {
-  depends_on = [
-    huaweicloud_workspace_desktop_pool.test
-  ]
-}
-
-# filter by name
-data "huaweicloud_workspace_desktop_pools" "filter_by_name" {
-  name = local.name
-
-  depends_on = [
-    huaweicloud_workspace_desktop_pool.test
-  ]
-}
-
-locals {
-  name_filter_result = [
-    for v in data.huaweicloud_workspace_desktop_pools.filter_by_name.desktop_pools[*].name : v == local.name
-  ]
-}
-
-output "is_name_filter_useful" {
-  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
-}
-
-# filter by type
-data "huaweicloud_workspace_desktop_pools" "filter_by_type" {
-  type = local.type
-
-  depends_on = [
-    huaweicloud_workspace_desktop_pool.test
-  ]
-}
-
-locals {
-  type_filter_result = [
-    for v in data.huaweicloud_workspace_desktop_pools.filter_by_type.desktop_pools[*].type : v == local.type
-  ]
-}
-
-output "is_type_filter_useful" {
-  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
-}
-
-# filter by enterprise project id
-data "huaweicloud_workspace_desktop_pools" "filter_by_enterprise_project_id" {
-  enterprise_project_id = local.enterprise_project_id
-
-  depends_on = [
-    huaweicloud_workspace_desktop_pool.test
-  ]
-}
-
-locals {
-  enterprise_project_id_filter_result = [
-    for v in data.huaweicloud_workspace_desktop_pools.filter_by_enterprise_project_id.desktop_pools[*].enterprise_project_id : 
-      v == local.enterprise_project_id
-  ]
-}
-
-output "is_enterprise_project_id_filter_useful" {
-  value = length(local.enterprise_project_id_filter_result) > 0 && alltrue(local.enterprise_project_id_filter_result)
-}
-
-# filter by in maintenance mode 
-data "huaweicloud_workspace_desktop_pools" "filter_by_in_maintenance_mode" {
-  in_maintenance_mode = local.in_maintenance_mode
-
-  depends_on = [
-    huaweicloud_workspace_desktop_pool.test
-  ]
-}
-
-locals {
-  in_maintenance_mode_filter_result = [
-    for v in data.huaweicloud_workspace_desktop_pools.filter_by_in_maintenance_mode.desktop_pools[*].in_maintenance_mode : 
-      v == local.in_maintenance_mode
-  ]
-}
-
-output "is_in_maintenance_mode_filter_useful" {
-  value = length(local.in_maintenance_mode_filter_result) > 0 && alltrue(local.in_maintenance_mode_filter_result)
-}
-`, testAccDataSourceDesktopPools_base(name))
-}
-
-func testAccDataSourceDesktopPools_base(name string) string {
+func testAccDataDesktopPools_base(name string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_workspace_service" "test" {}
 
@@ -194,18 +99,13 @@ data "huaweicloud_workspace_flavors" "test" {
 
 data "huaweicloud_availability_zones" "test" {}
 
-data "huaweicloud_images_images" "test" {
-  name_regex = "WORKSPACE"
-  visibility = "market"
-}
-
 resource "huaweicloud_workspace_desktop_pool" "test" {
   name                          = "%[1]s"
   type                          = "DYNAMIC"
   size                          = 2
   product_id                    = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "")
   image_type                    = "gold"
-  image_id                      = try(data.huaweicloud_images_images.test.images[0].id, "")
+  image_id                      = "%[2]s"
   subnet_ids                    = data.huaweicloud_workspace_service.test.network_ids
   vpc_id                        = data.huaweicloud_workspace_service.test.vpc_id
   availability_zone             = data.huaweicloud_availability_zones.test.names[0]
@@ -237,5 +137,103 @@ resource "huaweicloud_workspace_desktop_pool" "test" {
     once_auto_created = 1
   }
 }
-`, name)
+`, name, acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID)
+}
+
+func testAccDataDesktopPools_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  name                  = huaweicloud_workspace_desktop_pool.test.name
+  type                  = huaweicloud_workspace_desktop_pool.test.type
+  enterprise_project_id = huaweicloud_workspace_desktop_pool.test.enterprise_project_id
+  in_maintenance_mode 	= huaweicloud_workspace_desktop_pool.test.in_maintenance_mode
+}
+
+# Without any filter parameter.
+data "huaweicloud_workspace_desktop_pools" "all" {
+  depends_on = [
+    huaweicloud_workspace_desktop_pool.test
+  ]
+}
+
+# Filter by 'name' parameter.
+data "huaweicloud_workspace_desktop_pools" "filter_by_name" {
+  name = local.name
+
+  depends_on = [
+    huaweicloud_workspace_desktop_pool.test
+  ]
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_workspace_desktop_pools.filter_by_name.desktop_pools[*].name : v == local.name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by 'type' parameter.
+data "huaweicloud_workspace_desktop_pools" "filter_by_type" {
+  type = local.type
+
+  depends_on = [
+    huaweicloud_workspace_desktop_pool.test
+  ]
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_workspace_desktop_pools.filter_by_type.desktop_pools[*].type : v == local.type
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+
+# Filter by 'enterprise_project_id' parameter.
+data "huaweicloud_workspace_desktop_pools" "filter_by_enterprise_project_id" {
+  enterprise_project_id = local.enterprise_project_id
+
+  depends_on = [
+    huaweicloud_workspace_desktop_pool.test
+  ]
+}
+
+locals {
+  enterprise_project_id_filter_result = [
+    for v in data.huaweicloud_workspace_desktop_pools.filter_by_enterprise_project_id.desktop_pools[*].enterprise_project_id : 
+      v == local.enterprise_project_id
+  ]
+}
+
+output "is_enterprise_project_id_filter_useful" {
+  value = length(local.enterprise_project_id_filter_result) > 0 && alltrue(local.enterprise_project_id_filter_result)
+}
+
+# Filter by 'in_maintenance_mode' parameter.
+data "huaweicloud_workspace_desktop_pools" "filter_by_in_maintenance_mode" {
+  in_maintenance_mode = local.in_maintenance_mode
+
+  depends_on = [
+    huaweicloud_workspace_desktop_pool.test
+  ]
+}
+
+locals {
+  in_maintenance_mode_filter_result = [
+    for v in data.huaweicloud_workspace_desktop_pools.filter_by_in_maintenance_mode.desktop_pools[*].in_maintenance_mode : 
+      v == local.in_maintenance_mode
+  ]
+}
+
+output "is_in_maintenance_mode_filter_useful" {
+  value = length(local.in_maintenance_mode_filter_result) > 0 && alltrue(local.in_maintenance_mode_filter_result)
+}
+`, testAccDataDesktopPools_base(name))
 }

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_sysprep_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_sysprep_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDesktopSysprepDataSource_basic(t *testing.T) {
+func TestAccDataDesktopSysprep_basic(t *testing.T) {
 	var (
 		name = acceptance.RandomAccResourceNameWithDash()
 
@@ -25,7 +25,7 @@ func TestAccDesktopSysprepDataSource_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDesktopSysprepDataSource_basic(name),
+				Config: testAccDataDesktopSysprep_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestMatchResourceAttr(dcName, "sysprep_info.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
@@ -37,69 +37,12 @@ func TestAccDesktopSysprepDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccDesktopSysprepDataSource_base(name string) string {
-	return fmt.Sprintf(`
-data "huaweicloud_workspace_service" "test" {}
-
-data "huaweicloud_workspace_flavors" "test" {
-  os_type = "Windows"
-}
-
-data "huaweicloud_availability_zones" "test" {}
-
-data "huaweicloud_images_images" "test" {
-  name_regex = "WORKSPACE"
-  visibility = "market"
-}
-
-resource "huaweicloud_workspace_desktop" "test" {
-  flavor_id         = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "NOT_FOUND")
-  image_type        = "market"
-  image_id          = try(data.huaweicloud_images_images.test.images[0].id, "NOT_FOUND")
-  availability_zone = try(data.huaweicloud_availability_zones.test.names[0], "NOT_FOUND")
-  vpc_id            = data.huaweicloud_workspace_service.test.vpc_id
-
-  security_groups = [
-    try(data.huaweicloud_workspace_service.test.desktop_security_group[0].id, "NOT_FOUND"),
-    try(data.huaweicloud_workspace_service.test.infrastructure_security_group[0].id, "NOT_FOUND"),
-  ]
-  
-  nic {
-    network_id = try(data.huaweicloud_workspace_service.test.network_ids[0], "NOT_FOUND")
-  }
-
-  name       = "%[1]s"
-  user_name  = "%[1]s-user"
-  user_email = "terraform@example.com"
-  user_group = "administrators"
-
-  root_volume {
-    type = "SAS"
-    size = 80
-  }
-
-  data_volume {
-    type = "SAS"
-    size = 50
-  }
-
-  tags = {
-    foo   = "bar"
-    owner = "terraform"
-  }
-
-  email_notification = true
-  delete_user        = true
-}
-`, name)
-}
-
-func testAccDesktopSysprepDataSource_basic(name string) string {
+func testAccDataDesktopSysprep_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 data "huaweicloud_workspace_desktop_sysprep" "test" {
   desktop_id = huaweicloud_workspace_desktop.test.id
 }
-`, testAccDesktopSysprepDataSource_base(name))
+`, testAccDataDesktops_base(name))
 }

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_tags_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_tags_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceDesktopTags_basic(t *testing.T) {
+func TestAccDataDesktopTags_basic(t *testing.T) {
 	var (
-		rName = acceptance.RandomAccResourceNameWithDash()
+		name = acceptance.RandomAccResourceNameWithDash()
 
-		dcName = "data.huaweicloud_workspace_desktop_tags.filterByDesktopId"
-		dc     = acceptance.InitDataSourceCheck(dcName)
+		all = "data.huaweicloud_workspace_desktop_tags.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -26,60 +26,34 @@ func TestAccDataSourceDesktopTags_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDesktopTags_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_tags_valid", "true"),
-					resource.TestCheckOutput("is_key_valid", "true"),
-					resource.TestCheckOutput("is_value_valid", "true"),
-				),
+				Config:      testAccDataDesktopTags_basic_invalidDesktopId(),
+				ExpectError: regexp.MustCompile(`The resource does not exist or is a resource of another project. DesktopId is not exist.`),
 			},
 			{
-				Config:      testAccDataSourceDesktopTags_ExpectError(),
-				ExpectError: regexp.MustCompile(`The resource does not exist or is a resource of another project. DesktopId is not exist.`),
+				Config: testAccDataDesktopTags_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "tags.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "tags.0.key"),
+					resource.TestCheckResourceAttrSet(all, "tags.0.value"),
+				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceDesktopTags_basic(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-# filter by desktop id
-data "huaweicloud_workspace_desktop_tags" "filterByDesktopId" {
-  desktop_id = huaweicloud_workspace_desktop.test.id
-}
-
-locals {
-  tag_result = try(data.huaweicloud_workspace_desktop_tags.filterByDesktopId.tags[0], {})
-}
-
-output "is_tags_valid" {
-  value = length(data.huaweicloud_workspace_desktop_tags.filterByDesktopId.tags) > 0
-}
-
-output "is_key_valid" {
-  value = try(local.tag_result.key != null && local.tag_result.key != "", false)
-}
-
-output "is_value_valid" {
-  value = try(local.tag_result.value != null, false)
-}
-`, testAccDataSourceDesktopTags_base(rName))
-}
-
-func testAccDataSourceDesktopTags_ExpectError() string {
+func testAccDataDesktopTags_basic_invalidDesktopId() string {
 	randomId, _ := uuid.GenerateUUID()
 	return fmt.Sprintf(`
-# expect error where id non exist
-data "huaweicloud_workspace_desktop_tags" "expectErrorWhereIdNonExist" {
+# Filter by 'desktop_id' parameter and with invalid value.
+data "huaweicloud_workspace_desktop_tags" "invalid_desktop_id" {
   desktop_id = "%[1]s"
 }
 `, randomId)
 }
 
-func testAccDataSourceDesktopTags_base(rName string) string {
+func testAccDataDesktopTags_base(name string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_workspace_service" "test" {}
 
@@ -87,39 +61,31 @@ data "huaweicloud_workspace_flavors" "test" {
   os_type = "Windows"
 }
 
+locals {
+  cpu_flavors = [for v in data.huaweicloud_workspace_flavors.test.flavors : v if v.is_gpu == false]
+}
+
 data "huaweicloud_availability_zones" "test" {}
 
-data "huaweicloud_images_images" "test" {
-  name_regex = "WORKSPACE"
-  visibility = "market"
-}
-
-# Ready for Desktop
-locals {
-  name              = "%[1]s"
-  user_name         = "%[1]s-user"
-  data_volume_sizes = [50, 70]
-}
-
 resource "huaweicloud_workspace_desktop" "test" {
-  flavor_id         = data.huaweicloud_workspace_flavors.test.flavors[0].id
+  flavor_id         = try(data.huaweicloud_workspace_flavors.test.flavors[0].id)
   image_type        = "market"
-  image_id          = try(data.huaweicloud_images_images.test.images[0].id, "")
+  image_id          = "%[1]s"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   vpc_id            = data.huaweicloud_workspace_service.test.vpc_id
   security_groups   = [
-    data.huaweicloud_workspace_service.test.desktop_security_group[0].id,
-    data.huaweicloud_workspace_service.test.infrastructure_security_group[0].id,
+    data.huaweicloud_workspace_service.test.desktop_security_group.0.id,
   ]
 
   nic {
     network_id = data.huaweicloud_workspace_service.test.network_ids[0]
   }
 
-  name       = local.name
-  user_name  = local.user_name
-  user_email = "terraform@example.com"
-  user_group = "administrators"
+  name        = "%[2]s"
+  user_name   = "user-%[2]s"
+  user_email  = "terraform@example.com"
+  user_group  = "administrators"
+  delete_user = true
 
   root_volume {
     type = "SAS"
@@ -135,13 +101,21 @@ resource "huaweicloud_workspace_desktop" "test" {
     foo   = "bar"
     owner = "terraform"
   }
-
-  email_notification = true
-  delete_user        = true
-
-  lifecycle {
-    ignore_changes = [ name ]
-  }
 }
-`, rName)
+`, acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID, name)
+}
+
+func testAccDataDesktopTags_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameter.
+data "huaweicloud_workspace_desktop_tags" "all" {
+  desktop_id = huaweicloud_workspace_desktop.test.id
+}
+
+locals {
+  tag_result = try(data.huaweicloud_workspace_desktop_tags.all.tags[0], {})
+}
+`, testAccDataDesktopTags_base(name))
 }

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktops_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktops_test.go
@@ -9,69 +9,74 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceDesktops_basic(t *testing.T) {
+func TestAccDataDesktops_basic(t *testing.T) {
 	var (
-		name           = acceptance.RandomAccResourceNameWithDash()
-		dataSourceName = "data.huaweicloud_workspace_desktops.test"
-		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		name = acceptance.RandomAccResourceNameWithDash()
 
-		byDesktopId   = "data.huaweicloud_workspace_desktops.filter_by_desktop_id"
-		dcByDesktopId = acceptance.InitDataSourceCheck(byDesktopId)
+		all = "data.huaweicloud_workspace_desktops.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
-		byName   = "data.huaweicloud_workspace_desktops.filter_by_name"
-		dcByName = acceptance.InitDataSourceCheck(byName)
+		filterByDesktopId   = "data.huaweicloud_workspace_desktops.filter_by_desktop_id"
+		dcFilterByDesktopId = acceptance.InitDataSourceCheck(filterByDesktopId)
 
-		byUserName = "data.huaweicloud_workspace_desktops.filter_by_user_name"
-		dcUserName = acceptance.InitDataSourceCheck(byUserName)
+		filterByName   = "data.huaweicloud_workspace_desktops.filter_by_name"
+		dcFilterByName = acceptance.InitDataSourceCheck(filterByName)
 
-		byTags = "data.huaweicloud_workspace_desktops.filter_by_tags"
-		dcTags = acceptance.InitDataSourceCheck(byTags)
+		filterByUserName   = "data.huaweicloud_workspace_desktops.filter_by_user_name"
+		dcFilterByUserName = acceptance.InitDataSourceCheck(filterByUserName)
 
-		byImageId = "data.huaweicloud_workspace_desktops.filter_by_image_id"
-		dcImageId = acceptance.InitDataSourceCheck(byImageId)
+		filterByTags   = "data.huaweicloud_workspace_desktops.filter_by_tags"
+		dcFilterByTags = acceptance.InitDataSourceCheck(filterByTags)
 
-		byEnterpriseProjectId = "data.huaweicloud_workspace_desktops.filter_by_eps_id"
-		dcEnterpriseProjectId = acceptance.InitDataSourceCheck(byEnterpriseProjectId)
+		filterByImageId   = "data.huaweicloud_workspace_desktops.filter_by_image_id"
+		dcFilterByImageId = acceptance.InitDataSourceCheck(filterByImageId)
 
-		bySubnetId = "data.huaweicloud_workspace_desktops.filter_by_subnet_id"
-		dcSubnetId = acceptance.InitDataSourceCheck(bySubnetId)
+		filterByEnterpriseProjectId   = "data.huaweicloud_workspace_desktops.filter_by_eps_id"
+		dcFilterByEnterpriseProjectId = acceptance.InitDataSourceCheck(filterByEnterpriseProjectId)
 
-		byStatus = "data.huaweicloud_workspace_desktops.filter_by_status"
-		dcStatus = acceptance.InitDataSourceCheck(byStatus)
+		filterBySubnetId   = "data.huaweicloud_workspace_desktops.filter_by_subnet_id"
+		dcFilterBySubnetId = acceptance.InitDataSourceCheck(filterBySubnetId)
+
+		filterByStatus   = "data.huaweicloud_workspace_desktops.filter_by_status"
+		dcFilterByStatus = acceptance.InitDataSourceCheck(filterByStatus)
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceDesktopPoolImageId(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDesktops_basic(name),
+				Config: testAccDataDesktops_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.#"),
-					resource.TestCheckResourceAttr(dataSourceName, "desktops.0.is_support_internet", "false"),
-					dcByDesktopId.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(all, "desktops.#"),
+					resource.TestCheckResourceAttr(all, "desktops.0.is_support_internet", "false"),
+
+					dcFilterByDesktopId.CheckResourceExists(),
 					resource.TestCheckOutput("is_desktop_id_filter_useful", "true"),
 
-					dcByName.CheckResourceExists(),
+					dcFilterByName.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
 
-					dcUserName.CheckResourceExists(),
+					dcFilterByUserName.CheckResourceExists(),
 					resource.TestCheckOutput("is_user_name_filter_useful", "true"),
 
-					dcTags.CheckResourceExists(),
+					dcFilterByTags.CheckResourceExists(),
 					resource.TestCheckOutput("is_tags_filter_useful", "true"),
 
-					dcImageId.CheckResourceExists(),
+					dcFilterByImageId.CheckResourceExists(),
 					resource.TestCheckOutput("is_image_id_filter_useful", "true"),
 
-					dcEnterpriseProjectId.CheckResourceExists(),
+					dcFilterByEnterpriseProjectId.CheckResourceExists(),
 					resource.TestCheckOutput("is_enterprise_project_id_filter_useful", "true"),
 
-					dcSubnetId.CheckResourceExists(),
+					dcFilterBySubnetId.CheckResourceExists(),
 					resource.TestCheckOutput("is_subnet_id_filter_useful", "true"),
 
-					dcStatus.CheckResourceExists(),
+					dcFilterByStatus.CheckResourceExists(),
 					resource.TestCheckOutput("is_status_filter_useful", "true"),
 				),
 			},
@@ -79,28 +84,32 @@ func TestAccDataSourceDesktops_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceDesktops_basic(rName string) string {
+func testAccDataDesktops_base(name string) string {
 	return fmt.Sprintf(`
-%[1]s
-		
+data "huaweicloud_workspace_service" "test" {}
+
 data "huaweicloud_workspace_flavors" "test" {
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  os_type           = "Windows"
+  os_type = "Windows"
 }
+
+locals {
+  cpu_flavors = [for v in data.huaweicloud_workspace_flavors.test.flavors : v if v.is_gpu == false]
+}
+
+data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_workspace_desktop" "test" {
   flavor_id         = try(data.huaweicloud_workspace_flavors.test.flavors[0].id)
   image_type        = "market"
-  image_id          = try(data.huaweicloud_images_images.test.images[0].id)
+  image_id          = "%[1]s"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  vpc_id            = huaweicloud_vpc.test.id
+  vpc_id            = data.huaweicloud_workspace_service.test.vpc_id
   security_groups   = [
-    huaweicloud_workspace_service.test.desktop_security_group.0.id,
-    huaweicloud_networking_secgroup.test.id,
+    data.huaweicloud_workspace_service.test.desktop_security_group.0.id,
   ]
 
   nic {
-    network_id = huaweicloud_vpc_subnet.test.id
+    network_id = data.huaweicloud_workspace_service.test.network_ids[0]
   }
 
   name        = "%[2]s"
@@ -119,16 +128,23 @@ resource "huaweicloud_workspace_desktop" "test" {
     size = 50
   }
 }
-
-data "huaweicloud_workspace_desktops" "test" {
-  depends_on = [
-    huaweicloud_workspace_desktop.test
-  ] 
+`, acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID, name)
 }
 
-// By desktop ID filter
+func testAccDataDesktops_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameter.
+data "huaweicloud_workspace_desktops" "all" {
+  depends_on = [
+    huaweicloud_workspace_desktop.test
+  ]
+}
+
+# Filter by 'desktop_id' parameter.
 locals {
-  desktop_id = data.huaweicloud_workspace_desktops.test.desktops[0].id
+  desktop_id = data.huaweicloud_workspace_desktops.all.desktops[0].id
 }
 
 data "huaweicloud_workspace_desktops" "filter_by_desktop_id" {
@@ -141,9 +157,9 @@ output "is_desktop_id_filter_useful" {
   )
 }
 
-// By desktop name filter
+# Filter by 'name' parameter.
 locals {
-  name = data.huaweicloud_workspace_desktops.test.desktops[0].name
+  name = data.huaweicloud_workspace_desktops.all.desktops[0].name
 }
 
 data "huaweicloud_workspace_desktops" "filter_by_name" {
@@ -156,9 +172,9 @@ output "is_name_filter_useful" {
   )
 }
 
-// By user name filter
+# Filter by 'user_name' parameter.
 locals {
-  user_name = data.huaweicloud_workspace_desktops.test.desktops[0].attach_user_infos[0].user_name
+  user_name = data.huaweicloud_workspace_desktops.all.desktops[0].attach_user_infos[0].user_name
 }
 
 data "huaweicloud_workspace_desktops" "filter_by_user_name" {
@@ -171,9 +187,9 @@ output "is_user_name_filter_useful" {
   )
 }
 
-// By tags filter
+# Filter by 'tags' parameter.
 locals {
-  tags = data.huaweicloud_workspace_desktops.test.desktops[0].tags
+  tags = data.huaweicloud_workspace_desktops.all.desktops[0].tags
 }
 
 data "huaweicloud_workspace_desktops" "filter_by_tags" {
@@ -190,9 +206,9 @@ output "is_tags_filter_useful" {
   value = alltrue(local.tags_filter_result) && length(local.tags_filter_result) > 0
 }
 
-// By image ID filter
+# Filter by 'image_id' parameter.
 locals {
-  image_id = data.huaweicloud_workspace_desktops.test.desktops[0].image_id
+  image_id = data.huaweicloud_workspace_desktops.all.desktops[0].image_id
 }
 
 data "huaweicloud_workspace_desktops" "filter_by_image_id" {
@@ -205,9 +221,9 @@ output "is_image_id_filter_useful" {
   )
 }
 
-// By enperprise project ID filter
+# Filter by 'enterprise_project_id' parameter.
 locals {
-  eps_id = data.huaweicloud_workspace_desktops.test.desktops[0].enterprise_project_id
+  eps_id = data.huaweicloud_workspace_desktops.all.desktops[0].enterprise_project_id
 }
 
 data "huaweicloud_workspace_desktops" "filter_by_eps_id" {
@@ -220,9 +236,9 @@ output "is_enterprise_project_id_filter_useful" {
   )
 }
 
-// By subnet ID filter
+# Filter by 'subnet_id' parameter.
 locals {
-  subnet_id = data.huaweicloud_workspace_desktops.test.desktops[0].subnet_id
+  subnet_id = data.huaweicloud_workspace_desktops.all.desktops[0].subnet_id
 }
 
 data "huaweicloud_workspace_desktops" "filter_by_subnet_id" {
@@ -235,9 +251,9 @@ output "is_subnet_id_filter_useful" {
   )
 }
 
-// By desktop status filter
+# Filter by 'status' parameter.
 locals {
-  status = data.huaweicloud_workspace_desktops.test.desktops[0].status
+  status = data.huaweicloud_workspace_desktops.all.desktops[0].status
 }
 
 data "huaweicloud_workspace_desktops" "filter_by_status" {
@@ -249,5 +265,5 @@ output "is_status_filter_useful" {
     [for v in data.huaweicloud_workspace_desktops.filter_by_status.desktops[*].status : v == local.status]
   )
 }
-`, testAccDesktop_base(rName), rName)
+`, testAccDataDesktops_base(name))
 }

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_hour_packages_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_hour_packages_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccHourPackagesDataSource_basic(t *testing.T) {
+func TestAccDataHourPackages_basic(t *testing.T) {
 	var (
-		dcName = "data.huaweicloud_workspace_hour_packages.all"
-		dc     = acceptance.InitDataSourceCheck(dcName)
+		all = "data.huaweicloud_workspace_hour_packages.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
 		filterByDesktopResourceSpecCodeName   = "data.huaweicloud_workspace_hour_packages.filter_by_desktop_resource_spec_code"
 		dcFilterByDesktopResourceSpecCodeName = acceptance.InitDataSourceCheck(filterByDesktopResourceSpecCodeName)
@@ -28,22 +28,23 @@ func TestAccHourPackagesDataSource_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHourPackagesDataSource_basic,
+				Config: testAccDataHourPackages_basic,
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dcName, "hour_packages.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestCheckResourceAttrSet(dcName, "hour_packages.0.cloud_service_type"),
-					resource.TestCheckResourceAttrSet(dcName, "hour_packages.0.resource_type"),
-					resource.TestCheckResourceAttrSet(dcName, "hour_packages.0.resource_spec_code"),
-					resource.TestCheckResourceAttrSet(dcName, "hour_packages.0.desktop_resource_spec_code"),
-					resource.TestCheckResourceAttrSet(dcName, "hour_packages.0.descriptions.0.zh_cn"),
-					resource.TestCheckResourceAttrSet(dcName, "hour_packages.0.descriptions.0.en_us"),
-					resource.TestCheckResourceAttrSet(dcName, "hour_packages.0.package_duration"),
-					resource.TestCheckResourceAttrSet(dcName, "hour_packages.0.status"),
-					// filter by desktop resource spec code
+					resource.TestMatchResourceAttr(all, "hour_packages.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "hour_packages.0.cloud_service_type"),
+					resource.TestCheckResourceAttrSet(all, "hour_packages.0.resource_type"),
+					resource.TestCheckResourceAttrSet(all, "hour_packages.0.resource_spec_code"),
+					resource.TestCheckResourceAttrSet(all, "hour_packages.0.desktop_resource_spec_code"),
+					resource.TestCheckResourceAttrSet(all, "hour_packages.0.descriptions.0.zh_cn"),
+					resource.TestCheckResourceAttrSet(all, "hour_packages.0.descriptions.0.en_us"),
+					resource.TestCheckResourceAttrSet(all, "hour_packages.0.package_duration"),
+					resource.TestCheckResourceAttrSet(all, "hour_packages.0.status"),
+					// Filter by 'desktop_resource_spec_code' parameter.
 					dcFilterByDesktopResourceSpecCodeName.CheckResourceExists(),
 					resource.TestCheckOutput("is_desktop_resource_spec_code_filter_useful", "true"),
-					// filter by resource spec code
+					// Filter by 'resource_spec_code' parameter.
 					dcFilterByResourceSpecCodeName.CheckResourceExists(),
 					resource.TestCheckOutput("is_resource_spec_code_filter_useful", "true"),
 				),
@@ -52,7 +53,8 @@ func TestAccHourPackagesDataSource_basic(t *testing.T) {
 	})
 }
 
-const testAccHourPackagesDataSource_basic = `
+const testAccDataHourPackages_basic = `
+// Without any filter parameter.
 data "huaweicloud_workspace_hour_packages" "all" {}
 
 locals {
@@ -60,7 +62,7 @@ locals {
   resource_spec_code         = try(data.huaweicloud_workspace_hour_packages.all.hour_packages[0].resource_spec_code, "NOT_FOUND")
 }
 
-# Filter by desktop resource spec code
+# Filter by 'desktop_resource_spec_code' parameter.
 data "huaweicloud_workspace_hour_packages" "filter_by_desktop_resource_spec_code" {
   desktop_resource_spec_code = local.desktop_resource_spec_code
 }
@@ -76,7 +78,7 @@ output "is_desktop_resource_spec_code_filter_useful" {
   value = length(local.desktop_resource_spec_code_filter_result) > 0 && alltrue(local.desktop_resource_spec_code_filter_result)
 }
 
-# Filter by resource spec code
+# Filter by 'resource_spec_code' parameter.
 data "huaweicloud_workspace_hour_packages" "filter_by_resource_spec_code" {
   resource_spec_code = local.resource_spec_code
 }

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_policy_groups_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_policy_groups_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourcePolicyGroups_basic(t *testing.T) {
+func TestAccDataPolicyGroups_basic(t *testing.T) {
 	var (
 		name = acceptance.RandomAccResourceName()
 
-		dcName = "data.huaweicloud_workspace_policy_groups.all"
-		dc     = acceptance.InitDataSourceCheck(dcName)
+		all = "data.huaweicloud_workspace_policy_groups.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
 		filterById   = "data.huaweicloud_workspace_policy_groups.filter_by_policy_group_id"
 		dcFilterById = acceptance.InitDataSourceCheck(filterById)
@@ -37,25 +37,25 @@ func TestAccDataSourcePolicyGroups_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourcePolicyGroups_basic(name),
+				Config: testAccDataPolicyGroups_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					// Query policy groups without any filter parameter
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dcName, "policy_groups.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestCheckResourceAttrSet(dcName, "policy_groups.0.policy_group_id"),
-					resource.TestCheckResourceAttrSet(dcName, "policy_groups.0.policy_group_name"),
-					resource.TestCheckResourceAttrSet(dcName, "policy_groups.0.priority"),
-					resource.TestCheckResourceAttrSet(dcName, "policy_groups.0.update_time"),
-					// Filter by ID
+					resource.TestMatchResourceAttr(all, "policy_groups.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "policy_groups.0.policy_group_id"),
+					resource.TestCheckResourceAttrSet(all, "policy_groups.0.policy_group_name"),
+					resource.TestCheckResourceAttrSet(all, "policy_groups.0.priority"),
+					resource.TestCheckResourceAttrSet(all, "policy_groups.0.update_time"),
+					// Filter by 'policy_group_id' parameter.
 					dcFilterById.CheckResourceExists(),
-					resource.TestCheckOutput("is_id_filter_useful", "true"),
-					// Filter by name
+					resource.TestCheckOutput("is_policy_group_id_filter_useful", "true"),
+					// Filter by 'policy_group_name' parameter.
 					dcFilterByName.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
-					// Filter by priority
+					// Filter by 'priority' parameter.
 					dcFilterByPriority.CheckResourceExists(),
 					resource.TestCheckOutput("is_priority_filter_useful", "true"),
-					// Filter by description
+					// Filter by 'description' parameter.
 					dcFilterByDescription.CheckResourceExists(),
 					resource.TestCheckOutput("is_description_filter_useful", "true"),
 				),
@@ -64,105 +64,7 @@ func TestAccDataSourcePolicyGroups_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourcePolicyGroups_basic(name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_workspace_policy_groups" "all" {
-  depends_on = [
-    huaweicloud_workspace_policy_group.test,
-    huaweicloud_workspace_policy_group.nontest,
-  ]
-}
-
-locals {
-  policy_group_id   = try(data.huaweicloud_workspace_policy_groups.all.policy_groups[0].policy_group_id, "NOT_FOUND")
-  policy_group_name = try(data.huaweicloud_workspace_policy_groups.all.policy_groups[0].policy_group_name, "NOT_FOUND")
-  priority          = try(data.huaweicloud_workspace_policy_groups.all.policy_groups[0].priority, -1)
-  update_time       = try(data.huaweicloud_workspace_policy_groups.all.policy_groups[0].update_time, "1900-01-01T01:01:01Z")
-  description       = try(data.huaweicloud_workspace_policy_groups.all.policy_groups[0].description, "NOT_FOUND")
-}
-
-# Filter by policy group id
-data "huaweicloud_workspace_policy_groups" "filter_by_policy_group_id" {
-  policy_group_id = local.policy_group_id
-
-  depends_on = [
-    huaweicloud_workspace_policy_group.test,
-    huaweicloud_workspace_policy_group.nontest,
-  ]
-}
-
-locals {
-  id_filter_result = [
-    for v in data.huaweicloud_workspace_policy_groups.filter_by_policy_group_id.policy_groups[*].policy_group_id :
-    v == local.policy_group_id
-  ]
-}
-
-output "is_id_filter_useful" {
-  value = length(local.id_filter_result) < 2 && alltrue(local.id_filter_result)
-}
-
-# Filter by policy group name
-data "huaweicloud_workspace_policy_groups" "filter_by_policy_group_name" {
-  policy_group_name = local.policy_group_name
-
-  depends_on = [
-    huaweicloud_workspace_policy_group.test,
-    huaweicloud_workspace_policy_group.nontest,
-  ]
-}
-
-output "is_name_filter_useful" {
-  value = length(data.huaweicloud_workspace_policy_groups.filter_by_policy_group_name.policy_groups) > 0
-}
-
-# Filter by priority
-data "huaweicloud_workspace_policy_groups" "filter_by_priority" {
-  priority = local.priority
-
-  depends_on = [
-    huaweicloud_workspace_policy_group.test,
-    huaweicloud_workspace_policy_group.nontest,
-  ]
-}
-
-locals {
-  priority_filter_result = [
-    for v in data.huaweicloud_workspace_policy_groups.filter_by_priority.policy_groups[*].priority :
-    v == local.priority
-  ]
-}
-
-output "is_priority_filter_useful" {
-  value = length(local.priority_filter_result) > 0 && alltrue(local.priority_filter_result)
-}
-
-# Filter by description
-data "huaweicloud_workspace_policy_groups" "filter_by_description" {
-  description = local.description
-
-  depends_on = [
-    huaweicloud_workspace_policy_group.test,
-    huaweicloud_workspace_policy_group.nontest,
-  ]
-}
-
-locals {
-  description_filter_result = [
-    for v in data.huaweicloud_workspace_policy_groups.filter_by_description.policy_groups[*].description :
-    strcontains(v, local.description)
-  ]
-}
-
-output "is_description_filter_useful" {
-  value = length(local.description_filter_result) > 0 && alltrue(local.description_filter_result)
-}
-`, testAccDataSourcePolicyGroups_base(name))
-}
-
-func testAccDataSourcePolicyGroups_base(name string) string {
+func testAccDataPolicyGroups_base(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_workspace_user" "test" {
   name  = "%[1]s"
@@ -203,4 +105,103 @@ resource "huaweicloud_workspace_policy_group" "nontest" {
   }
 }
 `, name)
+}
+
+func testAccDataPolicyGroups_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameter.
+data "huaweicloud_workspace_policy_groups" "all" {
+  depends_on = [
+    huaweicloud_workspace_policy_group.test,
+    huaweicloud_workspace_policy_group.nontest,
+  ]
+}
+
+locals {
+  policy_group_id   = try(data.huaweicloud_workspace_policy_groups.all.policy_groups[0].policy_group_id, "NOT_FOUND")
+  policy_group_name = try(data.huaweicloud_workspace_policy_groups.all.policy_groups[0].policy_group_name, "NOT_FOUND")
+  priority          = try(data.huaweicloud_workspace_policy_groups.all.policy_groups[0].priority, -1)
+  update_time       = try(data.huaweicloud_workspace_policy_groups.all.policy_groups[0].update_time, "1900-01-01T01:01:01Z")
+  description       = try(data.huaweicloud_workspace_policy_groups.all.policy_groups[0].description, "NOT_FOUND")
+}
+
+# Filter by 'policy_group_id' parameter.
+data "huaweicloud_workspace_policy_groups" "filter_by_policy_group_id" {
+  policy_group_id = local.policy_group_id
+
+  depends_on = [
+    huaweicloud_workspace_policy_group.test,
+    huaweicloud_workspace_policy_group.nontest,
+  ]
+}
+
+locals {
+  policy_group_id_filter_result = [
+    for v in data.huaweicloud_workspace_policy_groups.filter_by_policy_group_id.policy_groups[*].policy_group_id :
+    v == local.policy_group_id
+  ]
+}
+
+output "is_policy_group_id_filter_useful" {
+  value = length(local.policy_group_id_filter_result) < 2 && alltrue(local.policy_group_id_filter_result)
+}
+
+# Filter by 'policy_group_name' parameter.
+data "huaweicloud_workspace_policy_groups" "filter_by_policy_group_name" {
+  policy_group_name = local.policy_group_name
+
+  depends_on = [
+    huaweicloud_workspace_policy_group.test,
+    huaweicloud_workspace_policy_group.nontest,
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(data.huaweicloud_workspace_policy_groups.filter_by_policy_group_name.policy_groups) > 0
+}
+
+# Filter by 'priority' parameter.
+data "huaweicloud_workspace_policy_groups" "filter_by_priority" {
+  priority = local.priority
+
+  depends_on = [
+    huaweicloud_workspace_policy_group.test,
+    huaweicloud_workspace_policy_group.nontest,
+  ]
+}
+
+locals {
+  priority_filter_result = [
+    for v in data.huaweicloud_workspace_policy_groups.filter_by_priority.policy_groups[*].priority :
+    v == local.priority
+  ]
+}
+
+output "is_priority_filter_useful" {
+  value = length(local.priority_filter_result) > 0 && alltrue(local.priority_filter_result)
+}
+
+# Filter by 'description' parameter.
+data "huaweicloud_workspace_policy_groups" "filter_by_description" {
+  description = local.description
+
+  depends_on = [
+    huaweicloud_workspace_policy_group.test,
+    huaweicloud_workspace_policy_group.nontest,
+  ]
+}
+
+locals {
+  description_filter_result = [
+    for v in data.huaweicloud_workspace_policy_groups.filter_by_description.policy_groups[*].description :
+    strcontains(v, local.description)
+  ]
+}
+
+output "is_description_filter_useful" {
+  value = length(local.description_filter_result) > 0 && alltrue(local.description_filter_result)
+}
+`, testAccDataPolicyGroups_base(name))
 }

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_quotas_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_quotas_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestAccDataQuotas_basic(t *testing.T) {
 	var (
-		dataSourceName = "data.huaweicloud_workspace_quotas.test"
-		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		all = "data.huaweicloud_workspace_quotas.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -22,17 +22,18 @@ func TestAccDataQuotas_basic(t *testing.T) {
 			{
 				Config: testAccDataQuotas_basic,
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dataSourceName, "quotas.#", regexp.MustCompile(`^[0-9]+$`)),
-					resource.TestMatchResourceAttr(dataSourceName, "quotas.0.resources.#", regexp.MustCompile(`^[0-9]+$`)),
-					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.resources.0.type"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.resources.0.quota"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.resources.0.used"),
-					resource.TestMatchResourceAttr(dataSourceName, "site_quotas.#", regexp.MustCompile(`^[0-9]+$`)),
-					resource.TestMatchResourceAttr(dataSourceName, "site_quotas.0.resources.#", regexp.MustCompile(`^[0-9]+$`)),
-					resource.TestCheckResourceAttrSet(dataSourceName, "site_quotas.0.resources.0.type"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "site_quotas.0.resources.0.quota"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "site_quotas.0.resources.0.used"),
+					resource.TestMatchResourceAttr(all, "quotas.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestMatchResourceAttr(all, "quotas.0.resources.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(all, "quotas.0.resources.0.type"),
+					resource.TestCheckResourceAttrSet(all, "quotas.0.resources.0.quota"),
+					resource.TestCheckResourceAttrSet(all, "quotas.0.resources.0.used"),
+					resource.TestMatchResourceAttr(all, "site_quotas.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestMatchResourceAttr(all, "site_quotas.0.resources.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(all, "site_quotas.0.resources.0.type"),
+					resource.TestCheckResourceAttrSet(all, "site_quotas.0.resources.0.quota"),
+					resource.TestCheckResourceAttrSet(all, "site_quotas.0.resources.0.used"),
 				),
 			},
 		},
@@ -40,5 +41,5 @@ func TestAccDataQuotas_basic(t *testing.T) {
 }
 
 const testAccDataQuotas_basic = `
-data "huaweicloud_workspace_quotas" "test" {}
+data "huaweicloud_workspace_quotas" "all" {}
 `

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_scheduled_task_record_details_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_scheduled_task_record_details_test.go
@@ -13,8 +13,8 @@ import (
 // Before running this acceptance test, make sure that the scheduled task has been executed at least once.
 func TestAccDataScheduledTaskRecordDetails_basic(t *testing.T) {
 	var (
-		dataSource = "data.huaweicloud_workspace_scheduled_task_record_details.test"
-		dc         = acceptance.InitDataSourceCheck(dataSource)
+		all = "data.huaweicloud_workspace_scheduled_task_record_details.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -27,16 +27,17 @@ func TestAccDataScheduledTaskRecordDetails_basic(t *testing.T) {
 			{
 				Config: testAccDataScheduledTaskRecordDetails_basic(),
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dataSource, "details.#", regexp.MustCompile(`^[0-9]+$`)),
-					resource.TestCheckResourceAttrSet(dataSource, "details.0.id"),
-					resource.TestCheckResourceAttrSet(dataSource, "details.0.record_id"),
-					resource.TestCheckResourceAttrPair(dataSource, "details.0.record_id",
+					resource.TestMatchResourceAttr(all, "details.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(all, "details.0.id"),
+					resource.TestCheckResourceAttrSet(all, "details.0.record_id"),
+					resource.TestCheckResourceAttrPair(all, "details.0.record_id",
 						"data.huaweicloud_workspace_scheduled_task_records.test", "records.0.id"),
-					resource.TestCheckResourceAttrSet(dataSource, "details.0.desktop_id"),
-					resource.TestCheckResourceAttrSet(dataSource, "details.0.desktop_name"),
-					resource.TestCheckResourceAttrSet(dataSource, "details.0.exec_status"),
-					resource.TestMatchResourceAttr(dataSource, "details.0.start_time",
+					resource.TestCheckResourceAttrSet(all, "details.0.desktop_id"),
+					resource.TestCheckResourceAttrSet(all, "details.0.desktop_name"),
+					resource.TestCheckResourceAttrSet(all, "details.0.exec_status"),
+					resource.TestMatchResourceAttr(all, "details.0.start_time",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
@@ -50,7 +51,7 @@ data "huaweicloud_workspace_scheduled_task_records" "test" {
   task_id = "%[1]s"
 }
 
-data "huaweicloud_workspace_scheduled_task_record_details" "test" {
+data "huaweicloud_workspace_scheduled_task_record_details" "all" {
   task_id   = "%[1]s"
   record_id = try(data.huaweicloud_workspace_scheduled_task_records.test.records[0].id, "")
 }

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_scheduled_task_records_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_scheduled_task_records_test.go
@@ -14,8 +14,8 @@ import (
 // Before running this acceptance test, make sure that the scheduled task has been executed at least once.
 func TestAccDataScheduledTaskRecords_basic(t *testing.T) {
 	var (
-		dataSource = "data.huaweicloud_workspace_scheduled_task_records.test"
-		dc         = acceptance.InitDataSourceCheck(dataSource)
+		all = "data.huaweicloud_workspace_scheduled_task_records.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -32,17 +32,18 @@ func TestAccDataScheduledTaskRecords_basic(t *testing.T) {
 			{
 				Config: testAccDataScheduledTaskRecords_basic(),
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dataSource, "records.#", regexp.MustCompile(`^[0-9]+$`)),
-					resource.TestCheckResourceAttrSet(dataSource, "records.0.id"),
-					resource.TestCheckResourceAttrSet(dataSource, "records.0.start_time"),
-					resource.TestCheckResourceAttrSet(dataSource, "records.0.task_type"),
-					resource.TestCheckResourceAttrSet(dataSource, "records.0.scheduled_type"),
-					resource.TestCheckResourceAttrSet(dataSource, "records.0.status"),
-					resource.TestCheckResourceAttrSet(dataSource, "records.0.success_num"),
-					resource.TestCheckResourceAttrSet(dataSource, "records.0.failed_num"),
-					resource.TestCheckResourceAttrSet(dataSource, "records.0.skip_num"),
-					resource.TestMatchResourceAttr(dataSource, "records.0.start_time",
+					resource.TestMatchResourceAttr(all, "records.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(all, "records.0.id"),
+					resource.TestCheckResourceAttrSet(all, "records.0.start_time"),
+					resource.TestCheckResourceAttrSet(all, "records.0.task_type"),
+					resource.TestCheckResourceAttrSet(all, "records.0.scheduled_type"),
+					resource.TestCheckResourceAttrSet(all, "records.0.status"),
+					resource.TestCheckResourceAttrSet(all, "records.0.success_num"),
+					resource.TestCheckResourceAttrSet(all, "records.0.failed_num"),
+					resource.TestCheckResourceAttrSet(all, "records.0.skip_num"),
+					resource.TestMatchResourceAttr(all, "records.0.start_time",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
@@ -54,7 +55,7 @@ func testAccDataScheduledTaskRecords_invalidTaskId() string {
 	randUUID, _ := uuid.GenerateUUID()
 
 	return fmt.Sprintf(`
-data "huaweicloud_workspace_scheduled_task_records" "test" {
+data "huaweicloud_workspace_scheduled_task_records" "invalid_task_id" {
   task_id = "%s"
 }
 `, randUUID)
@@ -62,7 +63,7 @@ data "huaweicloud_workspace_scheduled_task_records" "test" {
 
 func testAccDataScheduledTaskRecords_basic() string {
 	return fmt.Sprintf(`
-data "huaweicloud_workspace_scheduled_task_records" "test" {
+data "huaweicloud_workspace_scheduled_task_records" "all" {
   task_id = "%s"
 }
 `, acceptance.HW_WORKSPACE_SCHEDULED_TASK_ID)

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_scheduled_tasks_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_scheduled_tasks_test.go
@@ -11,22 +11,21 @@ import (
 
 func TestAccDataScheduledTasks_basic(t *testing.T) {
 	var (
-		dataSourceName = "data.huaweicloud_workspace_scheduled_tasks.test"
-		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		all = "data.huaweicloud_workspace_scheduled_tasks.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
-		byTaskName   = "data.huaweicloud_workspace_scheduled_tasks.filter_by_task_name"
-		dcByTaskName = acceptance.InitDataSourceCheck(byTaskName)
+		filterByTaskName   = "data.huaweicloud_workspace_scheduled_tasks.filter_by_task_name"
+		dcFilterByTaskName = acceptance.InitDataSourceCheck(filterByTaskName)
 
-		byTaskType   = "data.huaweicloud_workspace_scheduled_tasks.filter_by_task_type"
-		dcByTaskType = acceptance.InitDataSourceCheck(byTaskType)
+		filterByTaskType   = "data.huaweicloud_workspace_scheduled_tasks.filter_by_task_type"
+		dcFilterByTaskType = acceptance.InitDataSourceCheck(filterByTaskType)
 
-		byScheduledType   = "data.huaweicloud_workspace_scheduled_tasks.filter_by_scheduled_type"
-		dcByScheduledType = acceptance.InitDataSourceCheck(byScheduledType)
+		filterByScheduledType   = "data.huaweicloud_workspace_scheduled_tasks.filter_by_scheduled_type"
+		dcFilterByScheduledType = acceptance.InitDataSourceCheck(filterByScheduledType)
 
-		byLastStatus   = "data.huaweicloud_workspace_scheduled_tasks.filter_by_last_status"
-		dcByLastStatus = acceptance.InitDataSourceCheck(byLastStatus)
+		filterByLastStatus   = "data.huaweicloud_workspace_scheduled_tasks.filter_by_last_status"
+		dcFilterByLastStatus = acceptance.InitDataSourceCheck(filterByLastStatus)
 	)
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -34,21 +33,26 @@ func TestAccDataScheduledTasks_basic(t *testing.T) {
 			{
 				Config: testAccDataScheduledTasks_basic,
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dataSourceName, "tasks.#", regexp.MustCompile(`^[0-9]+$`)),
-					dcByTaskName.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "tasks.#", regexp.MustCompile(`^[0-9]+$`)),
+					// Filter by 'task_name' parameter.
+					dcFilterByTaskName.CheckResourceExists(),
 					resource.TestCheckOutput("is_task_name_filter_useful", "true"),
-					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.id"),
-					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.name"),
-					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.type"),
-					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.scheduled_type"),
-					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.enable"),
-					resource.TestCheckResourceAttrSet(byTaskName, "tasks.0.time_zone"),
-					dcByTaskType.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(filterByTaskName, "tasks.0.id"),
+					resource.TestCheckResourceAttrSet(filterByTaskName, "tasks.0.name"),
+					resource.TestCheckResourceAttrSet(filterByTaskName, "tasks.0.type"),
+					resource.TestCheckResourceAttrSet(filterByTaskName, "tasks.0.scheduled_type"),
+					resource.TestCheckResourceAttrSet(filterByTaskName, "tasks.0.enable"),
+					resource.TestCheckResourceAttrSet(filterByTaskName, "tasks.0.time_zone"),
+					// Filter by 'task_type' parameter.
+					dcFilterByTaskType.CheckResourceExists(),
 					resource.TestCheckOutput("is_task_type_filter_useful", "true"),
-					dcByScheduledType.CheckResourceExists(),
+					// Filter by 'scheduled_type' parameter.
+					dcFilterByScheduledType.CheckResourceExists(),
 					resource.TestCheckOutput("is_scheduled_type_filter_useful", "true"),
-					dcByLastStatus.CheckResourceExists(),
+					// Filter by 'last_status' parameter.
+					dcFilterByLastStatus.CheckResourceExists(),
 					resource.TestCheckOutput("is_last_status_filter_useful", "true"),
 				),
 			},
@@ -58,13 +62,13 @@ func TestAccDataScheduledTasks_basic(t *testing.T) {
 
 const testAccDataScheduledTasks_basic = `
 # Query all scheduled tasks without any filter parameters.
-data "huaweicloud_workspace_scheduled_tasks" "test" {}
+data "huaweicloud_workspace_scheduled_tasks" "all" {}
 
 locals {
-  task_name      = try(data.huaweicloud_workspace_scheduled_tasks.test.tasks[0].name, "NOT_FOUND")
-  task_type      = try(data.huaweicloud_workspace_scheduled_tasks.test.tasks[0].type, "NOT_FOUND")
-  scheduled_type = try(data.huaweicloud_workspace_scheduled_tasks.test.tasks[0].scheduled_type, "NOT_FOUND")
-  last_status    = try([for v in data.huaweicloud_workspace_scheduled_tasks.test.tasks : v.last_status if v.last_status != ""][0], "NOT_FOUND")
+  task_name      = try(data.huaweicloud_workspace_scheduled_tasks.all.tasks[0].name, "NOT_FOUND")
+  task_type      = try(data.huaweicloud_workspace_scheduled_tasks.all.tasks[0].type, "NOT_FOUND")
+  scheduled_type = try(data.huaweicloud_workspace_scheduled_tasks.all.tasks[0].scheduled_type, "NOT_FOUND")
+  last_status    = try([for v in data.huaweicloud_workspace_scheduled_tasks.all.tasks : v.last_status if v.last_status != ""][0], "NOT_FOUND")
 }
 
 # Filter by task name.

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_service_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_service_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceService_basic(t *testing.T) {
+func TestAccDataService_basic(t *testing.T) {
 	var (
 		dcName = "data.huaweicloud_workspace_service.test"
 		dc     = acceptance.InitDataSourceCheck(dcName)
@@ -23,7 +23,7 @@ func TestAccDataSourceService_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceService_basic(),
+				Config: testAccDataService_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckOutput("is_service_id_set_and_valid", "true"),
@@ -38,7 +38,7 @@ func TestAccDataSourceService_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceService_basic() string {
+func testAccDataService_basic() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_workspace_service" "test" {
   ad_domain {

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_tags_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_tags_test.go
@@ -10,28 +10,33 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceTags_basic(t *testing.T) {
+func TestAccDataTags_basic(t *testing.T) {
 	var (
 		name = acceptance.RandomAccResourceNameWithDash()
 
-		all     = "data.huaweicloud_workspace_tags.all"
-		dcByAll = acceptance.InitDataSourceCheck(all)
+		all = "data.huaweicloud_workspace_tags.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
 		filterByKey   = "data.huaweicloud_workspace_tags.filter_by_key"
 		dcFilterByKey = acceptance.InitDataSourceCheck(filterByKey)
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceDesktopPoolImageId(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceTags_basic(name),
+				Config: testAccDataTags_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					dcByAll.CheckResourceExists(),
+					// Without any filter parameter.
+					dc.CheckResourceExists(),
 					resource.TestMatchResourceAttr(all, "tags.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
 					resource.TestCheckResourceAttrSet(all, "tags.0.key"),
 					resource.TestMatchResourceAttr(all, "tags.0.values.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'key' parameter.
 					dcFilterByKey.CheckResourceExists(),
 					resource.TestCheckOutput("is_key_filter_useful", "true"),
 				),
@@ -40,41 +45,7 @@ func TestAccDataSourceTags_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceTags_basic(name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_workspace_tags" "all" {
-  depends_on = [
-    huaweicloud_workspace_desktop.test
-  ]
-}
-
-locals {
-  key = "owner"
-}
-
-data "huaweicloud_workspace_tags" "filter_by_key" {
-  key = local.key
-
-  depends_on = [
-    huaweicloud_workspace_desktop.test
-  ]
-}
-
-locals {
-  tag_filter_result = [
-    for v in data.huaweicloud_workspace_tags.filter_by_key.tags[*].key : v == local.key
-  ]
-}
-
-output "is_key_filter_useful" {
-  value = length(local.tag_filter_result) > 0 && alltrue(local.tag_filter_result)
-}
-`, testAccDataSourceTags_base(name))
-}
-
-func testAccDataSourceTags_base(name string) string {
+func testAccDataTags_base(name string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_workspace_service" "test" {}
 
@@ -84,16 +55,10 @@ data "huaweicloud_workspace_flavors" "test" {
 
 data "huaweicloud_availability_zones" "test" {}
 
-data "huaweicloud_images_images" "test" {
-  name_regex = "WORKSPACE"
-  visibility = "market"
-}
-
-# Ready for Desktop
 resource "huaweicloud_workspace_desktop" "test" {
   flavor_id         = data.huaweicloud_workspace_flavors.test.flavors[0].id
   image_type        = "market"
-  image_id          = try(data.huaweicloud_images_images.test.images[0].id, "")
+  image_id          = "%[1]s"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   vpc_id            = data.huaweicloud_workspace_service.test.vpc_id
   security_groups   = [
@@ -105,8 +70,8 @@ resource "huaweicloud_workspace_desktop" "test" {
     network_id = data.huaweicloud_workspace_service.test.network_ids[0]
   }
 
-  name       = "%[1]s"
-  user_name  = "%[1]s-user"
+  name       = "%[2]s"
+  user_name  = "%[2]s-user"
   user_email = "terraform@example.com"
   user_group = "administrators"
 
@@ -129,8 +94,44 @@ resource "huaweicloud_workspace_desktop" "test" {
   delete_user        = true
 
   lifecycle {
-    ignore_changes = [ name ]
+    ignore_changes = [
+      name
+    ]
   }
 }
-`, name)
+`, acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID, name)
+}
+
+func testAccDataTags_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_workspace_tags" "all" {
+  depends_on = [
+    huaweicloud_workspace_desktop.test
+  ]
+}
+
+locals {
+  key = "owner"
+}
+
+data "huaweicloud_workspace_tags" "filter_by_key" {
+  depends_on = [
+    huaweicloud_workspace_desktop.test
+  ]
+
+  key = local.key
+}
+
+locals {
+  tag_filter_result = [
+    for v in data.huaweicloud_workspace_tags.filter_by_key.tags[*].key : v == local.key
+  ]
+}
+
+output "is_key_filter_useful" {
+  value = length(local.tag_filter_result) > 0 && alltrue(local.tag_filter_result)
+}
+`, testAccDataTags_base(name))
 }

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_timezones_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_timezones_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceTimezones_basic(t *testing.T) {
+func TestAccDataTimezones_basic(t *testing.T) {
 	var (
-		dataSourceName = "data.huaweicloud_workspace_timezones.test"
-		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		all = "data.huaweicloud_workspace_timezones.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -20,20 +20,21 @@ func TestAccDataSourceTimezones_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceTimezones_basic,
+				Config: testAccDataTimezones_basic,
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dataSourceName, "time_zones.#", regexp.MustCompile(`^[0-9]+$`)),
-					resource.TestCheckResourceAttrSet(dataSourceName, "time_zones.0.name"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "time_zones.0.offset"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "time_zones.0.us_description"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "time_zones.0.cn_description"),
+					resource.TestMatchResourceAttr(all, "time_zones.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(all, "time_zones.0.name"),
+					resource.TestCheckResourceAttrSet(all, "time_zones.0.offset"),
+					resource.TestCheckResourceAttrSet(all, "time_zones.0.us_description"),
+					resource.TestCheckResourceAttrSet(all, "time_zones.0.cn_description"),
 				),
 			},
 		},
 	})
 }
 
-const testAccDataSourceTimezones_basic = `
-data "huaweicloud_workspace_timezones" "test" {}
+const testAccDataTimezones_basic = `
+data "huaweicloud_workspace_timezones" "all" {}
 `

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_volume_products_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_volume_products_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccVolumeProductsDataSource_basic(t *testing.T) {
+func TestAccDataVolumeProducts_basic(t *testing.T) {
 	var (
-		dcName = "data.huaweicloud_workspace_volume_products.all"
-		dc     = acceptance.InitDataSourceCheck(dcName)
+		all = "data.huaweicloud_workspace_volume_products.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
 		filterByZoneCode   = "data.huaweicloud_workspace_volume_products.filter_by_zone_code"
 		dcFilterByZoneCode = acceptance.InitDataSourceCheck(filterByZoneCode)
@@ -28,24 +28,24 @@ func TestAccVolumeProductsDataSource_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVolumeProductsDataSource_basic,
+				Config: testAccDataVolumeProducts_basic,
 				Check: resource.ComposeTestCheckFunc(
-					// Query volume products without any filter parameter
+					// Without any filter parameter.
 					dc.CheckResourceExists(),
-					resource.TestMatchResourceAttr(dcName, "volume_products.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					resource.TestCheckResourceAttrSet(dcName, "volume_products.0.resource_spec_code"),
-					resource.TestCheckResourceAttrSet(dcName, "volume_products.0.volume_type"),
-					resource.TestCheckResourceAttrSet(dcName, "volume_products.0.volume_product_type"),
-					resource.TestCheckResourceAttrSet(dcName, "volume_products.0.resource_type"),
-					resource.TestCheckResourceAttrSet(dcName, "volume_products.0.cloud_service_type"),
-					resource.TestCheckResourceAttrSet(dcName, "volume_products.0.names.#"),
-					resource.TestCheckResourceAttrSet(dcName, "volume_products.0.names.0.language"),
-					resource.TestCheckResourceAttrSet(dcName, "volume_products.0.names.0.value"),
-					resource.TestCheckResourceAttrSet(dcName, "volume_products.0.status"),
-					// Filter By zone code
+					resource.TestMatchResourceAttr(all, "volume_products.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "volume_products.0.resource_spec_code"),
+					resource.TestCheckResourceAttrSet(all, "volume_products.0.volume_type"),
+					resource.TestCheckResourceAttrSet(all, "volume_products.0.volume_product_type"),
+					resource.TestCheckResourceAttrSet(all, "volume_products.0.resource_type"),
+					resource.TestCheckResourceAttrSet(all, "volume_products.0.cloud_service_type"),
+					resource.TestCheckResourceAttrSet(all, "volume_products.0.names.#"),
+					resource.TestCheckResourceAttrSet(all, "volume_products.0.names.0.language"),
+					resource.TestCheckResourceAttrSet(all, "volume_products.0.names.0.value"),
+					resource.TestCheckResourceAttrSet(all, "volume_products.0.status"),
+					// Filter by 'zone_code' parameter.
 					dcFilterByZoneCode.CheckResourceExists(),
 					resource.TestMatchResourceAttr(filterByZoneCode, "volume_products.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
-					// Filter By volume type
+					// Filter by 'volume_type' parameter.
 					dcFilterByVolumeType.CheckResourceExists(),
 					resource.TestCheckOutput("is_volume_type_filter_useful", "true"),
 				),
@@ -54,21 +54,36 @@ func TestAccVolumeProductsDataSource_basic(t *testing.T) {
 	})
 }
 
-const testAccVolumeProductsDataSource_basic = `
+const testAccDataVolumeProducts_basic = `
 data "huaweicloud_workspace_volume_products" "all" {}
-
-locals {
-  volume_type = try(data.huaweicloud_workspace_volume_products.all.volume_products[0].volume_type, "NOT_FOUND")
-}
 
 # Filter by zone code
 data "huaweicloud_availability_zones" "test" {}
 
+locals {
+  zone_code = try(data.huaweicloud_availability_zones.test.names[0], "NOT_FOUND")
+}
+
 data "huaweicloud_workspace_volume_products" "filter_by_zone_code" {
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  availability_zone = local.zone_code
+}
+
+locals {
+  zone_code_filter_result = [
+    for v in data.huaweicloud_workspace_volume_products.filter_by_zone_code.volume_products[*].availability_zone :
+    v == local.zone_code
+  ]
+}
+
+output "is_zone_code_filter_useful" {
+  value = length(local.zone_code_filter_result) > 0 && alltrue(local.zone_code_filter_result)
 }
 
 # Filter by volume type
+locals {
+  volume_type = try(data.huaweicloud_workspace_volume_products.all.volume_products[0].volume_type, "NOT_FOUND")
+}
+
 data "huaweicloud_workspace_volume_products" "filter_by_volume_type" {
   volume_type = local.volume_type
 }

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_action_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_action_test.go
@@ -19,7 +19,7 @@ func TestAccAppServerAction_changeImage(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
-			acceptance.TestAccPreCheckWorkspaceAppServerImageInfo(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerImageId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		// This resource is a one-time action resource and there is no logic in the delete method.
@@ -75,14 +75,18 @@ func testAccAppServerAction_changeImage(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
+variable "image_product_id" {
+  default = "%[2]s"
+}
+
 resource "huaweicloud_workspace_app_server_action" "test" {
   type      = "change-image"
   server_id = huaweicloud_workspace_app_server.test.id
   content   = jsonencode({
-    image_id            = "%[2]s"
-    image_type          = "gold"
+    image_id            = "%[3]s"
     os_type             = "Windows"
-	image_product_id    = "%[3]s"
+    image_type          = var.image_product_id != "" ? "gold" : null
+	image_product_id    = var.image_product_id != "" ? var.image_product_id : null
     update_access_agent = true
   })
 
@@ -93,8 +97,8 @@ resource "huaweicloud_workspace_app_server_action" "test" {
   }
 }
 `, testAccAppServerAction_base(name),
-		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID,
-		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID)
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID,
+		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID)
 }
 
 func TestAccAppServerAction_reinstall(t *testing.T) {

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_warehouse_application_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_warehouse_application_test.go
@@ -20,7 +20,7 @@ func getWarehouseApplicationFunc(conf *config.Config, state *terraform.ResourceS
 	return workspace.GetWarehouseApplicationById(client, state.Primary.ID)
 }
 
-func TestAccResourceAppWarehouseApplication_basic(t *testing.T) {
+func TestAccAppWarehouseApplication_basic(t *testing.T) {
 	var (
 		application  interface{}
 		resourceName = "huaweicloud_workspace_app_warehouse_application.test"
@@ -48,7 +48,7 @@ func TestAccResourceAppWarehouseApplication_basic(t *testing.T) {
 		CheckDestroy: rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceWarehouseApplication_basic_step1(name),
+				Config: testAccAppWarehouseApplication_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -62,7 +62,7 @@ func TestAccResourceAppWarehouseApplication_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceWarehouseApplication_basic_step2(updateName),
+				Config: testAccAppWarehouseApplication_basic_step2(updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
@@ -128,7 +128,7 @@ resource "huaweicloud_obs_bucket_object" "test" {
 }`, acceptance.HW_REGION_NAME, acceptance.HW_WORKSPACE_APP_FILE_NAME)
 }
 
-func testAccResourceWarehouseApplication_basic_step1(name string) string {
+func testAccAppWarehouseApplication_basic_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -144,7 +144,7 @@ resource "huaweicloud_workspace_app_warehouse_application" "test" {
 `, executionFileUploadResourcesConfig(), name, acceptance.HW_WORKSPACE_APP_FILE_NAME)
 }
 
-func testAccResourceWarehouseApplication_basic_step2(name string) string {
+func testAccAppWarehouseApplication_basic_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Keep all acceptance tests' coding format be same.
- function name
- resource or data source naming
- checklist

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. keep all acceptance tests' coding format be same
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataAppServerQuotas_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppServerQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppServerQuotas_basic
=== PAUSE TestAccDataAppServerQuotas_basic
=== CONT  TestAccDataAppServerQuotas_basic
--- PASS: TestAccDataAppServerQuotas_basic (18.43s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 18.509s coverage: 3.7% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccAppServers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppServers_basic -timeout 360m -parallel 10
=== RUN   TestAccAppServers_basic
=== PAUSE TestAccAppServers_basic
=== CONT  TestAccAppServers_basic
--- PASS: TestAccAppServers_basic (627.23s)
PASS
coverage: 6.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 627.357s        coverage: 6.2% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataAppService_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppService_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppService_basic
=== PAUSE TestAccDataAppService_basic
=== CONT  TestAccDataAppService_basic
--- PASS: TestAccDataAppService_basic (11.35s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 11.444s coverage: 3.0% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataAppSessionTypes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppSessionTypes_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppSessionTypes_basic
=== PAUSE TestAccDataAppSessionTypes_basic
=== CONT  TestAccDataAppSessionTypes_basic
--- PASS: TestAccDataAppSessionTypes_basic (11.76s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 11.853s coverage: 3.1% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataAppStoragePolicies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppStoragePolicies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppStoragePolicies_basic
=== PAUSE TestAccDataAppStoragePolicies_basic
=== CONT  TestAccDataAppStoragePolicies_basic
--- PASS: TestAccDataAppStoragePolicies_basic (15.26s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 15.351s coverage: 3.7% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataAppVncRemote_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppVncRemote_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppVncRemote_basic
=== PAUSE TestAccDataAppVncRemote_basic
=== CONT  TestAccDataAppVncRemote_basic
--- PASS: TestAccDataAppVncRemote_basic (17.69s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 17.788s coverage: 3.0% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataAppWarehouseApplications_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAppWarehouseApplications_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAppWarehouseApplications_basic
=== PAUSE TestAccDataAppWarehouseApplications_basic
=== CONT  TestAccDataAppWarehouseApplications_basic
--- PASS: TestAccDataAppWarehouseApplications_basic (41.61s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 41.692s coverage: 4.1% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccAppWarehouseApplication_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppWarehouseApplication_basic -timeout 360m -parallel 10
=== RUN   TestAccAppWarehouseApplication_basic
=== PAUSE TestAccAppWarehouseApplication_basic
=== CONT  TestAccAppWarehouseApplication_basic
--- PASS: TestAccAppWarehouseApplication_basic (103.54s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 103.624s        coverage: 3.7% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataApplicationAuthorizations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataApplicationAuthorizations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataApplicationAuthorizations_basic
=== PAUSE TestAccDataApplicationAuthorizations_basic
=== CONT  TestAccDataApplicationAuthorizations_basic
--- PASS: TestAccDataApplicationAuthorizations_basic (18.19s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 18.282s coverage: 6.1% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataApplicationCatalogs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataApplicationCatalogs_basic -timeout 360m -parallel 10
=== RUN   TestAccDataApplicationCatalogs_basic
=== PAUSE TestAccDataApplicationCatalogs_basic
=== CONT  TestAccDataApplicationCatalogs_basic
--- PASS: TestAccDataApplicationCatalogs_basic (9.16s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 9.266s  coverage: 3.1% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataApplicationRestrictedRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataApplicationRestrictedRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataApplicationRestrictedRules_basic
--- PASS: TestAccDataApplicationRestrictedRules_basic (12.27s)
PASS
coverage: 5.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 12.367s coverage: 5.5% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataApplicationRuleRestrictionSetting_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataApplicationRuleRestrictionSetting_basic -timeout 360m -parallel 10
=== RUN   TestAccDataApplicationRuleRestrictionSetting_basic
=== PAUSE TestAccDataApplicationRuleRestrictionSetting_basic
=== CONT  TestAccDataApplicationRuleRestrictionSetting_basic
--- PASS: TestAccDataApplicationRuleRestrictionSetting_basic (11.01s)
PASS
coverage: 3.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 11.164s coverage: 3.2% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataApplicationRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataApplicationRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataApplicationRules_basic
--- PASS: TestAccDataApplicationRules_basic (11.37s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 11.513s coverage: 4.3% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataApplications_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataApplications_basic -timeout 360m -parallel 10
=== RUN   TestAccDataApplications_basic
--- PASS: TestAccDataApplications_basic (14.17s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 14.257s coverage: 4.6% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataAvailableIpNumber_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataAvailableIpNumber_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAvailableIpNumber_basic
=== PAUSE TestAccDataAvailableIpNumber_basic
=== CONT  TestAccDataAvailableIpNumber_basic
--- PASS: TestAccDataAvailableIpNumber_basic (27.89s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 27.979s coverage: 3.9% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataDesktopConnections_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataDesktopConnections_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDesktopConnections_basic
--- PASS: TestAccDataDesktopConnections_basic (416.56s)
PASS
coverage: 7.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 416.658s        coverage: 7.5% of statements in ./huaweicloud/services/workspace
```
```

```
```
/scripts/coverage.sh -o workspace -f TestAccDataDesktopRemoteConsole_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataDesktopRemoteConsole_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDesktopRemoteConsole_basic
--- PASS: TestAccDataDesktopRemoteConsole_basic (378.50s)
PASS
coverage: 7.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 378.609s        coverage: 7.1% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataDesktopSysprep_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataDesktopSysprep_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDesktopSysprep_basic
=== PAUSE TestAccDataDesktopSysprep_basic
=== CONT  TestAccDataDesktopSysprep_basic
--- PASS: TestAccDataDesktopSysprep_basic (397.34s)
PASS
coverage: 7.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 397.439s        coverage: 7.1% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataDesktopTagsFilter_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataDesktopTagsFilter_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDesktopTagsFilter_basic
--- PASS: TestAccDataDesktopTagsFilter_basic (376.59s)
PASS
coverage: 7.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 376.702s        coverage: 7.8% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataDesktopTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataDesktopTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDesktopTags_basic
--- PASS: TestAccDataDesktopTags_basic (378.13s)
PASS
coverage: 7.3% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 378.227s        coverage: 7.3% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataFlavors_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataFlavors_basic -timeout 360m -parallel 10
=== RUN   TestAccDataFlavors_basic
=== PAUSE TestAccDataFlavors_basic
=== CONT  TestAccDataFlavors_basic
--- PASS: TestAccDataFlavors_basic (13.72s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 13.820s coverage: 3.5% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataHourPackages_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataHourPackages_basic -timeout 360m -parallel 10
=== RUN   TestAccDataHourPackages_basic
=== PAUSE TestAccDataHourPackages_basic
=== CONT  TestAccDataHourPackages_basic
--- PASS: TestAccDataHourPackages_basic (11.55s)
PASS
coverage: 3.3% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 11.704s coverage: 3.3% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataDesktops_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataDesktops_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDesktops_basic
--- PASS: TestAccDataDesktops_basic (596.50s)
PASS
coverage: 7.9% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 596.589s        coverage: 7.9% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataPolicyGroups_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataPolicyGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccDataPolicyGroups_basic
--- PASS: TestAccDataPolicyGroups_basic (30.31s)
PASS
coverage: 5.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 30.442s coverage: 5.0% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataQuotas_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataQuotas_basic
=== PAUSE TestAccDataQuotas_basic
=== CONT  TestAccDataQuotas_basic
--- PASS: TestAccDataQuotas_basic (9.78s)
PASS
coverage: 3.2% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 9.969s  coverage: 3.2% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataScheduledTaskRecordDetails_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataScheduledTaskRecordDetails_basic -timeout 360m -parallel 10
=== RUN   TestAccDataScheduledTaskRecordDetails_basic
=== PAUSE TestAccDataScheduledTaskRecordDetails_basic
=== CONT  TestAccDataScheduledTaskRecordDetails_basic
--- PASS: TestAccDataScheduledTaskRecordDetails_basic (10.17s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 10.265s coverage: 3.8% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataScheduledTaskRecords_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataScheduledTaskRecords_basic -timeout 360m -parallel 10
=== RUN   TestAccDataScheduledTaskRecords_basic
=== PAUSE TestAccDataScheduledTaskRecords_basic
=== CONT  TestAccDataScheduledTaskRecords_basic
--- PASS: TestAccDataScheduledTaskRecords_basic (11.17s)
PASS
coverage: 3.3% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 11.300s coverage: 3.3% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataScheduledTasks_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataScheduledTasks_basic -timeout 360m -parallel 10
=== RUN   TestAccDataScheduledTasks_basic
=== PAUSE TestAccDataScheduledTasks_basic
=== CONT  TestAccDataScheduledTasks_basic
--- PASS: TestAccDataScheduledTasks_basic (10.90s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 10.986s coverage: 3.4% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTags_basic
--- PASS: TestAccDataTags_basic (383.26s)
PASS
coverage: 7.4% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 383.390s        coverage: 7.4% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataTimezones_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataTimezones_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTimezones_basic
=== PAUSE TestAccDataTimezones_basic
=== CONT  TestAccDataTimezones_basic
--- PASS: TestAccDataTimezones_basic (12.05s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 12.187s coverage: 3.1% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccDataVolumeProducts_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataVolumeProducts_basic -timeout 360m -parallel 10
=== RUN   TestAccDataVolumeProducts_basic
=== PAUSE TestAccDataVolumeProducts_basic
=== CONT  TestAccDataVolumeProducts_basic
--- PASS: TestAccDataVolumeProducts_basic (14.17s)
PASS
coverage: 3.3% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 14.252s coverage: 3.3% of statements in ./huaweicloud/services/workspace
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
