### PR TITLE
fix(checkdeleted): remove the incorrect error formating

### DIFF
--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_group_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_group_rule.go
@@ -237,17 +237,24 @@ func GetAlarmGroupRule(client *golangsdk.ServiceClient, name string) (interface{
 
 	listResp, err := client.Request("GET", listPath, &listOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving alarm group rule: %s", err)
+		return nil, err
 	}
 	listRespBody, err := utils.FlattenResponse(listResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening alarm group rule: %s", err)
+		return nil, err
 	}
 
 	jsonPath := fmt.Sprintf("[?name=='%s']|[0]", name)
 	rule := utils.PathSearch(jsonPath, listRespBody, nil)
 	if rule == nil {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/alert/group-rules",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the alarm group rule (%s) does not exist", name)),
+			},
+		}
 	}
 
 	return rule, nil

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
@@ -180,11 +180,11 @@ func GetPrometheusInstanceById(client *golangsdk.ServiceClient, isntanceId strin
 	}
 	requestResp, err := client.Request("GET", listPath, &listOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving AOM prometheus instance: %s", err)
+		return nil, err
 	}
 	respBody, err := utils.FlattenResponse(requestResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening AOM prometheus instance: %s", err)
+		return nil, err
 	}
 
 	instance := utils.PathSearch("prometheus[0]", respBody, nil)

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_recording_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_recording_rule.go
@@ -107,7 +107,7 @@ func GetRecordingRuleByInstanceId(client *golangsdk.ServiceClient, instanceId st
 
 	respBody, err := utils.FlattenResponse(getResp)
 	if err != nil {
-		return "", fmt.Errorf("error flattening the response: %s", err)
+		return "", err
 	}
 
 	return respBody, nil

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_service_discovery_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_service_discovery_rule.go
@@ -337,17 +337,24 @@ func GetServiceDiscoveryRule(client *golangsdk.ServiceClient, name string) (inte
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error getting the service discovery rule: %s", err)
+		return nil, err
 	}
 	getRespBody, err := utils.FlattenResponse(getResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening the response: %s", err)
+		return nil, err
 	}
 
 	searchPath := fmt.Sprintf("appRules[?name=='%s']|[0]", name)
 	rule := utils.PathSearch(searchPath, getRespBody, nil)
 	if rule == nil {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/inv/servicediscoveryrules",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the service discovery rule (%s) does not exist", name)),
+			},
+		}
 	}
 
 	return rule, nil

--- a/huaweicloud/services/cci/resource_huaweicloud_cci_namespace.go
+++ b/huaweicloud/services/cci/resource_huaweicloud_cci_namespace.go
@@ -298,18 +298,25 @@ func GetCciNamespaceInfoById(c *golangsdk.ServiceClient, id string) (*namespaces
 	var response *namespaces.Namespace
 	pages, err := namespaces.List(c, namespaces.ListOpts{}).AllPages()
 	if err != nil {
-		return response, fmt.Errorf("error finding the namespaces from the server: %s", err)
+		return response, err
 	}
 	responses, err := namespaces.ExtractNamespaces(pages)
 	if err != nil {
-		return response, fmt.Errorf("error extracting CCI namespaces: %s", err)
+		return response, err
 	}
 	for _, v := range responses {
 		if v.Metadata.UID == id {
 			return &v, nil
 		}
 	}
-	return nil, golangsdk.ErrDefault404{}
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/api/v1/namespaces",
+			RequestId: "NONE",
+			Body:      []byte(fmt.Sprintf("the namespace (%s) does not exist", id)),
+		},
+	}
 }
 
 func resourceCciNamespaceImportState(_ context.Context, d *schema.ResourceData,

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_refresh.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_refresh.go
@@ -212,7 +212,7 @@ func GetCacheDetailById(client *golangsdk.ServiceClient, id string) (interface{}
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving cache detail: %s", err)
+		return nil, err
 	}
 
 	getRespBody, err := utils.FlattenResponse(getResp)
@@ -231,7 +231,14 @@ func GetCacheDetailById(client *golangsdk.ServiceClient, id string) (interface{}
 	// Return a `404` status code for handling this scenario.
 	errorCode := utils.PathSearch("error.error_code", getRespBody, "").(string)
 	if errorCode == "CDN.0108" {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1.0/cdn/historytasks/{history_tasks_id}/detail",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the cache detail (%s) does not exist", id)),
+			},
+		}
 	}
 
 	return getRespBody, nil

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_application.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_application.go
@@ -176,12 +176,19 @@ func GetApplication(client *golangsdk.ServiceClient, applicationID string) (inte
 	}
 	getRespBody, err := utils.FlattenResponse(getResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening application: %s", err)
+		return nil, err
 	}
 
 	application := utils.PathSearch("data[0]", getRespBody, nil)
 	if application == nil {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/applications",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the application (%s) does not exist", applicationID)),
