### PR TITLE
fix(fgs/function): fix the incorrect list reference to order mounts rightly

### DIFF
--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -1031,7 +1031,7 @@ func updateFunctionMetadata(client *golangsdk.ServiceClient, functionUrn string,
 }
 
 func buildFunctionMountsOrder(d *schema.ResourceData) []interface{} {
-	mounts, ok := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "func_mounts_order").([]interface{})
+	mounts, ok := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "func_mounts").([]interface{})
 	if !ok || mounts == nil {
 		return nil
 	}
@@ -1450,7 +1450,7 @@ func orderMountsByMountsOrderOrigin(mounts, mountsOrderOrigin []interface{}) []i
 	mountsCopy := mounts
 	for _, mountOrigin := range mountsOrderOrigin {
 		localMountPathOrigin := utils.PathSearch("local_mount_path", mountOrigin, "").(string)
-		for index, mount := range mounts {
+		for index, mount := range mountsCopy {
 			if utils.PathSearch("local_mount_path", mount, "").(string) != localMountPathOrigin {
 				continue
 			}
@@ -1918,6 +1918,10 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		err := updateFunctionMetadata(client, funcUrnWithoutVersion, params)
 		if err != nil {
 			return diag.FromErr(err)
+		}
+
+		if err = d.Set("func_mounts_order", buildFunctionMountsOrder(d)); err != nil {
+			log.Printf("[ERROR] error setting the func_mounts_order field after updating function: %s", err)
 		}
 	}
 	// If the request is successful, obtain the values ​​of all JSON|object parameters first and save them to the


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Before we fixing this mounting reorder issue, we will found following issue when `terraform plan` command result display after function create completed
<img width="905" height="635" alt="image" src="https://github.com/user-attachments/assets/e8e7c04f-96c2-46fc-b8b8-ed1337030c8c" />

Fix that cause the func_mounts_order value forgot set after update completed.
And range reference is incorrect, should be `mountsCopy `, not `mounts`. If not, maybe trigger an out of index issue.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the incorrect list reference to order mounts rightly
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o fgs -f TestAccFunction_funcMounts
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccFunction_funcMounts -timeout 360m -parallel 10
=== RUN   TestAccFunction_funcMounts
=== PAUSE TestAccFunction_funcMounts
=== CONT  TestAccFunction_funcMounts
--- PASS: TestAccFunction_funcMounts (614.50s)
PASS
coverage: 12.5% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       614.578s        coverage: 12.5% of statements in ./huaweicloud/services/fgs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
