### PR TITLE
feat(iam): add new resource to attach a policy to a user group

### DIFF
--- a/docs/resources/identityv5_policy_group_attach.md
+++ b/docs/resources/identityv5_policy_group_attach.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_identityv5_policy_group_attach"
+description: |-
+  Use this resource to attach an identity policy to an IAM user group within HuaweiCloud.
+---
+
+# huaweicloud_identityv5_policy_group_attach
+
+Use this resource to attach an identity policy to an IAM user group within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "policy_id" {}
+variable "group_id" {}
+
+resource "huaweicloud_identityv5_policy_group_attach" "test" {
+  policy_id = var.policy_id
+  group_id  = var.group_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, String, NonUpdatable) Specifies the ID of the identity policy to be attached.
+
+* `group_id` - (Required, String, NonUpdatable) Specifies the ID of the IAM user group associated with the identity policy.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `policy_name` - The name of the identity policy associated with the user group.
+
+* `urn` - The URN of the attached identity policy.
+
+* `attached_at` - The time when the identity policy was attached to the user group, in RFC3339 format.
+
+## Import
+
+The resource can be imported using the `policy_id` and `group_id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_identityv5_policy_group_attach.test <policy_id>/<group_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3303,6 +3303,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identityv5_login_policy":                iam.ResourceIdentityV5LoginPolicy(),
 			"huaweicloud_identityv5_password_policy":             iam.ResourceIdentityV5PasswordPolicy(),
 			"huaweicloud_identityv5_policy_default_version":      iam.ResourceIamV5PolicyDefaultVersion(),
+			"huaweicloud_identityv5_policy_group_attach":         iam.ResourceIdentityV5PolicyGroupAttach(),
 			"huaweicloud_identityv5_virtual_mfa_device":          iam.ResourceIdentityV5VirtualMFADevice(),
 			"huaweicloud_identityv5_group":                       iam.ResourceIdentityV5Group(),
 			"huaweicloud_identityv5_group_membership":            iam.ResourceIdentityV5GroupMembership(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_policy_group_attach_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_policy_group_attach_test.go
@@ -1,0 +1,107 @@
+package iam
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
+)
+
+func getIdentityV5PolicyGroupAttachResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("iam", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IAM client: %s", err)
+	}
+
+	return iam.GetGroupAttachedIdentityV5Policy(client, state.Primary.Attributes["group_id"], state.Primary.Attributes["policy_id"])
+}
+
+func TestAccIdentityV5PolicyGroupAttach_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_identityv5_policy_group_attach.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getIdentityV5PolicyGroupAttachResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityV5PolicyGroupAttach_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "policy_id", "huaweicloud_identity_policy.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "group_id", "huaweicloud_identityv5_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "policy_name", "huaweicloud_identity_policy.test", "name"),
+					resource.TestCheckResourceAttrSet(rName, "urn"),
+					resource.TestMatchResourceAttr(rName, "attached_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccIdentityV5PolicyGroupAttachImportState(rName),
+			},
+		},
+	})
+}
+
+func testAccIdentityV5PolicyGroupAttach_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_policy" "test" {
+  name            = "%[1]s"
+  policy_document = jsonencode(
+    {
+      Statement = [
+        {
+          Action = ["*"]
+          Effect = "Allow"
+        }
+      ]
+      Version = "5.0"
+    }
+  )
+}
+
+resource "huaweicloud_identityv5_group" "test" {
+  group_name = "%[1]s"
+}
+
+resource "huaweicloud_identityv5_policy_group_attach" "test" {
+  policy_id = huaweicloud_identity_policy.test.id
+  group_id  = huaweicloud_identityv5_group.test.id
+}
+`, rName)
+}
+
+func testAccIdentityV5PolicyGroupAttachImportState(rName string) resource.ImportStateIdFunc {
+	return func(state *terraform.State) (string, error) {
+		rs, ok := state.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		policyId := rs.Primary.Attributes["policy_id"]
+		groupId := rs.Primary.Attributes["group_id"]
+		if policyId == "" || groupId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<policy_id>/<group_id>', but got '%s/%s'",
+				policyId, groupId)
+		}
+
+		return fmt.Sprintf("%s/%s", policyId, groupId), nil
+	}
+}

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy_group_attach.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy_group_attach.go
@@ -1,0 +1,221 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var identityV5policyGroupAttachNonUpdatableParams = []string{"policy_id", "group_id"}
+
+// @API IAM POST /v5/policies/{policy_id}/attach-group
+// @API IAM POST /v5/policies/{policy_id}/detach-group
+// @API IAM GET /v5/groups/{group_id}/attached-policies
+func ResourceIdentityV5PolicyGroupAttach() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIdentityV5PolicyGroupAttachCreate,
+		ReadContext:   resourceIdentityV5PolicyGroupAttachRead,
+		UpdateContext: resourceIdentityV5PolicyGroupAttachUpdate,
+		DeleteContext: resourceIdentityV5PolicyGroupAttachDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceIdentityV5PolicyGroupAttachImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(identityV5policyGroupAttachNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the identity policy to be attached.`,
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the IAM user group associated with the identity policy.`,
+			},
+			"policy_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the identity policy associated with the user group.`,
+			},
+			"urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URN of the attached identity policy.`,
+			},
+			"attached_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the identity policy was attached to the user group, in RFC3339 format.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceIdentityV5PolicyGroupAttachCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		groupId  = d.Get("group_id").(string)
+		policyId = d.Get("policy_id").(string)
+		httpUrl  = "v5/policies/{policy_id}/attach-group"
+	)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{policy_id}", policyId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"group_id": groupId,
+		},
+	}
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error attaching policy(%s) to the specified user group(%s): %s", policyId, groupId, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", policyId, groupId))
+
+	return resourceIdentityV5PolicyGroupAttachRead(ctx, d, meta)
+}
+
+func GetGroupAttachedIdentityV5Policy(client *golangsdk.ServiceClient, groupId, policyId string) (interface{}, error) {
+	httpUrl := "v5/groups/{group_id}/attached-policies"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{group_id}", groupId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	marker := ""
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s?marker=%s", listPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", listPathWithMarker, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		policy := utils.PathSearch(fmt.Sprintf("attached_policies[?policy_id=='%s']|[0]", policyId), respBody, nil)
+		if policy != nil {
+			return policy, nil
+		}
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/v5/groups/{group_id}/attached-policies",
+			RequestId: "NONE",
+			Body:      []byte(fmt.Sprintf("the policy (%s) associated with the group (%s) does not exist", policyId, groupId)),
+		},
+	}
+}
+
+func resourceIdentityV5PolicyGroupAttachRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		groupId  = d.Get("group_id").(string)
+		policyId = d.Get("policy_id").(string)
+	)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	policy, err := GetGroupAttachedIdentityV5Policy(client, groupId, policyId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving policy associated with group")
+	}
+
+	mErr := multierror.Append(
+		d.Set("policy_name", utils.PathSearch("policy_name", policy, nil)),
+		d.Set("urn", utils.PathSearch("urn", policy, nil)),
+		d.Set("attached_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("attached_at",
+			policy, "").(string))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceIdentityV5PolicyGroupAttachUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceIdentityV5PolicyGroupAttachDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		groupId  = d.Get("group_id").(string)
+		policyId = d.Get("policy_id").(string)
+		httpUrl  = "v5/policies/{policy_id}/detach-group"
+	)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{policy_id}", policyId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"group_id": groupId,
+		},
+	}
+	_, err = client.Request("POST", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error detaching policy(%s) from group(%s)", policyId, groupId))
+	}
+
+	return nil
+}
+
+func resourceIdentityV5PolicyGroupAttachImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<policy_id>/<group_id>', but got '%s'", importedId)
+	}
+
+	mErr := multierror.Append(
+		d.Set("policy_id", parts[0]),
+		d.Set("group_id", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource(`huaweicloud_identityv5_policy_group_attach`) to attach policy to user group.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccIdentityV5PolicyGroupAttach_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccIdentityV5PolicyGroupAttach_basic -timeout 360m -parallel 10
=== RUN   TestAccIdentityV5PolicyGroupAttach_basic
=== PAUSE TestAccIdentityV5PolicyGroupAttach_basic
=== CONT  TestAccIdentityV5PolicyGroupAttach_basic
--- PASS: TestAccIdentityV5PolicyGroupAttach_basic (17.21s)
PASS
coverage: 5.0% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       17.325s coverage: 5.0% of statements in ./huaweicloud/services/iam
```
<img width="996" height="504" alt="image" src="https://github.com/user-attachments/assets/8980cfce-d076-462c-9617-8a82f69dd741" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    The policy does not exist.
    <img width="1469" height="904" alt="image" src="https://github.com/user-attachments/assets/cba05d1e-940e-4eff-b3f4-11ad1f0407df" />
    
    ab. Related resources (parent resources) not found
    The user group does not exist.
    <img width="1317" height="783" alt="image" src="https://github.com/user-attachments/assets/864f74bc-4c70-4537-aaf1-f2adf2d23038" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    The policy does not exist.
    <img width="1456" height="865" alt="image" src="https://github.com/user-attachments/assets/bdaf2c78-aeca-4aca-97a9-f20208f210f8" />

      bb. Related resources (parent resources) not found
     The user group does not exist.
    <img width="1547" height="912" alt="image" src="https://github.com/user-attachments/assets/8a1d4f57-137e-4d37-be6c-b3b14d7490ad" />

