### PR TITLE
feat(waf): new resource to batch create cc rules

### DIFF
--- a/docs/resources/waf_batch_create_cc_rules.md
+++ b/docs/resources/waf_batch_create_cc_rules.md
@@ -1,0 +1,205 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_batch_create_cc_rules"
+description: |-
+  Manages a resource to batch create WAF CC protection rules within HuaweiCloud WAF.
+---
+
+# huaweicloud_waf_batch_create_cc_rules
+
+Manages a resource to batch create WAF CC protection rules within HuaweiCloud WAF.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+-> This resource is a one-time action resource for batch creating CC protection rules. Deleting this resource
+   will not remove the created rules, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+variable "policy_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_waf_batch_create_cc_rules" "test" {
+  name                  = "test_cc_rule"
+  description           = "CC protection rule for admin paths"
+  tag_type              = "ip"
+  limit_num             = 100
+  limit_period          = 60
+  policy_ids            = var.policy_ids
+  enterprise_project_id = var.enterprise_project_id
+  
+  conditions {
+    category        = "url"
+    logic_operation = "prefix"
+    contents        = ["/admin"]
+  }
+
+  action {
+    category = "block"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the CC protection rule.
+
+* `conditions` - (Required, List, NonUpdatable) Specifies the list of matching conditions for rate limiting.
+  The [conditions](#Rule_conditions) structure is documented below.
+
+* `action` - (Required, List, NonUpdatable) Specifies the action to take when the rate limit is reached.
+  The [action](#Rule_action) structure is documented below.
+
+* `tag_type` - (Required, String, NonUpdatable) Specifies how to identify unique web visitors for rate limiting.
+  The value can be:
+  + **ip**: Rate limit by IP address
+  + **cookie**: Rate limit by cookie value (requires `tag_index`)
+  + **header**: Rate limit by header value (requires `tag_index`)
+  + **other**: Rate limit by Referer (requires `tag_condition`)
+  + **policy**: Rate limit by policy
+  + **domain**: Rate limit by domain
+  + **url**: Rate limit by URL
+
+* `limit_num` - (Required, Int, NonUpdatable) Specifies the maximum number of requests allowed in the rate limit period.
+  The value ranges from `1` to `2,147,483,647`.
+
+* `limit_period` - (Required, Int, NonUpdatable) Specifies the rate limit period in seconds.
+  The value ranges from `1` to `3,600` (1 hour).
+
+* `policy_ids` - (Required, List, NonUpdatable) Specifies the list of policy IDs to which the CC rule will be applied.
+
+* `tag_index` - (Optional, String, NonUpdatable) Specifies the cookie or header name when `tag_type` is set to
+  **cookie** or **header**.
+  + When selecting a cookie, set the cookie field name. This is a specific attribute variable name in the cookie that
+    the user needs to configure to uniquely identify the web visitor, based on the website's actual situation.
+    User-identifying cookies do not support regular expressions; they must be exact matches. For example, if the website
+    uses a field called "name" in the cookie to uniquely identify a user, then the "name" field can be selected to
+    distinguish web visitors.
+  + When selecting a header, set the custom HTTP headers that need to be protected. This means that users need to
+    configure HTTP headers that can identify web visitors according to the actual situation of the website.
+
+* `tag_condition` - (Optional, List, NonUpdatable) Specifies the condition when `tag_type` is set to **other**.
+  The [tag_condition](#Tag_condition) structure is documented below.
+
+* `unlock_num` - (Optional, Int, NonUpdatable) Specifies the number of requests to allow after rate limiting is triggered.
+  The value ranges from `0` to `2,147,483,647`.
+  This parameter is valid only when the action `category` is set to **dynamic_block**.
+
+* `lock_time` - (Optional, Int, NonUpdatable) Specifies the duration (in seconds) to block requests when the rate limit
+  is exceeded. The value ranges from `0` to `65,535` seconds.
+  This parameter is valid only when the action `category` is set to **block**.
+
+* `domain_aggregation` - (Optional, Bool, NonUpdatable) Specifies whether to enable domain aggregation statistics.
+  Defaults to **false**.
+
+* `region_aggregation` - (Optional, Bool, NonUpdatable) Specifies whether to enable global counting.
+  Defaults to **false**.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the CC protection rule.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  Value `0` indicates the default enterprise project.
+  Value **all_granted_eps** indicates all enterprise projects to which the user has been granted access.
+  Defaults to `0`.
+
+<a name="Rule_conditions"></a>
+The `conditions` block supports:
+
+* `category` - (Required, String, NonUpdatable) Specifies the field type to match against.
+  The value can be:
+  + **url**
+  + **ip**
+  + **ipv6**
+  + **asn**
+  + **params**
+  + **cookie**
+  + **referer**
+  + **user-agent**
+  + **header**
+  + **response_code**
+  + **response_header**
+  + **response_body**
+  + **request_body**
+  + **method**
+  + **tls_fingerprint**
+  + **tls_ja3_fingerprint**
+
+* `logic_operation` - (Required, String, NonUpdatable) Specifies the matching logic operation.
+  The available values depend on the `category`:
+  + For **url**: **contain**, **not_contain**, **equal**, **not_equal**, **prefix**, **not_prefix**, **suffix**,
+    **not_suffix**, **contain_any**, **not_contain_all**, **equal_any**, **not_equal_all**, **prefix_any**,
+    **not_prefix_all**, **suffix_any**, **not_suffix_all**, **len_greater**, **len_less**, **len_equal**,
+    **len_not_equal**
+  + For **ip** or **ipv6**: **equal**, **not_equal**, **equal_any**, **not_equal_all**
+  + For **params**, **cookie**, or **header**: **contain**, **not_contain**, **equal**, **not_equal**, **prefix**,
+    **not_prefix**, **suffix**, **not_suffix**, **contain_any**, **not_contain_all**, **equal_any**, **not_equal_all**,
+    **prefix_any**, **not_prefix_all**, **suffix_any**, **not_suffix_all**, **len_greater**, **len_less**, **len_equal**,
+    **len_not_equal**, **num_greater**, **num_less**, **num_equal**, **num_not_equal**, **exist**, **not_exist**
+
+* `contents` - (Optional, List, NonUpdatable) Specifies the content to match against.
+  Required when `logic_operation` does not end with **any** or **all**.
+
+* `value_list_id` - (Optional, String, NonUpdatable) Specifies the reference table ID.
+  Required when `logic_operation` ends with **any** or **all**.
+
+* `index` - (Optional, String, NonUpdatable) Specifies the subfield name when `category` is **params**, **cookie**,
+  or **header**.
+  For other categories, leave this empty.
+
+<a name="Rule_action"></a>
+The `action` block supports:
+
+* `category` - (Required, String, NonUpdatable) Specifies the action to take when the rate limit is reached.
+  The value can be:
+  + **captcha**: After a human-machine verification is blocked, the user needs to enter the correct verification code
+    to restore access to the correct page
+  + **log**: Only records the request
+  + **dynamic_block**: In the previous rate limit period, if the request frequency exceeds the "rate limit frequency",
+    it will be blocked. In the next rate limit period, if the request frequency exceeds the "release frequency",
+    it will be blocked. Note: Only when the CC protection rule mode is set to advanced mode can `dynamic_block`
+    protection action be set
+  + **block**: Blocks the request
+
+* `detail` - (Optional, List, NonUpdatable) Specifies the detailed action configuration. The returned blocking page is
+  only required when the protection action (`category`) is selected as either `block` or `dynamic_block`.
+  + If you need the system's default blocking page to be returned, you do not need to pass this parameter.
+  + If users want to protect against a custom blocking page, they can configure this setting.
+
+  The [detail](#Action_detail) structure is documented below.
+
+<a name="Action_detail"></a>
+The `detail` block supports:
+
+* `response` - (Optional, List, NonUpdatable) Specifies the custom response configuration.
+  The [response](#Response) structure is documented below.
+
+<a name="Response"></a>
+The `response` block supports:
+
+* `content_type` - (Optional, String, NonUpdatable) Specifies the content type of the response.
+  The value can be **application/json**, **text/html**, or **text/xml**.
+
+* `content` - (Optional, String, NonUpdatable) Specifies the content of the response.
+
+<a name="Tag_condition"></a>
+The `tag_condition` block supports:
+
+* `category` - (Optional, String, NonUpdatable) Specifies the field type to match against. The value can be **referer**.
+
+* `contents` - (Optional, List, NonUpdatable) Specifies the content to match against.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3883,6 +3883,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_alarm_notification":                  waf.ResourceWafAlarmNotification(),
 			"huaweicloud_waf_batch_create_whiteblackip_rules":     waf.ResourceWafBatchCreateWhiteBlackIpRules(),
 			"huaweicloud_waf_batch_create_antileakage_rules":      waf.ResourceWafBatchCreateAntileakageRules(),
+			"huaweicloud_waf_batch_create_cc_rules":               waf.ResourceWafBatchCreateCcRules(),
 			"huaweicloud_waf_batch_create_custom_rules":           waf.ResourceWafBatchCreateCustomRules(),
 			"huaweicloud_waf_batch_create_ignore_rules":           waf.ResourceWafBatchCreateIgnoreRules(),
 			"huaweicloud_waf_batch_delete_alarm_notifications":    waf.ResourceWafBatchDeleteAlarmNotifications(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_create_cc_rules_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_create_cc_rules_test.go
@@ -1,0 +1,62 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchCreateCcRules_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckWafPolicyId(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchCreateCcRules_basic(),
+			},
+		},
+	})
+}
+
+func testAccBatchCreateCcRules_basic() string {
+	name := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_batch_create_cc_rules" "test" {
+  name                  = "%[1]s"
+  description           = "CC protection rule for admin paths"
+  tag_type              = "ip"
+  limit_num             = 100
+  limit_period          = 60
+  policy_ids            = ["%[2]s"]
+  enterprise_project_id = "%[3]s"
+  lock_time             = 2
+  region_aggregation    = true
+  domain_aggregation    = true
+  
+  conditions {
+    category        = "url"
+    logic_operation = "prefix"
+    contents        = ["/admin"]
+  }
+
+  action {
+    category = "block"
+	detail {
+	  response {
+		content_type = "application/json"
+		content      = "block application json"
+	  }
+	}
+  }
+}
+`, name, acceptance.HW_WAF_POLICY_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_batch_create_cc_rules.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_batch_create_cc_rules.go
@@ -1,0 +1,408 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF POST /v1/{project_id}/waf/rule/cc
+func ResourceWafBatchCreateCcRules() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafBatchCreateCcRulesCreate,
+		ReadContext:   resourceWafBatchCreateCcRulesRead,
+		UpdateContext: resourceWafBatchCreateCcRulesUpdate,
+		DeleteContext: resourceWafBatchCreateCcRulesDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"name",
+			"conditions",
+			"conditions.*.category",
+			"conditions.*.logic_operation",
+			"conditions.*.contents",
+			"conditions.*.value_list_id",
+			"conditions.*.index",
+			"action",
+			"action.*.category",
+			"action.*.detail",
+			"action.*.detail.*.response",
+			"action.*.detail.*.response.*.content_type",
+			"action.*.detail.*.response.*.content",
+			"tag_type",
+			"limit_num",
+			"limit_period",
+			"policy_ids",
+			"tag_index",
+			"tag_condition",
+			"tag_condition.*.category",
+			"tag_condition.*.contents",
+			"unlock_num",
+			"lock_time",
+			"domain_aggregation",
+			"region_aggregation",
+			"description",
+			"enterprise_project_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"conditions": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     buildBatchCreateCcRulesConditionsSchema(),
+			},
+			"action": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem:     buildBatchCreateCcRulesActionSchema(),
+			},
+			"tag_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"limit_num": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"limit_period": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"policy_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"tag_index": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tag_condition": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     buildBatchCreateCcRulesTagConditionSchema(),
+			},
+			"unlock_num": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"lock_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"domain_aggregation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"region_aggregation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildBatchCreateCcRulesTagConditionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"category": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"contents": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func buildBatchCreateCcRulesActionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"detail": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     buildBatchCreateCcRulesActionDetailSchema(),
+			},
+		},
+	}
+}
+
+func buildBatchCreateCcRulesActionDetailSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"response": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     buildBatchCreateCcRulesActionDetailResponseSchema(),
+			},
+		},
+	}
+}
+
+func buildBatchCreateCcRulesActionDetailResponseSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"content_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"content": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func buildBatchCreateCcRulesConditionsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"logic_operation": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"contents": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"value_list_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"index": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func buildBatchCreateCcRulesQueryParams(epsId string) string {
+	if epsId == "" {
+		return ""
+	}
+	return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+}
+
+func buildBatchCreateCcRulesConditionsBodyParam(d *schema.ResourceData) []map[string]interface{} {
+	rawArray, ok := d.Get("conditions").([]interface{})
+	if !ok || len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"category":        rawMap["category"],
+			"logic_operation": rawMap["logic_operation"],
+			"contents":        utils.ValueIgnoreEmpty(rawMap["contents"]),
+			"value_list_id":   utils.ValueIgnoreEmpty(rawMap["value_list_id"]),
+			"index":           utils.ValueIgnoreEmpty(rawMap["index"]),
+		})
+	}
+	return rst
+}
+
+func buildBatchCreateCcRulesActionDetailResponseBodyParam(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"content_type": utils.ValueIgnoreEmpty(rawMap["content_type"]),
+		"content":      utils.ValueIgnoreEmpty(rawMap["content"]),
+	}
+}
+
+func buildBatchCreateCcRulesActionDetailBodyParam(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"response": buildBatchCreateCcRulesActionDetailResponseBodyParam(rawMap["response"].([]interface{})),
+	}
+}
+
+func buildBatchCreateCcRulesActionBodyParam(d *schema.ResourceData) map[string]interface{} {
+	rawArray, ok := d.Get("action").([]interface{})
+	if !ok || len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"category": rawMap["category"],
+		"detail":   buildBatchCreateCcRulesActionDetailBodyParam(rawMap["detail"].([]interface{})),
+	}
+}
+
+func buildBatchCreateCcRulesTagConditionBodyParam(d *schema.ResourceData) map[string]interface{} {
+	rawArray, ok := d.Get("tag_condition").([]interface{})
+	if !ok || len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"category": utils.ValueIgnoreEmpty(rawMap["category"]),
+		"contents": utils.ValueIgnoreEmpty(rawMap["contents"]),
+	}
+}
+
+func buildBatchCreateCcRulesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":               d.Get("name"),
+		"mode":               1,
+		"conditions":         buildBatchCreateCcRulesConditionsBodyParam(d),
+		"action":             buildBatchCreateCcRulesActionBodyParam(d),
+		"tag_type":           d.Get("tag_type"),
+		"limit_num":          d.Get("limit_num"),
+		"limit_period":       d.Get("limit_period"),
+		"policy_ids":         d.Get("policy_ids"),
+		"tag_index":          utils.ValueIgnoreEmpty(d.Get("tag_index")),
+		"tag_condition":      buildBatchCreateCcRulesTagConditionBodyParam(d),
+		"unlock_num":         utils.ValueIgnoreEmpty(d.Get("unlock_num")),
+		"lock_time":          utils.ValueIgnoreEmpty(d.Get("lock_time")),
+		"domain_aggregation": utils.ValueIgnoreEmpty(d.Get("domain_aggregation")),
+		"region_aggregation": utils.ValueIgnoreEmpty(d.Get("region_aggregation")),
+		"description":        utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
+func resourceWafBatchCreateCcRulesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/rule/cc"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath += buildBatchCreateCcRulesQueryParams(epsId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildBatchCreateCcRulesBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error batch creating WAF CC rules: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	return resourceWafBatchCreateCcRulesRead(ctx, d, meta)
+}
+
+func resourceWafBatchCreateCcRulesRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchCreateCcRulesUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchCreateCcRulesDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch create WAF cc rules. Deleting this resource
+    will not remove the created rules, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to batch create cc rules

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccBatchCreateCcRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccBatchCreateCcRules_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchCreateCcRules_basic
=== PAUSE TestAccBatchCreateCcRules_basic
=== CONT  TestAccBatchCreateCcRules_basic
--- PASS: TestAccBatchCreateCcRules_basic (12.59s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       12.711s coverage: 4.3% of statements in ./huaweicloud/services/waf
```
<img width="1338" height="51" alt="image" src="https://github.com/user-attachments/assets/7fffcdc2-fbe1-43a7-8a4f-d7ffc00d85ff" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
