### PR TITLE
feat(workspace): add new data source to query associated desktops

### DIFF
--- a/docs/data-sources/workspace_desktop_pool_associated_desktops.md
+++ b/docs/data-sources/workspace_desktop_pool_associated_desktops.md
@@ -1,0 +1,156 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_desktop_pool_associated_desktops"
+description: |-
+  Use this data source to query the associated desktops under the desktop pool within HuaweiCloud.
+---
+
+# huaweicloud_workspace_desktop_pool_associated_desktops
+
+Use this data source to query the associated desktops under the desktop pool within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "desktop_pool_id" {}
+
+data "huaweicloud_workspace_desktop_pool_associated_desktops" "test" {
+  pool_id = var.desktop_pool_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the associated desktops are located.
+
+* `pool_id` - (Required, String) Specifies the ID of the desktop pool to which the associated desktops belong.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `desktops` - The list of associated desktops.  
+  The [desktops](#workspace_desktop_pool_associated_desktops_attr) structure is documented below.
+
+<a name="workspace_desktop_pool_associated_desktops_attr"></a>
+The `desktops` block supports:
+
+* `desktop_id` - The ID of the desktop.
+
+* `computer_name` - The name of the desktop.
+
+* `os_host_name` - The OS host name of the desktop.
+
+* `ip_addresses` - The list of IP addresses of the desktop.
+
+* `ipv4` - The IPv4 address of the desktop.
+
+* `ipv6` - The IPv6 address of the desktop.
+
+* `desktop_type` - The type of the desktop.
+
+* `status` - The status of the desktop.
+
+* `in_maintenance_mode` - Whether the desktop is in maintenance mode.
+
+* `created` - The creation time of the desktop.
+
+* `login_status` - The login status of the desktop.
+
+* `product_id` - The product ID of the desktop.
+
+* `root_volume` - The root volume information of the desktop.  
+  The [root_volume](#workspace_desktop_pool_associated_desktops_volume) structure is documented below.
+
+* `data_volumes` - The list of data volumes of the desktop.  
+  The [data_volumes](#workspace_desktop_pool_associated_desktops_volume) structure is documented below.
+
+* `availability_zone` - The availability zone of the desktop.
+
+* `site_type` - The site type of the desktop.
+
+* `site_name` - The site name of the desktop.
+
+* `product` - The product information of the desktop.  
+  The [product](#workspace_desktop_pool_associated_desktops_product) structure is documented below.
+
+* `os_version` - The OS version of the desktop.
+
+* `sid` - The SID of the desktop.
+
+* `tags` - The tags of the desktop.
+
+* `is_support_internet` - Whether the desktop supports internet access.
+
+* `is_attaching_eip` - Whether the desktop is attaching an EIP.
+
+* `attach_state` - The attach state of the desktop.
+
+* `enterprise_project_id` - The enterprise project ID of the desktop.
+
+* `subnet_id` - The subnet ID of the desktop.
+
+* `bill_resource_id` - The billing resource ID of the desktop.
+
+<a name="workspace_desktop_pool_associated_desktops_volume"></a>
+The `root_volume` and `data_volumes` block supports:
+
+* `type` - The type of the volume.
+
+* `size` - The size of the volume in GB.
+
+* `device` - The device name of the volume.
+
+* `id` - The ID of the volume.
+
+* `volume_id` - The volume ID.
+
+* `bill_resource_id` - The billing resource ID of the volume.
+
+* `create_time` - The creation time of the volume.
+
+* `display_name` - The display name of the volume.
+
+* `resource_spec_code` - The resource specification code of the volume.
+
+<a name="workspace_desktop_pool_associated_desktops_product"></a>
+The `product` block supports:
+
+* `product_id` - The product ID.
+
+* `flavor_id` - The flavor ID.
+
+* `type` - The product type.
+
+* `cpu` - The CPU specification.
+
+* `memory` - The memory specification.
+
+* `descriptions` - The product description.
+
+* `charge_mode` - The charging mode.
+
+* `architecture` - The architecture of the product.
+
+* `is_gpu` - Whether the product is GPU type.
+
+* `package_type` - The package type of the product.
+
+* `system_disk_type` - The system disk type.
+
+* `system_disk_size` - The system disk size.
+
+* `contain_data_disk` - Whether the product contains data disk.
+
+* `resource_type` - The resource type.
+
+* `cloud_service_type` - The cloud service type.
+
+* `volume_product_type` - The volume product type.
+
+* `status` - The status of the product.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2302,6 +2302,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_workspace_desktop_remote_console":                    workspace.DataSourceDesktopRemoteConsole(),
 			"huaweicloud_workspace_desktop_sysprep":                           workspace.DataSourceDesktopSysprep(),
 			"huaweicloud_workspace_desktop_pools":                             workspace.DataSourceDesktopPools(),
+			"huaweicloud_workspace_desktop_pool_associated_desktops":          workspace.DataSourceDesktopPoolAssociatedDesktops(),
 			"huaweicloud_workspace_desktop_tags":                              workspace.DataSourceDesktopTags(),
 			"huaweicloud_workspace_desktop_tags_filter":                       workspace.DataSourceDesktopTagsFilter(),
 			"huaweicloud_workspace_flavors":                                   workspace.DataSourceWorkspaceFlavors(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_pool_associated_desktops_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktop_pool_associated_desktops_test.go
@@ -1,0 +1,176 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataDesktopPoolAssociatedDesktops_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		dataSourceName = "data.huaweicloud_workspace_desktop_pool_associated_desktops.all"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceDesktopPoolImageId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataDesktopPoolAssociatedDesktops_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "desktops.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.desktop_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.computer_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.os_host_name"),
+					resource.TestMatchResourceAttr(dataSourceName, "desktops.0.ip_addresses.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.ipv4"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.desktop_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.in_maintenance_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.created"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.login_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product_id"),
+					resource.TestMatchResourceAttr(dataSourceName, "desktops.0.root_volume.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.root_volume.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.root_volume.0.size"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.root_volume.0.device"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.root_volume.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.root_volume.0.volume_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.root_volume.0.bill_resource_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.root_volume.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.root_volume.0.display_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.root_volume.0.resource_spec_code"),
+					resource.TestMatchResourceAttr(dataSourceName, "desktops.0.data_volumes.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.data_volumes.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.data_volumes.0.size"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.data_volumes.0.device"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.data_volumes.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.data_volumes.0.volume_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.data_volumes.0.bill_resource_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.data_volumes.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.data_volumes.0.display_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.data_volumes.0.resource_spec_code"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.availability_zone"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.site_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.site_name"),
+					resource.TestMatchResourceAttr(dataSourceName, "desktops.0.product.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.product_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.cpu"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.memory"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.descriptions"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.charge_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.architecture"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.is_gpu"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.package_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.system_disk_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.system_disk_size"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.contain_data_disk"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.resource_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.cloud_service_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.volume_product_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.product.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.os_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.sid"),
+					resource.TestMatchResourceAttr(dataSourceName, "desktops.0.tags.%", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(dataSourceName, "desktops.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "desktops.0.tags.owner", "terraform"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.is_support_internet"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.is_attaching_eip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.attach_state"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.0.bill_resource_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataDesktopPoolAssociatedDesktops_basic(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_workspace_service" "test" {}
+
+data "huaweicloud_workspace_flavors" "test" {
+  availability_zone = try(data.huaweicloud_availability_zones.test.names[0], null)
+  os_type           = "Windows"
+}
+
+resource "huaweicloud_workspace_user" "test" {
+  name  = "%[1]s"
+  email = "test@example.com"
+}
+
+resource "huaweicloud_workspace_desktop_pool" "test" {
+  name                          = "%[1]s"
+  type                          = "DYNAMIC"
+  size                          = 2
+  product_id                    = try(data.huaweicloud_workspace_flavors.test.flavors[0].id, "")
+  image_type                    = "gold"
+  image_id                      = "%[2]s"
+  subnet_ids                    = try(slice(data.huaweicloud_workspace_service.test.network_ids, 0, 1), [])
+  vpc_id                        = data.huaweicloud_workspace_service.test.vpc_id
+  availability_zone             = data.huaweicloud_availability_zones.test.names[0]
+  in_maintenance_mode           = true
+  enable_autoscale              = true
+  disconnected_retention_period = 10
+
+  security_groups {
+    id = data.huaweicloud_workspace_service.test.desktop_security_group[0].id
+  }
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  data_volumes {
+    type = "SAS"
+    size = 50
+  }
+
+  authorized_objects {
+    object_id   = huaweicloud_workspace_user.test.id
+    object_type = "USER"
+    object_name = huaweicloud_workspace_user.test.name
+    user_group  = "administrators"
+  }
+
+  autoscale_policy {
+    autoscale_type    = "AUTO_CREATED"
+    min_idle          = 1
+    max_auto_created  = 2
+    once_auto_created = 1
+  }
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      size,
+    ]
+  }
+}
+
+data "huaweicloud_workspace_desktop_pool_associated_desktops" "all" {
+  pool_id = huaweicloud_workspace_desktop_pool.test.id
+}
+`, name, acceptance.HW_WORKSPACE_DESKTOP_POOL_IMAGE_ID)
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_desktop_pool_associated_desktops.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_desktop_pool_associated_desktops.go
@@ -1,0 +1,517 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Workspace GET /v2/{project_id}/desktop-pools/{pool_id}/desktops
+func DataSourceDesktopPoolAssociatedDesktops() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDesktopPoolAssociatedDesktopsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the associated desktops are located.`,
+			},
+
+			// Required parameters.
+			"pool_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the desktop pool to which the associated desktops belong.`,
+			},
+
+			// Attributes.
+			"desktops": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of associated desktops.`,
+				Elem:        desktopPoolAssociatedDesktopSchema(),
+			},
+		},
+	}
+}
+
+func desktopPoolAssociatedDesktopSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"desktop_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the desktop.`,
+			},
+			"computer_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the desktop.`,
+			},
+			"os_host_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The OS host name of the desktop.`,
+			},
+			"ip_addresses": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of IP addresses of the desktop.`,
+			},
+			"ipv4": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The IPv4 address of the desktop.`,
+			},
+			"ipv6": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The IPv6 address of the desktop.`,
+			},
+			"desktop_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the desktop.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the desktop.`,
+			},
+			"in_maintenance_mode": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the desktop is in maintenance mode.`,
+			},
+			"created": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the desktop.`,
+			},
+			"login_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The login status of the desktop.`,
+			},
+			"product_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The product ID of the desktop.`,
+			},
+			"root_volume": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        desktopPoolAssociatedDesktopVolumeSchema(),
+				Description: `The root volume information of the desktop.`,
+			},
+			"data_volumes": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        desktopPoolAssociatedDesktopVolumeSchema(),
+				Description: `The list of data volumes of the desktop.`,
+			},
+			"availability_zone": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The availability zone of the desktop.`,
+			},
+			"site_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The site type of the desktop.`,
+			},
+			"site_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The site name of the desktop.`,
+			},
+			"product": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        desktopPoolAssociatedDesktopProductSchema(),
+				Description: `The product information of the desktop.`,
+			},
+			"os_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The OS version of the desktop.`,
+			},
+			"sid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The SID of the desktop.`,
+			},
+			"tags": common.TagsComputedSchema(`The tags of the desktop.`),
+			"is_support_internet": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the desktop supports internet access.`,
+			},
+			"is_attaching_eip": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the desktop is attaching an EIP.`,
+			},
+			"attach_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The attach state of the desktop.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The enterprise project ID of the desktop.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subnet ID of the desktop.`,
+			},
+			"bill_resource_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The billing resource ID of the desktop.`,
+			},
+		},
+	}
+}
+
+func desktopPoolAssociatedDesktopVolumeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the volume.`,
+			},
+			"size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The size of the volume in GB.`,
+			},
+			"device": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The device name of the volume.`,
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the volume.`,
+			},
+			"volume_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The volume ID.`,
+			},
+			"bill_resource_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The billing resource ID of the volume.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the volume.`,
+			},
+			"display_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The display name of the volume.`,
+			},
+			"resource_spec_code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resource specification code of the volume.`,
+			},
+		},
+	}
+}
+
+func desktopPoolAssociatedDesktopProductSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"product_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The product ID.`,
+			},
+			"flavor_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor ID.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The product type.`,
+			},
+			"cpu": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The CPU specification.`,
+			},
+			"memory": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The memory specification.`,
+			},
+			"descriptions": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The product description.`,
+			},
+			"charge_mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The charging mode.`,
+			},
+			"architecture": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The architecture of the product.`,
+			},
+			"is_gpu": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the product is GPU type.`,
+			},
+			"package_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The package type of the product.`,
+			},
+			"system_disk_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The system disk type.`,
+			},
+			"system_disk_size": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The system disk size.`,
+			},
+			"contain_data_disk": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the product contains data disk.`,
+			},
+			"resource_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resource type.`,
+			},
+			"cloud_service_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The cloud service type.`,
+			},
+			"volume_product_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The volume product type.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the product.`,
+			},
+		},
+	}
+}
+
+func listDesktopPoolAssociatedDesktops(client *golangsdk.ServiceClient, poolId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/desktop-pools/{pool_id}/desktops?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{pool_id}", poolId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		desktops := utils.PathSearch("pool_desktops", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, desktops...)
+		if len(desktops) < limit {
+			break
+		}
+		offset += len(desktops)
+	}
+
+	return result, nil
+}
+
+func flattenDesktopPoolAssociatedDesktopRootVolume(volume interface{}) []map[string]interface{} {
+	if volume == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"type":               utils.PathSearch("type", volume, nil),
+			"size":               utils.PathSearch("size", volume, nil),
+			"device":             utils.PathSearch("device", volume, nil),
+			"id":                 utils.PathSearch("id", volume, nil),
+			"volume_id":          utils.PathSearch("volume_id", volume, nil),
+			"bill_resource_id":   utils.PathSearch("bill_resource_id", volume, nil),
+			"create_time":        utils.PathSearch("create_time", volume, nil),
+			"display_name":       utils.PathSearch("display_name", volume, nil),
+			"resource_spec_code": utils.PathSearch("resource_spec_code", volume, nil),
+		},
+	}
+}
+
+func flattenDesktopPoolAssociatedDesktopVolumes(volumes []interface{}) []map[string]interface{} {
+	if len(volumes) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(volumes))
+	for _, volume := range volumes {
+		result = append(result, map[string]interface{}{
+			"type":               utils.PathSearch("type", volume, nil),
+			"size":               utils.PathSearch("size", volume, nil),
+			"device":             utils.PathSearch("device", volume, nil),
+			"id":                 utils.PathSearch("id", volume, nil),
+			"volume_id":          utils.PathSearch("volume_id", volume, nil),
+			"bill_resource_id":   utils.PathSearch("bill_resource_id", volume, nil),
+			"create_time":        utils.PathSearch("create_time", volume, nil),
+			"display_name":       utils.PathSearch("display_name", volume, nil),
+			"resource_spec_code": utils.PathSearch("resource_spec_code", volume, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenDesktopPoolAssociatedDesktopProduct(product interface{}) []map[string]interface{} {
+	if product == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"product_id":          utils.PathSearch("product_id", product, nil),
+			"flavor_id":           utils.PathSearch("flavor_id", product, nil),
+			"type":                utils.PathSearch("type", product, nil),
+			"cpu":                 utils.PathSearch("cpu", product, nil),
+			"memory":              utils.PathSearch("memory", product, nil),
+			"descriptions":        utils.PathSearch("descriptions", product, nil),
+			"charge_mode":         utils.PathSearch("charge_mode", product, nil),
+			"architecture":        utils.PathSearch("architecture", product, nil),
+			"is_gpu":              utils.PathSearch("is_gpu", product, nil),
+			"package_type":        utils.PathSearch("package_type", product, nil),
+			"system_disk_type":    utils.PathSearch("system_disk_type", product, nil),
+			"system_disk_size":    utils.PathSearch("system_disk_size", product, nil),
+			"contain_data_disk":   utils.PathSearch("contain_data_disk", product, nil),
+			"resource_type":       utils.PathSearch("resource_type", product, nil),
+			"cloud_service_type":  utils.PathSearch("cloud_service_type", product, nil),
+			"volume_product_type": utils.PathSearch("volume_product_type", product, nil),
+			"status":              utils.PathSearch("status", product, nil),
+		},
+	}
+}
+
+func flattenDesktopPoolAssociatedDesktops(desktops []interface{}) []map[string]interface{} {
+	if len(desktops) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(desktops))
+	for _, desktop := range desktops {
+		result = append(result, map[string]interface{}{
+			"desktop_id":          utils.PathSearch("desktop_id", desktop, nil),
+			"computer_name":       utils.PathSearch("computer_name", desktop, nil),
+			"os_host_name":        utils.PathSearch("os_host_name", desktop, nil),
+			"ip_addresses":        utils.PathSearch("ip_addresses", desktop, make([]interface{}, 0)),
+			"ipv4":                utils.PathSearch("ipv4", desktop, nil),
+			"ipv6":                utils.PathSearch("ipv6", desktop, nil),
+			"desktop_type":        utils.PathSearch("desktop_type", desktop, nil),
+			"status":              utils.PathSearch("status", desktop, nil),
+			"in_maintenance_mode": utils.PathSearch("in_maintenance_mode", desktop, nil),
+			"created":             utils.PathSearch("created", desktop, nil),
+			"login_status":        utils.PathSearch("login_status", desktop, nil),
+			"product_id":          utils.PathSearch("product_id", desktop, nil),
+			"root_volume":         flattenDesktopPoolAssociatedDesktopRootVolume(utils.PathSearch("root_volume", desktop, nil)),
+			"data_volumes": flattenDesktopPoolAssociatedDesktopVolumes(utils.PathSearch("data_volumes",
+				desktop, make([]interface{}, 0)).([]interface{})),
+			"availability_zone":     utils.PathSearch("availability_zone", desktop, nil),
+			"site_type":             utils.PathSearch("site_type", desktop, nil),
+			"site_name":             utils.PathSearch("site_name", desktop, nil),
+			"product":               flattenDesktopPoolAssociatedDesktopProduct(utils.PathSearch("product", desktop, nil)),
+			"os_version":            utils.PathSearch("os_version", desktop, nil),
+			"sid":                   utils.PathSearch("sid", desktop, nil),
+			"tags":                  utils.FlattenTagsToMap(utils.PathSearch("tags", desktop, make([]interface{}, 0)).([]interface{})),
+			"is_support_internet":   utils.PathSearch("is_support_internet", desktop, nil),
+			"is_attaching_eip":      utils.PathSearch("is_attaching_eip", desktop, nil),
+			"attach_state":          utils.PathSearch("attach_state", desktop, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", desktop, nil),
+			"subnet_id":             utils.PathSearch("subnet_id", desktop, nil),
+			"bill_resource_id":      utils.PathSearch("bill_resource_id", desktop, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceDesktopPoolAssociatedDesktopsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("workspace", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace client: %s", err)
+	}
+
+	desktops, err := listDesktopPoolAssociatedDesktops(client, d.Get("pool_id").(string))
+	if err != nil {
+		return diag.Errorf("error querying the associated desktops under the Workspace desktop pool: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("desktops", flattenDesktopPoolAssociatedDesktops(desktops)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new data source that used to query associated desktops of the desktop pool.
Some attributes are not response by Workspace API:
- inconsistent_types
- internet_mode_list
- tags
- task_status
- user_group_list
- user_list

And the flavor attribute value are already be included in product attribute value.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="1120" height="396" alt="image" src="https://github.com/user-attachments/assets/4e52eb94-0a51-430b-8d65-911587be1a76" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query associated desktops of the desktop pool
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccDataDesktopPoolAssociatedDesktops_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccDataDesktopPoolAssociatedDesktops_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDesktopPoolAssociatedDesktops_basic
--- PASS: TestAccDataDesktopPoolAssociatedDesktops_basic (445.77s)
PASS
coverage: 8.4% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 445.851s        coverage: 8.4% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
