### PR TITLE
feat(VPCEP): support to update service connection description

### DIFF
--- a/docs/resources/vpcep_service_connection_update.md
+++ b/docs/resources/vpcep_service_connection_update.md
@@ -1,0 +1,54 @@
+---
+subcategory: "VPC Endpoint (VPCEP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpcep_service_connection_update"
+description: -|
+  Manages a VPC endpoint service connection description update resource within HuaweiCloud.
+---
+
+# huaweicloud_vpcep_service_connection_update
+
+Manages a VPC endpoint service connection description update resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "service_id" {}
+variable "endpoint_id" {}
+variable "description" {}
+
+resource "huaweicloud_vpcep_service_connection_update" "test" {
+  service_id  = var.service_id
+  endpoint_id = var.endpoint_id
+  description = var.description
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `service_id` - (Required, String, NonUpdatable) Specifies the VPC endpoint service ID.
+
+* `endpoint_id` - (Required, String, NonUpdatable) Specifies the VPC endpoint ID.
+
+* `description` - (Optional, String) Specifies the description.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The VPC endpoint service connection with description can be imported using the `service_id` and `endpoint_id`, separated
+by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_vpcep_service_connection_update <service_id>/<endpoint_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3778,10 +3778,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_traffic_mirror_session":      vpc.ResourceTrafficMirrorSession(),
 			"huaweicloud_vpc_subnet_cidr_reservation":     vpc.ResourceVpcSubnetCidrReservation(),
 
-			"huaweicloud_vpcep_approval":        vpcep.ResourceVPCEndpointApproval(),
-			"huaweicloud_vpcep_endpoint":        vpcep.ResourceVPCEndpoint(),
-			"huaweicloud_vpcep_service":         vpcep.ResourceVPCEndpointService(),
-			"huaweicloud_vpcep_service_upgrade": vpcep.ResourceVPCServiceUpgrade(),
+			"huaweicloud_vpcep_approval":                  vpcep.ResourceVPCEndpointApproval(),
+			"huaweicloud_vpcep_endpoint":                  vpcep.ResourceVPCEndpoint(),
+			"huaweicloud_vpcep_service":                   vpcep.ResourceVPCEndpointService(),
+			"huaweicloud_vpcep_service_upgrade":           vpcep.ResourceVPCServiceUpgrade(),
+			"huaweicloud_vpcep_service_connection_update": vpcep.ResourceVPCEndpointServiceConnectionUpdate(),
 
 			"huaweicloud_vpn_access_policy":                     vpn.ResourceAccessPolicy(),
 			"huaweicloud_vpn_gateway":                           vpn.ResourceGateway(),

--- a/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_connection_update_test.go
+++ b/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_connection_update_test.go
@@ -1,0 +1,127 @@
+package vpcep
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getVpcEndpointServiceConnectionResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.VPCEPClient(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating VPCEP client: %s", err)
+	}
+
+	parts := strings.Split(state.Primary.ID, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid ID format, want '<service_id>/<endpoint_id>', but got '%s'", state.Primary.ID)
+	}
+	serviceId := parts[0]
+	endpointId := parts[1]
+
+	getHttpUrl := "v1/{project_id}/vpc-endpoint-services/{vpc_endpoint_service_id}/connections?limit=1000&id={endpoint_id}"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{vpc_endpoint_service_id}", serviceId)
+	getPath = strings.ReplaceAll(getPath, "{endpoint_id}", endpointId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving VPC endpoint service connection: %s", err)
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, fmt.Errorf("error flattening VPC endpoint service connection response: %s", err)
+	}
+
+	connection := utils.PathSearch("connections|[0]", getRespBody, nil)
+	if connection == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return connection, nil
+}
+
+func TestAccVpcEndpointServiceConnectionUpdate_Basic(t *testing.T) {
+	var v interface{}
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_vpcep_service_connection_update.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&v,
+		getVpcEndpointServiceConnectionResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcEndpointServiceConnectionUpdate_Basic(rName, "desc"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "service_id", "huaweicloud_vpcep_service.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "endpoint_id",
+						"data.huaweicloud_vpcep_service_connections.test", "connections.0.endpoint_id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "desc"),
+				),
+			},
+			{
+				Config: testAccVpcEndpointServiceConnectionUpdate_Basic(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+				),
+			},
+			{
+				Config: testAccVpcEndpointServiceConnectionUpdate_Basic(rName, "update"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "description", "update"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccVpcEndpointServiceConnectionUpdate_Base(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpcep_service_connections" "test" {
+  service_id = huaweicloud_vpcep_endpoint.test.service_id
+}
+`, testAccVPCEndpoint_Basic(name))
+}
+
+func testAccVpcEndpointServiceConnectionUpdate_Basic(rName, desc string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpcep_service_connection_update" "test" {
+  service_id  = huaweicloud_vpcep_service.test.id
+  endpoint_id = data.huaweicloud_vpcep_service_connections.test.connections.0.endpoint_id
+  description = "%[2]s"
+}
+`, testAccVpcEndpointServiceConnectionUpdate_Base(rName), desc)
+}

