### PR TITLE
feat(hss): support `hss_login_white_ip` resource

### DIFF
--- a/docs/resources/hss_login_white_ip.md
+++ b/docs/resources/hss_login_white_ip.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_login_white_ip"
+description: |-
+  Manages an HSS login white ip operation resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_login_white_ip
+
+Manages an HSS login white ip operation resource within HuaweiCloud.
+
+-> This resource is a one-time action resource using to operation HSS login white ip. Deleting this resource will not
+  clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "white_ip" {}
+variable "host_id_list" {
+  type = list(string)
+}
+
+resource "huaweicloud_hss_login_white_ip" "test" {
+  white_ip     = var.white_ip
+  host_id_list = var.host_id_list
+  enabled      = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `white_ip` - (Required, String, NonUpdatable) Specifies whitelist IP or IP network segment,
+  a single account can add up to `10` SSH login IP whitelist.
+
+* `host_id_list` - (Required, List, NonUpdatable) Specifies the list of host IDs. When deleting whitelist IPs or
+  IP segments, the server ID list needs to be set to an empty list.
+
+* `enabled` - (Optional, Bool, NonUpdatable) Specifies whitelist activation status.  
+  The valid values are as follows:
+  + **true**: Enabled.
+  + **false**: Disabled.
+
+  Defaults to **false**.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the hosts under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3238,6 +3238,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_event_login_white_list":                         hss.ResourceEventLoginWhiteList(),
 			"huaweicloud_hss_image_batch_scan":                               hss.ResourceImageBatchScan(),
 			"huaweicloud_hss_login_common_location":                          hss.ResourceLoginCommonLocation(),
+			"huaweicloud_hss_login_white_ip":                                 hss.ResourceLoginWhiteIp(),
 			"huaweicloud_hss_modify_webtamper_protection_policy":             hss.ResourceModifyWebtamperProtectionPolicy(),
 			"huaweicloud_hss_modify_webtamper_rasp_path":                     hss.ResourceModifyWebtamperRaspPath(),
 			"huaweicloud_hss_rasp_protection_policy":                         hss.ResourceRaspProtectionPolicy(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_login_white_ip_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_login_white_ip_test.go
@@ -1,0 +1,39 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccLoginWhiteIp_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID with host protection enabled,
+			// and the host is under the default enterprise project.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoginWhiteIp_basic(),
+			},
+		},
+	})
+}
+
+func testAccLoginWhiteIp_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_login_white_ip" "test" {
+  white_ip              = "192.168.0.0/16"
+  host_id_list          = ["%s"]
+  enabled               = true
+  enterprise_project_id = "0"
+}
+`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_login_white_ip.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_login_white_ip.go
@@ -1,0 +1,143 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS POST /v5/{project_id}/setting/login-white-ip
+func ResourceLoginWhiteIp() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceLoginWhiteIpCreate,
+		ReadContext:   resourceLoginWhiteIpRead,
+		UpdateContext: resourceLoginWhiteIpUpdate,
+		DeleteContext: resourceLoginWhiteIpDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"white_ip",
+			"host_id_list",
+			"enabled",
+			"enterprise_project_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"white_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"host_id_list": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildLoginWhiteIpQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	return ""
+}
+
+func buildLoginWhiteIpBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"white_ip":     d.Get("white_ip"),
+		"host_id_list": utils.ExpandToStringList(d.Get("host_id_list").([]interface{})),
+		"enabled":      d.Get("enabled"),
+	}
+
+	return bodyParams
+}
+
+func resourceLoginWhiteIpCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/setting/login-white-ip"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildLoginWhiteIpQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildLoginWhiteIpBodyParams(d),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error operating HSS login white ip: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return resourceLoginWhiteIpRead(ctx, d, meta)
+}
+
+func resourceLoginWhiteIpRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceLoginWhiteIpUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceLoginWhiteIpDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to operation HSS login white ip. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_login_white_ip` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_login_white_ip` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccLoginWhiteIp_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccLoginWhiteIp_basic -timeout 360m -parallel 4
=== RUN   TestAccLoginWhiteIp_basic
=== PAUSE TestAccLoginWhiteIp_basic
=== CONT  TestAccLoginWhiteIp_basic
--- PASS: TestAccLoginWhiteIp_basic (14.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       14.401s

```
<img width="836" height="29" alt="image" src="https://github.com/user-attachments/assets/d13464e5-0f69-455f-837b-db30e1ca09a3" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
