### PR TITLE
feat(waf): new resource to batch delete alarm notificationa

### DIFF
--- a/docs/resources/waf_batch_delete_alarm_notifications.md
+++ b/docs/resources/waf_batch_delete_alarm_notifications.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_batch_delete_alarm_notifications"
+description: |-
+  Manages a resource to batch delete the alarm notifications within HuaweiCloud.
+---
+
+# huaweicloud_waf_batch_delete_alarm_notifications
+
+Manages a resource to batch delete the alarm notifications within HuaweiCloud.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+-> This resource is only a one-time action resource using to batch delete alarm notifications. Deleting this resource
+  will not clear the corresponding request record, but will only remove the resource information from the tf state
+  file.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+variable "config_id"  {}
+
+resource "huaweicloud_waf_batch_delete_alarm_notifications" "test" {
+  enterprise_project_id = var.enterprise_project_id
+
+  alert_notice_configs {
+    id = var.config_id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `enterprise_project_id` - (Required, String, NonUpdatable) Specifies the enterprise project ID.
+
+* `alert_notice_configs` - (Required, List, NonUpdatable) Specifies the alarm notification details.
+  The [alert_notice_configs](#alert_notice_configs) structure is documented below.
+
+<a name="alert_notice_configs"></a>
+The `alert_notice_configs` block supports:
+
+* `id` - (Required, String, NonUpdatable) Specifies the ID of the alarm notification.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3865,6 +3865,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_ip_intelligence_rule":                waf.ResourceIpIntelligenceRule(),
 			"huaweicloud_waf_modify_alarm_notification":           waf.ResourceModifyAlarmNotification(),
 			"huaweicloud_waf_alarm_notification":                  waf.ResourceWafAlarmNotification(),
+			"huaweicloud_waf_batch_delete_alarm_notifications":    waf.ResourceWafBatchDeleteAlarmNotifications(),
 			"huaweicloud_waf_migrate_domain":                      waf.ResourceMigrateDomain(),
 			"huaweicloud_waf_policy":                              waf.ResourceWafPolicy(),
 			"huaweicloud_waf_policies_batch_delete":               waf.ResourcePoliciesBatchDelete(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -134,6 +134,7 @@ var (
 	HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID = os.Getenv("HW_WAF_DEDICATED_INSTANCE_SECURITY_GROUP_ID")
 	HW_WAF_RULE_ID                              = os.Getenv("HW_WAF_RULE_ID")
 	HW_WAF_GEO_RULE_ID                          = os.Getenv("HW_WAF_GEO_RULE_ID")
+	HW_WAF_ALARM_NOTIFICATION_ID                = os.Getenv("HW_WAF_ALARM_NOTIFICATION_ID")
 
 	HW_ELB_CERT_ID         = os.Getenv("HW_ELB_CERT_ID")
 	HW_ELB_LOADBALANCER_ID = os.Getenv("HW_ELB_LOADBALANCER_ID")
@@ -1376,6 +1377,13 @@ func TestAccPrecheckWafInstance(t *testing.T) {
 func TestAccPrecheckWafSecurityReportSubscription(t *testing.T) {
 	if HW_WAF_SECURITY_REPORT_SUBSCRIPTION_ID == "" {
 		t.Skip("HW_WAF_SECURITY_REPORT_SUBSCRIPTION_ID must be set for WAF security report subscription acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckWafAlarmNotificationId(t *testing.T) {
+	if HW_WAF_ALARM_NOTIFICATION_ID == "" {
+		t.Skip("HW_WAF_ALARM_NOTIFICATION_ID must be set for WAF alarm notification ID acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_delete_alarm_notifications_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_delete_alarm_notifications_test.go
@@ -1,0 +1,42 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchDeleteAlarmNotifications_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running the test case, please ensure that there is at least one WAF instance in the current region.
+			// Prepare a WAF policy with a WAF CC protection rule.
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPrecheckWafAlarmNotificationId(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchDeleteAlarmNotifications_basic(),
+			},
+		},
+	})
+}
+
+func testAccBatchDeleteAlarmNotifications_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_batch_delete_alarm_notifications" "test" {
+  enterprise_project_id = "%[1]s"
+
+  alert_notice_configs {
+    id = "%[2]s"
+  }
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, acceptance.HW_WAF_ALARM_NOTIFICATION_ID)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_batch_delete_alarm_notifications.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_batch_delete_alarm_notifications.go
@@ -1,0 +1,149 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var batchDeleteAlarmNotificationsNonUpdatableParams = []string{
+	"enterprise_project_id",
+	"alert_notice_configs",
+	"alert_notice_configs.*.id",
+}
+
+// @API WAF POST /v2/{project_id}/waf/alert/batch-delete
+func ResourceWafBatchDeleteAlarmNotifications() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafBatchDeleteAlarmNotificationsCreate,
+		ReadContext:   resourceWafBatchDeleteAlarmNotificationsRead,
+		UpdateContext: resourceWafBatchDeleteAlarmNotificationsUpdate,
+		DeleteContext: resourceWafBatchDeleteAlarmNotificationsDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(batchDeleteAlarmNotificationsNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"alert_notice_configs": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildBatchDeleteAlarmNotificationsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	rawArray := d.Get("alert_notice_configs").([]interface{})
+	noticeConfigs := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		noticeConfigs = append(noticeConfigs, map[string]interface{}{
+			"id": rawMap["id"],
+		})
+	}
+
+	bodyParams := map[string]interface{}{
+		"alert_notice_configs": noticeConfigs,
+	}
+
+	return bodyParams
+}
+
+func resourceWafBatchDeleteAlarmNotificationsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/waf/alert/batch-delete"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath += fmt.Sprintf("?enterpriseProjectId=%s", epsId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+			"X-Language":   "en-us",
+		},
+		JSONBody: buildBatchDeleteAlarmNotificationsBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error batch deleting WAF alarm notifications: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	return resourceWafBatchDeleteAlarmNotificationsRead(ctx, d, meta)
+}
+
+func resourceWafBatchDeleteAlarmNotificationsRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchDeleteAlarmNotificationsUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchDeleteAlarmNotificationsDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch delete alarm notifications. Deleting this resource
+    will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to batch delete alarm notificationa

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccBatchDeleteAlarmNotifications_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccBatchDeleteAlarmNotifications_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchDeleteAlarmNotifications_basic
=== PAUSE TestAccBatchDeleteAlarmNotifications_basic
=== CONT  TestAccBatchDeleteAlarmNotifications_basic
--- PASS: TestAccBatchDeleteAlarmNotifications_basic (12.11s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       12.226s coverage: 3.8% of statements in ./huaweicloud/services/waf
```
<img width="1364" height="78" alt="image" src="https://github.com/user-attachments/assets/29fb6994-6b24-44b9-8058-749401e8ac00" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
