### PR TITLE
feat(hss): support `hss_container_network_statistics` data source

### DIFF
--- a/docs/data-sources/hss_container_network_statistics.md
+++ b/docs/data-sources/hss_container_network_statistics.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_network_statistics"
+description: |-
+  Use this data source to get the network statistics of HSS container clusters within HuaweiCloud.
+---
+
+# huaweicloud_hss_container_network_statistics
+
+Use this data source to get the network statistics of HSS container clusters within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_container_network_statistics" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `protected_cluster_total_num` - The number of unprotected clusters.
+
+* `cluster_total_num` - The total number of clusters.
+
+* `namespace_total_num` - The total number of namespaces.
+
+* `network_policy_total_num` - The total number of network policies.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1428,6 +1428,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_network_cluster":                  hss.DataSourceContainerNetworkCluster(),
 			"huaweicloud_hss_container_network_info":                     hss.DataSourceContainerNetworkInfo(),
 			"huaweicloud_hss_container_network_security_groups":          hss.DataSourceContainerNetworkSecurityGroups(),
+			"huaweicloud_hss_container_network_statistics":               hss.DataSourceContainerNetworkStatistics(),
 			"huaweicloud_hss_container_iac_files":                        hss.DataSourceContainerIacFiles(),
 			"huaweicloud_hss_container_iac_file_risks":                   hss.DataSourceContainerIacFileRisks(),
 			"huaweicloud_hss_container_logs":                             hss.DataSourceContainerLogs(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_network_statistics_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_network_statistics_test.go
@@ -1,0 +1,43 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceContainerNetworkStatistics_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_container_network_statistics.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceContainerNetworkStatistics_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "protected_cluster_total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "cluster_total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "namespace_total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_policy_total_num"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceContainerNetworkStatistics_basic() string {
+	return `
+data "huaweicloud_hss_container_network_statistics" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_container_network_statistics.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_container_network_statistics.go
@@ -1,0 +1,109 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/container-network/network-statistics
+func DataSourceContainerNetworkStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceContainerNetworkStatisticsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"protected_cluster_total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cluster_total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"namespace_total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"network_policy_total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildContainerNetworkStatisticsQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	return ""
+}
+
+func dataSourceContainerNetworkStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/container-network/network-statistics"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildContainerNetworkStatisticsQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS container network statistics: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("protected_cluster_total_num", utils.PathSearch("protected_cluster_total_num", respBody, nil)),
+		d.Set("cluster_total_num", utils.PathSearch("cluster_total_num", respBody, nil)),
+		d.Set("namespace_total_num", utils.PathSearch("namespace_total_num", respBody, nil)),
+		d.Set("network_policy_total_num", utils.PathSearch("network_policy_total_num", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_container_network_statistics` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_container_network_statistics` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceContainerNetworkStatistics_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceContainerNetworkStatistics_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceContainerNetworkStatistics_basic
=== PAUSE TestAccDataSourceContainerNetworkStatistics_basic
=== CONT  TestAccDataSourceContainerNetworkStatistics_basic
--- PASS: TestAccDataSourceContainerNetworkStatistics_basic (17.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       17.368s

```
<img width="933" height="31" alt="image" src="https://github.com/user-attachments/assets/3140c8ba-b78e-427e-89e1-e55955ce8d88" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