+			},
+		}
 	}
 
 	return application, nil

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_document_execute.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_document_execute.go
@@ -2,7 +2,6 @@ package coc
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -312,7 +311,7 @@ func GetDocumentExecution(client *golangsdk.ServiceClient, executionID string) (
 	}
 	readDocumentExecutionRespBody, err := utils.FlattenResponse(readDocumentExecutionResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening document execution: %s", err)
+		return nil, err
 	}
 	return readDocumentExecutionRespBody, nil
 }

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_enterprise_project_collection.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_enterprise_project_collection.go
@@ -101,7 +101,7 @@ func getEnterpriseProjectCollection(client *golangsdk.ServiceClient, collectionI
 	getResp, err := client.Request("GET", getPath, &getOpt)
 
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving COC enterprise project collections: %s", err)
+		return nil, err
 	}
 
 	getRespBody, err := utils.FlattenResponse(getResp)
@@ -111,7 +111,14 @@ func getEnterpriseProjectCollection(client *golangsdk.ServiceClient, collectionI
 
 	enterpriseProjectCollection := utils.PathSearch("data[0]", getRespBody, nil)
 	if enterpriseProjectCollection == nil {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/enterprise-project-collect",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the enterprise project collection (%s) does not exist", collectionID)),
+			},
+		}
 	}
 
 	return enterpriseProjectCollection, nil

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_group.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_group.go
@@ -300,12 +300,19 @@ func GetGroup(client *golangsdk.ServiceClient, componentID string, groupID strin
 	}
 	getRespBody, err := utils.FlattenResponse(getResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening group: %s", err)
+		return nil, err
 	}
 
 	group := utils.PathSearch("data|[0]", getRespBody, nil)
 	if group == nil {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/groups",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the group (%s) does not exist", groupID)),
+			},
+		}
 	}
 
 	return group, nil

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_war_room.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_war_room.go
@@ -411,12 +411,19 @@ func GetWarRoom(client *golangsdk.ServiceClient, warRoomNum string) (interface{}
 	}
 	readWarRoomRespBody, err := utils.FlattenResponse(readWarRoomResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening war room: %s", err)
+		return nil, err
 	}
 
 	warRoomRespBody := utils.PathSearch(fmt.Sprintf("data.list[?war_room_num=='%s']|[0]", warRoomNum), readWarRoomRespBody, nil)
 	if warRoomRespBody == nil {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "POST",
+				URL:       "/v1/external/warrooms/list",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the war room (%s) does not exist", warRoomNum)),
+			},
+		}
 	}
 	return warRoomRespBody, nil
 }

--- a/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_application_group.go
+++ b/huaweicloud/services/codeartsdeploy/resource_huaweicloud_codearts_deploy_application_group.go
@@ -189,18 +189,21 @@ func getDeployApplicationGroup(client *golangsdk.ServiceClient, d *schema.Resour
 
 	listResp, err := client.Request("GET", listPath, &listOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving application groups: %s", err)
+		return nil, err
 	}
 	listRespBody, err := utils.FlattenResponse(listResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening application groups: %s", err)
+		return nil, err
 	}
 
 	groups := utils.PathSearch("result", listRespBody, make([]interface{}, 0)).([]interface{})
 	if len(groups) == 0 {
 		return nil, golangsdk.ErrDefault404{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte("error retrieving application groups, empty list"),
+				Method:    "GET",
+				URL:       "/v1/projects/{project_id}/applications/groups",
+				RequestId: "NONE",
+				Body:      []byte("the application groups does not exist, the result field is empty"),
 			},
 		}
 	}

