### PR TITLE
fix(workspace): fix desktop volumes change error test case match string

### DIFF
--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_test.go
@@ -922,7 +922,7 @@ func TestAccDesktop_volumeChangeErrors(t *testing.T) {
 			},
 			{
 				Config:      testAccDesktop_volumeChangeErrors_GPSSD2MissingQoS(rName),
-				ExpectError: regexp.MustCompile(`the type of the .*th volume is GPSSD2, iops and throughput cannot be empty`),
+				ExpectError: regexp.MustCompile(`the type of the volume \(index number: \d+\) is GPSSD2, iops and throughput cannot be empty`),
 			},
 			{
 				Config:      testAccDesktop_volumeChangeErrors_volumeCountDecrease(rName),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The test case for the desktop resource disk error needs to have the 4th sample matching string modified to accommodate changes in the source code.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Fix the 4th sample match string in the volume change error test case.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktop_volumeChangeErrors -timeout 360m -parallel 10
=== RUN   TestAccDesktop_volumeChangeErrors
--- PASS: TestAccDesktop_volumeChangeErrors (867.26s)
PASS
coverage: 7.4% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 867.443s        coverage: 7.4% of statements in ./huaweicloud/services/workspace
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.