### PR TITLE
docs(identity center): add new best practice for password policy

### DIFF
--- a/examples/identity-center/group/README.md
+++ b/examples/identity-center/group/README.md
@@ -45,16 +45,8 @@ The following variables need to be configured:
 * Create a `terraform.tfvars` file and fill in the required variables:
 
   ```hcl
-  group_name = "your_group_name"
+  group_name        = "your_group_name"
   group_description = "Your group description"
-  ```
-
-* Create an `authentication.auto.tfvars` file (or use environment variables) for authentication:
-
-  ```hcl
-  access_key  = "your_access_key"
-  secret_key  = "your_secret_key"
-  region_name = "cn-north-4"
   ```
 
 * Initialize Terraform:
@@ -94,9 +86,9 @@ This is the default scenario. The example will:
 Set the following variables:
 
 ```hcl
-is_instance_create     = true
+is_instance_create      = true
 is_region_need_register = true
-group_name             = "my_test_group"
+group_name              = "my_test_group"
 ```
 
 ### Scenario 2: Create a Group in an Existing Instance

--- a/examples/identity-center/password-policy/README.md
+++ b/examples/identity-center/password-policy/README.md
@@ -1,0 +1,146 @@
+# Create an Identity Center Password Policy
+
+This example provides best practice code for using Terraform to create an Identity Center password policy in HuaweiCloud.
+
+## Prerequisites
+
+* A HuaweiCloud account with Identity Center permissions
+* Terraform installed
+* HuaweiCloud access key and secret key (AK/SK)
+* An Identity Center instance (or permission to create one)
+
+## Variable Introduction
+
+The following variables need to be configured:
+
+### Authentication Variables
+
+* `region_name` - The region where the Identity Center service is located
+* `access_key` - The access key of the IAM user
+* `secret_key` - The secret key of the IAM user
+
+### Resource Variables
+
+#### Optional Variables
+
+* `is_instance_create` - Whether to create the Identity Center instance (default: `true`)
+  + If set to `true`, the example will create a new Identity Center instance
+  + If set to `false`, the example will query an existing Identity Center instance
+* `is_region_need_register` - Whether to register the region before creating the instance (default: `true`)
+  + Only applicable when `is_instance_create` is `true`
+  + If set to `true`, the example will register the region before creating the instance
+* `instance_store_id_alias` - The alias of the Identity Center instance (default: `""`)
+  + Only applicable when `is_instance_create` is `true`
+  + If left empty, the instance will be created without an alias
+
+#### Password Policy Variables
+
+* `policy_max_password_age` - The max password age of the identity center password policy, unit in days (default: `10`)
+  + Valid value range: 1 to 1095
+* `policy_minimum_password_length` - The minimum password length of the identity center password policy (default: `10`)
+* `policy_password_reuse_prevention` - Whether to prohibit the use of the same password as the previous one (default: `true`)
+* `policy_require_uppercase_characters` - Whether to require uppercase characters in passwords (default: `true`)
+* `policy_require_lowercase_characters` - Whether to require lowercase characters in passwords (default: `true`)
+* `policy_require_numbers` - Whether to require numbers in passwords (default: `true`)
+* `policy_require_symbols` - Whether to require symbols in passwords (default: `true`)
+
+## Usage
+
+* Copy this example script to your `main.tf`.
+
+* Create a `terraform.tfvars` file and fill in the required variables:
+
+  ```hcl
+  # The policy defines a minimum password length of 8 characters, allows uppercase and lowercase letters, numbers,
+  # and special characters, and a password validity period of 30 days.
+  policy_max_password_age        = 30
+  policy_minimum_password_length = 8
+  ```
+
+* Initialize Terraform:
+
+  ```bash
+  $ terraform init
+  ```
+
+* Review the Terraform plan:
+
+  ```bash
+  $ terraform plan
+  ```
+
+* Apply the configuration:
+
+  ```bash
+  $ terraform apply
+  ```
+
+* To clean up the resources:
+
+  ```bash
+  $ terraform destroy
+  ```
+
+## Example Scenarios
+
+### Scenario 1: Create a Password Policy with a New Instance
+
+This is the default scenario. The example will:
+
+1. Register the region (if `is_region_need_register` is `true`)
+2. Create a new Identity Center instance
+3. Create a password policy in the instance
+
+Set the following variables:
+
+```hcl
+is_instance_create             = true
+is_region_need_register        = true
+policy_max_password_age        = 30
+policy_minimum_password_length = 8
+```
+
+### Scenario 2: Create a Password Policy in an Existing Instance
+
+If you already have an Identity Center instance, you can create a password policy in it:
+
+1. Query the existing Identity Center instance
+2. Create a password policy in the existing instance
+
+Set the following variables:
+
+```hcl
+is_instance_create             = false
+policy_max_password_age        = 30
+policy_minimum_password_length = 8
+```
+
+### Scenario 3: Custom Password Policy Configuration
+
+You can customize the password policy according to your security requirements:
+
+```hcl
+policy_max_password_age             = 90
+policy_minimum_password_length      = 12
+policy_password_reuse_prevention    = false
+policy_require_uppercase_characters = false
+```
+
+## Note
+
+* Make sure to keep your credentials secure and never commit them to version control
+* The Identity Center instance must exist in the specified region before creating password policies
+* If you need to create a new instance, ensure the region is registered first
+* Each Identity Center instance can only have one password policy
+* The `identity_store_id` is automatically obtained from the instance (created or queried)
+* All resources will be created in the specified region
+* The `password_reuse_prevention` parameter accepts `1` (enabled) or `null` (disabled) in the API, but the example uses
+  a boolean variable for better usability
+* The `max_password_age` must be between 1 and 1095 days
+
+## Requirements
+
+| Name | Version |
+| ---- | ---- |
+| terraform | >= 0.14.0 |
+| huaweicloud | >= 1.80.4 |

