### PR TITLE
feat(hss): support `hss_host_manual_detection` resource

### DIFF
--- a/docs/resources/hss_host_manual_detection.md
+++ b/docs/resources/hss_host_manual_detection.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_host_manual_detection"
+description: |-
+  Manages an HSS host manual detection operation resource within HuaweiCloud.
+---
+
+# huaweicloud_hss_host_manual_detection
+
+Manages an HSS host manual detection operation resource within HuaweiCloud.
+
+-> This resource is a one-time action resource using to operation HSS host manual detection. Deleting this resource will
+  not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "host_id" {}
+variable "type" {}
+
+resource "huaweicloud_hss_host_manual_detection" "test" {
+  host_id = var.host_id
+  type    = var.type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `host_id` - (Required, String, NonUpdatable) Specifies the host ID.
+
+* `type` - (Required, String, NonUpdatable) Specifies the type of detection.  
+  The valid values are as follows:
+  + **pwd**: Weak password detection.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate the asset under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3264,6 +3264,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_login_common_location":                          hss.ResourceLoginCommonLocation(),
 			"huaweicloud_hss_login_white_ip":                                 hss.ResourceLoginWhiteIp(),
 			"huaweicloud_hss_change_host_ignore_status":                      hss.ResourceChangeHostIgnoreStatus(),
+			"huaweicloud_hss_host_manual_detection":                          hss.ResourceHostManualDetection(),
 			"huaweicloud_hss_modify_webtamper_protection_policy":             hss.ResourceModifyWebtamperProtectionPolicy(),
 			"huaweicloud_hss_modify_webtamper_rasp_path":                     hss.ResourceModifyWebtamperRaspPath(),
 			"huaweicloud_hss_rasp_protection_policy":                         hss.ResourceRaspProtectionPolicy(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_manual_detection_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_manual_detection_test.go
@@ -1,0 +1,38 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceHostManualDetection_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a host ID with host protection enabled,
+			// and the host is under the default enterprise project.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testHostManualDetection_basic(),
+			},
+		},
+	})
+}
+
+func testHostManualDetection_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_host_manual_detection" "test" {
+  host_id               = "%s"
+  type                  = "pwd"
+  enterprise_project_id = "0"
+}
+`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_host_manual_detection.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_host_manual_detection.go
@@ -1,0 +1,134 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS POST /v5/{project_id}/host-management/{host_id}/manual-detect
+func ResourceHostManualDetection() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHostManualDetectionCreate,
+		ReadContext:   resourceHostManualDetectionRead,
+		UpdateContext: resourceHostManualDetectionUpdate,
+		DeleteContext: resourceHostManualDetectionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"host_id",
+			"type",
+			"enterprise_project_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildHostManualDetectionQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	return ""
+}
+
+func buildHostManualDetectionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"type": d.Get("type"),
+	}
+}
+
+func resourceHostManualDetectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/host-management/{host_id}/manual-detect"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{host_id}", d.Get("host_id").(string))
+	requestPath += buildHostManualDetectionQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildHostManualDetectionBodyParams(d),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error operating HSS host manual detection: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return resourceHostManualDetectionRead(ctx, d, meta)
+}
+
+func resourceHostManualDetectionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceHostManualDetectionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceHostManualDetectionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to operation HSS host manual detection. Deleting
+    this resource will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_host_manual_detection` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_host_manual_detection` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccResourceHostManualDetection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccResourceHostManualDetection_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceHostManualDetection_basic
=== PAUSE TestAccResourceHostManualDetection_basic
=== CONT  TestAccResourceHostManualDetection_basic
--- PASS: TestAccResourceHostManualDetection_basic (16.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       17.000s
```
<img width="881" height="29" alt="image" src="https://github.com/user-attachments/assets/b655bedd-3b80-4beb-b5a5-00a96aee4656" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
