### PR TITLE
feat(hss): support `hss_image_pay_per_scan_statistics` data source

### DIFF
--- a/docs/data-sources/hss_image_pay_per_scan_statistics.md
+++ b/docs/data-sources/hss_image_pay_per_scan_statistics.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_image_pay_per_scan_statistics"
+description: |-
+  Use this data source to get the HSS image pay per scan statistics within HuaweiCloud.
+---
+
+# huaweicloud_hss_image_pay_per_scan_statistics
+
+Use this data source to get the HSS image pay per scan statistics within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_image_pay_per_scan_statistics" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `repository_scan_num` - The number of repository image scans successfully.
+
+* `cicd_scan_num` - The number of CICD image scans successfully.
+
+* `free_quota_num` - The number of free scans.
+
+* `already_given` - Whether free quota has been given.
+
+* `image_free_quota` - The number of free quotas given when logging into the container image interface.
+
+* `high_risk` - The high risk images.
+
+  The [high_risk](#hss_imageType_riskInfo) structure is documented below.
+
+* `has_risk` - The risky images.
+
+  The [has_risk](#hss_imageType_riskInfo) structure is documented below.
+
+* `total` - The total number of images.
+
+  The [total](#hss_imageType_riskInfo) structure is documented below.
+
+* `unscan` - The number of unscanned images.
+
+  The [unscan](#hss_imageType_riskInfo) structure is documented below.
+
+<a name="hss_imageType_riskInfo"></a>
+The `high_risk`, `has_risk`, `total`, and `unscan` blocks support:
+
+* `local` - The number of local images.
+
+* `registriy` - The number of repository images.
+
+* `cicd` - The number of CICD images.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1411,6 +1411,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_image_registry_statistics":                  hss.DataSourceHssImageRegistryStatistics(),
 			"huaweicloud_hss_image_upload_command":                       hss.DataSourceHssImageUploadCommand(),
 			"huaweicloud_hss_image_asset_statistics":                     hss.DataSourceImageAssetStatistics(),
+			"huaweicloud_hss_image_pay_per_scan_statistics":              hss.DataSourceImagePayPerScanStatistics(),
 			"huaweicloud_hss_image_baseline_risk_configs":                hss.DataSourceImageBaselineRiskConfigs(),
 			"huaweicloud_hss_container_clusters_policy_templates":        hss.DataSourceContainerClustersPolicyTemplates(),
 			"huaweicloud_hss_container_clusters_policy_template":         hss.DataSourceContainerClustersPolicyTemplate(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_image_pay_per_scan_statistics_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_image_pay_per_scan_statistics_test.go
@@ -1,0 +1,60 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceImagePayPerScanStatistics_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_image_pay_per_scan_statistics.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceImagePayPerScanStatistics_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "repository_scan_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "cicd_scan_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "free_quota_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "already_given"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "image_free_quota"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "high_risk.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "high_risk.0.local"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "high_risk.0.registriy"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "high_risk.0.cicd"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "has_risk.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "has_risk.0.local"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "has_risk.0.registriy"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "has_risk.0.cicd"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total.0.local"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total.0.registriy"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total.0.cicd"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "unscan.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "unscan.0.local"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "unscan.0.registriy"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "unscan.0.cicd"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceImagePayPerScanStatistics_basic() string {
+	return `
+data "huaweicloud_hss_image_pay_per_scan_statistics" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_image_pay_per_scan_statistics.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_image_pay_per_scan_statistics.go
@@ -1,0 +1,172 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/image/pay-per-scan/statistics
+func DataSourceImagePayPerScanStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceImagePayPerScanStatisticsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// Attributes
+			"repository_scan_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cicd_scan_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"free_quota_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"already_given": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"image_free_quota": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"high_risk": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceImageTypeRiskInfoSchema(),
+			},
+			"has_risk": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceImageTypeRiskInfoSchema(),
+			},
+			"total": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceImageTypeRiskInfoSchema(),
+			},
+			"unscan": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceImageTypeRiskInfoSchema(),
+			},
+		},
+	}
+}
+
+func dataSourceImageTypeRiskInfoSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"local": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"registriy": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cicd": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+
+	return &sc
+}
+
+func dataSourceImagePayPerScanStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/image/pay-per-scan/statistics"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	if epsId != "" {
+		requestPath = fmt.Sprintf("%s?enterprise_project_id=%v", requestPath, epsId)
+	}
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS image pay per scan statistics: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("repository_scan_num", utils.PathSearch("repository_scan_num", respBody, nil)),
+		d.Set("cicd_scan_num", utils.PathSearch("cicd_scan_num", respBody, nil)),
+		d.Set("free_quota_num", utils.PathSearch("free_quota_num", respBody, nil)),
+		d.Set("already_given", utils.PathSearch("already_given", respBody, nil)),
+		d.Set("image_free_quota", utils.PathSearch("image_free_quota", respBody, nil)),
+		d.Set("high_risk",
+			flattenDataSourceImageTypeRiskInfo(utils.PathSearch("high_risk", respBody, nil))),
+		d.Set("has_risk",
+			flattenDataSourceImageTypeRiskInfo(utils.PathSearch("has_risk", respBody, nil))),
+		d.Set("total",
+			flattenDataSourceImageTypeRiskInfo(utils.PathSearch("total", respBody, nil))),
+		d.Set("unscan",
+			flattenDataSourceImageTypeRiskInfo(utils.PathSearch("unscan", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDataSourceImageTypeRiskInfo(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"local":     utils.PathSearch("local", resp, nil),
+			"registriy": utils.PathSearch("registriy", resp, nil),
+			"cicd":      utils.PathSearch("cicd", resp, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_image_pay_per_scan_statistics` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_image_pay_per_scan_statistics` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceImagePayPerScanStatistics_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceImagePayPerScanStatistics_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceImagePayPerScanStatistics_basic
=== PAUSE TestAccDataSourceImagePayPerScanStatistics_basic
=== CONT  TestAccDataSourceImagePayPerScanStatistics_basic
--- PASS: TestAccDataSourceImagePayPerScanStatistics_basic (11.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.313s
```
<img width="961" height="33" alt="image" src="https://github.com/user-attachments/assets/a8daaf82-7aa6-4645-bc2a-09e5fc5ece37" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
