### PR TITLE
feat(hss): support `hss_honeypot_port_default_config` data source

### DIFF
--- a/docs/data-sources/hss_honeypot_port_default_config.md
+++ b/docs/data-sources/hss_honeypot_port_default_config.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_honeypot_port_default_config"
+description: |-
+  Use this data source to get the default configuration of HSS honeypot port within HuaweiCloud.
+---
+
+# huaweicloud_hss_honeypot_port_default_config
+
+Use this data source to get the default configuration of HSS honeypot port within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_honeypot_port_default_config" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `auto_bind` - Is it automatically bound.
+
+* `windows_policy_id` - The default policy ID bound to Windows hosts.
+
+* `linux_policy_id` - The default policy ID bound to Linux hosts.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1528,6 +1528,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_kubernetes_mciuc":                 hss.DataSourceHssContainerKubernetesMciuc(),
 			"huaweicloud_hss_operational_report_notification":            hss.DataSourceOperationalReportNotification(),
 			"huaweicloud_hss_resource_locked_status":                     hss.DataSourceResourceLockedStatus(),
+			"huaweicloud_hss_honeypot_port_default_config":               hss.DataSourceHoneypotPortDefaultConfig(),
 
 			"huaweicloud_identity_permissions":                  iam.DataSourceIdentityPermissions(),
 			"huaweicloud_identity_role":                         iam.DataSourceIdentityRole(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_honeypot_port_default_config_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_honeypot_port_default_config_test.go
@@ -1,0 +1,42 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceHoneypotPortDefaultConfig_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_honeypot_port_default_config.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceHoneypotPortDefaultConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "auto_bind"),
+					resource.TestCheckResourceAttrSet(dataSource, "windows_policy_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "linux_policy_id"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceHoneypotPortDefaultConfig_basic() string {
+	return `
+data "huaweicloud_hss_honeypot_port_default_config" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_honeypot_port_default_config.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_honeypot_port_default_config.go
@@ -1,0 +1,108 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/honeypot-port/default-config
+func DataSourceHoneypotPortDefaultConfig() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceHoneypotPortDefaultConfigRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"auto_bind": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			// The field name in the API document is `windows_policy`,
+			// but the actual returned name is `windows_policy_id`.
+			"windows_policy_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			// The field name in the API document is `linux_policy`,
+			// but the actual returned name is `linux_policy_id`.
+			"linux_policy_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildHoneypotPortDefaultConfigQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	return ""
+}
+
+func dataSourceHoneypotPortDefaultConfigRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/honeypot-port/default-config"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildHoneypotPortDefaultConfigQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS honeypot port default config: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("auto_bind", utils.PathSearch("auto_bind", respBody, nil)),
+		d.Set("windows_policy_id", utils.PathSearch("windows_policy_id", respBody, nil)),
+		d.Set("linux_policy_id", utils.PathSearch("linux_policy_id", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_honeypot_port_default_config` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_honeypot_port_default_config` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceHoneypotPortDefaultConfig_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceHoneypotPortDefaultConfig_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceHoneypotPortDefaultConfig_basic
=== PAUSE TestAccDataSourceHoneypotPortDefaultConfig_basic
=== CONT  TestAccDataSourceHoneypotPortDefaultConfig_basic
--- PASS: TestAccDataSourceHoneypotPortDefaultConfig_basic (11.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.075s

```
<img width="941" height="27" alt="image" src="https://github.com/user-attachments/assets/4ec17901-dfa6-4e8a-bcd2-d42915a52968" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