--- a/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service_connection_update.go
+++ b/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service_connection_update.go
@@ -1,0 +1,164 @@
+package vpcep
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var vpcepServiceConnectionUpdateNonUpdatableParams = []string{
+	"service_id", "endpoint_id",
+}
+
+// @API VPCEP PUT /v1/{project_id}/vpc-endpoint-services/{vpc_endpoint_service_id}/connections/description
+// @API VPCEP GET /v1/{project_id}/vpc-endpoint-services/{vpc_endpoint_service_id}/connections
+func ResourceVPCEndpointServiceConnectionUpdate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVPCEPServiceConnectionUpdateCreateOrUpdate,
+		ReadContext:   resourceVPCEPServiceConnectionUpdateRead,
+		UpdateContext: resourceVPCEPServiceConnectionUpdateCreateOrUpdate,
+		DeleteContext: resourceVPCEPServiceConnectionUpdateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(vpcepServiceConnectionUpdateNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"service_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"endpoint_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceVPCEPServiceConnectionUpdateCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.VPCEPClient(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC endpoint client: %s", err)
+	}
+
+	serviceId := d.Get("service_id").(string)
+	endpointId := d.Get("endpoint_id").(string)
+
+	createHttpUrl := "v1/{project_id}/vpc-endpoint-services/{vpc_endpoint_service_id}/connections/description"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{vpc_endpoint_service_id}", serviceId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"connections": []map[string]interface{}{
+				{
+					"id":          endpointId,
+					"description": d.Get("description"),
+				},
+			},
+		},
+	}
+
+	_, err = client.Request("PUT", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error updating VPCEP connection description: %s", err)
+	}
+
+	if d.IsNewResource() {
+		d.SetId(serviceId + "/" + endpointId)
+	}
+
+	return resourceVPCEPServiceConnectionUpdateRead(ctx, d, meta)
+}
+
+func resourceVPCEPServiceConnectionUpdateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.VPCEPClient(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC endpoint client: %s", err)
+	}
+
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return diag.Errorf("invalid ID format, want '<service_id>/<endpoint_id>', but got '%s'", d.Id())
+	}
+	serviceId := parts[0]
+	endpointId := parts[1]
+
+	getHttpUrl := "v1/{project_id}/vpc-endpoint-services/{vpc_endpoint_service_id}/connections?limit=1000&id={endpoint_id}"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{vpc_endpoint_service_id}", serviceId)
+	getPath = strings.ReplaceAll(getPath, "{endpoint_id}", endpointId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving VPC endpoint service connection")
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.Errorf("error flattening VPC endpoint service connection response: %s", err)
+	}
+
+	connection := utils.PathSearch("connections|[0]", getRespBody, nil)
+	if connection == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error finding VPC endpoint service connection from API response")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("service_id", serviceId),
+		d.Set("endpoint_id", endpointId),
+		d.Set("description", utils.PathSearch("description", connection, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceVPCEPServiceConnectionUpdateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting VPC endpoint service connection update resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to update service connection description
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to update service connection description
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccVpcEndpointServiceConnectionUpdate_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVpcEndpointServiceConnectionUpdate_Basic -timeout 360m -parallel 4
=== RUN   TestAccVpcEndpointServiceConnectionUpdate_Basic
=== PAUSE TestAccVpcEndpointServiceConnectionUpdate_Basic
=== CONT  TestAccVpcEndpointServiceConnectionUpdate_Basic
--- PASS: TestAccVpcEndpointServiceConnectionUpdate_Basic (193.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     193.855s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
    <img width="1527" height="202" alt="image" src="https://github.com/user-attachments/assets/57d6af15-1b05-4ec2-b54e-792f62425084" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
