### PR TITLE
feat(mrs/cluster): the cluster supports setting agency

### DIFF
--- a/docs/data-sources/mapreduce_clusters.md
+++ b/docs/data-sources/mapreduce_clusters.md
@@ -245,6 +245,8 @@ The `Clusters` block supports:
 * `eipv6_address` - IPv6 address of the cluster EIP.  
   This parameter is not returned when an IPv4 address is used.
 
+* `mrs_ecs_default_agency` - The default agency name bound to the cluster node.
+
 <a name="MrsClusters_ClustersComponentList"></a>
 The `component_list` block supports:
 

--- a/docs/resources/mapreduce_cluster.md
+++ b/docs/resources/mapreduce_cluster.md
@@ -488,6 +488,9 @@ The EIP must have been created and must be in the same region as the cluster.
   structure is documented below.
   Changing this will create a new MapReduce cluster resource.
 
+* `mrs_ecs_default_agency` - (Optional, String, ForceNew) Specifies the default agency name bound to the cluster node.  
+  Changing this will create a new MapReduce cluster resource.
+
 * `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the cluster.  
   Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.  
   Changing this parameter will create a new MapReduce cluster resource.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20251218073404-b0ffc97d9103
+	github.com/chnsz/golangsdk v0.0.0-20251223022605-afc4ab0a25d5
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20251218073404-b0ffc97d9103 h1:GxRHchywOZfm4fbLyh4ktn9QK9ATVsDw1Gq8QWajybU=
-github.com/chnsz/golangsdk v0.0.0-20251218073404-b0ffc97d9103/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
+github.com/chnsz/golangsdk v0.0.0-20251223022605-afc4ab0a25d5 h1:LaIwc+PTMiOHNJiOA8FdBefYbWZi8W4ZwWtnZHa1OC4=
+github.com/chnsz/golangsdk v0.0.0-20251223022605-afc4ab0a25d5/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_clusters_test.go
+++ b/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_clusters_test.go
@@ -2,94 +2,229 @@ package mrs
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func TestAccDatasourceMrsClusters_basic(t *testing.T) {
-	rName := "data.huaweicloud_mapreduce_clusters.name_filter"
-	dc := acceptance.InitDataSourceCheck(rName)
-	name := acceptance.RandomAccResourceName()
-	pwd := acceptance.RandomPassword()
+func TestAccDatasourceClusters_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_mapreduce_clusters.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_mapreduce_clusters.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byStatus   = "data.huaweicloud_mapreduce_clusters.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byTags   = "data.huaweicloud_mapreduce_clusters.filter_by_tags"
+		dcByTags = acceptance.InitDataSourceCheck(byTags)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMrsClusterFlavorID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceMrsClusters_basic(name, pwd),
+				Config: testAccDatasourceClusters_basic(),
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(rName, "clusters.0.name", "huaweicloud_mapreduce_cluster.test", "name"),
-					resource.TestCheckResourceAttrPair(rName, "clusters.0.enterprise_project_id",
+					resource.TestMatchResourceAttr(all, "clusters.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'name' parameter.
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					// Filter by 'status' parameter.
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					// Filter by 'tags' parameter.
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+					// Check attributes.
+					resource.TestCheckResourceAttrPair(byName, "clusters.0.name", "huaweicloud_mapreduce_cluster.test", "name"),
+					resource.TestCheckResourceAttrPair(byName, "clusters.0.enterprise_project_id",
 						"huaweicloud_mapreduce_cluster.test", "enterprise_project_id"),
-					resource.TestCheckResourceAttr(rName, "clusters.0.type", "1"),
-					resource.TestCheckResourceAttrPair(rName, "clusters.0.version",
+					resource.TestCheckResourceAttr(byName, "clusters.0.type", "3"),
+					resource.TestCheckResourceAttrPair(byName, "clusters.0.version",
 						"huaweicloud_mapreduce_cluster.test", "version"),
-					resource.TestCheckResourceAttr(rName, "clusters.0.safe_mode", "1"),
-					resource.TestCheckResourceAttrSet(rName, "clusters.0.id"),
-					resource.TestCheckResourceAttrSet(rName, "clusters.0.vpc_id"),
-					resource.TestCheckResourceAttrSet(rName, "clusters.0.subnet_id"),
-					resource.TestCheckResourceAttrSet(rName, "clusters.0.vnc"),
-					resource.TestCheckResourceAttr(rName, "clusters.0.component_list.0.component_name", "Storm"),
-
-					resource.TestCheckOutput("name_filter_is_useful", "true"),
-
-					resource.TestCheckOutput("status_filter_is_useful", "true"),
-
-					resource.TestCheckOutput("tags_filter_is_useful", "true"),
+					resource.TestCheckResourceAttr(byName, "clusters.0.safe_mode", "1"),
+					resource.TestCheckResourceAttrSet(byName, "clusters.0.id"),
+					resource.TestCheckResourceAttrSet(byName, "clusters.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(byName, "clusters.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(byName, "clusters.0.vnc"),
+					resource.TestCheckResourceAttrSet(byName, "clusters.0.availability_zone"),
+					resource.TestMatchResourceAttr(byName, "clusters.0.component_list.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(byName, "clusters.0.component_list.0.component_id"),
+					resource.TestCheckResourceAttrSet(byName, "clusters.0.component_list.0.component_name"),
+					resource.TestCheckResourceAttrSet(byName, "clusters.0.component_list.0.component_version"),
+					resource.TestCheckResourceAttrSet(byName, "clusters.0.component_list.0.component_desc"),
+					resource.TestMatchResourceAttr(byName, "clusters.0.task_node_groups.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(byName, "clusters.0.master_data_volume_count", "1"),
+					resource.TestCheckResourceAttr(byName, "clusters.0.master_data_volume_size", "600"),
+					resource.TestCheckResourceAttr(byName, "clusters.0.master_data_volume_type", "SAS"),
+					resource.TestCheckResourceAttr(byName, "clusters.0.master_node_num", "3"),
+					resource.TestCheckResourceAttr(byName, "clusters.0.master_node_size", acceptance.HW_MRS_CLUSTER_FLAVOR_ID),
+					resource.TestCheckResourceAttrSet(byName, "clusters.0.master_node_spec_id"),
+					resource.TestCheckResourceAttrSet(byName, "clusters.0.master_node_ip"),
+					resource.TestCheckResourceAttrSet(byName, "clusters.0.security_group_id"),
+					resource.TestCheckResourceAttr(byName, "clusters.0.log_collection", "1"),
+					resource.TestCheckResourceAttr(byName, "clusters.0.mrs_ecs_default_agency", "MRS_ECS_DEFAULT_AGENCY"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDatasourceMrsClusters_basic(name, pwd string) string {
+func testAccDataClusters_base(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-data "huaweicloud_mapreduce_clusters" "status_filter" {
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_mapreduce_cluster" "test" {
+  availability_zone      = try(data.huaweicloud_availability_zones.test.names[0], "")
+  name                   = "%[2]s_basic"
+  type                   = "CUSTOM"
+  version                = "MRS 3.5.0-LTS"
+  manager_admin_pass     = "%[3]s"
+  node_admin_pass        = "%[3]s"
+  subnet_id              = huaweicloud_vpc_subnet.test.id
+  vpc_id                 = huaweicloud_vpc.test.id
+  component_list         = ["Hadoop", "ZooKeeper", "Ranger", "DBService"]
+  mrs_ecs_default_agency = "MRS_ECS_DEFAULT_AGENCY"
+
+  master_nodes {
+    flavor            = "%[4]s"
+    node_number       = 3
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+
+    assigned_roles = [
+      "OMSServer:1,2",
+      "SlapdServer:1,2",
+      "KerberosServer:1,2",
+      "KerberosAdmin:1,2",
+      "quorumpeer:1,2,3",
+      "NameNode:2,3",
+      "Zkfc:2,3",
+      "JournalNode:1,2,3",
+      "ResourceManager:2,3",
+      "JobHistoryServer:3",
+      "DBServer:1,3",
+      "HttpFS:1,3",
+      "TimelineServer:3",
+      "RangerAdmin:1,2",
+      "UserSync:2",
+      "TagSync:2",
+      "KerberosClient",
+      "SlapdClient",
+      "meta"
+    ]
+  }
+
+  custom_nodes {
+    group_name        = "node_group_1"
+    flavor            = "%[4]s"
+    node_number       = 4
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+
+    assigned_roles = [
+      "NodeManager",
+      "KerberosClient",
+      "SlapdClient",
+      "DataNode",
+      "meta"
+    ]
+  }
+
+  tags = {
+    foo = "%[2]s"
+  }
+}
+`, common.TestVpc(name), name, acceptance.RandomPassword(), acceptance.HW_MRS_CLUSTER_FLAVOR_ID)
+}
+
+func testAccDatasourceClusters_basic() string {
+	name := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_mapreduce_clusters" "all" {}
+
+# Filter by 'name' parameter.
+locals {
+  name = huaweicloud_mapreduce_cluster.test.name
+}
+
+data "huaweicloud_mapreduce_clusters" "filter_by_name" {
+  name   = local.name
   status = "running"
 
-  depends_on = [
-    huaweicloud_mapreduce_cluster.test
-  ]
+  depends_on = [huaweicloud_mapreduce_cluster.test]
 }
 
-output "status_filter_is_useful" {
-  value = length(data.huaweicloud_mapreduce_clusters.status_filter.clusters) > 0 && alltrue(
-    [for v in data.huaweicloud_mapreduce_clusters.status_filter.clusters[*].status : v == "running"]
-  )  
+locals {
+  name_filter_result = [for v in data.huaweicloud_mapreduce_clusters.filter_by_name.clusters[*].name : strcontains(v, local.name)]
 }
 
-data "huaweicloud_mapreduce_clusters" "name_filter" {
-  name   = "%[2]s"
-  status = "existing"
-
-  depends_on = [
-    huaweicloud_mapreduce_cluster.test
-  ]
-}
-output "name_filter_is_useful" {
-  value = length(data.huaweicloud_mapreduce_clusters.name_filter.clusters) > 0 && alltrue(
-    [for v in data.huaweicloud_mapreduce_clusters.name_filter.clusters[*].name : v == "%[2]s"]
-  )  
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
 }
 
-data "huaweicloud_mapreduce_clusters" "tags_filter" {
-  tags = "foo*bar,key*value"
+# Filter by 'status' parameter.
+locals {
+  status = huaweicloud_mapreduce_cluster.test.status
+}
 
-  depends_on = [
-    huaweicloud_mapreduce_cluster.test
-  ]
+data "huaweicloud_mapreduce_clusters" "filter_by_status" {
+  status = local.status
+
+  depends_on = [huaweicloud_mapreduce_cluster.test]
 }
-output "tags_filter_is_useful" {
-  value = length(data.huaweicloud_mapreduce_clusters.tags_filter.clusters) > 0 && alltrue(
-    [for v in data.huaweicloud_mapreduce_clusters.tags_filter.clusters[*].tags.foo : v == "bar"]
-  )  
+
+locals {
+  status_filter_result = [for v in data.huaweicloud_mapreduce_clusters.filter_by_status.clusters : v.status == local.status]
 }
-`, testAccMrsMapReduceClusterConfig_basic(name, pwd), name)
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+# Filter by 'tags' parameter.
+locals {
+  tags     = huaweicloud_mapreduce_cluster.test.tags
+  tags_str = join(",", [for k, v in huaweicloud_mapreduce_cluster.test.tags : format("%%s*%%s", k, v)])
+}
+
+data "huaweicloud_mapreduce_clusters" "filter_by_tags" {
+  tags = local.tags_str
+
+  depends_on = [huaweicloud_mapreduce_cluster.test]
+}
+
+locals {
+  tags_filter_result = [for item in data.huaweicloud_mapreduce_clusters.filter_by_tags.clusters :
+  alltrue([for k, v in local.tags : v == item.tags[k]])]
+}
+
+output "is_tags_filter_useful" {
+  value = length(local.tags_filter_result) > 0 && alltrue(local.tags_filter_result)
+}
+`, testAccDataClusters_base(name))
 }

--- a/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_clusters.go
+++ b/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_clusters.go
@@ -337,6 +337,11 @@ func mrsClustersClustersSchema() *schema.Resource {
 				Computed:    true,
 				Description: `IPv6 address of the cluster EIP.`,
 			},
+			"mrs_ecs_default_agency": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The default agency name bound to the cluster node.`,
+			},
 		},
 	}
 	return &sc
@@ -616,6 +621,7 @@ func flattenGetClustersResponseBodyClusters(clusters []interface{}) []interface{
 			"eip_id":                   utils.PathSearch("eipId", v, nil),
 			"eip_address":              utils.PathSearch("eipAddress", v, nil),
 			"eipv6_address":            utils.PathSearch("eipv6Address", v, nil),
+			"mrs_ecs_default_agency":   utils.PathSearch("mrsEcsDefaultAgency", v, nil),
 		})
 	}
 	return rst

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster.go
@@ -252,6 +252,14 @@ func ResourceMRSClusterV2() *schema.Resource {
 				MaxItems: 1,
 				Elem:     smnNotifySchema(),
 			},
+			"mrs_ecs_default_agency": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				// Adding `Computed` to prevent changes when some regions return a default agency name.
+				Computed:    true,
+				Description: `The default agency name to be bound to the cluster node.`,
+			},
 			"charging_mode": common.SchemaChargingMode(nil),
 			"period_unit":   common.SchemaPeriodUnit(nil),
 			"period":        common.SchemaPeriod(nil),
@@ -790,6 +798,7 @@ func resourceMRSClusterV2Create(ctx context.Context, d *schema.ResourceData, met
 		ExternalDatasources:  buildClusterExternalDatasources(d.Get("external_datasources")),
 		BootstrapScripts:     buildBootstrapScripts(d.Get("bootstrap_scripts").(*schema.Set)),
 		SMNNotifyConfig:      buildSMNNotify(d),
+		MrsEcsDefaultAgency:  d.Get("mrs_ecs_default_agency").(string),
 	}
 	if v, ok := d.GetOk("node_key_pair"); ok {
 		createOpts.NodeKeypair = v.(string)
@@ -1161,6 +1170,7 @@ func resourceMRSClusterV2Read(_ context.Context, d *schema.ResourceData, meta in
 		setMrsClusterNodeGroups(d, client, resp),
 		d.Set("tags", flattenTags(resp.Tags)),
 		d.Set("bootstrap_scripts", flattenBootstrapScripts(resp.BootstrapScripts)),
+		d.Set("mrs_ecs_default_agency", resp.MrsEcsDefaultAgency),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())

--- a/vendor/github.com/chnsz/golangsdk/openstack/mrs/v1/cluster/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/mrs/v1/cluster/results.go
@@ -69,6 +69,8 @@ type Cluster struct {
 	EipAddress            string            `json:"eipAddress"`
 	Eipv6Address          string            `json:"eipv6Address"`
 	Tags                  string            `json:"tags"`
+	// The default agency name bound to the cluster node.
+	MrsEcsDefaultAgency string `json:"mrsEcsDefaultAgency"`
 }
 
 type Component struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20251218073404-b0ffc97d9103
+# github.com/chnsz/golangsdk v0.0.0-20251223022605-afc4ab0a25d5
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. The cluster resource and data source supports new field `mrs_ecs_default_agency`.
2. Adjust acceptance test of the data source.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o mrs -f TestAccMrsMapReduceCluster_custom_compact
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccMrsMapReduceCluster_custom_compact -timeout 360m -parallel 10
=== RUN   TestAccMrsMapReduceCluster_custom_compact
=== PAUSE TestAccMrsMapReduceCluster_custom_compact
=== CONT  TestAccMrsMapReduceCluster_custom_compact
---- PASS: TestAccMrsMapReduceCluster_custom_compact (959.57s)
PASS
coverage: 21.6% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       959.717s        coverage: 21.6% of statements in ./huaweicloud/services/mrs
```

```
./scripts/coverage.sh -o mrs -f TestAccDatasourceClusters_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccDatasourceClusters_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceClusters_basic
=== PAUSE TestAccDatasourceClusters_basic
=== CONT  TestAccDatasourceClusters_basic
--- PASS: TestAccDatasourceClusters_basic (919.55s)
PASS
coverage: 27.0% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       919.689s        coverage: 27.0% of statements in ./huaweicloud/services/mrs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
