### PR TITLE
feat(DC): add dc vif peer detection resource

### DIFF
--- a/docs/data-sources/dc_vif_peer_detections.md
+++ b/docs/data-sources/dc_vif_peer_detections.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Direct Connect (DC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dc_vif_peer_detections"
+description:
+  Use this data source to get the list of DC virtual interface peer detections.
+---
+
+# huaweicloud_dc_vif_peer_detections
+
+Use this data source to get the list of DC virtual interface peer detections.
+
+## Example Usage
+
+```hcl
+variable "vif_peer_id" {}
+
+data "huaweicloud_dc_vif_peer_detections" "test" {
+  vif_peer_id = var.vif_peer_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `vif_peer_id` - (Required, String) Specifies the ID of the virtual interface peer.
+
+* `sort_key` - (Optional, String) Specifies the sort key.
+
+* `sort_dir` - (Optional, List) Specifies the list of sort dir. Value options: **desc**, **asc**. Defaults to **asc**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `vif_peer_detections` - Indicates the list of virtual interface peer detection.
+  The [vif_peer_detections](#vif_peer_detections_struct) structure is documented below.
+
+<a name="vif_peer_detections_struct"></a>
+The `vif_peer_detections` block supports:
+
+* `id` - The virtual interface peer detection ID.
+
+* `vif_peer_id` - Indicates the virtual interface peer ID.
+
+* `project_id` - Indicates the project ID.
+
+* `domain_id` - Indicates the domain ID.
+
+* `status` - Indicates the status of the virtual interface peer detection.
+
+* `start_time` - Indicates the start time of the virtual interface peer detection.
+
+* `end_time` - Indicates the end time of the virtual interface peer detection.
+
+* `loss_ratio` - Indicates the loss ratio.

--- a/docs/resources/dc_vif_peer_detection.md
+++ b/docs/resources/dc_vif_peer_detection.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Direct Connect (DC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dc_vif_peer_detection"
+description: |-
+  Manages a DC vif peer detection resource within HuaweiCloud.
+---
+
+# huaweicloud_dc_vif_peer_detection
+
+Manages a DC vif peer detection resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "vif_peer_id" {}
+
+resource "huaweicloud_dc_vif_peer_detection" "test" {
+  vif_peer_id = var.vif_peer_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `vif_peer_id` - (Required, String, NonUpdatable) Specifies the ID of the virtual interface peer.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - Indicates the status of the virtual interface peer detection.
+
+* `start_time` - Indicates the start time of the virtual interface peer detection.
+
+* `end_time` - Indicates the end time of the virtual interface peer detection.
+
+* `loss_ratio` - Indicates the loss ratio.
+
+## Import
+
+The DC vif peer detection resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dc_vif_peer_detection.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1028,6 +1028,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dc_connect_gateway_geips":                dc.DataSourceDcConnectGatewayGeips(),
 			"huaweicloud_dc_tags":                                 dc.DataSourceDcTags(),
 			"huaweicloud_dc_resources_by_tags":                    dc.DataSourceDcResourcesByTags(),
+			"huaweicloud_dc_vif_peer_detections":                  dc.DataSourceDcVifPeerDetections(),
 
 			"huaweicloud_dcs_quotas":                              dcs.DataSourceDcsQuotas(),
 			"huaweicloud_dcs_flavors":                             dcs.DataSourceDcsFlavorsV2(),
@@ -2875,6 +2876,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dc_global_gateway_route_table":     dc.ResourceDcGlobalGatewayRouteTable(),
 			"huaweicloud_dc_connect_gateway":                dc.ResourceDcConnectGateway(),
 			"huaweicloud_dc_connect_gateway_geip_associate": dc.ResourceDcConnectGatewayGeipAssociate(),
+			"huaweicloud_dc_vif_peer_detection":             dc.ResourceDcVifPeerDetection(),
 
 			"huaweicloud_dcs_instance":                           dcs.ResourceDcsInstance(),
 			"huaweicloud_dcs_instance_public_access":             dcs.ResourceDcsInstancePublicAccess(),

--- a/huaweicloud/services/acceptance/dc/data_source_huaweicloud_dc_vif_peer_detections_test.go
+++ b/huaweicloud/services/acceptance/dc/data_source_huaweicloud_dc_vif_peer_detections_test.go
@@ -1,0 +1,67 @@
+package dc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDcVifPeerDetections_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	dataSource := "data.huaweicloud_dc_vif_peer_detections.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDcDirectConnection(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDcVifPeerDetections_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "vif_peer_detections.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "vif_peer_detections.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "vif_peer_detections.0.vif_peer_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "vif_peer_detections.0.project_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "vif_peer_detections.0.domain_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "vif_peer_detections.0.start_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "vif_peer_detections.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "vif_peer_detections.0.loss_ratio"),
+
+					resource.TestCheckOutput("sort_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDcVifPeerDetections_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+
+data "huaweicloud_dc_vif_peer_detections" "test" {
+  depends_on = [huaweicloud_dc_vif_peer_detection.test]
+
+  vif_peer_id = huaweicloud_dc_vif_peer_detection.test.id
+}
+
+data "huaweicloud_dc_vif_peer_detections" "sort_filter" {
+  depends_on = [huaweicloud_dc_vif_peer_detection.test]
+
+  vif_peer_id = huaweicloud_dc_vif_peer_detection.test.id
+  sort_key    = "id"
+  sort_dir    = ["asc"]
+}
+
+output "sort_filter_is_useful" {
+  value = length(data.huaweicloud_dc_vif_peer_detections.sort_filter.vif_peer_detections) > 0
+}
+`, testResourceDcVifPeerDetection_basic(name))
+}

