### PR TITLE
feat(hss): support `hss_event_operations` data source

### DIFF
--- a/docs/data-sources/hss_event_operations.md
+++ b/docs/data-sources/hss_event_operations.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_event_operations"
+description: |-
+  Use this data source to get the list of HSS event operations within HuaweiCloud.
+---
+
+# huaweicloud_hss_event_operations
+
+Use this data source to get the list of HSS event operations within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_event_operations" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `event_type` - (Optional, String) Specifies the type of the event.  
+  The valid values are as follows:
+  + **1001**: General Malware.
+  + **1002**: Virus.
+  + **1003**: Worm.
+  + **1004**: Trojan.
+  + **1005**: Botnet.
+  + **1006**: Backdoor.
+  + **1010**: Rootkit.
+  + **1011**: Ransomware.
+  + **1012**: Hacker Tool.
+  + **1015**: Web Shell.
+  + **1016**: Cryptomining.
+  + **1017**: Reverse Shell.
+  + **2001**: General Vulnerability Exploitation.
+  + **2012**: Remote Code Execution.
+  + **2047**: Redis Vulnerability Exploitation.
+  + **2048**: Hadoop Vulnerability Exploitation.
+  + **2049**: MySQL Vulnerability Exploitation.
+  + **3002**: File Privilege Escalation.
+  + **3003**: Process Privilege Escalation.
+  + **3004**: Critical File Modification.
+  + **3005**: File/Directory Modification.
+  + **3007**: Abnormal Process Behavior.
+  + **3015**: High-Risk Command Execution.
+  + **3018**: Abnormal Shell.
+  + **3027**: Suspicious Crontab Task.
+  + **3029**: System Security Protection Disabled.
+  + **3030**: Backup Deletion.
+  + **3031**: Abnormal Registry Operation.
+  + **3036**: Container Image Blocking.
+  + **4002**: Brute-Force Attack.
+  + **4004**: Abnormal Login.
+  + **4006**: Unauthorized System Account.
+  + **4014**: User Account Added.
+  + **4020**: User Password Theft.
+  + **6002**: Port Scanning.
+  + **6003**: Host Scanning.
+  + **13001**: Kubernetes Event Deletion.
+  + **13002**: Abnormal Pod Behavior.
+  + **13003**: User Information Enumeration.
+  + **13004**: Cluster User Role Binding.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `operate_accept_list` - The list of supported processing operations.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1464,6 +1464,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_images":                           hss.DataSourceContainerImages(),
 			"huaweicloud_hss_event_att_ck_statistics":                    hss.DataSourceEventAttCkStatistics(),
 			"huaweicloud_hss_event_handle_history":                       hss.DataSourceEventHandleHistory(),
+			"huaweicloud_hss_event_operations":                           hss.DataSourceEventOperations(),
 			"huaweicloud_hss_event_intrusion_events":                     hss.DataSourceEventIntrusionEvents(),
 			"huaweicloud_hss_event_system_user_white_lists":              hss.DataSourceEventSystemUserWhiteLists(),
 			"huaweicloud_hss_event_login_white_lists":                    hss.DataSourceEventLoginWhiteLists(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_event_operations_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_event_operations_test.go
@@ -1,0 +1,39 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEventOperations_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_event_operations.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceEventOperations_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "operate_accept_list.#"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceEventOperations_basic string = `
+data "huaweicloud_hss_event_operations" "test" {
+  event_type            = "1001"
+  enterprise_project_id = "0"
+}
+`

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_event_operations.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_event_operations.go
@@ -1,0 +1,111 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/event/batch-operate
+func DataSourceEventOperations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEventOperationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"event_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"operate_accept_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func buildEventOperationsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("event_type"); ok {
+		queryParams = fmt.Sprintf("%s&event_type=%v", queryParams, v)
+	}
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func dataSourceEventOperationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/event/batch-operate"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildEventOperationsQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS event operations: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("operate_accept_list", utils.ExpandToStringList(
+			utils.PathSearch("operate_accept_list", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_event_operations` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_event_operations` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceEventOperations_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceEventOperations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceEventOperations_basic
=== PAUSE TestAccDataSourceEventOperations_basic
=== CONT  TestAccDataSourceEventOperations_basic
--- PASS: TestAccDataSourceEventOperations_basic (12.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.319s
```
<img width="870" height="30" alt="image" src="https://github.com/user-attachments/assets/83ae05db-5262-4f6d-a39d-44d8b571fb26" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