--- a/huaweicloud/services/codeartspipeline/resource_huaweicloud_codearts_pipeline_permission.go
+++ b/huaweicloud/services/codeartspipeline/resource_huaweicloud_codearts_pipeline_permission.go
@@ -230,7 +230,7 @@ func GetPipelineUesrPermissions(client *golangsdk.ServiceClient, projectId, pipe
 		}
 		getRespBody, err := utils.FlattenResponse(getResp)
 		if err != nil {
-			return nil, fmt.Errorf("error flatten response: %s", err)
+			return nil, err
 		}
 		if err := checkResponseError(getRespBody, projectNotFoundError2); err != nil {
 			return nil, err
@@ -244,7 +244,14 @@ func GetPipelineUesrPermissions(client *golangsdk.ServiceClient, projectId, pipe
 
 		users := utils.PathSearch("users", getRespBody, make([]interface{}, 0)).([]interface{})
 		if len(users) == 0 {
-			return nil, golangsdk.ErrDefault404{}
+			return nil, golangsdk.ErrDefault404{
+				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+					Method:    "GET",
+					URL:       "/v5/{project_id}/api/pipeline-permissions/{pipeline_id}/user-permission",
+					RequestId: "NONE",
+					Body:      []byte(fmt.Sprintf("the user permission (user_id: %s) does not exist", userId)),
+				},
+			}
 		}
 
 		offset += 10
@@ -266,7 +273,7 @@ func GetPipelineRolePermissions(client *golangsdk.ServiceClient, projectId, pipe
 	}
 	getRespBody, err := utils.FlattenResponse(getResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flatten response: %s", err)
+		return nil, err
 	}
 	if err := checkResponseError(getRespBody, projectNotFoundError2); err != nil {
 		return nil, err
@@ -275,7 +282,14 @@ func GetPipelineRolePermissions(client *golangsdk.ServiceClient, projectId, pipe
 	expression := fmt.Sprintf("roles[?role_id==`%v`]|[0]", roleId)
 	role := utils.PathSearch(expression, getRespBody, nil)
 	if role == nil {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v5/{project_id}/api/pipeline-permissions/{pipeline_id}/role-permission",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the role permission (role_id: %s) does not exist", roleId)),
+			},
+		}
 	}
 
 	return role, nil

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api_publishment.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api_publishment.go
@@ -25,6 +25,7 @@ var exclusiveApiNotPublishErrors = []string{
 }
 
 // @API DataArtsStudio POST /v1/{project_id}/service/apis/{api_id}/instances/{instance_id}/publish
+// @API DataArtsStudio GET /v1/{project_id}/service/apis/{api_id}/publish-info
 func ResourceDataServiceApiPublishment() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDataServiceApiPublishmentCreate,
@@ -169,12 +170,23 @@ func QueryApiPublishInfoByInstanceId(client *golangsdk.ServiceClient, workspaceI
 	if apiStatus == "" || apiStatus == "API_STATUS_OFFLINE" {
 		return nil, golangsdk.ErrDefault404{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("the API has been unpublished (%s)", apiId)),
-			}}
+				Method:    "GET",
+				URL:       "/v1/{project_id}/service/apis/{api_id}/publish-info",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the API has been unpublished (%s)", apiId)),
+			},
+		}
 	}
 	if apiStatus != "API_STATUS_PUBLISHED" {
-		return nil, fmt.Errorf("the API status is not in expect, want 'API_STATUS_PUBLISHED', "+
-			"but got '%s'", apiStatus)
+		return nil, golangsdk.ErrDefault500{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/service/apis/{api_id}/publish-info",
+				RequestId: "NONE",
+				Body: []byte(fmt.Sprintf("the API status is not in expect, want 'API_STATUS_PUBLISHED', "+
+					"but got '%s'", apiStatus)),
+			},
+		}
 	}
 	return publishRecord, nil
 }

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
@@ -364,7 +364,11 @@ func chooseDNSClientbyZoneID(d *schema.ResourceData, zoneID string, meta interfa
 	// Firstly, try to ues the DNS global endpoint
 	client, err := conf.DnsV2Client(region)
 	if err != nil {
-		return nil, "", fmt.Errorf("error creating DNS client: %s", err)
+		return nil, "", golangsdk.ErrDefault400{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("error creating DNS client: %s", err)),
+			},
+		}
 	}
 
 	// get zone with DNS global endpoint

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_eip_associate.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_eip_associate.go
@@ -380,7 +380,7 @@ func getFloatingIPbyAddress(client *golangsdk.ServiceClient, floatingIP, epsID s
 
 	allEips, err := eips.ExtractPublicIPs(pages)
 	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve EIP: %s ", err)
+		return nil, err
 	}
 
 	if len(allEips) != 1 {

--- a/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
@@ -154,7 +154,11 @@ func QueryPropagationById(client *golangsdk.ServiceClient, instanceId, routeTabl
 	log.Printf("[DEBUG] The result filtered by resource ID (%s) is: %#v", propagationId, result)
 	association, ok := result[0].(propagations.Propagation)
 	if !ok {
-		return nil, fmt.Errorf("the element type of filter result is incorrect, want 'propagations.Propagation', but got '%T'", result[0])
+		return nil, golangsdk.ErrDefault400{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("the element type of filter result is incorrect, want 'propagations.Propagation', but got '%T'", result[0])),
+			},
+		}
 	}
 
 	return &association, nil

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
@@ -188,7 +188,7 @@ func GetDependencyVersionById(client *golangsdk.ServiceClient, resourceId string
 
 	requestResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error querying dependency package version (%s): %s", dependVersion, err)
+		return nil, err
 	}
 	return utils.FlattenResponse(requestResp)
 }

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_vulnerability_scan_task.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_vulnerability_scan_task.go
@@ -194,7 +194,7 @@ func GetVulnerabilityScanTask(client *golangsdk.ServiceClient, taskId, epsId str
 
 	requestResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving vulnerability scan task: %s", err)
+		return nil, err
 	}
 
 	respBody, err := utils.FlattenResponse(requestResp)
