### PR TITLE
feat(waf): new resource to batch create whiteblack IP rules

### DIFF
--- a/docs/resources/waf_batch_create_whiteblackip_rules.md
+++ b/docs/resources/waf_batch_create_whiteblackip_rules.md
@@ -1,0 +1,85 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_batch_create_whiteblackip_rules"
+description: |-
+  Manages a resource to batch create whitelist/blacklist IP rules within HuaweiCloud WAF.
+---
+
+# huaweicloud_waf_batch_create_whiteblackip_rules
+
+Manages a resource to batch create whitelist/blacklist IP rules within HuaweiCloud WAF.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+-> This resource is a one-time action resource for batch creating whitelist/blacklist IP rules. Deleting this resource
+   will not remove the created rules, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+variable "addr" {}
+variable "policy_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_waf_batch_create_whiteblackip_rules" "test" {
+  name                  = "test_rule"
+  white                 = 1
+  policy_ids            = var.policy_ids
+  addr                  = var.addr
+  description           = "test description"
+  enterprise_project_id = var.enterprise_project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, NonUpdatable) Specifies the rule name.
+  The name can contain only letters, digits, hyphens (-), underscores (_), and periods (.),
+  and cannot exceed `64` characters.
+
+* `white` - (Required, Int, NonUpdatable) Specifies the protection action.
+  The value can be:
+  + `0`: block
+  + `1`: allow
+  + `2`: log only
+
+* `policy_ids` - (Required, List, NonUpdatable) Specifies the list of policy IDs to which the rule will be applied.
+
+* `addr` - (Optional, String, NonUpdatable) Specifies the IP address or CIDR block.
+  This parameter and `ip_group_id` are alternative.
+
+* `ip_group_id` - (Optional, String, NonUpdatable) Specifies the IP address group ID.
+  This parameter and `addr` are alternative.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the rule.
+
+* `time_mode` - (Optional, String, NonUpdatable) Specifies the time mode.
+  The value can be:
+  + **permanent**: The rule takes effect immediately (default).
+  + **customize**: The rule takes effect during the specified time period.
+
+* `start` - (Optional, Int, NonUpdatable) Specifies the start timestamp.
+  This field is valid only when `time_mode` is set to **customize**.
+
+* `terminal` - (Optional, Int, NonUpdatable) Specifies the end timestamp.
+  This field is valid only when `time_mode` is set to **customize**.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  Value `0` indicates the default enterprise project.
+  Value **all_granted_eps** indicates all enterprise projects to which the user has been granted access.
+  Defaults to `0`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3869,6 +3869,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_ip_intelligence_rule":                waf.ResourceIpIntelligenceRule(),
 			"huaweicloud_waf_modify_alarm_notification":           waf.ResourceModifyAlarmNotification(),
 			"huaweicloud_waf_alarm_notification":                  waf.ResourceWafAlarmNotification(),
+			"huaweicloud_waf_batch_create_whiteblackip_rules":     waf.ResourceWafBatchCreateWhiteBlackIpRules(),
 			"huaweicloud_waf_batch_delete_alarm_notifications":    waf.ResourceWafBatchDeleteAlarmNotifications(),
 			"huaweicloud_waf_migrate_domain":                      waf.ResourceMigrateDomain(),
 			"huaweicloud_waf_policy":                              waf.ResourceWafPolicy(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_create_whiteblackip_rules_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_create_whiteblackip_rules_test.go
@@ -1,0 +1,43 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchCreateWhiteBlackIpRules_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckWafPolicyId(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchCreateWhiteBlackIpRules_basic(name),
+			},
+		},
+	})
+}
+
+func testAccBatchCreateWhiteBlackIpRules_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_batch_create_whiteblackip_rules" "test" {
+  name                  = "%[1]s"
+  white                 = 1
+  policy_ids            = ["%[2]s"]
+  addr                  = "127.0.0.1"
+  description           = "test description"
+  time_mode             = "permanent"
+  enterprise_project_id = "%[3]s"
+}
+`, name, acceptance.HW_WAF_POLICY_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_batch_create_whiteblackip_rules.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_batch_create_whiteblackip_rules.go
@@ -1,0 +1,180 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF POST /v1/{project_id}/waf/rule/whiteblackip
+func ResourceWafBatchCreateWhiteBlackIpRules() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafBatchCreateWhiteBlackIpRulesCreate,
+		ReadContext:   resourceWafBatchCreateWhiteBlackIpRulesRead,
+		UpdateContext: resourceWafBatchCreateWhiteBlackIpRulesUpdate,
+		DeleteContext: resourceWafBatchCreateWhiteBlackIpRulesDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"name",
+			"white",
+			"policy_ids",
+			"addr",
+			"description",
+			"ip_group_id",
+			"time_mode",
+			"start",
+			"terminal",
+			"enterprise_project_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"white": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"policy_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"addr": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"time_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"start": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"terminal": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildBatchCreateWhiteBlackIpRulesQueryParams(epsId string) string {
+	if epsId == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+}
+
+func buildBatchCreateWhiteBlackIpRulesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"white":       d.Get("white"),
+		"policy_ids":  d.Get("policy_ids"),
+		"addr":        utils.ValueIgnoreEmpty(d.Get("addr")),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+		"ip_group_id": utils.ValueIgnoreEmpty(d.Get("ip_group_id")),
+		"time_mode":   utils.ValueIgnoreEmpty(d.Get("time_mode")),
+		"start":       utils.ValueIgnoreEmpty(d.Get("start")),
+		"terminal":    utils.ValueIgnoreEmpty(d.Get("terminal")),
+	}
+}
+
+func resourceWafBatchCreateWhiteBlackIpRulesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/rule/whiteblackip"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath += buildBatchCreateWhiteBlackIpRulesQueryParams(epsId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildBatchCreateWhiteBlackIpRulesBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error batch creating WAF whiteblack IP rules: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	return resourceWafBatchCreateWhiteBlackIpRulesRead(ctx, d, meta)
+}
+
+func resourceWafBatchCreateWhiteBlackIpRulesRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchCreateWhiteBlackIpRulesUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchCreateWhiteBlackIpRulesDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch create whiteblack IP rules. Deleting this resource
+    will not remove the created rules, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to batch create whiteblack IP rules

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccBatchCreateWhiteBlackIpRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccBatchCreateWhiteBlackIpRules_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchCreateWhiteBlackIpRules_basic
=== PAUSE TestAccBatchCreateWhiteBlackIpRules_basic
=== CONT  TestAccBatchCreateWhiteBlackIpRules_basic
--- PASS: TestAccBatchCreateWhiteBlackIpRules_basic (14.89s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       14.999s coverage: 3.7% of statements in ./huaweicloud/services/waf
```
<img width="1348" height="47" alt="image" src="https://github.com/user-attachments/assets/e2ac7486-b192-4f76-a6c9-52569a3b8f55" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
