### PR TITLE
feat(secmaster): new datasource to query collector connections

### DIFF
--- a/docs/data-sources/secmaster_collector_connections.md
+++ b/docs/data-sources/secmaster_collector_connections.md
@@ -1,0 +1,73 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_collector_connections"
+description: |-
+  Use this data source to get the list of collector connections.
+---
+
+# huaweicloud_secmaster_collector_connections
+
+Use this data source to get the list of collector connections.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_collector_connections" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID to which the collector connections belong.
+
+* `connection_type` - (Optional, String) Specifies the connection type. Valid values are:
+  + **FILTER**
+  + **INPUT**
+  + **OUTPUT**
+
+* `title` - (Optional, String) Specifies the title of the collector connection.
+
+* `description` - (Optional, String) Specifies the description of the collector connection.
+
+* `sort_key` - (Optional, String) Specifies the sort key of the collector connection.
+
+* `sort_dir` - (Optional, String) Specifies the sort direction of the collector connection.
+  Valid values are **asc** and **desc**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The list of collector connection details.
+
+  The [records](#records_struct) structure is documented below.
+
+<a name="records_struct"></a>
+The `records` block supports:
+
+* `channel_refer_count` - The channel reference count of the collector connection.
+
+* `connection_id` - The ID of the collector connection.
+
+* `connection_type` - The connection type of the collector connection.
+
+* `description` - The description of the collector connection.
+
+* `info` - The info of the collector connection.
+
+* `module_id` - The module ID of the collector connection.
+
+* `template_title` - The template title of the collector connection.
+
+* `title` - The title of the collector connection.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1981,6 +1981,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_collector_logstash_parsers":   secmaster.DataSourceCollectorLogstashParsers(),
 			"huaweicloud_secmaster_collector_parser_templates":   secmaster.DataSourceSecmasterCollectorParserTemplates(),
 			"huaweicloud_secmaster_collector_channel_instances":  secmaster.DataSourceCollectorChannelInstances(),
+			"huaweicloud_secmaster_collector_connections":        secmaster.DataSourceCollectorConnections(),
 			"huaweicloud_secmaster_installation_scripts":         secmaster.DataSourceSecmasterInstallationScripts(),
 			"huaweicloud_secmaster_retrieve_scripts":             secmaster.DataSourceRetrieveScripts(),
 			"huaweicloud_secmaster_tables":                       secmaster.DataSourceTables(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_collector_connections_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_collector_connections_test.go
@@ -1,0 +1,84 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCollectorConnections_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_secmaster_collector_connections.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running test, prepare a collector channel group.
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCollectorConnections_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.channel_refer_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.connection_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.connection_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.description"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.info"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.module_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.template_title"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.title"),
+
+					resource.TestCheckOutput("is_connection_type_filter_useful", "true"),
+					resource.TestCheckOutput("is_title_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCollectorConnections_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_collector_connections" "test" {
+  workspace_id = "%[1]s"
+}
+
+# Filter by connection_type
+locals {
+  connection_type = data.huaweicloud_secmaster_collector_connections.test.records[0].connection_type
+}
+
+data "huaweicloud_secmaster_collector_connections" "filter_by_connection_type" {
+  workspace_id    = "%[1]s"
+  connection_type = local.connection_type
+}
+
+output "is_connection_type_filter_useful" {
+  value = length(data.huaweicloud_secmaster_collector_connections.filter_by_connection_type.records) > 0 && alltrue(
+    [for v in data.huaweicloud_secmaster_collector_connections.filter_by_connection_type.records[*].connection_type :
+    v == local.connection_type]
+  )
+}
+
+# Filter by title
+locals {
+  title = data.huaweicloud_secmaster_collector_connections.test.records[0].title
+}
+
+data "huaweicloud_secmaster_collector_connections" "filter_by_title" {
+  workspace_id = "%[1]s"
+  title        = local.title
+}
+
+output "is_title_filter_useful" {
+  value = length(data.huaweicloud_secmaster_collector_connections.filter_by_title.records) > 0 && alltrue(
+    [for v in data.huaweicloud_secmaster_collector_connections.filter_by_title.records[*].title : v == local.title]
+  )
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_collector_connections.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_collector_connections.go
@@ -1,0 +1,205 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/collector/connections
+func DataSourceCollectorConnections() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCollectorConnectionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"connection_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"title": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"channel_refer_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"connection_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"connection_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"info": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"module_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"template_title": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"title": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildConnectionQueryParams(d *schema.ResourceData, offset int) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("connection_type"); ok {
+		queryParams = fmt.Sprintf("%s&connection_type=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("title"); ok {
+		queryParams = fmt.Sprintf("%s&title=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		queryParams = fmt.Sprintf("%s&description=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		queryParams = fmt.Sprintf("%s&sort_key=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		queryParams = fmt.Sprintf("%s&sort_dir=%v", queryParams, v)
+	}
+
+	if offset > 0 {
+		queryParams = fmt.Sprintf("%s&offset=%v", queryParams, offset)
+	}
+
+	if len(queryParams) > 0 {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func dataSourceCollectorConnectionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/collector/connections"
+		offset      = 0
+		allResult   = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{workspace_id}", workspaceId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := getPath + buildConnectionQueryParams(d, offset)
+		getResp, err := client.Request("GET", requestPathWithOffset, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving collector connections: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		records := utils.PathSearch("records", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(records) == 0 {
+			break
+		}
+
+		allResult = append(allResult, records...)
+		offset += len(records)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("records", flattenCollectorRecords(allResult)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCollectorRecords(allResult []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(allResult))
+	for _, v := range allResult {
+		rst = append(rst, map[string]interface{}{
+			"channel_refer_count": utils.PathSearch("channel_refer_count", v, nil),
+			"connection_id":       utils.PathSearch("connection_id", v, nil),
+			"connection_type":     utils.PathSearch("connection_type", v, nil),
+			"description":         utils.PathSearch("description", v, nil),
+			"info":                utils.PathSearch("info", v, nil),
+			"module_id":           utils.PathSearch("module_id", v, nil),
+			"template_title":      utils.PathSearch("template_title", v, nil),
+			"title":               utils.PathSearch("title", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query collector connections

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourceCollectorConnections_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceCollectorConnections_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCollectorConnections_basic
=== PAUSE TestAccDataSourceCollectorConnections_basic
=== CONT  TestAccDataSourceCollectorConnections_basic
--- PASS: TestAccDataSourceCollectorConnections_basic (15.67s)
PASS
coverage: 4.4% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 15.787s coverage: 4.4% of statements in ./huaweicloud/services/secmaster
```
<img width="1374" height="81" alt="image" src="https://github.com/user-attachments/assets/75a12ee3-2228-4996-a13d-4b3de97505e6" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
