### PR TITLE
feat(hss): support `hss_image_sensitive_information` data sources

### DIFF
--- a/docs/data-sources/hss_image_sensitive_information.md
+++ b/docs/data-sources/hss_image_sensitive_information.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_image_sensitive_information"
+description: |-
+  Use this data source to get the list of HSS image sensitive information within HuaweiCloud.
+---
+
+# huaweicloud_hss_image_sensitive_information
+
+Use this data source to get the list of HSS image sensitive information within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_image_sensitive_information" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `image_type` - (Optional, String) Specifies the image type. Valid values are:
+  + **registry**: Repository image.
+  + **cicd**: CICD image.
+
+  Defaults to **registry**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_num` - The total number of image sensitive information records.
+
+* `data_list` - The list of image sensitive information data.
+
+  The [data_list](#image_sensitive_information_data_list) structure is documented below.
+
+<a name="image_sensitive_information_data_list"></a>
+The `data_list` block supports:
+
+* `sensitive_info_id` - The sensitive event ID.
+
+* `severity` - The threat level. Valid values are:
+  + **critical**: Critical.
+  + **high**: High risk.
+  + **medium**: Medium risk.
+  + **low**: Low risk.
+
+* `name` - The rule name.
+
+* `description` - The rule description.
+
+* `position` - The layer where the sensitive information is located in the image.
+
+* `file_path` - The file path.
+
+* `content` - The sensitive information content.
+
+* `latest_scan_time` - The last scan time, in milliseconds.
+
+* `handle_status` - Whether it has been handled. Valid values are:
+  + **unhandled**: Not handled.
+  + **handled**: Handled.
+
+* `operate_accept` - The operation type. Valid values are:
+  + **ignore**: Ignore.
+  + **do_not_ignore**: Do not ignore.

--- a/docs/data-sources/hss_image_sensitive_information_detail.md
+++ b/docs/data-sources/hss_image_sensitive_information_detail.md
@@ -1,0 +1,107 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_image_sensitive_information_detail"
+description: |-
+  Use this data source to get the list of HSS image sensitive information detail within HuaweiCloud.
+---
+
+# huaweicloud_hss_image_sensitive_information_detail
+
+Use this data source to get the list of HSS image sensitive information detail within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "image_id" {}
+variable "image_type" {}
+
+data "huaweicloud_hss_image_sensitive_information_detail" "test" {
+  image_id   = var.image_id
+  image_type = var.image_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `image_id` - (Required, String) Specifies the image ID.
+
+* `image_type` - (Required, String) Specifies the image type. Valid values are:
+  + **private_image**: SWR private image.
+  + **shared_image**: SWR shared image.
+  + **instance_image**: SWR enterprise edition image.
+  + **cicd**: CICD image.
+  + **harbor**: Harbor repository image.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `namespace` - (Optional, String) Specifies the organization name.
+
+* `image_name` - (Optional, String) Specifies the image name.
+
+* `image_version` - (Optional, String) Specifies the image version name.
+
+* `file_path` - (Optional, String) Specifies the file path.
+
+* `severity` - (Optional, String) Specifies the threat level. Valid values are:
+  + **critical**: Critical.
+  + **high**: High risk.
+  + **medium**: Medium risk.
+  + **low**: Low risk.
+
+* `handle_status` - (Optional, String) Specifies whether it has been handled. Valid values are:
+  + **unhandled**: Not handled.
+  + **handled**: Handled.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_num` - The total number of image sensitive information records.
+
+* `data_list` - The list of image sensitive information data.
+
+  The [data_list](#image_sensitive_information_detail_data_list) structure is documented below.
+
+<a name="image_sensitive_information_detail_data_list"></a>
+The `data_list` block supports:
+
+* `sensitive_info_id` - The sensitive event ID.
+
+* `severity` - The threat level. Valid values are:
+  + **critical**: Critical.
+  + **high**: High risk.
+  + **medium**: Medium risk.
+  + **low**: Low risk.
+
+* `name` - The rule name.
+
+* `description` - The rule description.
+
+* `position` - The layer where the sensitive information is located in the image.
+
+* `file_path` - The file path.
+
+* `content` - The sensitive information content.
+
+* `latest_scan_time` - The last scan time, in milliseconds.
+
+* `handle_status` - Whether it has been handled. Valid values are:
+  + **unhandled**: Not handled.
+  + **handled**: Handled.
+
+* `operate_accept` - The operation type. Valid values are:
+  + **ignore**: Ignore.
+  + **do_not_ignore**: Do not ignore.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1408,6 +1408,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_cluster_protect_protection_items":           hss.DataSourceClusterProtectProtectionItems(),
 			"huaweicloud_hss_cluster_protect_alarm_events":               hss.DataSourceClusterProtectAlarmEvents(),
 			"huaweicloud_hss_image_local_repositories":                   hss.DataSourceImageLocalRepositories(),
+			"huaweicloud_hss_image_sensitive_information":                hss.DataSourceImageSensitiveInformation(),
 			"huaweicloud_hss_image_registry_images":                      hss.DataSourceHssImageRegistryImages(),
 			"huaweicloud_hss_image_registries":                           hss.DataSourceHssImageRegistries(),
 			"huaweicloud_hss_image_registry_statistics":                  hss.DataSourceHssImageRegistryStatistics(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1409,6 +1409,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_cluster_protect_alarm_events":               hss.DataSourceClusterProtectAlarmEvents(),
 			"huaweicloud_hss_image_local_repositories":                   hss.DataSourceImageLocalRepositories(),
 			"huaweicloud_hss_image_sensitive_information":                hss.DataSourceImageSensitiveInformation(),
+			"huaweicloud_hss_image_sensitive_information_detail":         hss.DataSourceImageSensitiveInformationDetail(),
 			"huaweicloud_hss_image_registry_images":                      hss.DataSourceHssImageRegistryImages(),
 			"huaweicloud_hss_image_registries":                           hss.DataSourceHssImageRegistries(),
 			"huaweicloud_hss_image_registry_statistics":                  hss.DataSourceHssImageRegistryStatistics(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_image_sensitive_information_detail_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_image_sensitive_information_detail_test.go
@@ -1,0 +1,91 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceImageSensitiveInformationDetail_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_image_sensitive_information_detail.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSImageId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceImageSensitiveInformationDetail_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.sensitive_info_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.severity"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.description"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.position"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.file_path"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.content"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.latest_scan_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.handle_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.operate_accept"),
+
+					resource.TestCheckOutput("is_severity_filter_useful", "true"),
+					resource.TestCheckOutput("is_handle_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceImageSensitiveInformationDetail_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_hss_image_sensitive_information_detail" "test" {
+  image_id   = "%[1]s"
+  image_type = "private_image"
+}
+
+# Filter using severity.
+locals {
+  severity = data.huaweicloud_hss_image_sensitive_information_detail.test.data_list[0].severity
+}
+
+data "huaweicloud_hss_image_sensitive_information_detail" "severity_filter" {
+  image_id   = "%[1]s"
+  image_type = "private_image"
+  severity   = local.severity
+}
+
+output "is_severity_filter_useful" {
+  value = length(data.huaweicloud_hss_image_sensitive_information_detail.severity_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_image_sensitive_information_detail.severity_filter.data_list[*].severity : v == local.severity]
+  )
+}
+
+# Filter using handle_status.
+locals {
+  handle_status = data.huaweicloud_hss_image_sensitive_information_detail.test.data_list[0].handle_status
+}
+
+data "huaweicloud_hss_image_sensitive_information_detail" "handle_status_filter" {
+  image_id      = "%[1]s"
+  image_type    = "private_image"
+  handle_status = local.handle_status
+}
+
+output "is_handle_status_filter_useful" {
+  value = length(data.huaweicloud_hss_image_sensitive_information_detail.handle_status_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_image_sensitive_information_detail.handle_status_filter.data_list[*].handle_status : v == local.handle_status]
+  )
+}
+`, acceptance.HW_HSS_IMAGE_ID)
+}

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_image_sensitive_information_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_image_sensitive_information_test.go
@@ -1,0 +1,52 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceImageSensitiveInformation_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_image_sensitive_information.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceImageSensitiveInformation_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.sensitive_info_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.severity"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.description"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.position"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.file_path"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.content"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.latest_scan_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.handle_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.operate_accept"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceImageSensitiveInformation_basic() string {
+	return `
+data "huaweicloud_hss_image_sensitive_information" "test" {
+  enterprise_project_id = "0"
+  image_type            = "registry"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_image_sensitive_information.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_image_sensitive_information.go
@@ -1,0 +1,196 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/image/sensitive-information
+func DataSourceImageSensitiveInformation() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceImageSensitiveInformationRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"image_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceImageSensitiveInformationDataListSchema(),
+			},
+		},
+	}
+}
+
+func dataSourceImageSensitiveInformationDataListSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"sensitive_info_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"severity": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"position": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"file_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"content": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"latest_scan_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"handle_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"operate_accept": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildImageSensitiveInformationQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("image_type"); ok {
+		queryParams = fmt.Sprintf("%s&image_type=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceImageSensitiveInformationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "hss"
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		result   = make([]interface{}, 0)
+		offset   = 0
+		totalNum float64
+		httpUrl  = "v5/{project_id}/image/sensitive-information"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildImageSensitiveInformationQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS image sensitive information: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalNum = utils.PathSearch("total_num", respBody, float64(0)).(float64)
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", totalNum),
+		d.Set("data_list", flattenImageSensitiveInformationDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenImageSensitiveInformationDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"sensitive_info_id": utils.PathSearch("sensitive_info_id", v, nil),
+			"severity":          utils.PathSearch("severity", v, nil),
+			"name":              utils.PathSearch("name", v, nil),
+			"description":       utils.PathSearch("description", v, nil),
+			"position":          utils.PathSearch("position", v, nil),
+			"file_path":         utils.PathSearch("file_path", v, nil),
+			"content":           utils.PathSearch("content", v, nil),
+			"latest_scan_time":  utils.PathSearch("latest_scan_time", v, nil),
+			"handle_status":     utils.PathSearch("handle_status", v, nil),
+			"operate_accept":    utils.PathSearch("operate_accept", v, nil),
+		})
+	}
+
+	return rst
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_image_sensitive_information_detail.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_image_sensitive_information_detail.go
@@ -1,0 +1,171 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/image/{image_id}/sensitive
+func DataSourceImageSensitiveInformationDetail() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceImageSensitiveInformationDetailRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"image_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"image_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"image_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"file_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"severity": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"handle_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceImageSensitiveInformationDataListSchema(),
+			},
+		},
+	}
+}
+
+func buildImageSensitiveInformationDetailQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+	queryParams = fmt.Sprintf("%s&image_type=%v", queryParams, d.Get("image_type"))
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("namespace"); ok {
+		queryParams = fmt.Sprintf("%s&namespace=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("image_name"); ok {
+		queryParams = fmt.Sprintf("%s&image_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("image_version"); ok {
+		queryParams = fmt.Sprintf("%s&image_version=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("file_path"); ok {
+		queryParams = fmt.Sprintf("%s&file_path=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("severity"); ok {
+		queryParams = fmt.Sprintf("%s&severity=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("handle_status"); ok {
+		queryParams = fmt.Sprintf("%s&handle_status=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceImageSensitiveInformationDetailRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "hss"
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		imageId  = d.Get("image_id").(string)
+		result   = make([]interface{}, 0)
+		offset   = 0
+		totalNum float64
+		httpUrl  = "v5/{project_id}/image/{image_id}/sensitive"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{image_id}", imageId)
+	requestPath += buildImageSensitiveInformationDetailQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS image sensitive information detail: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalNum = utils.PathSearch("total_num", respBody, float64(0)).(float64)
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", totalNum),
+		d.Set("data_list", flattenImageSensitiveInformationDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

commit1: support `hss_image_sensitive_information` data source
commit2: support `hss_image_sensitive_information_detail` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

commit1: support `hss_image_sensitive_information` data source
commit2: support `hss_image_sensitive_information_detail` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceImageSensitiveInformation_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceImageSensitiveInformation_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceImageSensitiveInformation_basic
=== PAUSE TestAccDataSourceImageSensitiveInformation_basic
=== CONT  TestAccDataSourceImageSensitiveInformation_basic
--- PASS: TestAccDataSourceImageSensitiveInformation_basic (12.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.312s


$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceImageSensitiveInformationDetail_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceImageSensitiveInformationDetail_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceImageSensitiveInformationDetail_basic
=== PAUSE TestAccDataSourceImageSensitiveInformationDetail_basic
=== CONT  TestAccDataSourceImageSensitiveInformationDetail_basic
--- PASS: TestAccDataSourceImageSensitiveInformationDetail_basic (17.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       17.219s
```
<img width="955" height="35" alt="image" src="https://github.com/user-attachments/assets/cffdb0a3-4446-454d-873e-6cf1ed0ea19e" />


<img width="990" height="32" alt="image" src="https://github.com/user-attachments/assets/0e35f158-aae8-407a-a18c-b494c21f1e91" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