@@ -204,7 +204,14 @@ func GetVulnerabilityScanTask(client *golangsdk.ServiceClient, taskId, epsId str
 
 	scanTask := utils.PathSearch("data_list|[0]", respBody, nil)
 	if scanTask == nil {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v5/{project_id}/vulnerability/scan-tasks",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the vulnerability scan task (%s) does not exist", taskId)),
+			},
+		}
 	}
 
 	return scanTask, nil

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_webtamper_protection.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_webtamper_protection.go
@@ -221,7 +221,7 @@ func GetWebTamperProtectionHost(client *golangsdk.ServiceClient, region, epsId, 
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving HSS web tamper protection host: %s", err)
+		return nil, err
 	}
 
 	getRespBody, err := utils.FlattenResponse(getResp)
@@ -231,7 +231,14 @@ func GetWebTamperProtectionHost(client *golangsdk.ServiceClient, region, epsId, 
 
 	hostResp := utils.PathSearch("data_list[0]", getRespBody, nil)
 	if hostResp == nil {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v5/{project_id}/webtamper/hosts",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the HSS web tamper protection host (%s) does not exist", hostId)),
+			},
+		}
 	}
 
 	return hostResp, nil

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_message_diagnosis_task.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_message_diagnosis_task.go
@@ -271,11 +271,11 @@ func filterKafkaMessageDiagnosisTaskFromList(client *golangsdk.ServiceClient, in
 		currentPath := listPath + fmt.Sprintf("&offset=%d", offset)
 		listResp, err := client.Request("GET", currentPath, &listOpt)
 		if err != nil {
-			return nil, fmt.Errorf("error retrieving the message diagnosis tasks list: %s", err)
+			return nil, err
 		}
 		listRespBody, err := utils.FlattenResponse(listResp)
 		if err != nil {
-			return nil, fmt.Errorf("error flattening the message diagnosis tasks list: %s", err)
+			return nil, err
 		}
 
 		searchPath := fmt.Sprintf("report_list[?report_id=='%s']|[0]", reportID)
@@ -344,11 +344,11 @@ func GetKafkaMessageDiagnosisTaskReport(client *golangsdk.ServiceClient, instanc
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving the message diagnosis task report: %s", err)
+		return nil, err
 	}
 	getRespBody, err := utils.FlattenResponse(getResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening the message diagnosis task report: %s", err)
+		return nil, err
 	}
 
 	return getRespBody, nil

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_aom_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_aom_access.go
@@ -262,10 +262,21 @@ func resourceAOMAccessRead(_ context.Context, d *schema.ResourceData, meta inter
 func parseGetResponseBody(getRespBody interface{}) (interface{}, error) {
 	arrayBody, ok := getRespBody.([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("the API response is not array")
+		return nil, golangsdk.ErrDefault400{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte("the API response is not array"),
+			},
+		}
 	}
 	if len(arrayBody) == 0 {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/lts/aom-mapping/{rule_id}",
+				RequestId: "NONE",
+				Body:      []byte(`the AOM to LTS log mapping rule (%s) does not exist`),
+			},
+		}
 	}
 	return arrayBody[0], nil
 }

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_structing_template.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_structing_template.go
@@ -238,12 +238,19 @@ func queryStructConfigDetail(client *golangsdk.ServiceClient, d *schema.Resource
 
 	rawString, isString := getRespBody.(string)
 	if !isString {
-		return nil, fmt.Errorf("the detail API response is not string")
+		return nil, err
 	}
 
 	if rawString == "" {
 		// the structuring configuration is not exist
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/lts/struct/template",
+				RequestId: "NONE",
+				Body:      []byte(`the structuring configuration is not exist`),
+			},
+		}
 	}
 
 	var rst map[string]interface{}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
@@ -1209,7 +1209,11 @@ func queryResourcePool(cfg *config.Config, region string, d *schema.ResourceData
 	)
 	getModelartsResourcePoolClient, err := cfg.NewServiceClient(getModelartsResourcePoolProduct, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating ModelArts client: %s", err)
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("error creating ModelArts client: %s", err)),
+			},
+		}
 	}
 
 	getModelartsResourcePoolPath := getModelartsResourcePoolClient.Endpoint + getModelartsResourcePoolHttpUrl

