### PR TITLE
feat(secmaster): add new data source to get list of regions

### DIFF
--- a/docs/data-sources/secmaster_collector_cloudlog_regions.md
+++ b/docs/data-sources/secmaster_collector_cloudlog_regions.md
@@ -1,0 +1,32 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_collector_cloudlog_regions"
+description: |-
+  Use this data source to get the list of regions.
+---
+
+# huaweicloud_secmaster_collector_cloudlog_regions
+
+Use this data source to get the list of regions.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_secmaster_collector_cloudlog_regions" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data` - The list of the regions.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1995,6 +1995,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_catalogues":                    secmaster.DataSourceSecmasterCatalogues(),
 			"huaweicloud_secmaster_collector_channel_groups":      secmaster.DataSourceCollectorChannelGroups(),
 			"huaweicloud_secmaster_collector_channel_instances":   secmaster.DataSourceCollectorChannelInstances(),
+			"huaweicloud_secmaster_collector_cloudlog_regions":    secmaster.DataSourceCollectorCloudlogRegions(),
 			"huaweicloud_secmaster_collector_connections":         secmaster.DataSourceCollectorConnections(),
 			"huaweicloud_secmaster_collector_logstash_parsers":    secmaster.DataSourceCollectorLogstashParsers(),
 			"huaweicloud_secmaster_collector_module_restrictions": secmaster.DataSourceCollectorModuleRestrictions(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_collector_cloudlog_regions_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_collector_cloudlog_regions_test.go
@@ -1,0 +1,34 @@
+package secmaster
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCollectorCloudlogRegions_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_collector_cloudlog_regions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCollectorCloudlogRegions_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceCollectorCloudlogRegions_basic = `data "huaweicloud_secmaster_collector_cloudlog_regions" "test" {}`

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_collector_cloudlog_regions.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_collector_cloudlog_regions.go
@@ -1,0 +1,80 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SecMaster GET /v1/{project_id}/collector/cloudlogs/regions
+func DataSourceCollectorCloudlogRegions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSocCollectorCloudlogRegionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceSocCollectorCloudlogRegionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/collector/cloudlogs/regions"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving regions: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", utils.PathSearch("data", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of regions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/secmaster" TESTARGS="-run TestAccDataSourceCollectorCloudlogRegions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run TestAccDataSourceCollectorCloudlogRegions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCollectorCloudlogRegions_basic
=== PAUSE TestAccDataSourceCollectorCloudlogRegions_basic
=== CONT  TestAccDataSourceCollectorCloudlogRegions_basic
--- PASS: TestAccDataSourceCollectorCloudlogRegions_basic (15.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 16.026s
```
<img width="1204" height="18" alt="image" src="https://github.com/user-attachments/assets/80627605-d2b4-4ed3-8f60-05413006fd6c" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
