### PR TITLE
feat(mrs): add new one-time resources to batch expand and shrink nodes

### DIFF
--- a/docs/resources/mapreduce_cluster_node_batch_expand.md
+++ b/docs/resources/mapreduce_cluster_node_batch_expand.md
@@ -1,0 +1,70 @@
+---
+subcategory: "MapReduce Service (MRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_mapreduce_cluster_node_batch_expand"
+description: |-
+  Use this resource to batch expand the nodes of the MRS cluster within HuaweiCloud.
+---
+
+# huaweicloud_mapreduce_cluster_node_batch_expand
+
+Use this resource to batch expand the nodes of the MRS cluster within HuaweiCloud.
+
+~> If you use this resource, please use `lifecycle.ignore_changes` to ignore the `node_count` parameter of the
+   corresponding node in the `huaweicloud_mapreduce_cluster` resource.
+
+-> This resource is only a one-time action resource for batch expanding the nodes of the cluster. Deleting this
+   resource will not clear the corresponding request record, but will only remove the resource information from the
+   tfstate file.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "node_group_name" {}
+
+resource "huaweicloud_mapreduce_cluster_node_batch_expand" "test" {
+  cluster_id      = var.cluster_id
+  node_group_name = var.node_group_name
+  node_count      = 2
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the MRS cluster is located.  
+  If omitted, the provider-level region will be used.  
+  Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies ID of the cluster to which the nodes
+   to be expanded belong.
+
+* `node_group_name` - (Required, String, NonUpdatable) Specifies the name of the node group to which the nodes to be
+  expanded belong.
+
+* `node_count` - (Required, Int, NonUpdatable) Specifies the number of nodes to be expanded.
+
+* `skip_bootstrap_scripts` - (Optional, Bool, NonUpdatable) Specifies whether to skip bootstrap scripts.  
+  Defaults to **true**.
+  + **true**: Skip bootstrap scripts.
+  + **false**: Do not skip bootstrap scripts.
+
+* `scale_without_start` - (Optional, Bool, NonUpdatable) Specifies whether to start the components on the node after it
+  has been expanded.  
+  Defaults to **false**.
+  + **true**: Do not start the components on the node after it has been expanded.
+  + **false**: Start the components on the node after it has been expanded.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/docs/resources/mapreduce_cluster_node_batch_shrink.md
+++ b/docs/resources/mapreduce_cluster_node_batch_shrink.md
@@ -1,0 +1,82 @@
+---
+subcategory: "MapReduce Service (MRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_mapreduce_cluster_node_batch_shrink"
+description: |-
+  Use this resource to batch shrink the nodes of the MRS cluster within HuaweiCloud.
+---
+
+# huaweicloud_mapreduce_cluster_node_batch_shrink
+
+Use this resource to batch shrink the nodes of the MRS cluster within HuaweiCloud.
+
+~> If you use this resource, please use `lifecycle.ignore_changes` to ignore the `node_count` parameter of the
+   corresponding node in the `huaweicloud_mapreduce_cluster` resource.
+
+-> 1. This resource only supports shrinking the nodes of the postpaid billing cluster.
+   <br>2. Currently, this resource only supports shrinking the nodes of Core nodes and Task nodes, not Master nodes.
+   <br>3. This resource is only a one-time action resource for batch shrinking the nodes of the cluster. Deleting
+   this resource will not clear the corresponding request record, but will only remove the resource information from
+   the tfstate file.
+
+## Example Usage
+
+### Shrink cluster nodes by count
+
+```hcl
+variable "cluster_id" {}
+variable "node_group_name" {}
+
+resource "huaweicloud_mapreduce_cluster_node_batch_shrink" "test" {
+  cluster_id      = var.cluster_id
+  node_group_name = var.node_group_name
+  node_count      = 2
+}
+```
+
+### Shrink cluster nodes by resource IDs
+
+```hcl
+variable "cluster_id" {}
+variable "node_group_name" {}
+variable "resource_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_mapreduce_cluster_node_batch_shrink" "test" {
+  cluster_id      = var.cluster_id
+  node_group_name = var.node_group_name
+  resource_ids    = var.resource_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the MRS cluster is located.  
+  If omitted, the provider-level region will be used.  
+  Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster to be shrunk.
+
+* `node_group_name` - (Required, String, NonUpdatable) Specifies the name of the node group to which the nodes to be
+  shrunk belong.
+
+* `node_count` - (Optional, Int, NonUpdatable) Specifies the number of nodes to be deleted from the node group.
+  If specified, nodes are automatically selected for deletion according to system rules.
+
+* `resource_ids` - (Optional, List, NonUpdatable) Specifies the ID list of resource nodes to be deleted.  
+  Only nodes in the **shutdown**, **lost**, **unknown**, **detached** and **error** states can be specified for shrinkage.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3477,6 +3477,8 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_mapreduce_cluster":                     mrs.ResourceMRSClusterV2(),
 			"huaweicloud_mapreduce_cluster_component_batch_add": mrs.ResourceClusterComponentBatchAdd(),
+			"huaweicloud_mapreduce_cluster_node_batch_expand":   mrs.ResourceClusterNodeBatchExpand(),
+			"huaweicloud_mapreduce_cluster_node_batch_shrink":   mrs.ResourceClusterNodeBatchShrink(),
 			"huaweicloud_mapreduce_job":                         mrs.ResourceMRSJobV2(),
 			"huaweicloud_mapreduce_data_connection":             mrs.ResourceDataConnection(),
 			"huaweicloud_mapreduce_scaling_policy":              mrs.ResourceScalingPolicy(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -100,9 +100,11 @@ var (
 
 	HW_CBC_UNSUBSCRIBE_RESOURCE_ID = os.Getenv("HW_CBC_UNSUBSCRIBE_RESOURCE_ID")
 
-	HW_MAPREDUCE_CUSTOM           = os.Getenv("HW_MAPREDUCE_CUSTOM")
-	HW_MAPREDUCE_BOOTSTRAP_SCRIPT = os.Getenv("HW_MAPREDUCE_BOOTSTRAP_SCRIPT")
-	HW_MRS_CLUSTER_FLAVOR_ID      = os.Getenv("HW_MRS_CLUSTER_FLAVOR_ID")
+	HW_MAPREDUCE_CUSTOM            = os.Getenv("HW_MAPREDUCE_CUSTOM")
+	HW_MAPREDUCE_BOOTSTRAP_SCRIPT  = os.Getenv("HW_MAPREDUCE_BOOTSTRAP_SCRIPT")
+	HW_MRS_CLUSTER_FLAVOR_ID       = os.Getenv("HW_MRS_CLUSTER_FLAVOR_ID")
+	HW_MRS_CLUSTER_ID              = os.Getenv("HW_MRS_CLUSTER_ID")
+	HW_MRS_CLUSTER_NODE_GROUP_NAME = os.Getenv("HW_MRS_CLUSTER_NODE_GROUP_NAME")
 
 	HW_CNAD_ENABLE_FLAG       = os.Getenv("HW_CNAD_ENABLE_FLAG")
 	HW_CNAD_PROJECT_OBJECT_ID = os.Getenv("HW_CNAD_PROJECT_OBJECT_ID")
@@ -1287,6 +1289,20 @@ func TestAccPreCheckMrsBootstrapScript(t *testing.T) {
 func TestAccPreCheckMrsClusterFlavorID(t *testing.T) {
 	if HW_MRS_CLUSTER_FLAVOR_ID == "" {
 		t.Skip("HW_MRS_CLUSTER_FLAVOR_ID must be set for MRS cluster acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckMrsClusterID(t *testing.T) {
+	if HW_MRS_CLUSTER_ID == "" {
+		t.Skip("HW_MRS_CLUSTER_ID must be set for acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckMrsClusterNodeGroupName(t *testing.T) {
+	if HW_MRS_CLUSTER_NODE_GROUP_NAME == "" {
+		t.Skip("HW_MRS_CLUSTER_NODE_GROUP_NAME must be set for acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_cluster_node_batch_shrink_test.go
+++ b/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_cluster_node_batch_shrink_test.go
@@ -1,0 +1,66 @@
+package mrs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccClusterNodeBatchShrink_basic(t *testing.T) {
+	var (
+		rNameWithExpand = "huaweicloud_mapreduce_cluster_node_batch_expand.test"
+		rNameWithShrink = "huaweicloud_mapreduce_cluster_node_batch_shrink.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMrsClusterID(t)
+			acceptance.TestAccPreCheckMrsClusterNodeGroupName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time batch action resource and there is no logic in the delete method.
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterNodeBatchShrinkConfig_basic_step1(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rNameWithExpand, "cluster_id"),
+					resource.TestCheckResourceAttrSet(rNameWithExpand, "node_group_name"),
+					resource.TestCheckResourceAttr(rNameWithExpand, "node_count", "2"),
+				),
+			},
+			{
+				Config: testAccClusterNodeBatchShrinkConfig_basic_step2(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rNameWithShrink, "cluster_id"),
+					resource.TestCheckResourceAttrSet(rNameWithShrink, "node_group_name"),
+					resource.TestCheckResourceAttr(rNameWithShrink, "node_count", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterNodeBatchShrinkConfig_basic_step1() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_mapreduce_cluster_node_batch_expand" "test" {
+  cluster_id      = "%[1]s"
+  node_group_name = "%[2]s"
+  node_count      = 2
+}
+`, acceptance.HW_MRS_CLUSTER_ID, acceptance.HW_MRS_CLUSTER_NODE_GROUP_NAME)
+}
+
+func testAccClusterNodeBatchShrinkConfig_basic_step2() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_mapreduce_cluster_node_batch_shrink" "test" {
+  cluster_id      = "%[1]s"
+  node_group_name = "%[2]s"
+  node_count      = 2
+}
+`, acceptance.HW_MRS_CLUSTER_ID, acceptance.HW_MRS_CLUSTER_NODE_GROUP_NAME)
+}

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster_node_batch_expand.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster_node_batch_expand.go
@@ -1,0 +1,191 @@
+package mrs
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var clusterNodeBatchExpandNonUpdatableParams = []string{
+	"cluster_id",
+	"node_group_name",
+	"node_count",
+	"skip_bootstrap_scripts",
+	"scale_without_start",
+}
+
+// @API MRS POST /v2/{project_id}/clusters/{cluster_id}/expand
+// @API MRS GET /v1.1/{project_id}/cluster_infos/{cluster_id}
+func ResourceClusterNodeBatchExpand() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceClusterNodeBatchExpandCreate,
+		ReadContext:   resourceClusterNodeBatchExpandRead,
+		UpdateContext: resourceClusterNodeBatchExpandUpdate,
+		DeleteContext: resourceClusterNodeBatchExpandDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(clusterNodeBatchExpandNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the MRS cluster is located.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster to which the nodes to be expanded belong.`,
+			},
+			"node_group_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the node group to which the nodes to be expanded belong.`,
+			},
+			"node_count": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The number of nodes to be expanded.`,
+			},
+			"skip_bootstrap_scripts": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to skip bootstrap scripts.`,
+			},
+			"scale_without_start": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to start the components on the node after it has been expanded.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildClusterNodeBatchExpandBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"node_group_name":     d.Get("node_group_name"),
+		"count":               d.Get("node_count"),
+		"scale_without_start": d.Get("scale_without_start"),
+	}
+
+	skipBootstrapScripts := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "skip_bootstrap_scripts")
+	if skipBootstrapScripts != nil {
+		bodyParams["skip_bootstrap_scripts"] = skipBootstrapScripts.(bool)
+	}
+
+	return bodyParams
+}
+
+func resourceClusterNodeBatchExpandCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v2/{project_id}/clusters/{cluster_id}/expand"
+		clusterId = d.Get("cluster_id").(string)
+	)
+
+	// Lock the resource to prevent concurrent.
+	config.MutexKV.Lock(clusterId)
+	defer config.MutexKV.Unlock(clusterId)
+
+	client, err := cfg.NewServiceClient("mrs", region)
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	expandPath := client.Endpoint + httpUrl
+	expandPath = strings.ReplaceAll(expandPath, "{project_id}", client.ProjectID)
+	expandPath = strings.ReplaceAll(expandPath, "{cluster_id}", clusterId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
+		JSONBody: buildClusterNodeBatchExpandBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", expandPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error expanding nodes for the cluster (%s): %s", clusterId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate resource ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	orderId := utils.PathSearch("order_id", respBody, "").(string)
+	if orderId != "" {
+		bssClient, err := cfg.NewServiceClient("bssv2", cfg.GetRegion(d))
+		if err != nil {
+			return diag.Errorf("error creating BSS client: %s", err)
+		}
+
+		// The expand nodes interface does not support auto-payment, so the CBC side interface is called to pay for the order.
+		if err := cbc.PaySubscriptionOrder(bssClient, orderId); err != nil {
+			return diag.Errorf("error paying for expansion order (%s) of cluster (%s): %s", orderId, clusterId, err)
+		}
+
+		if err := common.WaitOrderComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// The order for scaling nodes is not a primary resource, therefore the `common.WaitOrderResourceComplete` method cannot be used.
+	err = waitForClusterStatusCompleted(ctx, client, clusterId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the cluster expansion to complete: %s", err)
+	}
+
+	return nil
+}
+
+func resourceClusterNodeBatchExpandRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceClusterNodeBatchExpandUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceClusterNodeBatchExpandDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for batch expanding the nodes of the cluster. Deleting this resource
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster_node_batch_shrink.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster_node_batch_shrink.go
@@ -1,0 +1,155 @@
+package mrs
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var clusterNodeBatchShrinkNonUpdatableParams = []string{
+	"cluster_id",
+	"node_group_name",
+	"node_count",
+	"resource_ids",
+}
+
+// @API MRS POST /v2/{project_id}/clusters/{cluster_id}/shrink
+// @API MRS GET /v1.1/{project_id}/cluster_infos/{cluster_id}
+func ResourceClusterNodeBatchShrink() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceClusterNodeBatchShrinkCreate,
+		ReadContext:   resourceClusterNodeBatchShrinkRead,
+		UpdateContext: resourceClusterNodeBatchShrinkUpdate,
+		DeleteContext: resourceClusterNodeBatchShrinkDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(clusterNodeBatchShrinkNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the MRS cluster is located.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster to be shrunk.`,
+			},
+			"node_group_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the node group to which the nodes to be shrunk belong.`,
+			},
+			"node_count": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Description:   `The number of nodes to be deleted from the node group.`,
+				ConflictsWith: []string{"resource_ids"},
+			},
+			"resource_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The ID list of resource nodes to be deleted.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildClusterNodeBatchShrinkBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"node_group_name": d.Get("node_group_name").(string),
+		"count":           utils.ValueIgnoreEmpty(d.Get("node_count")),
+		"resource_ids":    utils.ValueIgnoreEmpty(d.Get("resource_ids")),
+	}
+}
+
+func resourceClusterNodeBatchShrinkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v2/{project_id}/clusters/{cluster_id}/shrink"
+		clusterId = d.Get("cluster_id").(string)
+	)
+
+	// Lock the resource to prevent concurrent.
+	config.MutexKV.Lock(clusterId)
+	defer config.MutexKV.Unlock(clusterId)
+
+	client, err := cfg.NewServiceClient("mrs", region)
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	shrinkPath := client.Endpoint + httpUrl
+	shrinkPath = strings.ReplaceAll(shrinkPath, "{project_id}", client.ProjectID)
+	shrinkPath = strings.ReplaceAll(shrinkPath, "{cluster_id}", clusterId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
+		JSONBody: utils.RemoveNil(buildClusterNodeBatchShrinkBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", shrinkPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error shrinking nodes for the cluster (%s): %s", clusterId, err)
+	}
+
+	err = waitForClusterStatusCompleted(ctx, client, clusterId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the cluster shrink to complete: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate resource ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	return nil
+}
+
+func resourceClusterNodeBatchShrinkRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceClusterNodeBatchShrinkUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceClusterNodeBatchShrinkDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for batch shrinking the nodes of the cluster. Deleting this resource
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new one-time resources to expand and shrink nodes.
   + huaweicloud_mapreduce_cluster_node_batch_expand
   + huaweicloud_mapreduce_cluster_node_batch_shrink

Add environment variables `HW_MRS_CLUSTER_ID` and `HW_MRS_CLUSTER_NODE_GROUP_NAME`, and `HW_MRS_CLUSTER_NODE_GROUP_NAME` must be a subset of `HW_MRS_CLUSTER_ID`.



**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add two one-time resources.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o mrs -f TestAccClusterNodeBatchShrink_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccClusterNodeBatchShrink_basic -timeout 360m -parallel 10
=== RUN   TestAccClusterNodeBatchShrink_basic
=== PAUSE TestAccClusterNodeBatchShrink_basic
=== CONT  TestAccClusterNodeBatchShrink_basic
--- PASS: TestAccClusterNodeBatchShrink_basic (619.03s)
PASS
coverage: 10.0% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       619.110s        coverage: 10.0% of statements in ./huaweicloud/services/mrs
```
<img width="1181" height="343" alt="image" src="https://github.com/user-attachments/assets/4b612869-e101-4184-b09e-b7586d67e8e3" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