--- a/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_exchange.go
+++ b/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_exchange.go
@@ -217,7 +217,7 @@ func GetRabbitmqExchange(client *golangsdk.ServiceClient, instanceID, vhost, nam
 		}
 		listRespBody, err := utils.FlattenResponse(listResp)
 		if err != nil {
-			return nil, fmt.Errorf("error flattening the exchanges list: %s", err)
+			return nil, err
 		}
 
 		searchPath := fmt.Sprintf("items[?name=='%s']|[0]", name)
@@ -230,7 +230,14 @@ func GetRabbitmqExchange(client *golangsdk.ServiceClient, instanceID, vhost, nam
 		offset += pageLimit
 		total := utils.PathSearch("total", listRespBody, float64(0))
 		if int(total.(float64)) <= offset {
-			return nil, golangsdk.ErrDefault404{}
+			return nil, golangsdk.ErrDefault404{
+				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+					Method:    "GET",
+					URL:       "/v2/rabbitmq/{project_id}/instances/{instance_id}/vhosts/{vhost}/exchanges",
+					RequestId: "NONE",
+					Body:      []byte(fmt.Sprintf("the exchange (%s) does not exist", name)),
+				},
+			}
 		}
 	}
 }

--- a/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_exchange_associate.go
+++ b/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_exchange_associate.go
@@ -161,11 +161,11 @@ func getRabbitmqExchangeAssociate(client *golangsdk.ServiceClient, d *schema.Res
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving the exchange association infos: %s", err)
+		return nil, err
 	}
 	getRespBody, err := utils.FlattenResponse(getResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening the exchanges association infos: %s", err)
+		return nil, err
 	}
 
 	// Queue or queue are all available for destination_type when creating,
@@ -183,7 +183,14 @@ func getRabbitmqExchangeAssociate(client *golangsdk.ServiceClient, d *schema.Res
 		}
 	}
 
-	return nil, golangsdk.ErrDefault404{}
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/v2/rabbitmq/{project_id}/instances/{instance_id}/vhosts/{vhost}/exchanges/{exchange}/binding",
+			RequestId: "NONE",
+			Body:      []byte(fmt.Sprintf("the exchange (%s) has no association", d.Get("exchange").(string))),
+		},
+	}
 }
 
 func resourceDmsRabbitmqExchangeAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/huaweicloud/services/ram/resource_huaweicloud_ram_resource_share.go
+++ b/huaweicloud/services/ram/resource_huaweicloud_ram_resource_share.go
@@ -248,7 +248,11 @@ func setRAMShareInstance(client *golangsdk.ServiceClient, d *schema.ResourceData
 		return golangsdk.ErrDefault404{}
 	}
 	if len(curArray) > 1 {
-		return fmt.Errorf("except retrieving one RAM share, but got %d", len(curArray))
+		return golangsdk.ErrDefault400{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("except retrieving one RAM share, but got %d", len(curArray))),
+			},
+		}
 	}
 
 	resourceShare := curArray[0]

--- a/huaweicloud/services/rfs/resource_huaweicloud_rfs_private_hook.go
+++ b/huaweicloud/services/rfs/resource_huaweicloud_rfs_private_hook.go
@@ -209,8 +209,13 @@ func queryPrivateHookByName(client *golangsdk.ServiceClient, name string) (inter
 	// Generate a random UUID as the RFS request ID.
 	requestId, err := uuid.GenerateUUID()
 	if err != nil {
-		return nil, fmt.Errorf("unable to generate RFS request ID: %s", err)
+		return nil, golangsdk.ErrDefault400{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("unable to generate RFS request ID: %s", err)),
+			},
+		}
 	}
+
 	getPath := client.Endpoint + httpUrl
 	getPath = strings.ReplaceAll(getPath, "{hook_name}", name)
 

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_collector_channel_group.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_collector_channel_group.go
@@ -125,7 +125,7 @@ func GetCollectorChannelGroupByName(client *golangsdk.ServiceClient, workspaceId
 
 	resp, err := client.Request("GET", listPath, &listOpts)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving colloector channel group: %s", err)
+		return nil, err
 	}
 
 	respBody, err := utils.FlattenResponse(resp)
@@ -140,7 +140,14 @@ func GetCollectorChannelGroupByName(client *golangsdk.ServiceClient, workspaceId
 	}
 
 	// When the collector channel group does not exist, the status code is `200`.
