### PR TITLE
feat(hss): support `hss_change_host_ignore_status` resource

### DIFF
--- a/docs/resources/hss_change_host_ignore_status.md
+++ b/docs/resources/hss_change_host_ignore_status.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_change_host_ignore_status"
+description: |-
+  Manages an HSS change host ignore status operation resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_change_host_ignore_status
+
+Manages an HSS change host ignore status operation resource within HuaweiCloud.
+
+-> This resource is a one-time action resource using to operation HSS change host ignore status. Deleting this resource
+  will not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "host_id_list" {
+  type = list(string)
+}
+
+resource "huaweicloud_hss_change_host_ignore_status" "test" {
+  operate_type = "ignore"
+  host_id_list = var.host_id_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `operate_type` - (Required, String, NonUpdatable) Specifies the operation type.  
+  The valid values are as follows:
+  + **ignore**: Ignore host.
+  + **un_ignore**: Cancel ignore host.
+
+* `host_id_list` - (Required, List, NonUpdatable) Specifies the list of host IDs.  
+  -> The host in protection cannot be ignored.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the hosts under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3241,6 +3241,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_image_batch_scan":                               hss.ResourceImageBatchScan(),
 			"huaweicloud_hss_login_common_location":                          hss.ResourceLoginCommonLocation(),
 			"huaweicloud_hss_login_white_ip":                                 hss.ResourceLoginWhiteIp(),
+			"huaweicloud_hss_change_host_ignore_status":                      hss.ResourceChangeHostIgnoreStatus(),
 			"huaweicloud_hss_modify_webtamper_protection_policy":             hss.ResourceModifyWebtamperProtectionPolicy(),
 			"huaweicloud_hss_modify_webtamper_rasp_path":                     hss.ResourceModifyWebtamperRaspPath(),
 			"huaweicloud_hss_rasp_protection_policy":                         hss.ResourceRaspProtectionPolicy(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_change_host_ignore_status_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_change_host_ignore_status_test.go
@@ -1,0 +1,38 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccChangeHostIgnoreStatus_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test requires preparing a host under the default enterprise project that
+			// has not enabled host protection.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testChangeHostIgnoreStatus_basic(),
+			},
+		},
+	})
+}
+
+func testChangeHostIgnoreStatus_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_change_host_ignore_status" "test" {
+  operate_type          = "ignore"
+  host_id_list          = ["%s"]
+  enterprise_project_id = "0"
+}
+`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_change_host_ignore_status.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_change_host_ignore_status.go
@@ -1,0 +1,137 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS PUT /v5/{project_id}/host/operate
+func ResourceChangeHostIgnoreStatus() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceChangeHostIgnoreStatusCreate,
+		ReadContext:   resourceChangeHostIgnoreStatusRead,
+		UpdateContext: resourceChangeHostIgnoreStatusUpdate,
+		DeleteContext: resourceChangeHostIgnoreStatusDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"operate_type",
+			"host_id_list",
+			"enterprise_project_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"operate_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"host_id_list": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildChangeHostIgnoreStatusQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	return ""
+}
+
+func buildChangeHostIgnoreStatusBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"operate_type": d.Get("operate_type"),
+		"host_id_list": utils.ExpandToStringList(d.Get("host_id_list").([]interface{})),
+	}
+
+	return bodyParams
+}
+
+func resourceChangeHostIgnoreStatusCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/host/operate"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildChangeHostIgnoreStatusQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildChangeHostIgnoreStatusBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error operating HSS change host ignore status: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return resourceChangeHostIgnoreStatusRead(ctx, d, meta)
+}
+
+func resourceChangeHostIgnoreStatusRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceChangeHostIgnoreStatusUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceChangeHostIgnoreStatusDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to operation HSS change host ignore status. Deleting
+    this resource will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_change_host_ignore_status` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_change_host_ignore_status` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccChangeHostIgnoreStatus_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccChangeHostIgnoreStatus_basic -timeout 360m -parallel 4
=== RUN   TestAccChangeHostIgnoreStatus_basic
=== PAUSE TestAccChangeHostIgnoreStatus_basic
=== CONT  TestAccChangeHostIgnoreStatus_basic
--- PASS: TestAccChangeHostIgnoreStatus_basic (12.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.562s
```
<img width="921" height="27" alt="image" src="https://github.com/user-attachments/assets/9d86266b-57c8-4c7d-9602-c7b21595723e" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
