### PR TITLE
feat(IMS): support to export image with new API

### DIFF
--- a/docs/resources/imsv21_image_export.md
+++ b/docs/resources/imsv21_image_export.md
@@ -3,7 +3,7 @@ subcategory: "Image Management Service (IMS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ims_image_export"
 description: |-
-  Manages an IMS image export resource within HuaweiCloud.
+  Manages an IMS image export resource by v2.1 API within HuaweiCloud.
 ---
 
 # huaweicloud_ims_image_export
@@ -53,18 +53,17 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `image_id` - (Required, String, ForceNew) Specifies the image ID to export.
-  Changing this parameter will create a new resource.
+* `image_id` - (Required, String, NonUpdatable) Specifies the image ID to export.
 
-* `bucket_url` - (Required, String, ForceNew) Specifies the URL of the image file to be exported to the OBS bucket, the
-  format is **OBS bucket name:image file name**, e.g. **test_bucket:test_image_file**. The storage category of the OBS
-  bucket and image file here must be OBS standard storage. Changing this parameter will create a new resource.
+* `bucket_url` - (Required, String, NonUpdatable) Specifies the URL of the image file to be exported to the OBS bucket,
+  the format is **OBS bucket name:image file name**, e.g. **test_bucket:test_image_file**. The storage category of the
+  OBS bucket and image file here must be OBS standard storage.
 
-* `file_format` - (Optional, String, ForceNew) Specifies the format of the image file to be exported. The valid values
-  are **qcow2**, **vhd**, **zvhd**, or **vmdk**. Changing this parameter will create a new resource.
+* `file_format` - (Optional, String, NonUpdatable) Specifies the format of the image file to be exported. The valid
+  values are **qcow2**, **vhd**, **zvhd**, or **vmdk**.
 
-* `is_quick_export` - (Optional, Bool, ForceNew) Specifies whether to use quick export. The valid value is **true** or
-  **false**. Changing this parameter will create a new resource.
+* `is_quick_export` - (Optional, Bool, NonUpdatable) Specifies whether to use quick export. The valid value is **true**
+  or **false**.
 
 -> 1. When the `is_quick_export` parameter is ignored or set to **false**, the `file_format` parameter is required.
    <br/>2. When the `is_quick_export` parameter is set to **true**, the `file_format` parameter must be ignored, and

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3278,6 +3278,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ims_obs_system_image":         ims.ResourceObsSystemImage(),
 			"huaweicloud_ims_obs_iso_image":            ims.ResourceObsIsoImage(),
 			"huaweicloud_ims_image_export":             ims.ResourceImageExport(),
+			"huaweicloud_imsv21_image_export":          ims.ResourceIMSV21ImageExport(),
 			"huaweicloud_ims_image_metadata":           ims.ResourceImageMetadata(),
 			"huaweicloud_ims_image_registration":       ims.ResourceImageRegistration(),
 			"huaweicloud_ims_quickimport_system_image": ims.ResourceQuickImportSystemImage(),

--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_imsv21_image_export_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_imsv21_image_export_test.go
@@ -1,0 +1,112 @@
+package ims
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccIMSV21ImageExport_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIMSV21ImageExport_basic(),
+			},
+		},
+	})
+}
+
+func TestAccIMSV21ImageExport_with_isQuickExport(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIMSV21ImageExport_with_isQuickExport(),
+			},
+		},
+	})
+}
+
+func testAccIMSV21ImageExport_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_name         = "Ubuntu 18.04 server 64bit"
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_ims_ecs_system_image" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_compute_instance.test.id
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[2]s"
+  acl           = "private"
+  force_destroy = true
+}
+`, common.TestBaseNetwork(rName), rName)
+}
+
+func testAccIMSV21ImageExport_basic() string {
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_imsv21_image_export" "test" {
+  image_id    = huaweicloud_ims_ecs_system_image.test.id
+  bucket_url  = "${huaweicloud_obs_bucket.test.bucket}:%[2]s.qcow2"
+  file_format = "qcow2"
+}
+`, testAccIMSV21ImageExport_base(rName), rName)
+}
+
+func testAccIMSV21ImageExport_with_isQuickExport() string {
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_imsv21_image_export" "test" {
+  image_id        = huaweicloud_ims_ecs_system_image.test.id
+  bucket_url      = "${huaweicloud_obs_bucket.test.bucket}:%[2]s.zvhd2"
+  is_quick_export = true
+}
+`, testAccIMSV21ImageExport_base(rName), rName)
+}

--- a/huaweicloud/services/ims/resource_huaweicloud_imsv21_image_export.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_imsv21_image_export.go
@@ -1,0 +1,126 @@
+package ims
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var v21ImageExportNonUpdatableParams = []string{
+	"image_id", "bucket_url", "file_format", "is_quick_export",
+}
+
+// @API IMS POST /v2.1/cloudimages/{image_id}/file
+// @API IMS GET /v1/{project_id}/jobs/{job_id}
+func ResourceIMSV21ImageExport() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIMSV21ImageExportCreate,
+		ReadContext:   resourceIMSV21ImageExportRead,
+		UpdateContext: resourceIMSV21ImageExportUpdate,
+		DeleteContext: resourceIMSV21ImageExportDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(v21ImageExportNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"bucket_url": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"file_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"is_quick_export": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceIMSV21ImageExportCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ims"
+		imageId = d.Get("image_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating IMS client: %s", err)
+	}
+
+	createPath := client.Endpoint + "v2.1/cloudimages/{image_id}/file"
+	createPath = strings.ReplaceAll(createPath, "{image_id}", imageId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildCreateImageExportBodyParam(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error exporting IMS image: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(imageId)
+
+	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error exporting IMS image: job ID is not found in API response")
+	}
+
+	err = waitForCreateImageExportJobCompleted(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for IMS image export to complete: %s", err)
+	}
+
+	return resourceIMSV21ImageExportRead(ctx, d, meta)
+}
+
+func resourceIMSV21ImageExportRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceIMSV21ImageExportUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceIMSV21ImageExportDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to export image with new API
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to export image with new API
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/ims' TESTARGS='-run TestAccIMSV21ImageExport_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccIMSV21ImageExport_basic -timeout 360m -parallel 4
=== RUN   TestAccIMSV21ImageExport_basic
=== PAUSE TestAccIMSV21ImageExport_basic
=== CONT  TestAccIMSV21ImageExport_basic
--- PASS: TestAccIMSV21ImageExport_basic (754.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       754.841s

make testacc TEST='./huaweicloud/services/acceptance/ims' TESTARGS='-run  TestAccIMSV21ImageExport_with_isQuickExport'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run  TestAccIMSV21ImageExport_with_isQuickExport -timeout 360m -parallel 4
=== RUN   TestAccIMSV21ImageExport_with_isQuickExport
=== PAUSE TestAccIMSV21ImageExport_with_isQuickExport
=== CONT  TestAccIMSV21ImageExport_with_isQuickExport
--- PASS: TestAccIMSV21ImageExport_with_isQuickExport (475.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       475.364s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