-	return nil, golangsdk.ErrDefault404{}
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/v1/{project_id}/workspaces/{workspace_id}/collector/channels/groups",
+			RequestId: "NONE",
+			Body:      []byte(fmt.Sprintf("the collector channel group (%s) does not exist", groupName)),
+		},
+	}
 }
 
 func resourceCollectorChannelGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_repo_token_authorization.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_repo_token_authorization.go
@@ -95,7 +95,14 @@ func getAuthorizationByName(c *golangsdk.ServiceClient, name string) (*repositor
 			return &auth, nil
 		}
 	}
-	return nil, fmt.Errorf("unable to find the authorization (%s)", name)
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/v1/{project_id}/git/auths",
+			RequestId: "NONE",
+			Body:      []byte(fmt.Sprintf("the authorization (%s) does not exist", name)),
+		},
+	}
 }
 
 func resourceRepoAuthRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/huaweicloud/services/sms/resource_huaweicloud_sms_migration_project.go
+++ b/huaweicloud/services/sms/resource_huaweicloud_sms_migration_project.go
@@ -3,7 +3,6 @@ package sms
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -209,7 +208,7 @@ func GetMigrationProject(client *golangsdk.ServiceClient, migrationProjectId str
 	}
 	getRespBody, err := utils.FlattenResponse(getResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening migration project: %s", err)
+		return nil, err
 	}
 
 	return getRespBody, nil

--- a/huaweicloud/services/sms/resource_huaweicloud_sms_source_server.go
+++ b/huaweicloud/services/sms/resource_huaweicloud_sms_source_server.go
@@ -1481,7 +1481,7 @@ func GetSourceServer(client *golangsdk.ServiceClient, sourceServerId string) (in
 	}
 	getRespBody, err := utils.FlattenResponse(getResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening source server: %s", err)
+		return nil, err
 	}
 
 	return getRespBody, nil

--- a/huaweicloud/services/sms/resource_huaweicloud_sms_task.go
+++ b/huaweicloud/services/sms/resource_huaweicloud_sms_task.go
@@ -776,7 +776,7 @@ func GetSmsTask(client *golangsdk.ServiceClient, taskID string) (interface{}, er
 	}
 	getRespBody, err := utils.FlattenResponse(getResp)
 	if err != nil {
-		return nil, fmt.Errorf("error flattening task: %s", err)
+		return nil, err
 	}
 
 	return getRespBody, nil

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_gaussdb_mysql_backup.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_gaussdb_mysql_backup.go
@@ -259,7 +259,7 @@ func getGaussDBBackup(client *golangsdk.ServiceClient, backupID string) (interfa
 	getResp, err := client.Request("GET", getPath, &getOpt)
 
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving GaussDB MySQL backup: %s", err)
+		return nil, err
 	}
 
 	getRespBody, err := utils.FlattenResponse(getResp)
@@ -268,7 +268,14 @@ func getGaussDBBackup(client *golangsdk.ServiceClient, backupID string) (interfa
 	}
 	backup := utils.PathSearch("backups|[0]", getRespBody, nil)
 	if backup == nil {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v3/{project_id}/backups",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the GaussDB MySQL backup (%s) does not exist", backupID)),
+			},
+		}
 	}
 	return backup, nil
 }

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_access_policy.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_access_policy.go
@@ -103,11 +103,19 @@ func buildAccessPolicyObjects(objects *schema.Set) []accesspolicies.AccessPolicy
 func GetAccessPolicyByPolicyName(client *golangsdk.ServiceClient, policyName string) (*accesspolicies.AccessPolicyDetailInfo, error) {
 	policies, err := accesspolicies.List(client)
 	if err != nil {
-		return nil, fmt.Errorf("error getting Workspace access policies: %s", err)
+		return nil, err
 	}
 	if len(policies) < 1 {
-		return nil, fmt.Errorf("resource not found, please check in the console")
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/access-policy",
+				RequestId: "NONE",
+				Body:      []byte("all access policies have been deleted"),
+			},
+		}
 	}
