### PR TITLE
feat(hss): support `hss_container_kubernetes_mcan` data source

### DIFF
--- a/docs/data-sources/hss_container_kubernetes_mcan.md
+++ b/docs/data-sources/hss_container_kubernetes_mcan.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_kubernetes_mcan"
+description: |-
+  Use this data source to get the HSS container kubernetes multi-cloud cluster public network access method network
+  configuration information within HuaweiCloud.
+---
+
+# huaweicloud_hss_container_kubernetes_mcan
+
+Use this data source to get the HSS container kubernetes multi-cloud cluster public network access method network
+configuration information within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_container_kubernetes_mcan" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `anp_address` - The pod_lb address.
+
+* `region_id` - The region ID.
+
+* `agent_address` - The public network access agent address.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1562,6 +1562,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_baseline_security_checks_default_policy":    hss.DataSourceBaselineSecurityChecksDefaultPolicy(),
 			"huaweicloud_hss_configs":                                    hss.DataSourceConfigs(),
 			"huaweicloud_hss_container_kubernetes_mciuc":                 hss.DataSourceHssContainerKubernetesMciuc(),
+			"huaweicloud_hss_container_kubernetes_mcan":                  hss.DataSourceContainerKubernetesMCAN(),
 			"huaweicloud_hss_operational_report_notification":            hss.DataSourceOperationalReportNotification(),
 			"huaweicloud_hss_resource_locked_status":                     hss.DataSourceResourceLockedStatus(),
 			"huaweicloud_hss_honeypot_port_default_config":               hss.DataSourceHoneypotPortDefaultConfig(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_kubernetes_mcan_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_kubernetes_mcan_test.go
@@ -1,0 +1,42 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceContainerKubernetesMCAN_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_container_kubernetes_mcan.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceContainerKubernetesMCAN_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "anp_address"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "region_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agent_address"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceContainerKubernetesMCAN_basic() string {
+	return `
+data "huaweicloud_hss_container_kubernetes_mcan" "test" {
+  enterprise_project_id = "0"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_container_kubernetes_mcan.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_container_kubernetes_mcan.go
@@ -1,0 +1,104 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/container/kubernetes/multi-cloud/agent-network
+func DataSourceContainerKubernetesMCAN() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceContainerKubernetesMCANRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"anp_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"agent_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildContainerKubernetesMCANQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func dataSourceContainerKubernetesMCANRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/container/kubernetes/multi-cloud/agent-network"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildContainerKubernetesMCANQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS container kubernetes MCAN: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("anp_address", utils.PathSearch("anp_address", respBody, nil)),
+		d.Set("region_id", utils.PathSearch("region_id", respBody, nil)),
+		d.Set("agent_address", utils.PathSearch("agent_address", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_container_kubernetes_mcan` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_container_kubernetes_mcan` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceContainerKubernetesMCAN_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceContainerKubernetesMCAN_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceContainerKubernetesMCAN_basic
=== PAUSE TestAccDataSourceContainerKubernetesMCAN_basic
=== CONT  TestAccDataSourceContainerKubernetesMCAN_basic
--- PASS: TestAccDataSourceContainerKubernetesMCAN_basic (12.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.404s
```
<img width="943" height="32" alt="image" src="https://github.com/user-attachments/assets/fc0b5deb-5721-40ef-be35-e2998194f040" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