--- a/examples/identity-center/password-policy/main.tf
+++ b/examples/identity-center/password-policy/main.tf
@@ -1,0 +1,28 @@
+data "huaweicloud_identitycenter_instance" "test" {
+  count = var.is_instance_create ? 0 : 1
+}
+
+resource "huaweicloud_identitycenter_registered_region" "test" {
+  count = var.is_instance_create ? var.is_region_need_register ? 1 : 0 : 0
+
+  region_id = var.region_name
+}
+
+resource "huaweicloud_identitycenter_instance" "test" {
+  count = var.is_instance_create ? 1 : 0
+
+  depends_on = [huaweicloud_identitycenter_registered_region.test]
+
+  alias = var.instance_store_id_alias != "" ? var.instance_store_id_alias : null
+}
+
+resource "huaweicloud_identitycenter_password_policy" "test" {
+  identity_store_id            = var.is_instance_create ? huaweicloud_identitycenter_instance.test[0].identity_store_id : data.huaweicloud_identitycenter_instance.test[0].identity_store_id
+  max_password_age             = var.policy_max_password_age
+  minimum_password_length      = var.policy_minimum_password_length
+  password_reuse_prevention    = var.policy_password_reuse_prevention ? 1 : null # 1 means the password reuse prevention is enabled
+  require_uppercase_characters = var.policy_require_uppercase_characters
+  require_lowercase_characters = var.policy_require_lowercase_characters
+  require_numbers              = var.policy_require_numbers
+  require_symbols              = var.policy_require_symbols
+}

--- a/examples/identity-center/password-policy/providers.tf
+++ b/examples/identity-center/password-policy/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.80.4"
+    }
+  }
+}
+
+provider "huaweicloud" {
+  region     = var.region_name
+  access_key = var.access_key
+  secret_key = var.secret_key
+}

--- a/examples/identity-center/password-policy/terraform.tfvars
+++ b/examples/identity-center/password-policy/terraform.tfvars
@@ -1,0 +1,4 @@
+# The policy defines a minimum password length of 8 characters, allows uppercase and lowercase letters, numbers,
+# and special characters, and a password validity period of 30 days.
+policy_max_password_age        = 30
+policy_minimum_password_length = 8

--- a/examples/identity-center/password-policy/variables.tf
+++ b/examples/identity-center/password-policy/variables.tf
@@ -1,0 +1,85 @@
+# Variable definitions for authentication
+variable "region_name" {
+  description = "The region where the LTS service is located"
+  type        = string
+}
+
+variable "access_key" {
+  description = "The access key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+variable "secret_key" {
+  description = "The secret key of the IAM user"
+  type        = string
+  sensitive   = true
+}
+
+# Variable definitions for resources/data sources
+variable "is_instance_create" {
+  description = "Whether to create the identity center instance"
+  type        = bool
+  default     = true
+}
+
+variable "is_region_need_register" {
+  description = "Whether to register the region"
+  type        = bool
+  default     = true
+}
+
+variable "instance_store_id_alias" {
+  description = "The alias of the identity center instance"
+  type        = string
+  default     = ""
+}
+
+# SC.005 Disable
+variable "policy_max_password_age" {
+  description = "The max password age of the identity center password policy, unit in days"
+  type        = number
+  default     = 10
+
+  validation {
+    condition     = var.policy_max_password_age >= 1 && var.policy_max_password_age <= 1095
+    error_message = "The valid value of the max password age is range from 1 to 1095"
+  }
+}
+
+variable "policy_minimum_password_length" {
+  description = "The minimum password length of the identity center password policy"
+  type        = number
+  default     = 10
+}
+
+variable "policy_password_reuse_prevention" {
+  description = "The password reuse prevention feature of the identity center's password policy indicates whether to prohibit the use of the same password as the previous one"
+  type        = bool
+  default     = true
+}
+# SC.005 Enable
+
+variable "policy_require_uppercase_characters" {
+  description = "The require uppercase characters of the identity center password policy"
+  type        = bool
+  default     = true
+}
+
+variable "policy_require_lowercase_characters" {
+  description = "The require lowercase characters of the identity center password policy"
+  type        = bool
+  default     = true
+}
+
+variable "policy_require_numbers" {
+  description = "The require numbers of the identity center password policy"
+  type        = bool
+  default     = true
+}
+
+variable "policy_require_symbols" {
+  description = "The require symbols of the identity center password policy"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new best practice that used to create a password policy for identity center.

And, fix some incorrect style codings for group practice.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new best practice for password policy
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

<img width="955" height="854" alt="image" src="https://github.com/user-attachments/assets/ff384b66-706f-4e0f-adec-f5f4ace324aa" />

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
