### PR TITLE
chore: feat(workspace/desktop_pool): support to modify 'data_volumes' and change its type to list

### DIFF
--- a/docs/resources/workspace_desktop_pool.md
+++ b/docs/resources/workspace_desktop_pool.md
@@ -115,7 +115,7 @@ The following arguments are supported:
 * `image_id` - (Required, String, NonUpdatable) Specifies the image ID of the desktop pool.
 
 * `root_volume` - (Required, List, NonUpdatable) Specifies the system volume configuration of the desktop pool.  
-  The [root_volume](#desktop_pool_volume) structure is documented below.
+  The [root_volume](#desktop_pool_root_volume) structure is documented below.
 
 * `subnet_ids` - (Required, List, NonUpdatable) Specifies the list of the subnet IDs to which the desktop pool belongs.
 
@@ -125,10 +125,19 @@ The following arguments are supported:
   desktop pool belongs.  
   The [security_groups](#desktop_pool_security_groups) structure is documented below.
 
-* `data_volumes` - (Optional, List, NonUpdatable) Specifies the list of the data volume configurations of
+* `data_volumes` - (Optional, List) Specifies the list of the data volume configurations of
   the desktop pool.  
-  The [data_volumes](#desktop_pool_volume) structure is documented below.
-  
+  The [data_volumes](#desktop_pool_data_volumes) structure is documented below.
+
+  ~> 1. Updating this parameter only adds or deletes disks, it does not expand the disk's capacity. If you modify
+     an existing disk, the old disk will be deleted first before being added.
+     <br/>2. When multiple disks of the same type and size exist, if you delete disks, they will be deleted
+     according to the order in the script. There is no guarantee that the disk you want to delete will be
+     the one you delete. Please delete them using other methods.
+
+  -> 1. Currently, only one disk can be deleted or added at a time during the update phase.
+     <br/>2. Before adding the disks, please ensure that all desktops in the desktop pool are running.
+
 * `authorized_objects` - (Optional, List) Specifies the list of the users or user groups
   to be authorized.  
   The [authorized_objects](#desktop_pool_authorized_objects) structure is documented below.
@@ -163,8 +172,8 @@ The following arguments are supported:
 * `in_maintenance_mode` - (Optional, Bool) Specifies whether to enable maintenance mode of the desktop pool.  
   Defaults to **false**.
 
-<a name="desktop_pool_volume"></a>
-The `root_volume` block supports:
+<a name="desktop_pool_data_volumes"></a>
+The `data_volumes` block supports:
 
 * `type` - (Required, String) Specifies the type of the volume.  
   The valid values are as follows:
@@ -172,6 +181,18 @@ The `root_volume` block supports:
   + **SSD**: Ultra-high I/O disk type.
 
 * `size` - (Required, Int) Specifies the size of the volume, in GB.
+  + For root volume, the valid value ranges from `80` to `1,020`.
+  + For data volume, the valid value ranges from `10` to `8,200`.
+
+<a name="desktop_pool_root_volume"></a>
+The `root_volume` block supports:
+
+* `type` - (Required, String, NonUpdatable) Specifies the type of the volume.  
+  The valid values are as follows:
+  + **SAS**: High I/O disk type.
+  + **SSD**: Ultra-high I/O disk type.
+
+* `size` - (Required, Int, NonUpdatable) Specifies the size of the volume, in GB.
   + For root volume, the valid value ranges from `80` to `1,020`.
   + For data volume, the valid value ranges from `10` to `8,200`.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Change `data_volumes` type to list, because the set type automatically removes duplicates, adding a disk with the same type and size as an existing disk will not result in any changes to the resources.
2. The order of `data_volumes` specified in the script is inconsistent with that returned by the query interface, so they need to be sorted manually.
3. Support modifying the `data_volumes` parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o workspace -f TestAccDesktopPool_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDesktopPool_basic -timeout 360m -parallel 10
=== RUN   TestAccDesktopPool_basic
=== PAUSE TestAccDesktopPool_basic
=== CONT  TestAccDesktopPool_basic
--- PASS: TestAccDesktopPool_basic (969.24s)
PASS
coverage: 10.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 969.430s        coverage: 10.5% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
