### PR TITLE
fix(AOM): add param query param

### DIFF
--- a/docs/data-sources/aom_alarm_rules_templates.md
+++ b/docs/data-sources/aom_alarm_rules_templates.md
@@ -257,6 +257,8 @@ The `trigger_conditions` block supports:
 
 * `query_match` - Indicates the query filter criteria.
 
+* `query_param` - Indicates the query parameters.
+
 * `thresholds` - Key-value pair. The key indicates the alarm severity while the value indicates the alarm threshold.
 
 * `trigger_interval` - Indicates the check interval.

--- a/docs/resources/aom_alarm_rules_template.md
+++ b/docs/resources/aom_alarm_rules_template.md
@@ -407,6 +407,8 @@ The `trigger_conditions` block supports:
 
 * `query_match` - (Optional, String) Specifies the query filter criteria.
 
+* `query_param` - (Optional, String) Specifies the query parameters.
+
 * `thresholds` - (Optional, Map) Specifies the thresholds. Key-value pair. The key indicates the alarm severity while
   the value indicates the alarm threshold.
 

--- a/huaweicloud/services/aom/data_source_huaweicloud_aom_alarm_rules_templates.go
+++ b/huaweicloud/services/aom/data_source_huaweicloud_aom_alarm_rules_templates.go
@@ -372,6 +372,10 @@ func dataSourceSchemeTemplateMetricTriggerConditions() *schema.Schema {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"query_param": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 				"metric_namespace": {
 					Type:     schema.TypeString,
 					Computed: true,

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_rules_template.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_rules_template.go
@@ -378,6 +378,10 @@ func resourceSchemeTemplateMetricTriggerConditions() *schema.Schema {
 					Type:     schema.TypeString,
 					Optional: true,
 				},
+				"query_param": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
 				"metric_namespace": {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -400,6 +404,7 @@ func resourceSchemeTemplateMetricTriggerConditions() *schema.Schema {
 				},
 			},
 		},
+		Set: resourceMetricTriggerConditionHash,
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccDataSourceAlarmRulesTemplates_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccDataSourceAlarmRulesTemplates_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAlarmRulesTemplates_basic
=== PAUSE TestAccDataSourceAlarmRulesTemplates_basic
=== CONT  TestAccDataSourceAlarmRulesTemplates_basic
--- PASS: TestAccDataSourceAlarmRulesTemplates_basic (34.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       34.664s

make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccAlarmRulesTemplate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccAlarmRulesTemplate_basic -timeout 360m -parallel 4
=== RUN   TestAccAlarmRulesTemplate_basic
=== PAUSE TestAccAlarmRulesTemplate_basic
=== CONT  TestAccAlarmRulesTemplate_basic
--- PASS: TestAccAlarmRulesTemplate_basic (44.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       45.029s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
