### PR TITLE
feat(waf): new resource to config dedicated agency

### DIFF
--- a/docs/resources/waf_dedicated_agency.md
+++ b/docs/resources/waf_dedicated_agency.md
@@ -1,0 +1,103 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_dedicated_agency"
+description: |-
+  Manages a WAF dedicated agency resource within HuaweiCloud.
+---
+
+# huaweicloud_waf_dedicated_agency
+
+Manages a WAF dedicated agency resource within HuaweiCloud.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+## Example Usage
+
+```hcl
+variable "role_name_list" {
+  type = list(string)
+}
+
+resource "huaweicloud_waf_dedicated_agency" "test" {
+  role_name_list = var.role_name_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `role_name_list` - (Required, List) Specifies the list of dedicated engine agent policy names to create.
+  Valid values are:
+  + **evs_to_waf_operate_policy**
+  + **vpc_to_waf_operate_policy**
+  + **ecs_to_waf_operate_policy**
+  + **elb_to_waf_operate_policy**
+
+* `purged` - (Optional, Bool) Specifies whether to delete delegates synchronously.
+  This field is valid only when destroying this resource. Defaults to **false**.
+  When `purged` is set to **true**, the `premium_waf_svc_trust` delegate created in IAM will be deleted synchronously.
+  When `purged` is set to **false**, the `premium_waf_svc_trust` delegate created in IAM will not be deleted synchronously.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (dedicated agency ID).
+
+* `name` - The agency name.
+
+* `version` - The version.
+
+* `duration` - The agent existence time period.
+
+* `domain_id` - The domain ID.
+
+* `is_valid` - Whether the agency is legal.
+
+* `role_list` - The list of dedicated engine agent policies.
+  The [role_list](#agency_role_list) structure is documented below.
+
+<a name="agency_role_list"></a>
+The `role_list` block supports:
+
+* `description` - The description.
+
+* `catalog` - The catalog.
+
+* `id` - The role ID.
+
+* `display_name` - The display name.
+
+* `is_granted` - Whether it is granted.
+
+## Import
+
+The resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_waf_dedicated_agency.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `role_name_list`, `purged`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_waf_dedicated_agency" "test" {
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      role_name_list,
+      purged,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3838,6 +3838,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_cc_protection_rule_batch_delete":     waf.ResourceCcRuleBatchDelete(),
 			"huaweicloud_waf_certificate":                         waf.ResourceWafCertificate(),
 			"huaweicloud_waf_cloud_instance":                      waf.ResourceCloudInstance(),
+			"huaweicloud_waf_dedicated_agency":                    waf.ResourceWafDedicatedAgency(),
 			"huaweicloud_waf_dedicated_domain":                    waf.ResourceWafDedicatedDomain(),
 			"huaweicloud_waf_dedicated_instance":                  waf.ResourceWafDedicatedInstance(),
 			"huaweicloud_waf_dedicated_instance_action":           waf.ResourceDedicatedInstanceAction(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_agency_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_agency_test.go
@@ -1,0 +1,93 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/waf"
+)
+
+func getDedicatedAgencyResourceFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "waf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating WAF client: %s", err)
+	}
+
+	return waf.QueryDedicatedAgency(client)
+}
+
+// Before running the test case, please ensure that there is at least one WAF instance in the current region.
+func TestAccDedicatedAgency_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_waf_dedicated_agency.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDedicatedAgencyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDedicatedAgency_basic,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "name"),
+					resource.TestCheckResourceAttrSet(rName, "version"),
+					resource.TestCheckResourceAttrSet(rName, "duration"),
+					resource.TestCheckResourceAttrSet(rName, "domain_id"),
+					resource.TestCheckResourceAttrSet(rName, "is_valid"),
+					resource.TestCheckResourceAttrSet(rName, "role_list.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "role_list.0.catalog"),
+					resource.TestCheckResourceAttrSet(rName, "role_list.0.display_name"),
+					resource.TestCheckResourceAttrSet(rName, "role_list.0.is_granted"),
+				),
+			},
+			{
+				Config: testDedicatedAgency_basic_update,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateVerifyIgnore: []string{
+					"role_name_list",
+					"purged",
+				},
+			},
+		},
+	})
+}
+
+const testDedicatedAgency_basic = `
+resource "huaweicloud_waf_dedicated_agency" "test" {
+  role_name_list = ["evs_to_waf_operate_policy", "vpc_to_waf_operate_policy", "ecs_to_waf_operate_policy"]
+  purged         = true
+}`
+
+const testDedicatedAgency_basic_update = `
+resource "huaweicloud_waf_dedicated_agency" "test" {
+  role_name_list = ["evs_to_waf_operate_policy"]
+  purged         = true
+}`

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_agency.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_agency.go
@@ -1,0 +1,296 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF POST /v1/{project_id}/premium-waf/agency
+// @API WAF DELETE /v1/{project_id}/premium-waf/agency
+// @API WAF GET /v1/{project_id}/premium-waf/agency
+func ResourceWafDedicatedAgency() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafDedicatedAgencyCreate,
+		ReadContext:   resourceWafDedicatedAgencyRead,
+		UpdateContext: resourceWafDedicatedAgencyUpdate,
+		DeleteContext: resourceWafDedicatedAgencyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+			// Field `role_name_list` is optional in API, make it required here.
+			// Field `role_name_list` is not exist in detail API response.
+			"role_name_list": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the list of dedicated engine agent policy names to create.`,
+			},
+			// Field `purged` only used in delete operation and not exist in API response.
+			"purged": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Specifies whether to delete delegates synchronously.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The agency name.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The version.`,
+			},
+			"duration": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The agent existence time period.`,
+			},
+			"domain_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain ID.`,
+			},
+			"is_valid": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the agency is legal.`,
+			},
+			// The `role_list` field does not exist in the API documentation, but it appears in the response body during
+			// actual testing. Use this field to determine if a `404` error has occurred.
+			"role_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description.`,
+						},
+						"catalog": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The catalog.`,
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The role ID.`,
+						},
+						"display_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The display name.`,
+						},
+						"is_granted": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether it is granted.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func configDedicatedAgency(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/premium-waf/agency"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: map[string]interface{}{
+			"role_name_list": d.Get("role_name_list"),
+		},
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceWafDedicatedAgencyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	respBody, err := configDedicatedAgency(client, d)
+	if err != nil {
+		return diag.Errorf("error creating WAF dedicated agency: %s", err)
+	}
+
+	id := utils.PathSearch("id", respBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating WAF dedicated agency: ID is not found in API response")
+	}
+	d.SetId(id)
+
+	return resourceWafDedicatedAgencyRead(ctx, d, meta)
+}
+
+func QueryDedicatedAgency(client *golangsdk.ServiceClient) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/premium-waf/agency"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	roleList := utils.PathSearch("role_list", respBody, make([]interface{}, 0)).([]interface{})
+	if len(roleList) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return respBody, nil
+}
+
+func resourceWafDedicatedAgencyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	respBody, err := QueryDedicatedAgency(client)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving WAF dedicated agency")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("version", utils.PathSearch("version", respBody, nil)),
+		d.Set("duration", utils.PathSearch("duration", respBody, nil)),
+		d.Set("domain_id", utils.PathSearch("domain_id", respBody, nil)),
+		d.Set("is_valid", utils.PathSearch("is_valid", respBody, nil)),
+		d.Set("role_list", flattenRoleListAttribute(utils.PathSearch("role_list", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRoleListAttribute(respArray []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"description":  utils.PathSearch("description", v, nil),
+			"catalog":      utils.PathSearch("catalog", v, nil),
+			"id":           utils.PathSearch("id", v, nil),
+			"display_name": utils.PathSearch("display_name", v, nil),
+			"is_granted":   utils.PathSearch("is_granted", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func resourceWafDedicatedAgencyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	if d.HasChange("role_name_list") {
+		_, err = configDedicatedAgency(client, d)
+		if err != nil {
+			return diag.Errorf("error updating WAF dedicated agency: %s", err)
+		}
+	}
+
+	return resourceWafDedicatedAgencyRead(ctx, d, meta)
+}
+
+func buildDeleteDedicatedAgencyQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?role_id_list=%s&purged=%v", d.Id(), d.Get("purged").(bool))
+}
+
+func resourceWafDedicatedAgencyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/premium-waf/agency"
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildDeleteDedicatedAgencyQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting WAF dedicated agency: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
new resource to config dedicated agency
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccDedicatedAgency_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccDedicatedAgency_basic -timeout 360m -parallel 10
=== RUN   TestAccDedicatedAgency_basic
=== PAUSE TestAccDedicatedAgency_basic
=== CONT  TestAccDedicatedAgency_basic
--- PASS: TestAccDedicatedAgency_basic (32.42s)
PASS
coverage: 4.4% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       32.527s coverage: 4.4% of statements in ./huaweicloud/services/waf
```
<img width="1322" height="83" alt="image" src="https://github.com/user-attachments/assets/69cbadd3-dfef-4ba3-b1f4-c7a4a44e0d38" />


* [X] Documentation updated.
* [X] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="960" height="288" alt="image" src="https://github.com/user-attachments/assets/ba1a8393-ba57-4042-b3ff-7c6c840a403e" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
