### PR TITLE
feat(mrs): add new one-time resource to add components for cluster

### DIFF
--- a/docs/resources/mapreduce_cluster_component_batch_add.md
+++ b/docs/resources/mapreduce_cluster_component_batch_add.md
@@ -1,0 +1,110 @@
+---
+subcategory: "MapReduce Service (MRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_mapreduce_cluster_component_batch_add"
+description: |-
+  Use this resource to batch add components to the specified MRS cluster within HuaweiCloud.
+---
+
+# huaweicloud_mapreduce_cluster_component_batch_add
+
+Use this resource to batch add components to the specified MRS cluster within HuaweiCloud.
+
+~> If you use this resource, please use `lifecycle.ignore_changes` to ignore the changes of `component_list`,
+   `analysis_core_nodes[0].assigned_roles`, `streaming_core_nodes[0].assigned_roles`,
+   `analysis_task_nodes[0].assigned_roles`, `streaming_task_nodes[0].assigned_roles`, and
+   `custom_nodes[0].assigned_roles` in `huaweicloud_mapreduce_cluster`.
+
+-> 1. Only MRS `3.1.2` and later normal versions and MRS `3.1.2-LTS.2` and later LTS versions of **custom clusters**
+   support adding components.
+   <br>2. This resource is a one-time action resource used to batch add components to the MRS cluster. Deleting this
+   resource will not clear the corresponding request record, but will only remove the resource information
+   from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "components" {
+  type = list(object({
+    component = string
+
+    node_groups = list(object({
+      name           = string
+      assigned_roles = list(string)
+    }))
+
+    user_password    = optional(string)
+    default_password = optional(string)
+  }))
+}
+
+resource "huaweicloud_mapreduce_cluster_component_batch_add" "test" {
+  cluster_id = huaweicloud_mapreduce_cluster.test.id
+
+  dynamic "components_install_mode" {
+    for_each = var.components
+
+    content {
+      component = components_install_mode.value.component
+
+      dynamic "node_groups" {
+        for_each = components_install_mode.value.node_groups
+
+        content {
+          name           = node_groups.value.name
+          assigned_roles = node_groups.value.assigned_roles
+        }
+      }
+
+      component_user_password    = components_install_mode.value.user_password
+      component_default_password = components_install_mode.value.default_password
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the components to be added are located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the MRS cluster.
+
+* `components_install_mode` - (Required, List, NonUpdatable) Specifies the list of components to be added.  
+  The [components_install_mode](#cluster_component_batch_add_components) structure is documented below.
+
+<a name="cluster_component_batch_add_components"></a>
+The `components_install_mode` block supports:
+
+* `component` - (Required, String, NonUpdatable) Specifies the name of the component.
+
+* `node_groups` - (Required, List, NonUpdatable) Specifies the node groups where the component roles will be deployed.  
+  The [node_groups](#cluster_component_batch_add_node_groups) structure is documented below.
+
+* `component_user_password` - (Optional, String, NonUpdatable) Specifies the password for the component user.  
+  This password is used for the ClickHouse component machine user to connect.
+
+* `component_default_password` - (Optional, String, NonUpdatable) Specifies the password for the component
+  default user.  
+  This password is used for the ClickHouse component machine default user to connect.
+
+<a name="cluster_component_batch_add_node_groups"></a>
+The `node_groups` block supports:
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the node group.
+
+* `assigned_roles` - (Required, List, NonUpdatable) Specifies the list of roles to be assigned to this node group.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following Timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3459,10 +3459,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_lts_transfer":                         lts.ResourceLtsTransfer(),
 			"huaweicloud_lts_waf_access":                       lts.ResourceWAFAccess(),
 
-			"huaweicloud_mapreduce_cluster":         mrs.ResourceMRSClusterV2(),
-			"huaweicloud_mapreduce_job":             mrs.ResourceMRSJobV2(),
-			"huaweicloud_mapreduce_data_connection": mrs.ResourceDataConnection(),
-			"huaweicloud_mapreduce_scaling_policy":  mrs.ResourceScalingPolicy(),
+			"huaweicloud_mapreduce_cluster":                     mrs.ResourceMRSClusterV2(),
+			"huaweicloud_mapreduce_cluster_component_batch_add": mrs.ResourceClusterComponentBatchAdd(),
+			"huaweicloud_mapreduce_job":                         mrs.ResourceMRSJobV2(),
+			"huaweicloud_mapreduce_data_connection":             mrs.ResourceDataConnection(),
+			"huaweicloud_mapreduce_scaling_policy":              mrs.ResourceScalingPolicy(),
 
 			"huaweicloud_meeting_admin_assignment": meeting.ResourceAdminAssignment(),
 			"huaweicloud_meeting_conference":       meeting.ResourceConference(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -100,6 +100,7 @@ var (
 
 	HW_MAPREDUCE_CUSTOM           = os.Getenv("HW_MAPREDUCE_CUSTOM")
 	HW_MAPREDUCE_BOOTSTRAP_SCRIPT = os.Getenv("HW_MAPREDUCE_BOOTSTRAP_SCRIPT")
+	HW_MRS_CLUSTER_FLAVOR_ID      = os.Getenv("HW_MRS_CLUSTER_FLAVOR_ID")
 
 	HW_CNAD_ENABLE_FLAG       = os.Getenv("HW_CNAD_ENABLE_FLAG")
 	HW_CNAD_PROJECT_OBJECT_ID = os.Getenv("HW_CNAD_PROJECT_OBJECT_ID")
@@ -1270,6 +1271,13 @@ func TestAccPreCheckMrsCustom(t *testing.T) {
 func TestAccPreCheckMrsBootstrapScript(t *testing.T) {
 	if HW_MAPREDUCE_BOOTSTRAP_SCRIPT == "" {
 		t.Skip("HW_MAPREDUCE_BOOTSTRAP_SCRIPT must be set for acceptance tests: cluster of map reduce with bootstrap")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckMrsClusterFlavorID(t *testing.T) {
+	if HW_MRS_CLUSTER_FLAVOR_ID == "" {
+		t.Skip("HW_MRS_CLUSTER_FLAVOR_ID must be set for MRS cluster acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_cluster_component_batch_add_test.go
+++ b/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_cluster_component_batch_add_test.go
@@ -1,0 +1,150 @@
+package mrs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccClusterComponentBatchAdd_basic(t *testing.T) {
+	rName := "huaweicloud_mapreduce_cluster_component_batch_add.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMrsClusterFlavorID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterComponentBatchAdd_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "components_install_mode.#", "2"),
+					resource.TestCheckResourceAttr(rName, "components_install_mode.0.component", "HBase"),
+					resource.TestCheckResourceAttr(rName, "components_install_mode.0.node_groups.#", "2"),
+					resource.TestCheckResourceAttr(rName, "components_install_mode.1.component", "Flink"),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterComponentBatchAdd_base() string {
+	name := acceptance.RandomAccResourceNameWithDash()
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_mapreduce_versions" "test" {}
+
+resource "huaweicloud_mapreduce_cluster" "test" {
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  name               = "%[2]s"
+  type               = "CUSTOM"
+  version            = try(data.huaweicloud_mapreduce_versions.test.versions[0], "")
+  manager_admin_pass = "%[3]s"
+  node_admin_pass    = "%[3]s"
+  subnet_id          = huaweicloud_vpc_subnet.test.id
+  vpc_id             = huaweicloud_vpc.test.id
+  component_list     = ["Hadoop", "ZooKeeper", "Ranger", "DBService"]
+
+  master_nodes {
+    flavor            = "%[4]s"
+    node_number       = 3
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+
+    assigned_roles = [
+      "OMSServer:1,2",
+      "SlapdServer:1,2",
+      "KerberosServer:1,2",
+      "KerberosAdmin:1,2",
+      "quorumpeer:1,2,3",
+      "NameNode:2,3",
+      "Zkfc:2,3",
+      "JournalNode:1,2,3",
+      "ResourceManager:2,3",
+      "JobHistoryServer:3",
+      "DBServer:1,3",
+      "HttpFS:1,3",
+      "TimelineServer:3",
+      "RangerAdmin:1,2",
+      "UserSync:2",
+      "TagSync:2",
+      "KerberosClient",
+      "SlapdClient",
+      "meta"
+    ]
+  }
+
+  custom_nodes {
+    group_name        = "node_group_1"
+    flavor            = "%[4]s"
+    node_number       = 3
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+
+    assigned_roles = [
+      "DataNode",
+      "NodeManager",
+      "KerberosClient",
+      "SlapdClient",
+      "meta"
+    ]
+  }
+
+  lifecycle {
+    ignore_changes = [
+      component_list,
+      master_nodes[0].assigned_roles,
+      custom_nodes[0].assigned_roles
+    ]
+  }
+}
+`, common.TestVpc(name), name, acceptance.RandomPassword(), acceptance.HW_MRS_CLUSTER_FLAVOR_ID)
+}
+
+func testAccClusterComponentBatchAdd_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_mapreduce_cluster_component_batch_add" "test" {
+  cluster_id = huaweicloud_mapreduce_cluster.test.id
+
+  components_install_mode {
+    component = "HBase"
+
+    node_groups {
+      name           = "master_node_default_group"
+      assigned_roles = ["HMaster:2,3"]
+    }
+    node_groups {
+      name           = "node_group_1"
+      assigned_roles = ["RegionServer"]
+    }
+  }
+  components_install_mode {
+    component = "Flink"
+
+    node_groups {
+      name           = "master_node_default_group"
+      assigned_roles = ["FlinkResource:2,3", "FlinkServer:2,3"]
+    }
+  }
+}
+`, testAccClusterComponentBatchAdd_base())
+}

--- a/huaweicloud/services/mrs/common.go
+++ b/huaweicloud/services/mrs/common.go
@@ -1,0 +1,78 @@
+package mrs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getClusterById(client *golangsdk.ServiceClient, clusterId string) (interface{}, error) {
+	httpUrl := "v1.1/{project_id}/cluster_infos/{cluster_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+	return utils.PathSearch("cluster", respBody, nil), nil
+}
+
+func waitForClusterStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, clusterId string, timeout time.Duration,
+	targets ...string) error {
+	stateConf := &resource.StateChangeConf{
+		Target:       []string{"COMPLETED"},
+		Pending:      []string{"PENDING"},
+		Refresh:      refreshClusterStatusFunc(client, clusterId, targets...),
+		Timeout:      timeout,
+		Delay:        20 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func refreshClusterStatusFunc(client *golangsdk.ServiceClient, clusterId string, targets ...string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := getClusterById(client, clusterId)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+
+		status := utils.PathSearch("clusterState", resp, "").(string)
+
+		if status == "failed" {
+			return resp, "ERROR", fmt.Errorf("unexpected status: %s", status)
+		}
+
+		if len(targets) == 0 {
+			targets = []string{"running", "abnormal"}
+		}
+
+		if utils.StrSliceContains(targets, status) {
+			return resp, "COMPLETED", nil
+		}
+
+		return resp, "PENDING", nil
+	}
+}

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster_component_batch_add.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster_component_batch_add.go
@@ -1,0 +1,210 @@
+package mrs
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var clusterComponentBatchAddNonUpdateParams = []string{
+	"cluster_id",
+	"components_install_mode",
+	"components_install_mode.*.component",
+	"components_install_mode.*.node_groups",
+	"components_install_mode.*.node_groups.*.name",
+	"components_install_mode.*.node_groups.*.assigned_roles",
+	"components_install_mode.*.component_user_password",
+	"components_install_mode.*.component_default_password",
+}
+
+// @API MRS POST /v2/{project_id}/clusters/{cluster_id}/components
+// @API MRS GET /v1.1/{project_id}/cluster_infos/{cluster_id}
+func ResourceClusterComponentBatchAdd() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceClusterComponentBatchAddCreate,
+		ReadContext:   resourceClusterComponentBatchAddRead,
+		UpdateContext: resourceClusterComponentBatchAddUpdate,
+		DeleteContext: resourceClusterComponentBatchAddDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(clusterComponentBatchAddNonUpdateParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the components to be added are located.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the MRS cluster.`,
+			},
+			"components_install_mode": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"component": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the component.`,
+						},
+						"node_groups": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `The name of the node group.`,
+									},
+									"assigned_roles": {
+										Type:        schema.TypeList,
+										Required:    true,
+										Description: `The list of roles to be assigned to this node group.`,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+							Description: `The node groups where the component roles will be deployed.`,
+						},
+						"component_user_password": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Sensitive:   true,
+							Description: `The password for the component user.`,
+						},
+						"component_default_password": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Sensitive:   true,
+							Description: `The password for the component default user.`,
+						},
+					},
+				},
+				Description: `The list of components to be added.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildClusterComponentBatchAddComponentInstallMode(components []interface{}) map[string]interface{} {
+	if len(components) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(components))
+	for _, com := range components {
+		result = append(result, map[string]interface{}{
+			"component": utils.PathSearch("component", com, nil),
+			"node_groups": buildClusterComponentBatchAddNodeGroups(utils.PathSearch("node_groups", com,
+				make([]interface{}, 0)).([]interface{})),
+			"component_user_password":    utils.ValueIgnoreEmpty(utils.PathSearch("component_user_password", com, nil)),
+			"component_default_password": utils.ValueIgnoreEmpty(utils.PathSearch("component_default_password", com, nil)),
+		})
+	}
+
+	return map[string]interface{}{
+		"components_install_mode": result,
+	}
+}
+
+func buildClusterComponentBatchAddNodeGroups(nodeGroups []interface{}) []map[string]interface{} {
+	if len(nodeGroups) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(nodeGroups))
+	for _, nodeGroup := range nodeGroups {
+		result = append(result, map[string]interface{}{
+			"name": utils.PathSearch("name", nodeGroup, nil),
+			"assigned_roles": utils.ExpandToStringList(utils.PathSearch("assigned_roles", nodeGroup,
+				make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func resourceClusterComponentBatchAddCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		httpUrl   = "v2/{project_id}/clusters/{cluster_id}/components"
+		clusterId = d.Get("cluster_id").(string)
+	)
+	client, err := cfg.NewServiceClient("mrs", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{cluster_id}", clusterId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildClusterComponentBatchAddComponentInstallMode(d.Get("components_install_mode").([]interface{}))),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("unable to add components to the cluster (%s): %s", clusterId, err)
+	}
+
+	err = waitForClusterStatusCompleted(ctx, client, clusterId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the cluster (%s) components to be added to complete: %s", clusterId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID)
+
+	return nil
+}
+
+func resourceClusterComponentBatchAddRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceClusterComponentBatchAddUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceClusterComponentBatchAddDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch add components to the MRS cluster. Deleting this
+resource will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new one-time resource(`huaweicloud_mapreduce_cluster_component_batch_add`) to add components to the cluster in batches.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new one-time resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o mrs -f TestAccClusterComponentBatchAdd_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccClusterComponentBatchAdd_basic -timeout 360m -parallel 10
=== RUN   TestAccClusterComponentBatchAdd_basic
=== PAUSE TestAccClusterComponentBatchAdd_basic
=== CONT  TestAccClusterComponentBatchAdd_basic
--- PASS: TestAccClusterComponentBatchAdd_basic (1143.67s)
PASS
coverage: 28.0% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       1143.772s       coverage: 28.0% of statements in ./huaweicloud/services/mrs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
