### PR TITLE
feat(waf): new resource to batch create custom rules

### DIFF
--- a/docs/resources/waf_batch_create_custom_rules.md
+++ b/docs/resources/waf_batch_create_custom_rules.md
@@ -1,0 +1,141 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_batch_create_custom_rules"
+description: |-
+  Manages a resource to batch create WAF custom (precise protection) rules within HuaweiCloud WAF.
+---
+
+# huaweicloud_waf_batch_create_custom_rules
+
+Manages a resource to batch create WAF custom rules (precise protection rules) within HuaweiCloud WAF.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+-> This resource is a one-time action resource for batch creating custom rules. Deleting this resource
+   will not remove the created rules, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+variable "policy_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_waf_batch_create_custom_rules" "test" {
+  name        = "test_rule"
+  description = "test description"
+  time        = false
+  priority    = 10
+  policy_ids  = var.policy_ids
+  
+  conditions {
+    category        = "url"
+    logic_operation = "equal"
+    contents        = ["/admin"]
+  }
+
+  action {
+    category = "block"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `time` - (Required, Bool, NonUpdatable) Specifies whether to customize the effective time of the rule.
+  The value can be:
+  + **false**: The rule takes effect immediately
+  + **true**: Customize the effective time
+
+* `conditions` - (Required, List, NonUpdatable) Specifies the list of matching conditions.
+  The [conditions](#Rule_conditions) structure is documented below.
+
+* `action` - (Required, List, NonUpdatable) Specifies the action to take when the rule is matched.
+  The [action](#Rule_action) structure is documented below.
+
+* `priority` - (Required, Int, NonUpdatable) Specifies the priority of the rule.
+  The value ranges from `0` to `65,535`. A smaller value indicates a higher priority.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the rule.
+
+* `policy_ids` - (Required, List, NonUpdatable) Specifies the list of policy IDs to which the rule will be applied.
+
+* `start` - (Optional, Int, NonUpdatable) Specifies the start timestamp (in seconds) when the rule takes effect.
+  This parameter is required when `time` is **true**.
+
+* `terminal` - (Optional, Int, NonUpdatable) Specifies the end timestamp (in seconds) when the rule takes effect.
+  This parameter is required when `time` is **true**.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the rule.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  Value `0` indicates the default enterprise project.
+  Value **all_granted_eps** indicates all enterprise projects to which the user has been granted access.
+  Defaults to `0`.
+
+<a name="Rule_conditions"></a>
+The `conditions` block supports:
+
+* `category` - (Optional, String) Specifies the field type to match against.
+  The value can be:
+  + **url**
+  + **user-agent**
+  + **ip**
+  + **params**
+  + **cookie**
+  + **referer**
+  + **header**
+  + **request_line**
+  + **method**
+  + **request**
+
+* `index` - (Optional, String) Specifies the subfield name.
+  + When `category` is **params**, **header**, or **cookie**, the value of `index` is custom subfield.
+  + For other `category` values, leave this empty.
+
+* `logic_operation` - (Optional, String) Specifies the matching logic operation.
+  + When `category` is **url**, **user-agent**, or **referer**, the value can be: **equal**, **not_equal**, **contain**,
+    **not_contain**, **prefix**, **not_prefix**, **suffix**, **not_suffix**, **contain_any**, **not_contain_all**,
+    **equal_any**, **not_equal_all**, **prefix_any**, **not_prefix_all**, **suffix_any**, **not_suffix_all**,
+    **len_greater**, **len_less**, **len_equal**, **len_not_equal**
+  + When `category` is **ip**, the value can be: **equal**, **not_equal**, **equal_any**, **not_equal_all**
+  + When `category` is **method**, the value can be: **equal**, **not_equal**
+  + When `category` is **request_line** or **request**, the value can be: **len_greater**, **len_less**, **len_equal**,
+    **len_not_equal**
+  + When `category` is **params**, **header**, or **cookie**, the value can be: **contain**, **not_contain**, **equal**,
+    **not_equal**, **prefix**, **not_prefix**, **suffix**, **not_suffix**, **contain_any**, **not_contain_all**,
+    **equal_any**, **not_equal_all**, **prefix_any**, **not_prefix_all**, **suffix_any**, **not_suffix_all**,
+    **len_greater**, **len_less**, **len_equal**, **len_not_equal**, **num_greater**, **num_less**, **num_equal**,
+    **num_not_equal**, **exist**, **not_exist**
+
+* `contents` - (Optional, List) Specifies the content to match against.
+  This parameter is required when `logic_operation` does not end with **any** or **all**.
+
+* `value_list_id` - (Optional, String) Specifies the reference table ID.
+  This parameter is required when `logic_operation` ends with **any** or **all**.
+
+<a name="Rule_action"></a>
+The `action` block supports:
+
+* `category` - (Required, String) Specifies the action to take when the rule is matched.
+  The value can be:
+  + **block**: Block the request
+  + **pass**: Allow the request
+  + **log**: Log the request only
+
+* `followed_action_id` - (Optional, String) Specifies the ID of the attack penalty rule.
+  This parameter is valid only when `category` is set to **block**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3880,6 +3880,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_alarm_notification":                  waf.ResourceWafAlarmNotification(),
 			"huaweicloud_waf_batch_create_whiteblackip_rules":     waf.ResourceWafBatchCreateWhiteBlackIpRules(),
 			"huaweicloud_waf_batch_create_antileakage_rules":      waf.ResourceWafBatchCreateAntileakageRules(),
+			"huaweicloud_waf_batch_create_custom_rules":           waf.ResourceWafBatchCreateCustomRules(),
 			"huaweicloud_waf_batch_create_ignore_rules":           waf.ResourceWafBatchCreateIgnoreRules(),
 			"huaweicloud_waf_batch_delete_alarm_notifications":    waf.ResourceWafBatchDeleteAlarmNotifications(),
 			"huaweicloud_waf_migrate_domain":                      waf.ResourceMigrateDomain(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_create_custom_rules_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_create_custom_rules_test.go
@@ -1,0 +1,51 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchCreateCustomRules_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckWafPolicyId(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchCreateCustomRules_basic(),
+			},
+		},
+	})
+}
+
+func testAccBatchCreateCustomRules_basic() string {
+	name := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_batch_create_custom_rules" "test" {
+  name        = "%[1]s"
+  description = "test description"
+  time        = false
+  priority    = 10
+  policy_ids  = ["%[2]s"]
+  
+  conditions {
+    category        = "url"
+    logic_operation = "equal"
+    contents        = ["/[1]s"]
+  }
+
+  action {
+    category = "block"
+  }
+}
+`, name, acceptance.HW_WAF_POLICY_ID)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_batch_create_custom_rules.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_batch_create_custom_rules.go
@@ -1,0 +1,277 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF POST /v1/{project_id}/waf/rule/custom
+func ResourceWafBatchCreateCustomRules() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafBatchCreateCustomRulesCreate,
+		ReadContext:   resourceWafBatchCreateCustomRulesRead,
+		UpdateContext: resourceWafBatchCreateCustomRulesUpdate,
+		DeleteContext: resourceWafBatchCreateCustomRulesDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"time",
+			"conditions",
+			"conditions.*.category",
+			"conditions.*.index",
+			"conditions.*.logic_operation",
+			"conditions.*.contents",
+			"conditions.*.value_list_id",
+			"action",
+			"action.*.category",
+			"action.*.followed_action_id",
+			"priority",
+			"name",
+			"policy_ids",
+			"start",
+			"terminal",
+			"description",
+			"enterprise_project_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"time": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"conditions": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     buildBatchCreateCustomRulesConditionsSchema(),
+			},
+			"action": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem:     buildBatchCreateCustomRulesActionSchema(),
+			},
+			"priority": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"policy_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"start": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"terminal": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildBatchCreateCustomRulesActionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"followed_action_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func buildBatchCreateCustomRulesConditionsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"category": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"index": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"logic_operation": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"contents": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"value_list_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func buildBatchCreateCustomRulesQueryParams(epsId string) string {
+	if epsId == "" {
+		return ""
+	}
+	return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+}
+
+func buildBatchCreateCustomRulesConditionsBodyParam(d *schema.ResourceData) []map[string]interface{} {
+	rawArray, ok := d.Get("conditions").([]interface{})
+	if !ok || len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"category":        utils.ValueIgnoreEmpty(rawMap["category"]),
+			"index":           utils.ValueIgnoreEmpty(rawMap["index"]),
+			"logic_operation": utils.ValueIgnoreEmpty(rawMap["logic_operation"]),
+			"contents":        utils.ValueIgnoreEmpty(rawMap["contents"]),
+			"value_list_id":   utils.ValueIgnoreEmpty(rawMap["value_list_id"]),
+		})
+	}
+	return rst
+}
+
+func buildBatchCreateCustomRulesActionBodyParam(d *schema.ResourceData) map[string]interface{} {
+	rawArray, ok := d.Get("action").([]interface{})
+	if !ok || len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"category":           rawMap["category"],
+		"followed_action_id": utils.ValueIgnoreEmpty(rawMap["followed_action_id"]),
+	}
+}
+
+func buildBatchCreateCustomRulesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"time":        d.Get("time"),
+		"conditions":  buildBatchCreateCustomRulesConditionsBodyParam(d),
+		"action":      buildBatchCreateCustomRulesActionBodyParam(d),
+		"priority":    d.Get("priority"),
+		"name":        d.Get("name"),
+		"policy_ids":  d.Get("policy_ids"),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+		"start":       utils.ValueIgnoreEmpty(d.Get("start")),
+		"terminal":    utils.ValueIgnoreEmpty(d.Get("terminal")),
+	}
+
+	return bodyParams
+}
+
+func resourceWafBatchCreateCustomRulesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/rule/custom"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath += buildBatchCreateCustomRulesQueryParams(epsId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildBatchCreateCustomRulesBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error batch creating WAF custom rules: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	return resourceWafBatchCreateCustomRulesRead(ctx, d, meta)
+}
+
+func resourceWafBatchCreateCustomRulesRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchCreateCustomRulesUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchCreateCustomRulesDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch create WAF custom rules. Deleting this resource
+    will not remove the created rules, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to batch create custom rules

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccBatchCreateCustomRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccBatchCreateCustomRules_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchCreateCustomRules_basic
=== PAUSE TestAccBatchCreateCustomRules_basic
=== CONT  TestAccBatchCreateCustomRules_basic
--- PASS: TestAccBatchCreateCustomRules_basic (12.16s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       12.285s coverage: 4.0% of statements in ./huaweicloud/services/waf
```
<img width="1415" height="63" alt="image" src="https://github.com/user-attachments/assets/ca06803e-58c9-4103-820b-39256fbfad69" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
