### PR TITLE
fix(aom): alarm query parameters supports json parsing

### DIFF
--- a/huaweicloud/utils/type_convert.go
+++ b/huaweicloud/utils/type_convert.go
@@ -131,25 +131,25 @@ func StringToJson(jsonStrObj string, defaultVal ...interface{}) interface{} {
 		}
 		return nil
 	}
-	jsonMap := make(map[string]interface{})
-	err := json.Unmarshal([]byte(jsonStrObj), &jsonMap)
+
+	var jsonResult interface{}
+	err := json.Unmarshal([]byte(jsonStrObj), &jsonResult)
 	if err != nil {
 		log.Printf("[ERROR] Unable to convert the JSON string to the map object: %s", err)
 	}
-	return jsonMap
+	return jsonResult
 }
 
 // Try to parse the string value as the JSON array format, if the operation failed, returns an empty list result.
-func StringToJsonArray(jsonStrArray string) []map[string]interface{} {
+func StringToJsonArray(jsonStrArray string) interface{} {
 	if jsonStrArray == "" {
 		return nil
 	}
 
-	var jsonArray []map[string]interface{}
+	jsonArray := make([]map[string]interface{}, 0)
 	err := json.Unmarshal([]byte(jsonStrArray), &jsonArray)
 	if err != nil {
 		log.Printf("[ERROR] Unable to convert the JSON string to the JSON array: %s", err)
-		return make([]map[string]interface{}, 0)
 	}
 	return jsonArray
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

One issue of the AOM alarm rule is the query_match does not supports JSON parsing.
Another one is the query_params missing JSON validation.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. alarm query parameters supports json parsing
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
