### PR TITLE
feat(workspace): support to modify 'product_id' and 'authorized_objec' parameters

### DIFF
--- a/docs/resources/workspace_desktop_pool.md
+++ b/docs/resources/workspace_desktop_pool.md
@@ -105,7 +105,7 @@ The following arguments are supported:
     `terraform apply`. If it is inconsistent with the script configuration, it can be ignored by `ignore_changes`
     in non-change scenarios.
 
-* `product_id` - (Required, String, NonUpdatable) Specifies the specification ID of the desktop pool.
+* `product_id` - (Required, String) Specifies the specification ID of the desktop pool.
 
 * `image_type` - (Required, String, NonUpdatable) Specifies the image type of the desktop pool.  
   The valid values are as follows:
@@ -129,7 +129,7 @@ The following arguments are supported:
   the desktop pool.  
   The [data_volumes](#desktop_pool_volume) structure is documented below.
   
-* `authorized_objects` - (Optional, List, NonUpdatable) Specifies the list of the users or user groups
+* `authorized_objects` - (Optional, List) Specifies the list of the users or user groups
   to be authorized.  
   The [authorized_objects](#desktop_pool_authorized_objects) structure is documented below.
 
@@ -275,6 +275,7 @@ The `product` block supports:
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 20 minutes.
+* `update` - Default is 20 minutes.
 * `delete` - Default is 20 minutes.
 
 ## Import


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

It supports modifying the `product_id` and `authorized_objects` parameters of the `huaweicloud_workspace_desktop_pool` resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDesktopPool_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktopPool_basic -timeout 360m -parallel 10
=== RUN   TestAccDesktopPool_basic
=== PAUSE TestAccDesktopPool_basic
=== CONT  TestAccDesktopPool_basic
--- PASS: TestAccDesktopPool_basic (720.59s)
PASS
coverage: 9.8% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 720.710s        coverage: 9.8% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
