### PR TITLE
feat(iam): add a one-time resource to set the default version of the policy

### DIFF
--- a/docs/resources/identityv5_policy_default_version.md
+++ b/docs/resources/identityv5_policy_default_version.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_identityv5_policy_default_version"
+description: |-
+  Use this resource to set the default version of an identity policy within HuaweiCloud.
+---
+
+# huaweicloud_identityv5_policy_default_version
+
+Use this resource to set the default version of an identity policy within HuaweiCloud.
+
+-> This resource is a one-time action resource used to set the default version of an identity policy. Deleting this
+   resource will not clear the corresponding request record, but will only remove the resource information from the
+   tfstate file.
+
+## Example Usage
+
+```hcl
+variable "policy_id" {}
+variable "version_id" {}
+
+resource "huaweicloud_identityv5_policy_default_version" "test" {
+  policy_id  = var.policy_id
+  version_id = var.version_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, String, NonUpdatable) Specifies the ID of the identity policy.
+
+* `version_id` - (Required, String, NonUpdatable) Specifies the version ID of the identity policy to be set
+  as default.  
+  The value must be a string starting with `v` followed by a number, e.g. `v1`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3288,6 +3288,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identityv5_login_profile":               iam.ResourceIdentityV5LoginProfile(),
 			"huaweicloud_identityv5_login_policy":                iam.ResourceIdentityV5LoginPolicy(),
 			"huaweicloud_identityv5_password_policy":             iam.ResourceIdentityV5PasswordPolicy(),
+			"huaweicloud_identityv5_policy_default_version":      iam.ResourceIamV5PolicyDefaultVersion(),
 			"huaweicloud_identityv5_virtual_mfa_device":          iam.ResourceIdentityV5VirtualMFADevice(),
 			"huaweicloud_identityv5_group":                       iam.ResourceIdentityV5Group(),
 			"huaweicloud_identityv5_group_membership":            iam.ResourceIdentityV5GroupMembership(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_policy_default_version_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_policy_default_version_test.go
@@ -1,0 +1,127 @@
+package iam
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccV5PolicyDefaultVersion_basic(t *testing.T) {
+	var (
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_identity_policy.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV5PolicyDefaultVersion_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "default_version_id", "v1"),
+					resource.TestCheckResourceAttr(rName, "version_ids.#", "1"),
+				),
+			},
+			{
+				Config: testAccV5PolicyDefaultVersion_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "default_version_id", "v2"),
+					resource.TestCheckResourceAttr(rName, "version_ids.#", "2"),
+				),
+			},
+			{
+				Config: testAccV5PolicyDefaultVersion_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					// After setting the default version, the resource was not refreshed, so 'default_version_id' still has the old value.
+					resource.TestCheckResourceAttr(rName, "default_version_id", "v2"),
+					resource.TestCheckResourceAttr(rName, "version_ids.#", "2"),
+				),
+			},
+			{
+				// Verify the default version modification was successful.
+				Config: testAccV5PolicyDefaultVersion_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "default_version_id", "v1"),
+					resource.TestCheckResourceAttr(rName, "version_ids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccV5PolicyDefaultVersion_step1(name string) string {
+	return fmt.Sprintf(`
+# Default version is v1.
+resource "huaweicloud_identity_policy" "test" {
+  name            = "%[1]s"
+  policy_document = jsonencode(
+    {
+      Statement = [
+        {
+          Action = ["*"]
+          Effect = "Allow"
+        }
+      ]
+      Version = "5.0"
+    }
+  )
+}
+`, name)
+}
+
+func testAccV5PolicyDefaultVersion_step2(name string) string {
+	return fmt.Sprintf(`
+# After updating the policy, the default version is v2.
+resource "huaweicloud_identity_policy" "test" {
+  name            = "%[1]s"
+  policy_document = jsonencode(
+    {
+      Statement = [
+        {
+          Action = ["*"]
+          Effect = "Deny"
+        }
+      ]
+      Version = "5.0"
+    }
+  )
+}
+`, name)
+}
+
+func testAccV5PolicyDefaultVersion_step3(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_policy" "test" {
+  name            = "%[1]s"
+  policy_document = jsonencode(
+    {
+      Statement = [
+        {
+          Action = ["*"]
+          Effect = "Deny"
+        }
+      ]
+      Version = "5.0"
+    }
+  )
+
+  # After the policy version changes, the 'policy_document' will also be updated to the corresponding version.
+  lifecycle {
+    ignore_changes = [policy_document]
+  }
+}
+
+# Set the default version to v1.
+resource "huaweicloud_identityv5_policy_default_version" "test" {
+  policy_id  = huaweicloud_identity_policy.test.id
+  version_id = "v1"
+}
+`, name)
+}

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy_default_version.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_policy_default_version.go
@@ -1,0 +1,95 @@
+package iam
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+var policyV5DefaultVersionNonUpdatableParams = []string{"policy_id", "version_id"}
+
+// @API IAM POST /v5/policies/{policy_id}/versions/{version_id}/set-default
+func ResourceIamV5PolicyDefaultVersion() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIamV5PolicyDefaultVersionCreate,
+		ReadContext:   resourceIamV5PolicyDefaultVersionRead,
+		UpdateContext: resourceIamV5PolicyDefaultVersionUpdate,
+		DeleteContext: resourceIamV5PolicyDefaultVersionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(policyV5DefaultVersionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the identity policy.`,
+			},
+			"version_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The version ID of the identity policy to be set as default.`,
+			},
+		},
+	}
+}
+
+func resourceIamV5PolicyDefaultVersionCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		policyId  = d.Get("policy_id").(string)
+		versionId = d.Get("version_id").(string)
+		httpUrl   = "v5/policies/{policy_id}/versions/{version_id}/set-default"
+	)
+
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{policy_id}", policyId)
+	createPath = strings.ReplaceAll(createPath, "{version_id}", versionId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error setting default version (%s) for identity policy (%s): %s", versionId, policyId, err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomId)
+
+	return nil
+}
+
+func resourceIamV5PolicyDefaultVersionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceIamV5PolicyDefaultVersionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceIamV5PolicyDefaultVersionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to set the default version of an identity policy. Deleting this
+	resource will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new one-time resource (`huaweicloud_identityv5_policy_default_version`) to set the default version of an identity policy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new one-time resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o iam -f TestAccV5PolicyDefaultVersion_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5PolicyDefaultVersion_basic -timeout 360m -parallel 10
=== RUN   TestAccV5PolicyDefaultVersion_basic
=== PAUSE TestAccV5PolicyDefaultVersion_basic
=== CONT  TestAccV5PolicyDefaultVersion_basic
--- PASS: TestAccV5PolicyDefaultVersion_basic (71.51s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       71.683s coverage: 3.9% of statements in ./huaweicloud/services/iam
```
<img width="975" height="514" alt="image" src="https://github.com/user-attachments/assets/903b5e1f-1050-4177-90b2-cb175ff0e80e" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
