### PR TITLE
feat(iam): add new resource to attach policy to user

### DIFF
--- a/docs/resources/identityv5_policy_user_attach.md
+++ b/docs/resources/identityv5_policy_user_attach.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_identityv5_policy_user_attach"
+description: |-
+  Use this resource to attach an identity policy to an IAM user within HuaweiCloud.
+---
+
+# huaweicloud_identityv5_policy_user_attach
+
+Use this resource to attach an identity policy to an IAM user within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "policy_id" {}
+variable "user_id" {}
+
+resource "huaweicloud_identityv5_policy_user_attach" "test" {
+  policy_id = var.policy_id
+  user_id   = var.user_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, String, NonUpdatable) Specifies the ID of the identity policy to be attached.
+
+* `user_id` - (Required, String, NonUpdatable) Specifies the ID of the IAM user associated with the identity policy.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `policy_name` - The name of the identity policy associated with the user.
+
+* `urn` - The URN of the attached identity policy.
+
+* `attached_at` - The time when the identity policy was attached to the user, in RFC3339 format.
+
+## Import
+
+The resource can be imported using the `policy_id` and `user_id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_identityv5_policy_user_attach.test <policy_id>/<user_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3305,6 +3305,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identityv5_password_policy":             iam.ResourceIdentityV5PasswordPolicy(),
 			"huaweicloud_identityv5_policy_default_version":      iam.ResourceIamV5PolicyDefaultVersion(),
 			"huaweicloud_identityv5_policy_group_attach":         iam.ResourceIdentityV5PolicyGroupAttach(),
+			"huaweicloud_identityv5_policy_user_attach":          iam.ResourceIdentityV5PolicyUserAttach(),
 			"huaweicloud_identityv5_virtual_mfa_device":          iam.ResourceIdentityV5VirtualMFADevice(),
 			"huaweicloud_identityv5_group":                       iam.ResourceIdentityV5Group(),
 			"huaweicloud_identityv5_group_membership":            iam.ResourceIdentityV5GroupMembership(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_policy_user_attach_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_policy_user_attach_test.go
@@ -1,0 +1,105 @@
+package iam
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
+)
+
+func getIdentityV5PolicyUserAttachResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("iam", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IAM client: %s", err)
+	}
+
+	return iam.GetUserAttachedIdentityV5Policy(client, state.Primary.Attributes["user_id"], state.Primary.Attributes["policy_id"])
+}
+
+func TestAccIdentityV5PolicyUserAttach_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_identityv5_policy_user_attach.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getIdentityV5PolicyUserAttachResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckUserId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityV5PolicyUserAttach_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "policy_id", "huaweicloud_identity_policy.test", "id"),
+					resource.TestCheckResourceAttr(rName, "user_id", acceptance.HW_USER_ID),
+					resource.TestCheckResourceAttrPair(rName, "policy_name", "huaweicloud_identity_policy.test", "name"),
+					resource.TestCheckResourceAttrPair(rName, "urn", "huaweicloud_identity_policy.test", "urn"),
+					resource.TestMatchResourceAttr(rName, "attached_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccIdentityV5PolicyUserAttachImportState(rName),
+			},
+		},
+	})
+}
+
+func testAccIdentityV5PolicyUserAttach_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_policy" "test" {
+  name            = "%[1]s"
+  description     = "test policy for terraform"
+  policy_document = jsonencode(
+    {
+      Statement = [
+        {
+          Action = ["*"]
+          Effect = "Allow"
+        }
+      ]
+      Version = "5.0"
+    }
+  )
+}
+
+resource "huaweicloud_identityv5_policy_user_attach" "test" {
+  policy_id = huaweicloud_identity_policy.test.id
+  user_id   = "%[2]s"
+}
+`, name, acceptance.HW_USER_ID)
+}
+
+func testAccIdentityV5PolicyUserAttachImportState(rName string) resource.ImportStateIdFunc {
+	return func(state *terraform.State) (string, error) {
+		rs, ok := state.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		policyId := rs.Primary.Attributes["policy_id"]
+		userId := rs.Primary.Attributes["user_id"]
+		if policyId == "" || userId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<policy_id>/<user_id>', but got '%s/%s'",
+				policyId, userId)
+		}
+
+		return fmt.Sprintf("%s/%s", policyId, userId), nil
+	}
+}

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy_user_attach.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy_user_attach.go
@@ -1,0 +1,225 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var policyV5UserAttachNonUpdatableParams = []string{"policy_id", "user_id"}
+
+// @API IAM POST /v5/policies/{policy_id}/attach-user
+// @API IAM POST /v5/policies/{policy_id}/detach-user
+// @API IAM GET /v5/users/{user_id}/attached-policies
+func ResourceIdentityV5PolicyUserAttach() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIdentityV5PolicyUserAttachCreate,
+		ReadContext:   resourceIdentityV5PolicyUserAttachRead,
+		UpdateContext: resourceIdentityV5PolicyUserAttachUpdate,
+		DeleteContext: resourceIdentityV5PolicyUserAttachDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceIdentityV5PolicyUserAttachImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(policyV5UserAttachNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the identity policy to be attached.`,
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the IAM user associated with the identity policy.`,
+			},
+			"policy_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the identity policy associated with the user.`,
+			},
+			"urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URN of the attached identity policy.`,
+			},
+			"attached_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the identity policy was attached to the user, in RFC3339 format.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceIdentityV5PolicyUserAttachCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		userId   = d.Get("user_id").(string)
+		policyId = d.Get("policy_id").(string)
+		httpUrl  = "v5/policies/{policy_id}/attach-user"
+	)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{policy_id}", policyId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"user_id": userId,
+		},
+	}
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error attaching policy(%s) to the specified user(%s): %s", policyId, userId, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", policyId, userId))
+
+	return resourceIdentityV5PolicyUserAttachRead(ctx, d, meta)
+}
+
+func GetUserAttachedIdentityV5Policy(client *golangsdk.ServiceClient, userId, policyId string) (interface{}, error) {
+	httpUrl := "v5/users/{user_id}/attached-policies"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{user_id}", userId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	marker := ""
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s&marker=%s", listPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", listPathWithMarker, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		policy := utils.PathSearch(fmt.Sprintf("attached_policies[?policy_id=='%s']|[0]", policyId), respBody, nil)
+		if policy != nil {
+			return policy, nil
+		}
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/v5/users/{user_id}/attached-policies",
+			RequestId: "NONE",
+			Body:      []byte(fmt.Sprintf("the policy (%s) associated with the user (%s) does not exist", policyId, userId)),
+		},
+	}
+}
+
+func resourceIdentityV5PolicyUserAttachRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		userId   = d.Get("user_id").(string)
+		policyId = d.Get("policy_id").(string)
+	)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	policy, err := GetUserAttachedIdentityV5Policy(client, userId, policyId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving policy associated with user")
+	}
+
+	mErr := multierror.Append(
+		d.Set("policy_name", utils.PathSearch("policy_name", policy, nil)),
+		d.Set("urn", utils.PathSearch("urn", policy, nil)),
+		d.Set("attached_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("attached_at",
+			policy, "").(string))/1000, false)),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceIdentityV5PolicyUserAttachUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceIdentityV5PolicyUserAttachDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		userId   = d.Get("user_id").(string)
+		policyId = d.Get("policy_id").(string)
+		httpUrl  = "v5/policies/{policy_id}/detach-user"
+	)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{policy_id}", policyId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"user_id": userId,
+		},
+	}
+	_, err = client.Request("POST", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error detaching policy(%s) from user(%s)", policyId, userId))
+	}
+
+	return nil
+}
+
+func resourceIdentityV5PolicyUserAttachImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<policy_id>/<user_id>', but got '%s'", importedId)
+	}
+
+	mErr := multierror.Append(
+		d.Set("policy_id", parts[0]),
+		d.Set("user_id", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource (`huaweicloud_identity_policy_user_attach`) to attach a policy to the specified IAM user.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccIdentityV5PolicyUserAttach_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccIdentityV5PolicyUserAttach_basic -timeout 360m -parallel 10
=== RUN   TestAccIdentityV5PolicyUserAttach_basic
=== PAUSE TestAccIdentityV5PolicyUserAttach_basic
=== CONT  TestAccIdentityV5PolicyUserAttach_basic
--- PASS: TestAccIdentityV5PolicyUserAttach_basic (27.79s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       27.891s coverage: 4.3% of statements in ./huaweicloud/services/iam
```
<img width="994" height="513" alt="image" src="https://github.com/user-attachments/assets/aed1b603-1575-4837-a3ae-a02d385efc4f" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    The poliy ID does not exist.
    <img width="1818" height="883" alt="image" src="https://github.com/user-attachments/assets/70d9d52d-44c8-48c8-97ff-c3c4b8abb9ee" />

      ab. Related resources (parent resources) not found
     The user ID does not exist.
     <img width="1414" height="904" alt="image" src="https://github.com/user-attachments/assets/d4cf42e3-d05d-49d9-b55c-87fd27191bf3" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    The poliy ID does not exist.
    <img width="1479" height="822" alt="image" src="https://github.com/user-attachments/assets/82b995d4-566b-4df6-b43c-00600aeff9ff" />
   
    bb. Related resources (parent resources) not found
    The user ID does not exist.
    <img width="1490" height="883" alt="image" src="https://github.com/user-attachments/assets/6039d224-a199-437d-b969-bda21975d251" />
