### PR TITLE
feat(EPS): add eps data source add fix resource

### DIFF
--- a/docs/data-sources/enterprise_project_services.md
+++ b/docs/data-sources/enterprise_project_services.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Enterprise Project Management Service (EPS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_enterprise_project_services"
+description: |-
+  Use this data source to get the services supported by EPS within HuaweiCloud.
+---
+
+# huaweicloud_enterprise_project_services
+
+Use this data source to get the services supported by EPS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_enterprise_project_services" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `locale` - (Optional, String) Specifies the display language.
+
+* `service` - (Optional, String) Specifies the cloud service name.  
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `services` - Indicates the cloud services.
+  The [service](#service) structure is documented below.
+
+<a name="service"></a>
+The `service` block supports:
+
+* `service` - Indicates the cloud service name.
+
+* `service_i18n_display_name` - Indicates the display name of the cloud service. You can set the language by setting the
+  locale parameter.
+
+* `resource_types` - Indicates the resource type list.
+  The [resource type](#resource_type) structure is documented below.
+
+<a name="resource_type"></a>
+The `resource type` block supports:
+
+* `resource_type` - Indicates the name of the resource type.
+
+* `resource_type_i18n_display_name` - Indicates the display name of the resource type. You can set the language by
+  setting the locale parameter.
+
+* `global` - Specifies whether the resource is a global resource.
+
+* `regions` - Indicates regions supported.

--- a/docs/resources/enterprise_project.md
+++ b/docs/resources/enterprise_project.md
@@ -38,6 +38,9 @@ resource "huaweicloud_enterprise_project" "test" {
 * `skip_disable_on_destroy` - (Optional, Bool) Specifies whether to skip disable the enterprise project on destroy.
   Defaults to **false**.
 
+* `delete_flag` - (Optional, Bool) Specifies whether to delete enterprise project.
+  Defaults to **false**.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -66,4 +69,22 @@ Enterprise projects can be imported using their `id`, e.g.
 
 ```bash
 $ terraform import huaweicloud_enterprise_project.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `delete_flag`. It is generally
+recommended running **terraform plan** after importing an enterprise project. You can then decide if changes should be
+applied to the enterprise project, or the resource definition should be updated to align with the enterprise project.
+Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_enterprise_project" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      delete_flag
+    ]
+  }
+}
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1195,6 +1195,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_enterprise_project_migrate_record":       eps.DataSourceMigrateRecord(),
 			"huaweicloud_enterprise_project_resources_mapping":    eps.DataSourceResourcesMapping(),
 			"huaweicloud_enterprise_project_associated_resources": eps.DataSourceAssociatedResources(),
+			"huaweicloud_enterprise_project_services":             eps.DataSourceEpsServices(),
 
 			"huaweicloud_er_associations":       er.DataSourceAssociations(),
 			"huaweicloud_er_attachments":        er.DataSourceAttachments(),

--- a/huaweicloud/services/acceptance/eps/data_source_huaweicloud_enterprise_project_services_test.go
+++ b/huaweicloud/services/acceptance/eps/data_source_huaweicloud_enterprise_project_services_test.go
@@ -1,0 +1,61 @@
+package eps
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataEnterpriseProjectServices_basic(t *testing.T) {
+	all := "data.huaweicloud_enterprise_project_services.test"
+	dc := acceptance.InitDataSourceCheck(all)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataEnterpriseProjectServices_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(all, "services.#"),
+					resource.TestCheckResourceAttrSet(all, "services.0.service"),
+					resource.TestCheckResourceAttrSet(all, "services.0.service_i18n_display_name"),
+					resource.TestCheckResourceAttrSet(all, "services.0.resource_types.#"),
+					resource.TestCheckResourceAttrSet(all, "services.0.resource_types.0.resource_type"),
+					resource.TestCheckResourceAttrSet(all, "services.0.resource_types.0.resource_type_i18n_display_name"),
+					resource.TestCheckResourceAttrSet(all, "services.0.resource_types.0.regions.#"),
+					resource.TestCheckOutput("huaweicloud_enterprise_project_services", "true"),
+					resource.TestCheckOutput("huaweicloud_enterprise_project_services_locale", "true"),
+					resource.TestCheckOutput("huaweicloud_enterprise_project_services_service", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataEnterpriseProjectServices_basic = `
+data "huaweicloud_enterprise_project_services" "test" {}
+
+output "huaweicloud_enterprise_project_services" {
+  value = length(data.huaweicloud_enterprise_project_services.test.services) > 0
+}
+
+data "huaweicloud_enterprise_project_services" "test_locale" {
+  locale  = "en-us"
+}
+
+output "huaweicloud_enterprise_project_services_locale" {
+  value = length(data.huaweicloud_enterprise_project_services.test_locale.services) > 0
+}
+
+data "huaweicloud_enterprise_project_services" "test_service" {
+  service  = "vpc"
+}
+
+output "huaweicloud_enterprise_project_services_service" {
+  value = length(data.huaweicloud_enterprise_project_services.test_service.services) > 0
+}
+`

--- a/huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_test.go
+++ b/huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_test.go
@@ -60,9 +60,47 @@ func TestAccEnterpriseProject_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_flag"},
+			},
+		},
+	})
+}
+
+func TestAccEnterpriseProject_delete(t *testing.T) {
+	var project enterpriseprojects.Project
+	deleteName := acceptance.RandomAccResourceName() + "delete"
+	resourceDeleteName := "huaweicloud_enterprise_project.test_delete"
+
+	rc_delete := acceptance.InitResourceCheck(
+		resourceDeleteName,
+		&project,
+		getResourceEnterpriseProject,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckEnterpriseProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnterpriseProject_delete(deleteName),
+				Check: resource.ComposeTestCheckFunc(
+					rc_delete.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceDeleteName, "name", deleteName),
+					resource.TestCheckResourceAttr(resourceDeleteName, "description", "terraform test delete"),
+					resource.TestCheckResourceAttr(resourceDeleteName, "status", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceDeleteName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_flag"},
 			},
 		},
 	})
@@ -104,5 +142,14 @@ func testAccEnterpriseProject_update(rName string) string {
 resource "huaweicloud_enterprise_project" "test" {
   name        = "%s"
   description = "terraform test update"
+}`, rName)
+}
+
+func testAccEnterpriseProject_delete(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_enterprise_project" "test_delete" {
+  name        = "%s"
+  description = "terraform test delete"
+  delete_flag = true
 }`, rName)
 }

--- a/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project_configs.go
+++ b/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project_configs.go
@@ -14,7 +14,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API EPS GET /v1.0/enterprise-projects/configs
+// @API EPS GET /v1/enterprise-projects/configs
 func DataSourceConfigs() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceConfigsRead,

--- a/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project_services.go
+++ b/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project_services.go
@@ -1,0 +1,184 @@
+package eps
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EPS GET /v1.0/enterprise-projects/providers
+func DataSourceEpsServices() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEpsServicesRead,
+
+		Schema: map[string]*schema.Schema{
+			"locale": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"service": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Attributes.
+			"services": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"service": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_i18n_display_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"resource_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"resource_type_i18n_display_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"global": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"regions": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceEpsServicesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("eps", region)
+	if err != nil {
+		return diag.Errorf("error creating EPS client: %s", err)
+	}
+
+	listPathBase := client.Endpoint + buildEpsServicesQueryParameter(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	res := make([]interface{}, 0)
+	offset := ""
+	for {
+		listPath := listPathBase + buildEpsServicesOffsetPath(offset)
+		getResp, err := client.Request("GET", listPath, &opt)
+		if err != nil {
+			return diag.Errorf("error retrieving EPS services: %s", err)
+		}
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		res = append(res, flattenListEpsServicesResponseBody(getRespBody)...)
+		offset = utils.PathSearch("offset", getRespBody, "").(string)
+		if offset == "" {
+			break
+		}
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("services", res),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildEpsServicesQueryParameter(d *schema.ResourceData) string {
+	httpUrl := "v1.0/enterprise-projects/providers?limit=200"
+
+	if d.Get("locale") != "" {
+		httpUrl += fmt.Sprintf("&locale=%s", d.Get("locale"))
+	}
+
+	if d.Get("service") != "" {
+		httpUrl += fmt.Sprintf("&provider=%s", d.Get("service"))
+	}
+
+	return httpUrl
+}
+
+func buildEpsServicesOffsetPath(offset string) string {
+	res := ""
+	if offset != "" {
+		res += fmt.Sprintf("&offset=%s", offset)
+	}
+	return res
+}
+
+func flattenListEpsServicesResponseBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("providers", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	res := make([]interface{}, 0)
+	for _, v := range curArray {
+		res = append(res, map[string]interface{}{
+			"service":                   utils.PathSearch("provider", v, nil),
+			"service_i18n_display_name": utils.PathSearch("provider_i18n_display_name", v, nil),
+			"resource_types":            flattenResourceTypeBody(utils.PathSearch("resource_types", v, nil)),
+		})
+	}
+	return res
+}
+
+func flattenResourceTypeBody(resourceTypeBody interface{}) []interface{} {
+	if resourceTypeBody == nil {
+		return nil
+	}
+	resourceTypeArray := resourceTypeBody.([]interface{})
+	res := make([]interface{}, 0)
+	for _, v := range resourceTypeArray {
+		res = append(res, map[string]interface{}{
+			"resource_type":                   utils.PathSearch("resource_type", v, nil),
+			"resource_type_i18n_display_name": utils.PathSearch("resource_type_i18n_display_name", v, nil),
+			"global":                          utils.PathSearch("global", v, nil),
+			"regions":                         utils.PathSearch("regions", v, nil),
+		})
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add eps data source add fix resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add eps data source add fix resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
