### PR TITLE
chore(workspace/warehouse): deprecate a worse name and supports a better one

### DIFF
--- a/docs/resources/workspace_app_warehouse_bucket_authorize.md
+++ b/docs/resources/workspace_app_warehouse_bucket_authorize.md
@@ -1,12 +1,12 @@
 ---
 subcategory: "Workspace"
 layout: "huaweicloud"
-page_title: "HuaweiCloud: huaweicloud_workspace_app_repo_bucket_assign"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_warehouse_bucket_authorize"
 description: |-
   Use this resource to assign a bucket for the app repository within HuaweiCloud.
 ---
 
-# huaweicloud_workspace_app_repo_bucket_assign
+# huaweicloud_workspace_app_warehouse_bucket_authorize
 
 Use this resource to assign a bucket for the app repository within HuaweiCloud.
 
@@ -19,7 +19,7 @@ Use this resource to assign a bucket for the app repository within HuaweiCloud.
 ```hcl
 variable "bucket_name" {}
 
-resource "huaweicloud_workspace_app_repo_bucket_assign" "test" {
+resource "huaweicloud_workspace_app_warehouse_bucket_authorize" "test" {
   bucket_name = var.bucket_name
 }
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3857,7 +3857,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_personal_folders":                        workspace.ResourceAppPersonalFolders(),
 			"huaweicloud_workspace_app_policy_group":                            workspace.ResourceAppPolicyGroup(),
 			"huaweicloud_workspace_app_policy_template":                         workspace.ResourceAppPolicyTemplate(),
-			"huaweicloud_workspace_app_repo_bucket_assign":                      workspace.ResourceAppRepoBucketAssign(),
 			"huaweicloud_workspace_app_schedule_task":                           workspace.ResourceAppScheduleTask(),
 			"huaweicloud_workspace_app_server":                                  workspace.ResourceAppServer(),
 			"huaweicloud_workspace_app_server_action":                           workspace.ResourceAppServerAction(),
@@ -3871,6 +3870,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_app_shared_folder_assign":                    workspace.ResourceAppSharedFolderAssign(),
 			"huaweicloud_workspace_app_storage_policy":                          workspace.ResourceAppStoragePolicy(),
 			"huaweicloud_workspace_app_warehouse_application":                   workspace.ResourceAppWarehouseApplication(),
+			"huaweicloud_workspace_app_warehouse_bucket_authorize":              workspace.ResourceAppWarehouseBucketAuthorize(),
 
 			"huaweicloud_cpts_project": cpts.ResourceProject(),
 			"huaweicloud_cpts_task":    cpts.ResourceTask(),
@@ -4044,7 +4044,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_domain_v1":               cdn.ResourceDomain(),
 			"huaweicloud_scm_certificate":             ccm.ResourceCertificateImport(),
 
-			"huaweicloud_workspace_app_publishment": workspace.ResourceAppApplicationPublishment(),
+			"huaweicloud_workspace_app_publishment":        workspace.ResourceAppApplicationPublishment(),
+			"huaweicloud_workspace_app_repo_bucket_assign": workspace.ResourceAppWarehouseBucketAuthorize(),
 
 			// Deprecated
 			"huaweicloud_apig_vpc_channel":               deprecated.ResourceApigVpcChannelV2(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_warehouse_bucket_authorize_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_warehouse_bucket_authorize_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccResourceAppRepoBucketAssign_basic(t *testing.T) {
+func TestAccResourceAppWarehouseBucketAuthorize_basic(t *testing.T) {
 	var (
 		name = acceptance.RandomAccResourceNameWithDash()
 	)
@@ -24,20 +24,20 @@ func TestAccResourceAppRepoBucketAssign_basic(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceAppRepoBucketAssign,
+				Config: testAccResourceAppWarehouseBucketAuthorize,
 			},
 			{
-				Config: testAccResourceAppRepoBucketAssign_withName(name),
+				Config: testAccResourceAppWarehouseBucketAuthorize_withName(name),
 			},
 		},
 	})
 }
 
-const testAccResourceAppRepoBucketAssign = `resource "huaweicloud_workspace_app_repo_bucket_assign" "test" {}`
+const testAccResourceAppWarehouseBucketAuthorize = `resource "huaweicloud_workspace_app_warehouse_bucket_authorize" "test" {}`
 
-func testAccResourceAppRepoBucketAssign_withName(name string) string {
+func testAccResourceAppWarehouseBucketAuthorize_withName(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_workspace_app_repo_bucket_assign" "test_with_name" {
+resource "huaweicloud_workspace_app_warehouse_bucket_authorize" "test_with_name" {
   bucket_name = "%[1]s"
 }`, name)
 }

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_warehouse_bucket_authorize.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_warehouse_bucket_authorize.go
@@ -14,17 +14,17 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var appRepoBucketAssignNonUpdatableParams = []string{"bucket_name"}
+var appWarehouseBucketAuthorizeNonUpdatableParams = []string{"bucket_name"}
 
 // @API Workspace POST /v1/{project_id}/app-warehouse/bucket
