### PR TITLE
feat(waf): new resource to batch create ip reputation

### DIFF
--- a/docs/resources/waf_batch_create_ip_reputation_rules.md
+++ b/docs/resources/waf_batch_create_ip_reputation_rules.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_batch_create_ip_reputation_rules"
+description: |-
+  Manages a resource to batch create WAF IP reputation rules within HuaweiCloud WAF.
+---
+
+# huaweicloud_waf_batch_create_ip_reputation_rules
+
+Manages a resource to batch create WAF IP reputation rules within HuaweiCloud WAF.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+-> This resource is a one-time action resource for batch creating IP reputation rules. Deleting this resource
+   will not remove the created rules, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+variable "policy_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_waf_batch_create_ip_reputation_rules" "test" {
+  name                  = "test_ip_reputation_rule"
+  type                  = "idc"
+  tags                  = ["Tencent"]
+  policy_ids            = var.policy_ids
+  enterprise_project_id = var.enterprise_project_id
+  description           = "test_ip_reputation_rule"
+
+  action {
+    category = "block"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the IP reputation rule.
+
+* `type` - (Required, String, NonUpdatable) Specifies the type of the IP reputation rule.
+  Only **idc** is supported.
+
+* `tags` - (Required, List, NonUpdatable) Specifies the list of tags for the IP reputation rule.
+
+* `action` - (Required, List, NonUpdatable) Specifies the action to take when the IP reputation rule is triggered.
+  The [action](#Rule_action) structure is documented below.
+
+* `policy_ids` - (Required, List, NonUpdatable) Specifies the list of policy IDs to which the IP reputation rule will be
+  applied.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the IP reputation rule.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  Value `0` indicates the default enterprise project.
+  Value **all_granted_eps** indicates all enterprise projects to which the user has been granted access.
+  Defaults to `0`.
+
+<a name="Rule_action"></a>
+The `action` block supports:
+
+* `category` - (Required, String, NonUpdatable) Specifies the action to take when the IP reputation rule is triggered.
+  Valid values are **pass**, **log**, and **block**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3888,6 +3888,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_batch_create_cc_rules":               waf.ResourceWafBatchCreateCcRules(),
 			"huaweicloud_waf_batch_create_custom_rules":           waf.ResourceWafBatchCreateCustomRules(),
 			"huaweicloud_waf_batch_create_ignore_rules":           waf.ResourceWafBatchCreateIgnoreRules(),
+			"huaweicloud_waf_batch_create_ip_reputation_rules":    waf.ResourceWafBatchCreateIpReputationRules(),
 			"huaweicloud_waf_batch_delete_alarm_notifications":    waf.ResourceWafBatchDeleteAlarmNotifications(),
 			"huaweicloud_waf_migrate_domain":                      waf.ResourceMigrateDomain(),
 			"huaweicloud_waf_policy":                              waf.ResourceWafPolicy(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_create_ip_reputation_rules_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_create_ip_reputation_rules_test.go
@@ -1,0 +1,46 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchCreateIpReputationRules_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckWafPolicyId(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchCreateIpReputationRules_basic(),
+			},
+		},
+	})
+}
+
+func testAccBatchCreateIpReputationRules_basic() string {
+	name := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_batch_create_ip_reputation_rules" "test" {
+  name                  = "%[1]s"
+  type                  = "idc"
+  tags                  = ["Tencent"]
+  policy_ids            = ["%[2]s"]
+  enterprise_project_id = "%[3]s"
+  description           = "test_ip_reputation_rule"
+
+  action {
+    category = "block"
+  }
+}
+`, name, acceptance.HW_WAF_POLICY_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_batch_create_ip_reputation_rules.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_batch_create_ip_reputation_rules.go
@@ -1,0 +1,195 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF POST /v1/{project_id}/waf/rule/ip-reputation
+func ResourceWafBatchCreateIpReputationRules() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafBatchCreateIpReputationRulesCreate,
+		ReadContext:   resourceWafBatchCreateIpReputationRulesRead,
+		UpdateContext: resourceWafBatchCreateIpReputationRulesUpdate,
+		DeleteContext: resourceWafBatchCreateIpReputationRulesDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"name",
+			"type",
+			"tags",
+			"action",
+			"action.*.category",
+			"policy_ids",
+			"description",
+			"enterprise_project_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"action": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem:     buildBatchCreateIpReputationRulesActionSchema(),
+			},
+			"policy_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildBatchCreateIpReputationRulesActionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func buildBatchCreateIpReputationRulesQueryParams(epsId string) string {
+	if epsId == "" {
+		return ""
+	}
+	return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+}
+
+// Empty array is allowed. SO the response type is interface{}
+func buildBatchCreateIpReputationRulesActionBodyParam(d *schema.ResourceData) map[string]interface{} {
+	rawArray, ok := d.Get("action").([]interface{})
+	if !ok || len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"category": rawMap["category"],
+	}
+}
+
+func buildBatchCreateIpReputationRulesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"type":        d.Get("type"),
+		"tags":        d.Get("tags"),
+		"action":      buildBatchCreateIpReputationRulesActionBodyParam(d),
+		"policy_ids":  d.Get("policy_ids"),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
+func resourceWafBatchCreateIpReputationRulesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/rule/ip-reputation"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath += buildBatchCreateIpReputationRulesQueryParams(epsId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildBatchCreateIpReputationRulesBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error batch creating WAF IP reputation rules: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	return resourceWafBatchCreateIpReputationRulesRead(ctx, d, meta)
+}
+
+func resourceWafBatchCreateIpReputationRulesRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchCreateIpReputationRulesUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchCreateIpReputationRulesDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch create WAF IP reputation rules. Deleting this resource
+    will not remove the created rules, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to batch create ip reputation

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccBatchCreateIpReputationRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccBatchCreateIpReputationRules_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchCreateIpReputationRules_basic
=== PAUSE TestAccBatchCreateIpReputationRules_basic
=== CONT  TestAccBatchCreateIpReputationRules_basic
--- PASS: TestAccBatchCreateIpReputationRules_basic (12.56s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       12.670s coverage: 3.9% of statements in ./huaweicloud/services/waf
```
<img width="1347" height="58" alt="image" src="https://github.com/user-attachments/assets/39e6d62d-179c-4402-95c4-bec9561c7880" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
