### PR TITLE
feat(waf): new resource to batct create antileakage rules

### DIFF
--- a/docs/resources/waf_batch_create_antileakage_rules.md
+++ b/docs/resources/waf_batch_create_antileakage_rules.md
@@ -1,0 +1,85 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_batch_create_antileakage_rules"
+description: |-
+  Manages a resource to batch create anti-leakage rules within HuaweiCloud WAF.
+---
+
+# huaweicloud_waf_batch_create_antileakage_rules
+
+Manages a resource to batch create anti-leakage rules within HuaweiCloud WAF.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+-> This resource is a one-time action resource for batch creating anti-leakage rules. Deleting this resource
+   will not remove the created rules, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+variable "policy_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_waf_batch_create_antileakage_rules" "test" {
+  url                   = "/admin"
+  category              = "sensitive"
+  contents              = ["id_card", "phone"]
+  policy_ids            = var.policy_ids
+  description           = "test description"
+  enterprise_project_id = var.enterprise_project_id
+
+  action {
+    category = "block"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `url` - (Required, String, NonUpdatable) Specifies the URL to which the rule applies.
+
+* `category` - (Required, String, NonUpdatable) Specifies the type of the rule.
+  The value can be:
+  + **code**: Response code
+  + **sensitive**: Sensitive information
+
+* `contents` - (Required, List, NonUpdatable) Specifies the content of the rule.
+  + When `category` is **code**, the value can be: `400`, `401`, `402`, `403`, `404`, `405`, `500`, `501`, `502`, `503`,
+    `504`, `507`.
+  + When `category` is **sensitive**, the value can be: **phone** (mobile number), **id_card** (ID card number),
+    **email** (email address).
+
+* `policy_ids` - (Required, List, NonUpdatable) Specifies the list of policy IDs to which the rule will be applied.
+
+* `action` - (Optional, List, NonUpdatable) Specifies the action to take when the rule is matched.
+  The [action](#Rule_action) structure is documented below.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the rule.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  Value `0` indicates the default enterprise project.
+  Value **all_granted_eps** indicates all enterprise projects to which the user has been granted access.
+  Defaults to `0`.
+
+<a name="Rule_action"></a>
+The `action` block supports:
+
+* `category` - (Required, String, NonUpdatable) Specifies the action to take when the rule is matched.
+  The value can be:
+  + **block**: Block the request
+  + **log**: Log the request only
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3874,6 +3874,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_modify_alarm_notification":           waf.ResourceModifyAlarmNotification(),
 			"huaweicloud_waf_alarm_notification":                  waf.ResourceWafAlarmNotification(),
 			"huaweicloud_waf_batch_create_whiteblackip_rules":     waf.ResourceWafBatchCreateWhiteBlackIpRules(),
+			"huaweicloud_waf_batch_create_antileakage_rules":      waf.ResourceWafBatchCreateAntileakageRules(),
 			"huaweicloud_waf_batch_delete_alarm_notifications":    waf.ResourceWafBatchDeleteAlarmNotifications(),
 			"huaweicloud_waf_migrate_domain":                      waf.ResourceMigrateDomain(),
 			"huaweicloud_waf_policy":                              waf.ResourceWafPolicy(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_create_antileakage_rules_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_create_antileakage_rules_test.go
@@ -1,0 +1,45 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchCreateAntileakageRules_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckWafPolicyId(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchCreateAntileakageRules_basic(),
+			},
+		},
+	})
+}
+
+func testAccBatchCreateAntileakageRules_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_batch_create_antileakage_rules" "test" {
+  url                   = "/test"
+  category              = "sensitive"
+  contents              = ["id_card", "phone"]
+  policy_ids            = ["%[1]s"]
+  description           = "test description"
+  enterprise_project_id = "%[2]s"
+
+  action {
+    category = "block"
+  }
+}
+`, acceptance.HW_WAF_POLICY_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_batch_create_antileakage_rules.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_batch_create_antileakage_rules.go
@@ -1,0 +1,192 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF POST /v1/{project_id}/waf/rule/antileakage
+func ResourceWafBatchCreateAntileakageRules() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafBatchCreateAntileakageRulesCreate,
+		ReadContext:   resourceWafBatchCreateAntileakageRulesRead,
+		UpdateContext: resourceWafBatchCreateAntileakageRulesUpdate,
+		DeleteContext: resourceWafBatchCreateAntileakageRulesDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"url",
+			"category",
+			"contents",
+			"policy_ids",
+			"action",
+			"action.*.category",
+			"description",
+			"enterprise_project_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"contents": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"policy_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"action": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"category": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildBatchCreateAntileakageRulesQueryParams(epsId string) string {
+	if epsId == "" {
+		return ""
+	}
+	return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+}
+
+func buildCreateAntileakageRulesAction(d *schema.ResourceData) map[string]interface{} {
+	rawArray := d.Get("action").([]interface{})
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"category": rawMap["category"],
+	}
+}
+
+func buildBatchCreateAntileakageRulesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"url":         d.Get("url"),
+		"category":    d.Get("category"),
+		"contents":    d.Get("contents"),
+		"policy_ids":  d.Get("policy_ids"),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+		"action":      buildCreateAntileakageRulesAction(d),
+	}
+
+	return bodyParams
+}
+
+func resourceWafBatchCreateAntileakageRulesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/rule/antileakage"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath += buildBatchCreateAntileakageRulesQueryParams(epsId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildBatchCreateAntileakageRulesBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error batch creating WAF anti-leakage rules: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	return resourceWafBatchCreateAntileakageRulesRead(ctx, d, meta)
+}
+
+func resourceWafBatchCreateAntileakageRulesRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchCreateAntileakageRulesUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchCreateAntileakageRulesDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch create anti-leakage rules. Deleting this resource
+    will not remove the created rules, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to batct create antileakage rules

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccBatchCreateAntileakageRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccBatchCreateAntileakageRules_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchCreateAntileakageRules_basic
=== PAUSE TestAccBatchCreateAntileakageRules_basic
=== CONT  TestAccBatchCreateAntileakageRules_basic
--- PASS: TestAccBatchCreateAntileakageRules_basic (13.10s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       13.201s coverage: 3.8% of statements in ./huaweicloud/services/waf
```
<img width="1372" height="51" alt="image" src="https://github.com/user-attachments/assets/9532e9dc-0f10-4baf-9d20-a66ec4ca4363" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