--- a/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_vif_peer_detection_test.go
+++ b/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_vif_peer_detection_test.go
@@ -1,0 +1,130 @@
+package dc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getResourceDcVifPeerDetectionFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dc", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DC client: %s", err)
+	}
+
+	getPath := client.Endpoint + "v3/{project_id}/dcaas/vif-peer-detections/{id}"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", state.Primary.ID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DC vif peer detection: %s", err)
+	}
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccResourceDcVifPeerDetection_basic(t *testing.T) {
+	var obj interface{}
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dc_vif_peer_detection.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getResourceDcVifPeerDetectionFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDcDirectConnection(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceDcVifPeerDetection_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "vif_peer_id",
+						"data.huaweicloud_dc_virtual_interfaces.test",
+						"virtual_interfaces.0.vif_peers.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "start_time"),
+					resource.TestCheckResourceAttrSet(rName, "loss_ratio"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testResourceDcVifPeerDetection_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_dc_virtual_gateway" "test" {
+  vpc_id = huaweicloud_vpc.test.id
+  name   = "%[1]s"
+
+  local_ep_group = [
+    huaweicloud_vpc.test.cidr,
+  ]
+}
+
+resource "huaweicloud_dc_virtual_interface" "test" {
+  direct_connect_id = "%[2]s"
+  vgw_id            = huaweicloud_dc_virtual_gateway.test.id
+  name              = "%[1]s"
+  description       = "Created by acc test"
+  type              = "private"
+  route_mode        = "static"
+  vlan              = 80
+  bandwidth         = 5
+  enable_bfd        = true
+  enable_nqa        = false
+
+  remote_ep_group = [
+    "1.1.1.0/30",
+  ]
+
+  address_family       = "ipv4"
+  local_gateway_v4_ip  = "1.1.1.1/30"
+  remote_gateway_v4_ip = "1.1.1.2/30"
+}
+
+data "huaweicloud_dc_virtual_interfaces" "test" {
+  virtual_interface_id = huaweicloud_dc_virtual_interface.test.id
+}
+`, name, acceptance.HW_DC_DIRECT_CONNECT_ID)
+}
+
+func testResourceDcVifPeerDetection_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dc_vif_peer_detection" "test" {
+  vif_peer_id = data.huaweicloud_dc_virtual_interfaces.test.virtual_interfaces[0].vif_peers[0].id
+}
+`, testResourceDcVifPeerDetection_base(name))
+}

