### PR TITLE
feat(examples/dew): add a best practice for KMS key

### DIFF
--- a/examples/dew/kms-key/README.md
+++ b/examples/dew/kms-key/README.md
@@ -1,0 +1,81 @@
+# Create a KMS key
+
+This example provides best practice code for using Terraform to create a KMS key in HuaweiCloud.
+
+## Prerequisites
+
+* A HuaweiCloud account
+* Terraform installed
+* HuaweiCloud access key and secret key (AK/SK)
+
+## Variables Introduction
+
+The following variables need to be configured:
+
+### Authentication Variables
+
+* `region_name` - The region where the KMS key is located
+* `access_key` - The access key of the IAM user
+* `secret_key` - The secret key of the IAM user
+
+### Resource Variables
+
+#### Required Variables
+
+* `key_name` - The alias name of the KMS key
+
+#### Optional Variables
+
+* `key_algorithm` - The generation algorithm of the KMS key (default: "AES_256")
+* `key_usage` - The usage of the KMS key (default: "ENCRYPT_DECRYPT")
+* `key_source` - The source of the KMS key (default: "kms")
+* `key_description` - The description of the KMS key (default: "")
+* `enterprise_project_id` - The ID of the enterprise project to which the KMS key belongs (default: null)
+* `key_tags` - The key/value pairs to associate with the KMS key (default: {})
+* `key_schedule_time` - The number of days after which the KMS key is scheduled to be deleted (default: "7")
+  The valid value rangs from `7` to `1,096`
+
+## Usage
+
+* Copy this example script to your `main.tf`.
+
+* Create a `terraform.tfvars` file and fill in the required variables:
+
+  ```hcl
+  key_name = "tf_test_Key"
+  ```
+
+* Initialize Terraform:
+
+  ```bash
+  $ terraform init
+  ```
+
+* Review the Terraform plan:
+
+  ```bash
+  $ terraform plan
+  ```
+
+* Apply the configuration:
+
+  ```bash
+  $ terraform apply
+  ```
+
+* To clean up the resources:
+
+  ```bash
+  $ terraform destroy
+  ```
+
+## Note
+
+* Make sure to keep your credentials secure and never commit them to version control
+
+## Requirements
+
+| Name | Version |
+| ---- | ---- |
+| terraform | >= 0.14.0 |
+| huaweicloud | >= 1.64.3 |

--- a/examples/dew/kms-key/main.tf
+++ b/examples/dew/kms-key/main.tf
@@ -1,0 +1,10 @@
+resource "huaweicloud_kms_key" "test" {
+  key_alias             = var.key_name
+  key_algorithm         = var.key_algorithm
+  key_usage             = var.key_usage
+  origin                = var.key_source
+  key_description       = var.key_description
+  enterprise_project_id = var.enterprise_project_id
+  tags                  = var.key_tags
+  pending_days          = var.key_schedule_time
+}

--- a/examples/dew/kms-key/providers.tf
+++ b/examples/dew/kms-key/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.64.3"
+    }
+  }
+}
+
+provider "huaweicloud" {
+  region     = var.region_name
+  access_key = var.access_key
+  secret_key = var.secret_key
+}

--- a/examples/dew/kms-key/terraform.tfvars
+++ b/examples/dew/kms-key/terraform.tfvars
@@ -1,0 +1,6 @@
+key_name              = "tf_test_key"
+key_description       = "This is a KMS key created by Terraform"
+enterprise_project_id = "0"
+key_tags              = {
+  owner = "terraform"
+}

--- a/examples/dew/kms-key/variables.tf
+++ b/examples/dew/kms-key/variables.tf
@@ -1,0 +1,65 @@
+# Variable definitions for authentication
+variable "region_name" {
+  description = "The region where the KMS key is located"
+  type        = string
+}
+
+variable "access_key" {
+  description = "The access key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+variable "secret_key" {
+  description = "The secret key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+# Variable definitions for resources
+variable "key_name" {
+  description = "The alias name of the KMS key"
+  type        = string
+}
+
+variable "key_algorithm" {
+  description = "The generation algorithm of the KMS key"
+  type        = string
+  default     = "AES_256"
+}
+
+variable "key_usage" {
+  description = "The usage of the KMS key"
+  type        = string
+  default     = "ENCRYPT_DECRYPT"
+}
+
+variable "key_source" {
+  description = "The source of the KMS key"
+  type        = string
+  default     = "kms"
+}
+
+variable "key_description" {
+  description = "The description of the KMS key"
+  type        = string
+  default     = ""
+}
+
+variable "enterprise_project_id" {
+  description = "The ID of the enterprise project to which the KMS key belongs"
+  type        = string
+  default     = null
+}
+
+variable "key_tags" {
+  description = "The key/value pairs to associate with the KMS key"
+  type        = map(string)
+  default     = {}
+}
+
+variable "key_schedule_time" {
+  description = "The number of days after which the KMS key is scheduled to be deleted"
+  type        = string
+  default     = "7"
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a best practice for KMS key.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
<img width="872" height="879" alt="init" src="https://github.com/user-attachments/assets/e41de7cd-045a-460f-a67b-4daa81995b94" />
<img width="970" height="802" alt="apply" src="https://github.com/user-attachments/assets/ff53905c-bfcb-4a14-85ac-5b3d859baa00" />
<img width="1652" height="98" alt="result" src="https://github.com/user-attachments/assets/02aaa048-bd2d-4c7c-be31-7234b376a467" />

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
