### PR TITLE
chore(workspace/app): add waitFor logic for operation servers

### DIFF
--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_action_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_action_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccAppServerAction_changeImage(t *testing.T) {
+func TestAccAppServerAction_basic(t *testing.T) {
 	var (
-		resourceName = "huaweicloud_workspace_app_server_action.test"
-		name         = acceptance.RandomAccResourceName()
+		name = acceptance.RandomAccResourceName()
+
+		changeImageRName = "huaweicloud_workspace_app_server_action.changeImage"
+		reinstallRName   = "huaweicloud_workspace_app_server_action.reinstall"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -29,7 +31,13 @@ func TestAccAppServerAction_changeImage(t *testing.T) {
 			{
 				Config: testAccAppServerAction_changeImage(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "type", "change-image"),
+					resource.TestCheckResourceAttr(changeImageRName, "type", "change-image"),
+				),
+			},
+			{
+				Config: testAccAppServerAction_reinstall(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(reinstallRName, "type", "reinstall"),
 				),
 			},
 		},
@@ -79,7 +87,7 @@ variable "image_product_id" {
   default = "%[2]s"
 }
 
-resource "huaweicloud_workspace_app_server_action" "test" {
+resource "huaweicloud_workspace_app_server_action" "changeImage" {
   type      = "change-image"
   server_id = huaweicloud_workspace_app_server.test.id
   content   = jsonencode({
@@ -91,47 +99,17 @@ resource "huaweicloud_workspace_app_server_action" "test" {
   })
 
   max_retries = 3
-
-  provisioner "local-exec" {
-    command = "sleep 600"
-  }
 }
 `, testAccAppServerAction_base(name),
 		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_PRODUCT_ID,
 		acceptance.HW_WORKSPACE_APP_SERVER_GROUP_IMAGE_ID)
 }
 
-func TestAccAppServerAction_reinstall(t *testing.T) {
-	var (
-		resourceName = "huaweicloud_workspace_app_server_action.test"
-		name         = acceptance.RandomAccResourceName()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		// This resource is a one-time action resource and there is no logic in the delete method.
-		// lintignore:AT001
-		CheckDestroy: nil,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAppServerAction_reinstall(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "type", "reinstall"),
-				),
-			},
-		},
-	})
-}
-
 func testAccAppServerAction_reinstall(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_workspace_app_server_action" "test" {
+resource "huaweicloud_workspace_app_server_action" "reinstall" {
   type      = "reinstall"
   server_id = huaweicloud_workspace_app_server.test.id
   content   = jsonencode({
@@ -139,10 +117,6 @@ resource "huaweicloud_workspace_app_server_action" "test" {
   })
 
   max_retries = 3
-
-  provisioner "local-exec" {
-    command = "sleep 1200"
-  }
 }
 `, testAccAppServerAction_base(name))
 }

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_servers.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_app_servers.go
@@ -530,7 +530,7 @@ func buildAppServersQueryParams(d *schema.ResourceData) string {
 	return res
 }
 
-func listAppServers(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+func listAppServers(client *golangsdk.ServiceClient, queryParams ...string) ([]interface{}, error) {
 	var (
 		httpUrl  = "v1/{project_id}/app-servers?limit={limit}"
 		limit    = 100
@@ -542,7 +542,9 @@ func listAppServers(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]
 	listPath := client.Endpoint + httpUrl
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
-	listPath += buildAppServersQueryParams(d)
+	if len(queryParams) > 0 && queryParams[0] != "" {
+		listPath += queryParams[0]
+	}
 
 	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -755,7 +757,7 @@ func dataSourceAppServersRead(_ context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("error creating Workspace APP client: %s", err)
 	}
 
-	servers, err := listAppServers(client, d)
+	servers, err := listAppServers(client, buildAppServersQueryParams(d))
 	if err != nil {
 		return diag.Errorf("error getting app servers: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add asynchronous wait logic to the `huaweicloud_workspace_app_server_action` and `huaweicloud_workspace_app_server_batch_action` resources.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppServerBatchAction_batchRejoinDomain
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppServerBatchAction_batchRejoinDomain -timeout 360m -parallel 10
=== RUN   TestAccAppServerBatchAction_batchRejoinDomain
=== PAUSE TestAccAppServerBatchAction_batchRejoinDomain
=== CONT  TestAccAppServerBatchAction_batchRejoinDomain
--- PASS: TestAccAppServerBatchAction_batchRejoinDomain (759.31s)
PASS
coverage: 5.6% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 759.443s        coverage: 5.6% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccAppServerBatchAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppServerBatchAction_basic -timeout 360m -parallel 10
=== RUN   TestAccAppServerBatchAction_basic
=== PAUSE TestAccAppServerBatchAction_basic
=== CONT  TestAccAppServerBatchAction_basic
--- PASS: TestAccAppServerBatchAction_basic (1642.75s)
PASS
coverage: 6.0% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1642.885s       coverage: 6.0% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccAppServerAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppServerAction_basic -timeout 360m -parallel 10
=== RUN   TestAccAppServerAction_basic
=== PAUSE TestAccAppServerAction_basic
=== CONT  TestAccAppServerAction_basic
--- PASS: TestAccAppServerAction_basic (956.79s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 956.913s        coverage: 4.1% of statements in ./huaweicloud/services/workspace
```
```
./scripts/coverage.sh -o workspace -f TestAccAppServers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppServers_basic -timeout 360m -parallel 10

=== RUN   TestAccAppServers_basic
=== PAUSE TestAccAppServers_basic
=== CONT  TestAccAppServers_basic
--- PASS: TestAccAppServers_basic (717.71s)
PASS
coverage: 5.7% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 718.345s        coverage: 5.7% of statements in ./huaweicloud/services/workspace
```
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
