### PR TITLE
fix(obs): fix protocol issues with the encrypt obs sdk

### DIFF
--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -581,7 +581,7 @@ func resourceObsBucketRead(_ context.Context, d *schema.ResourceData, meta inter
 	}
 
 	// Read the encryption configuration
-	if err := setObsBucketEncryption(obsClient, d); err != nil {
+	if err := setObsBucketEncryption(obsClientWithSignature, d); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix protocol issues with the encrypt obs sdk.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Incompatible changes made to the OBS server caused unexpected changes to the provider's sse_algorithm resource.
The protocol for querying the OBS Encrypt interface needs to be replaced with the OBS protocol.

Before fixing the problem:
<img width="1293" height="513" alt="image" src="https://github.com/user-attachments/assets/4787e6f3-a7e3-44fd-8d7a-4d2efee59ee8" />
```
./scripts/coverage.sh -o obs -f TestAccObsBucket_encryption
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccObsBucket_encryption -timeout 360m -parallel 10=== RUN   TestAccObsBucket_encryption
=== PAUSE TestAccObsBucket_encryption
=== CONT  TestAccObsBucket_encryption
    resource_huaweicloud_obs_bucket_test.go:174: Step 3/6 error: Error running apply: exit status 1

        Error: failed to enable default encryption of OBS bucket tf-test-bucket-1470643420077196974: obs: service returned error: Status=400 Bad Request, Code=InvalidArgument, Message=The configuration of bucket encryption contains illegal SSE algorithm, RequestId=0000019B4A06047E47CF63547D4CAF01

          on terraform_plugin_test.tf line 2, in resource "huaweicloud_obs_bucket" "bucket":
           2: resource "huaweicloud_obs_bucket" "bucket" {


--- FAIL: TestAccObsBucket_encryption (49.27s)
FAIL
coverage: 17.5% of statements in ./huaweicloud/services/obs
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       49.383s
FAIL
```



After the problem was fixed:
<img width="1285" height="496" alt="image" src="https://github.com/user-attachments/assets/96a79f54-7157-4807-874a-fd9efe46dfe6" />
```
./scripts/coverage.sh -o obs -f TestAccObsBucket_encryption
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccObsBucket_encryption -timeout 360m -parallel 10=== RUN   TestAccObsBucket_encryption
=== PAUSE TestAccObsBucket_encryption
=== CONT  TestAccObsBucket_encryption
--- PASS: TestAccObsBucket_encryption (95.22s)
PASS
coverage: 17.5% of statements in ./huaweicloud/services/obs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       95.313s coverage: 17.5% of statements in ./huaweicloud/services/obs
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o obs -f TestAccObsBucket_encryption
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccObsBucket_encryption -timeout 360m -parallel 10=== RUN   TestAccObsBucket_encryption
=== PAUSE TestAccObsBucket_encryption
=== CONT  TestAccObsBucket_encryption
--- PASS: TestAccObsBucket_encryption (95.22s)
PASS
coverage: 17.5% of statements in ./huaweicloud/services/obs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       95.313s coverage: 17.5% of statements in ./huaweicloud/services/obs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