+
 	for _, policy := range policies {
 		if policy.PolicyName == policyName {
 			return &policy, nil
@@ -115,7 +123,10 @@ func GetAccessPolicyByPolicyName(client *golangsdk.ServiceClient, policyName str
 	}
 	return nil, golangsdk.ErrDefault404{
 		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-			Body: []byte(fmt.Sprintf("no resource of name '%s' found", policyName)),
+			Method:    "GET",
+			URL:       "/v2/{project_id}/access-policy",
+			RequestId: "NONE",
+			Body:      []byte(fmt.Sprintf("no access policy matched the name '%s'", policyName)),
 		},
 	}
 }

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_nas_storage.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_nas_storage.go
@@ -160,7 +160,7 @@ func GetAppNasStorageById(client *golangsdk.ServiceClient, storageId string) (in
 
 	requestResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving NAS storage (%s): %s", storageId, err)
+		return nil, err
 	}
 	respBody, err := utils.FlattenResponse(requestResp)
 	if err != nil {
@@ -170,7 +170,10 @@ func GetAppNasStorageById(client *golangsdk.ServiceClient, storageId string) (in
 	if storageConfig == nil {
 		return nil, golangsdk.ErrDefault404{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte("the NAS storage has been removed from the Workspace APP service"),
+				Method:    "GET",
+				URL:       "/v1/{project_id}/persistent-storages",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the NAS storage (%s) has been removed from the Workspace APP service", storageId)),
 			},
 		}
 	}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_personal_folders.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_personal_folders.go
@@ -142,7 +142,7 @@ func ListAppPersonalFolders(client *golangsdk.ServiceClient, storageId string) (
 		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
 		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
 		if err != nil {
-			return nil, fmt.Errorf("error getting list of personal folders: %s", err)
+			return nil, err
 		}
 		respBody, err := utils.FlattenResponse(requestResp)
 		if err != nil {

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server_group.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server_group.go
@@ -412,12 +412,7 @@ func GetServerGroupById(client *golangsdk.ServiceClient, serverGroupId string) (
 		return nil, err
 	}
 
-	respBody, err := utils.FlattenResponse(requestResp)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parsing server group from API response: %s", err)
-	}
-
-	return respBody, nil
+	return utils.FlattenResponse(requestResp)
 }
 
 func flattenAppServerGroupFlavorLinks(links []interface{}) []map[string]interface{} {

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_warehouse_application.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_warehouse_application.go
@@ -178,7 +178,7 @@ func GetWarehouseApplicationById(client *golangsdk.ServiceClient, applicationId 
 	}
 	requestResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving application (%s) from warehouse: %s", applicationId, err)
+		return nil, err
 	}
 
 	respBody, err := utils.FlattenResponse(requestResp)
@@ -188,7 +188,14 @@ func GetWarehouseApplicationById(client *golangsdk.ServiceClient, applicationId 
 
 	application := utils.PathSearch("items|[0]", respBody, nil)
 	if application == nil {
-		return nil, golangsdk.ErrDefault404{}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/app-warehouse/apps",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the application (%s) does not exist", applicationId)),
+			},
+		}
 	}
 	return application, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

If the error returned by the CheckDeletedDiag method is processed by fmt.Sprintf, it will corrupt the original error type, causing types defined in the Golang SDK, such as ErrDefault404, to be unable to be effectively recognized.

The following are the resource issues and problematic code lines identified by the error-format-check tool:

```
================================================================================
ERROR - Issues found:
================================================================================
Error - aad/resource_huaweicloud_aad_forward_rule.go (line 125): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - aom/resource_huaweicloud_aomv4_alarm_rule.go (line 735): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - aom/resource_huaweicloud_aom_alarm_group_rule.go (line 240): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - aom/resource_huaweicloud_aom_alarm_rule.go (line 320): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - aom/resource_huaweicloud_aom_alarm_rules_template.go (line 715): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - aom/resource_huaweicloud_aom_dashboards_folder.go (line 157): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - aom/resource_huaweicloud_aom_cloud_service_access.go (line 165): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - aom/resource_huaweicloud_aom_recording_rule.go (line 110): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - aom/resource_huaweicloud_aom_service_discovery_rule.go (line 340): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - aom/resource_huaweicloud_aom_dashboard.go (line 232): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - aom/resource_huaweicloud_aom_dashboard.go (line 208): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - aom/resource_huaweicloud_aom_multi_account_aggregation_rule.go (line 214): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - aom/resource_huaweicloud_aom_prom_instance.go (line 183): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - as/resource_huaweicloud_as_instance_attach.go (line 313): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - cc/resource_huaweicloud_cc_central_network_connection_bandwidth_associate.go (line 214): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - cci/resource_huaweicloud_cci_pvc.go (line 298): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - cci/resource_huaweicloud_cci_namespace.go (line 301): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - cdn/resource_huaweicloud_cdn_cache_refresh.go (line 215): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - ces/resource_huaweicloud_ces_one_click_alarm.go (line 270): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - ces/resource_huaweicloud_ces_alarmrule.go (line 671): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - ces/resource_huaweicloud_ces_alarmrule.go (line 697): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - ces/resource_huaweicloud_ces_alarmrule.go (line 726): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - cfw/resource_huaweicloud_cfw_lts_log.go (line 219): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - coc/resource_huaweicloud_coc_application.go (line 179): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - coc/resource_huaweicloud_coc_document_execute.go (line 315): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - coc/resource_huaweicloud_coc_group.go (line 303): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - coc/resource_huaweicloud_coc_enterprise_project_collection.go (line 104): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - coc/resource_huaweicloud_coc_war_room.go (line 414): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - codeartsdeploy/resource_huaweicloud_codearts_deploy_application.go (line 587): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - codeartsdeploy/resource_huaweicloud_codearts_deploy_application_group.go (line 192): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - codeartspipeline/resource_huaweicloud_codearts_pipeline_plugin_version.go (line 363): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - codeartspipeline/resource_huaweicloud_codearts_pipeline_permission.go (line 233): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - codeartspipeline/resource_huaweicloud_codearts_pipeline_permission.go (line 269): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - css/resource_huaweicloud_css_scan_task.go (line 312): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - dataarts/resource_huaweicloud_dataarts_dataservice_api_publishment.go (line 176): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - dataarts/resource_huaweicloud_dataarts_security_permission_set_member.go (line 124): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - deprecated/resource_huaweicloud_images_image.go (line 358): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - dli/resource_huaweicloud_dli_database_privilege.go (line 167): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - dli/resource_huaweicloud_dli_database.go (line 141): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - dli/resource_huaweicloud_dli_queue.go (line 439): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - dns/resource_huaweicloud_dns_recordset_v2.go (line 367): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - ecs/resource_huaweicloud_compute_eip_associate.go (line 383): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - er/resource_huaweicloud_er_propagation.go (line 157): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - er/resource_huaweicloud_er_flow_log.go (line 188): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - fgs/resource_huaweicloud_fgs_dependency_version.go (line 191): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - ga/resource_huaweicloud_ga_address_group.go (line 196): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - hss/resource_huaweicloud_hss_webtamper_protection.go (line 224): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - hss/resource_huaweicloud_hss_vulnerability_scan_task.go (line 197): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - iotda/resource_huaweicloud_iotda_amqp.go (line 112): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - kafka/resource_huaweicloud_dms_kafka_message_diagnosis_task.go (line 274): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - kafka/resource_huaweicloud_dms_kafka_message_diagnosis_task.go (line 347): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - lts/resource_huaweicloud_lts_aom_access.go (line 265): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - lts/resource_huaweicloud_lts_structing_template.go (line 241): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - modelarts/resource_huaweicloud_modelarts_network.go (line 265): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - modelarts/resource_huaweicloud_modelarts_resource_pool.go (line 1212): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - rabbitmq/resource_huaweicloud_dms_rabbitmq_exchange.go (line 220): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - rabbitmq/resource_huaweicloud_dms_rabbitmq_exchange_associate.go (line 164): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - rabbitmq/resource_huaweicloud_dms_rabbitmq_user.go (line 183): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - rabbitmq/resource_huaweicloud_dms_rabbitmq_vhost.go (line 128): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - ram/resource_huaweicloud_ram_resource_share.go (line 251): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - rds/resource_huaweicloud_rds_pg_plugin.go (line 112): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - rfs/resource_huaweicloud_rfs_private_hook.go (line 212): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - secmaster/resource_huaweicloud_secmaster_collector_channel_group.go (line 128): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - servicestage/resource_huaweicloud_servicestage_repo_token_authorization.go (line 98): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - sfsturbo/resource_huaweicloud_sfs_turbo_obs_target.go (line 298): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - smn/resource_huaweicloud_smn_subscription_filter_policy.go (line 218): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - sms/resource_huaweicloud_sms_task.go (line 779): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - sms/resource_huaweicloud_sms_migration_project.go (line 212): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - sms/resource_huaweicloud_sms_source_server.go (line 1484): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - taurusdb/resource_huaweicloud_gaussdb_mysql_backup.go (line 262): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - vpc/resource_huaweicloud_vpc_sub_network_interface.go (line 164): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - workspace/resource_huaweicloud_workspace_access_policy.go (line 106): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - workspace/resource_huaweicloud_workspace_app_application_publishment.go (line 245): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - workspace/resource_huaweicloud_workspace_app_nas_storage.go (line 163): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - workspace/resource_huaweicloud_workspace_app_personal_folders.go (line 145): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - workspace/resource_huaweicloud_workspace_app_server_group.go (line 417): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.
Error - workspace/resource_huaweicloud_workspace_app_warehouse_application.go (line 181): Formatting the `error` argument of the `CheckDeleted` method is prohibited. It will corrupt the original error type, causing the method to fail to effectively recognize the error content.

Total: 77 issue(s) found
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

<img width="895" height="47" alt="image" src="https://github.com/user-attachments/assets/9045b781-bb0b-4d0d-b001-b6a5223a0a92" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