--- a/huaweicloud/services/dc/data_source_huaweicloud_dc_vif_peer_detections.go
+++ b/huaweicloud/services/dc/data_source_huaweicloud_dc_vif_peer_detections.go
@@ -1,0 +1,181 @@
+package dc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DC GET /v3/{project_id}/dcaas/vif-peer-detections
+func DataSourceDcVifPeerDetections() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDcVifPeerDetectionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"vif_peer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vif_peer_detections": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vif_peer_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"start_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"end_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"loss_ratio": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDcVifPeerDetectionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		httpUrl = "v3/{project_id}/dcaas/vif-peer-detections"
+		product = "dc"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DC client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	listQueryParams := buildListVifPeerDetectionsQueryParams(d)
+	listPath += listQueryParams
+
+	listResp, err := pagination.ListAllItems(
+		client,
+		"marker",
+		listPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return diag.Errorf("error retrieving DC vif peer detections: %s", err)
+	}
+
+	listRespJson, err := json.Marshal(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var listRespBody interface{}
+	err = json.Unmarshal(listRespJson, &listRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("vif_peer_detections", flattenListVifPeerDetectionsBody(listRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListVifPeerDetectionsBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("vif_peer_detections", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":          utils.PathSearch("id", v, nil),
+			"vif_peer_id": utils.PathSearch("vif_peer_id", v, nil),
+			"project_id":  utils.PathSearch("project_id", v, nil),
+			"domain_id":   utils.PathSearch("domain_id", v, nil),
+			"start_time":  utils.PathSearch("start_time", v, nil),
+			"end_time":    utils.PathSearch("end_time", v, nil),
+			"status":      utils.PathSearch("status", v, nil),
+			"loss_ratio":  utils.PathSearch("loss_ratio", v, nil),
+		})
+	}
+	return rst
+}
+
+func buildListVifPeerDetectionsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("sort_key"); ok {
+		res = fmt.Sprintf("%s&sort_key=%v", res, v)
+	}
+	if v, ok := d.GetOk("sort_dir"); ok {
+		for _, raw := range v.([]interface{}) {
+			res = fmt.Sprintf("%s&sort_dir=%v", res, raw.(string))
+		}
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}

--- a/huaweicloud/services/dc/resource_huaweicloud_dc_vif_peer_detection.go
+++ b/huaweicloud/services/dc/resource_huaweicloud_dc_vif_peer_detection.go
@@ -1,0 +1,193 @@
+package dc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var vifPeerDetectionNonUpdatableParams = []string{"vif_peer_id"}
+
+// @API DC POST /v3/{project_id}/dcaas/vif-peer-detections
+// @API DC GET /v3/{project_id}/dcaas/vif-peer-detections/{id}
+// @API DC DELETE /v3/{project_id}/dcaas/vif-peer-detections/{id}
+func ResourceDcVifPeerDetection() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDcVifPeerDetectionCreate,
+		ReadContext:   resourceDcVifPeerDetectionRead,
+		UpdateContext: resourceDcVifPeerDetectionUpdate,
+		DeleteContext: resourceDcVifPeerDetectionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(vifPeerDetectionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"vif_peer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"loss_ratio": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDcVifPeerDetectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	var (
+		httpUrl = "v3/{project_id}/dcaas/vif-peer-detections"
+		product = "dc"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DC client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateDcVifPeerDetectionBodyParams(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DC vif peer detection: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("vif_peer_detection.id", createRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating DC vif peer detection: ID is not found in API response")
+	}
+
+	d.SetId(id)
+
+	return resourceDcVifPeerDetectionRead(ctx, d, meta)
+}
+
+func buildCreateDcVifPeerDetectionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"vif_peer_id": d.Get("vif_peer_id"),
+	}
+
+	return map[string]interface{}{
+		"vif_peer_detection": bodyParams,
+	}
+}
+
+func resourceDcVifPeerDetectionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	var (
+		httpUrl = "v3/{project_id}/dcaas/vif-peer-detections/{id}"
+		product = "dc"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DC client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DC vif peer detection")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("vif_peer_id", utils.PathSearch("vif_peer_detection.vif_peer_id", getRespBody, nil)),
+		d.Set("status", utils.PathSearch("vif_peer_detection.status", getRespBody, nil)),
+		d.Set("start_time", utils.PathSearch("vif_peer_detection.start_time", getRespBody, nil)),
+		d.Set("end_time", utils.PathSearch("vif_peer_detection.end_time", getRespBody, nil)),
+		d.Set("loss_ratio", utils.PathSearch("vif_peer_detection.loss_ratio", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDcVifPeerDetectionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDcVifPeerDetectionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	var (
+		httpUrl = "v3/{project_id}/dcaas/vif-peer-detections/{id}"
+		product = "dc"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DC client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting DC vif peer detection")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add dc vif peer detection resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add dc vif peer detection resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dc/ TESTARGS='-run TestAccResourceDcVifPeerDetection_basic'      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc/ -v -run TestAccResourceDcVifPeerDetection_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDcVifPeerDetection_basic
=== PAUSE TestAccResourceDcVifPeerDetection_basic
=== CONT  TestAccResourceDcVifPeerDetection_basic
--- PASS: TestAccResourceDcVifPeerDetection_basic (146.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        146.221s

make testacc TEST=./huaweicloud/services/acceptance/dc/ TESTARGS='-run TestAccDataSourceDcVifPeerDetections_basic'   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc/ -v -run TestAccDataSourceDcVifPeerDetections_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDcVifPeerDetections_basic
=== PAUSE TestAccDataSourceDcVifPeerDetections_basic
=== CONT  TestAccDataSourceDcVifPeerDetections_basic
--- PASS: TestAccDataSourceDcVifPeerDetections_basic (216.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        217.081s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
