### PR TITLE
fix(workspace): rename the desktop maintenance batch manage resource

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3844,7 +3844,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_bucket_authorize":                            workspace.ResourceBucketAuthorize(),
 			"huaweicloud_workspace_desktop_name_rule":                           workspace.ResourceDesktopNameRule(),
 			"huaweicloud_workspace_desktop":                                     workspace.ResourceDesktop(),
-			"huaweicloud_workspace_desktop_maintenance_batch_manage":            workspace.ResourceMaintenanceBatchManage(),
+			"huaweicloud_workspace_desktop_maintenance_batch_manage":            workspace.ResourceDesktopMaintenanceBatchManage(),
 			"huaweicloud_workspace_desktop_notification":                        workspace.ResourceDesktopNotification(),
 			"huaweicloud_workspace_desktop_pool":                                workspace.ResourceDesktopPool(),
 			"huaweicloud_workspace_desktop_pool_action":                         workspace.ResourceDesktopPoolAction(),

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop_maintenance_batch_manage.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop_maintenance_batch_manage.go
@@ -15,20 +15,20 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var maintenanceBatchManageNonUpdatableParams = []string{
+var desktopMaintenanceBatchManageNonUpdatableParams = []string{
 	"desktop_ids",
 	"in_maintenance_mode",
 }
 
 // @API Workspace PUT /v2/{project_id}/desktops/maintenance-mode
-func ResourceMaintenanceBatchManage() *schema.Resource {
+func ResourceDesktopMaintenanceBatchManage() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceMaintenanceBatchManageCreate,
-		ReadContext:   resourceMaintenanceBatchManageRead,
-		UpdateContext: resourceMaintenanceBatchManageUpdate,
-		DeleteContext: resourceMaintenanceBatchManageDelete,
+		CreateContext: resourceDesktopMaintenanceBatchManageCreate,
+		ReadContext:   resourceDesktopMaintenanceBatchManageRead,
+		UpdateContext: resourceDesktopMaintenanceBatchManageUpdate,
+		DeleteContext: resourceDesktopMaintenanceBatchManageDelete,
 
-		CustomizeDiff: config.FlexibleForceNew(maintenanceBatchManageNonUpdatableParams),
+		CustomizeDiff: config.FlexibleForceNew(desktopMaintenanceBatchManageNonUpdatableParams),
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -63,7 +63,7 @@ func ResourceMaintenanceBatchManage() *schema.Resource {
 	}
 }
 
-func buildMaintenanceBatchManageBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildDesktopMaintenanceBatchManageBodyParams(d *schema.ResourceData) map[string]interface{} {
 	body := map[string]interface{}{
 		"desktop_ids":         d.Get("desktop_ids").([]interface{}),
 		"in_maintenance_mode": d.Get("in_maintenance_mode").(bool),
@@ -72,7 +72,7 @@ func buildMaintenanceBatchManageBodyParams(d *schema.ResourceData) map[string]in
 	return body
 }
 
-func resourceMaintenanceBatchManageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDesktopMaintenanceBatchManageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
 		region  = cfg.GetRegion(d)
@@ -92,7 +92,7 @@ func resourceMaintenanceBatchManageCreate(ctx context.Context, d *schema.Resourc
 		MoreHeaders: map[string]string{
 			"Content-Type": "application/json",
 		},
-		JSONBody: buildMaintenanceBatchManageBodyParams(d),
+		JSONBody: buildDesktopMaintenanceBatchManageBodyParams(d),
 	}
 
 	_, err = client.Request("PUT", createPath, &opt)
@@ -106,18 +106,18 @@ func resourceMaintenanceBatchManageCreate(ctx context.Context, d *schema.Resourc
 	}
 	d.SetId(randomUUID)
 
-	return resourceMaintenanceBatchManageRead(ctx, d, meta)
+	return resourceDesktopMaintenanceBatchManageRead(ctx, d, meta)
 }
 
-func resourceMaintenanceBatchManageRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceDesktopMaintenanceBatchManageRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceMaintenanceBatchManageUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceDesktopMaintenanceBatchManageUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceMaintenanceBatchManageDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceDesktopMaintenanceBatchManageDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	errorMsg := `This resource is a one-time action resource for batch managing desktops' maintenance mode. Deleting
     this resource will not clear the corresponding request record, but will only remove the resource information
     from the tfstate file.`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
rename the desktop maintenance batch manage resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