-func ResourceAppRepoBucketAssign() *schema.Resource {
+func ResourceAppWarehouseBucketAuthorize() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAppRepoBucketAssignCreate,
-		ReadContext:   resourceAppRepoBucketAssignRead,
-		UpdateContext: resourceAppRepoBucketAssignUpdate,
-		DeleteContext: resourceAppRepoBucketAssignDelete,
+		CreateContext: resourceAppWarehouseBucketAuthorizeCreate,
+		ReadContext:   resourceAppWarehouseBucketAuthorizeRead,
+		UpdateContext: resourceAppWarehouseBucketAuthorizeUpdate,
+		DeleteContext: resourceAppWarehouseBucketAuthorizeDelete,
 
-		CustomizeDiff: config.FlexibleForceNew(appRepoBucketAssignNonUpdatableParams),
+		CustomizeDiff: config.FlexibleForceNew(appWarehouseBucketAuthorizeNonUpdatableParams),
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -44,13 +44,13 @@ func ResourceAppRepoBucketAssign() *schema.Resource {
 	}
 }
 
-func buildAppRepoBucketAssignBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildAppWarehouseBucketAuthorizeBodyParams(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{
 		"bucket_name": utils.ValueIgnoreEmpty(d.Get("bucket_name")),
 	}
 }
 
-func resourceAppRepoBucketAssignCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAppWarehouseBucketAuthorizeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
 		region  = cfg.GetRegion(d)
@@ -69,7 +69,7 @@ func resourceAppRepoBucketAssignCreate(ctx context.Context, d *schema.ResourceDa
 		MoreHeaders: map[string]string{
 			"Content-Type": "application/json",
 		},
-		JSONBody: utils.RemoveNil(buildAppRepoBucketAssignBodyParams(d)),
+		JSONBody: utils.RemoveNil(buildAppWarehouseBucketAuthorizeBodyParams(d)),
 	}
 
 	_, err = client.Request("POST", createPath, &createOpt)
@@ -83,18 +83,18 @@ func resourceAppRepoBucketAssignCreate(ctx context.Context, d *schema.ResourceDa
 	}
 	d.SetId(randomUUID)
 
-	return resourceAppRepoBucketAssignRead(ctx, d, meta)
+	return resourceAppWarehouseBucketAuthorizeRead(ctx, d, meta)
 }
 
-func resourceAppRepoBucketAssignRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceAppWarehouseBucketAuthorizeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceAppRepoBucketAssignUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceAppWarehouseBucketAuthorizeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceAppRepoBucketAssignDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceAppWarehouseBucketAuthorizeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	errorMsg := `This resource is only a one-time action resource for assigning an app repository bucket.
 Deleting this resource will not clear the corresponding request record, but will only remove the resource information
 from the tfstate file.`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
deprecate a worse name and supports a better one
The `huaweicloud_workspace_app_repo_bucket_assign` is not recommended.
The recommended name is `huaweicloud_workspace_app_warehouse_bucket_authorize`.

**Which issue this PR fixes**:
fix name bug for app warehouse bucket authorize

**Special notes for your reviewer**:
nothing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. change the name of provider implement
2. change the content of provider implement
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```

```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.