### PR TITLE
feat(waf): new resource to batch create ignore rules

### DIFF
--- a/docs/resources/waf_batch_create_ignore_rules.md
+++ b/docs/resources/waf_batch_create_ignore_rules.md
@@ -1,0 +1,136 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_batch_create_ignore_rules"
+description: |-
+  Manages a resource to batch create WAF ignore rules (whitelist rules) within HuaweiCloud WAF.
+---
+
+# huaweicloud_waf_batch_create_ignore_rules
+
+Manages a resource to batch create WAF ignore rules (whitelist rules) within HuaweiCloud WAF.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+-> This resource is a one-time action resource for batch creating ignore rules. Deleting this resource
+   will not remove the created rules, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+variable "policy_ids" {
+  type = list(string)
+}
+variable "domain" {
+  type = list(string)
+}
+
+resource "huaweicloud_waf_batch_create_ignore_rules" "test" {
+  rule                  = "xss"
+  description           = "test description"
+  policy_ids            = var.policy_ids
+  enterprise_project_id = var.enterprise_project_id
+  domain                = var.domain
+
+  conditions {
+    category        = "url"
+    contents        = ["/admin"]
+    logic_operation = "equal"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `domain` - (Required, List, NonUpdatable) Specifies the protected domain name or website.
+  When the array length is `0`, the rule applies to all domain names or protected websites.
+  When the access mode of the protected domain name is cloud mode-ELB access, this parameter must be filled in the
+  format `<domain name>:[/topic/body/section/table/tgroup/tbody/row/entry/p/br {""}) (br]` (e.g., `www.example.com:id`).
+  If all listeners under the load balancer (ELB) bound to the domain name are connected to WAF protection, the ID entered
+  should be the load balancer (ELB) ID; otherwise, the ID entered should be the specified listener ID.
+  You can find the ELB instance ID bound to the domain name on the domain details page of the WAF console, and find its
+  listener ID under the ELB-side listener tab.
+
+* `conditions` - (Required, List, NonUpdatable) Specifies the matching conditions for the rule.
+  The [conditions](#Rule_conditions) structure is documented below.
+
+* `rule` - (Required, String, NonUpdatable) Specifies the rule to be ignored. You can block one or more characters;
+  when blocking multiple characters, use a half-width character (;) to separate them.
+
+  + If you want to block a specific built-in rule, the value of this parameter is the rule ID.
+  To query the rule ID, go to the WAF console, choose **Policies** and click the target policy name. On the displayed
+  page, in the **Basic Web Protection** area, select the **Protection Rules** tab, and view the ID of the specific rule.
+  You can also query the rule ID in the event details.
+
+  + If you want to mask a type of basic web protection rules, set this parameter to the name of the type of basic web
+  protection rules. Valid values are: **xss**(XSS attacks), **webshell**(Web shells), **vuln**(Other types of attacks),
+  **sqli**(SQL injection attack), **robot**(Malicious crawlers), **rfi**(Remote file inclusion),
+  **lfi**(Local file inclusion), **cmdi**(Command injection attack).
+
+  + To bypass the basic web protection, set this parameter to **all**.
+
+  + To bypass all WAF protection, set this parameter to **bypass**.
+
+* `policy_ids` - (Required, List, NonUpdatable) Specifies the list of policy IDs to which the rule will be applied.
+
+* `advanced` - (Optional, List, NonUpdatable) Specifies the advanced matching conditions for the rule.
+  The [advanced](#Rule_advanced) structure is documented below.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the rule.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  Value `0` indicates the default enterprise project.
+  Value **all_granted_eps** indicates all enterprise projects to which the user has been granted access.
+  Defaults to `0`.
+
+<a name="Rule_advanced"></a>
+The `advanced` block supports:
+
+* `index` - (Optional, String, NonUpdatable) Specifies the field type.
+  Supported field types include: **params**, **cookie**, **header**, **body**, and **multipart**.
+
+* `contents` - (Optional, List, NonUpdatable) Specifies the content of the condition.
+
+<a name="Rule_conditions"></a>
+The `conditions` block supports:
+
+* `category` - (Required, String, NonUpdatable) Specifies the field type.
+  The value can be: **ip**, **url**, **params**, **cookie**, or **header**.
+
+* `contents` - (Required, List, NonUpdatable) Specifies the content of the condition.
+  The array length is limited to `1`. The content format varies depending on the field type.
+  For example, when the `category` is **ip**, the content format must be an IP address or a range of IP addresses;
+  when the `category` is **url**, the content format must be a standard URL;
+  when the `category` is **params**, **cookie**, or **header**, there are no restrictions on the content format.
+
+* `logic_operation` - (Required, String, NonUpdatable) Specifies the matching logic.
+  The matching logic varies depending on the field type.
+  When the `category` is **ip**, the matching logic supports **equal** and **not_equal**.
+  When the `category` is **url**, **header**, **params**, or **cookie**, the matching logic supports **equal**,
+  **not_equal**, **contain**, **not_contain**, **prefix**, **not_prefix**, **suffix**, **not_suffix**, **regular_match**,
+  and **regular_not_match**.
+
+* `check_all_indexes_logic` - (Optional, Int, NonUpdatable) Specifies how to check subfields.
+  When using custom subfields or `category` is **url** or **ip**, the `check_all_indexes_logic` parameter is not required.
+  In other cases, the value can be:
+  + `1`: Check all subfields
+  + `2`: Check any subfield
+
+* `index` - (Optional, String, NonUpdatable) Specifies the subfield name.
+  When the `category` is **ip** and the subfield is the client's IP, the `index` parameter is not required.
+  When the subfield type is **X-Forwarded-For**, the value is **x-forwarded-for**;
+  when the `category` is **params**, **header**, or **cookie** and the subfield is custom, the value of `index` is the
+  custom subfield.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3878,6 +3878,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_alarm_notification":                  waf.ResourceWafAlarmNotification(),
 			"huaweicloud_waf_batch_create_whiteblackip_rules":     waf.ResourceWafBatchCreateWhiteBlackIpRules(),
 			"huaweicloud_waf_batch_create_antileakage_rules":      waf.ResourceWafBatchCreateAntileakageRules(),
+			"huaweicloud_waf_batch_create_ignore_rules":           waf.ResourceWafBatchCreateIgnoreRules(),
 			"huaweicloud_waf_batch_delete_alarm_notifications":    waf.ResourceWafBatchDeleteAlarmNotifications(),
 			"huaweicloud_waf_migrate_domain":                      waf.ResourceMigrateDomain(),
 			"huaweicloud_waf_policy":                              waf.ResourceWafPolicy(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_create_ignore_rules_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_create_ignore_rules_test.go
@@ -1,0 +1,52 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchCreateIgnoreRules_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckWafPolicyId(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchCreateIgnoreRules_basic(),
+			},
+		},
+	})
+}
+
+func testAccBatchCreateIgnoreRules_basic() string {
+	domainName := fmt.Sprintf("%s.huaweicloud.com", acceptance.RandomAccResourceName())
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_batch_create_ignore_rules" "test" {
+  rule                  = "xss"
+  description           = "test description"
+  policy_ids            = ["%[1]s"]
+  enterprise_project_id = "%[2]s"
+  domain                = ["%[3]s"]
+
+  conditions {
+    category        = "url"
+    contents        = ["/admin"]
+    logic_operation = "equal"
+  }
+
+  advanced {
+    index    = "params"
+    contents = ["test-param"]
+  }
+}
+`, acceptance.HW_WAF_POLICY_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, domainName)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_batch_create_ignore_rules.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_batch_create_ignore_rules.go
@@ -1,0 +1,267 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF POST /v1/{project_id}/waf/rule/ignore
+func ResourceWafBatchCreateIgnoreRules() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafBatchCreateIgnoreRulesCreate,
+		ReadContext:   resourceWafBatchCreateIgnoreRulesRead,
+		UpdateContext: resourceWafBatchCreateIgnoreRulesUpdate,
+		DeleteContext: resourceWafBatchCreateIgnoreRulesDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"conditions",
+			"conditions.*.category",
+			"conditions.*.contents",
+			"conditions.*.logic_operation",
+			"conditions.*.check_all_indexes_logic",
+			"conditions.*.index",
+			"rule",
+			"policy_ids",
+			"domain",
+			"advanced",
+			"advanced.*.index",
+			"advanced.*.contents",
+			"description",
+			"enterprise_project_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"domain": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"conditions": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     batchCreateIgnoreRulesConditionsSchema(),
+			},
+			"rule": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"policy_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"advanced": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     batchCreateIgnoreRulesAdvancedSchema(),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func batchCreateIgnoreRulesAdvancedSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"index": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"contents": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func batchCreateIgnoreRulesConditionsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"contents": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"logic_operation": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"check_all_indexes_logic": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"index": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func buildBatchCreateIgnoreRulesQueryParams(epsId string) string {
+	if epsId == "" {
+		return ""
+	}
+	return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+}
+
+func buildBatchCreateIgnoreRulesConditionsBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	rawArray, ok := d.Get("conditions").([]interface{})
+	if !ok {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"category":                rawMap["category"],
+			"contents":                rawMap["contents"],
+			"logic_operation":         rawMap["logic_operation"],
+			"check_all_indexes_logic": utils.ValueIgnoreEmpty(rawMap["check_all_indexes_logic"]),
+			"index":                   utils.ValueIgnoreEmpty(rawMap["index"]),
+		})
+	}
+
+	return rst
+}
+
+func buildBatchCreateIgnoreRulesAdvancedBodyParams(d *schema.ResourceData) map[string]interface{} {
+	rawArray, ok := d.Get("advanced").([]interface{})
+	if !ok || len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"index":    utils.ValueIgnoreEmpty(rawMap["index"]),
+		"contents": utils.ValueIgnoreEmpty(rawMap["contents"]),
+	}
+}
+
+func buildBatchCreateIgnoreRulesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"domain":      d.Get("domain"),
+		"conditions":  buildBatchCreateIgnoreRulesConditionsBodyParams(d),
+		"mode":        1,
+		"rule":        d.Get("rule"),
+		"policy_ids":  d.Get("policy_ids"),
+		"advanced":    buildBatchCreateIgnoreRulesAdvancedBodyParams(d),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+
+	return bodyParams
+}
+
+func resourceWafBatchCreateIgnoreRulesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/rule/ignore"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath += buildBatchCreateIgnoreRulesQueryParams(epsId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildBatchCreateIgnoreRulesBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error batch creating WAF ignore rules: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	return resourceWafBatchCreateIgnoreRulesRead(ctx, d, meta)
+}
+
+func resourceWafBatchCreateIgnoreRulesRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchCreateIgnoreRulesUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchCreateIgnoreRulesDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch create WAF ignore rules. Deleting this resource
+    will not remove the created rules, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to batch create ignore rules

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccBatchCreateIgnoreRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccBatchCreateIgnoreRules_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchCreateIgnoreRules_basic
=== PAUSE TestAccBatchCreateIgnoreRules_basic
=== CONT  TestAccBatchCreateIgnoreRules_basic
--- PASS: TestAccBatchCreateIgnoreRules_basic (12.25s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       12.376s coverage: 4.0% of statements in ./huaweicloud/services/waf
```
<img width="1397" height="57" alt="image" src="https://github.com/user-attachments/assets/91d5a3ef-6971-4ccf-8bb6-8d1b94b403f4" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
