### PR TITLE
feat(SWR): support to create agency

### DIFF
--- a/docs/resources/swr_agency.md
+++ b/docs/resources/swr_agency.md
@@ -1,0 +1,31 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_swr_agency"
+description: |-
+  Manages a SWR agency resource within HuaweiCloud.
+---
+
+# huaweicloud_swr_agency
+
+Manages a SWR agency resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_swr_agency" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3800,6 +3800,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_sms_task_consistency_result_report":      sms.ResourceTaskConsistencyResultReport(),
 			"huaweicloud_sms_task_network_check_info_report":      sms.ResourceTaskNetworkCheckInfoReport(),
 
+			"huaweicloud_swr_agency":                   swr.ResourceSwrAgency(),
 			"huaweicloud_swr_organization":             swr.ResourceSWROrganization(),
 			"huaweicloud_swr_organization_permissions": swr.ResourceSWROrganizationPermissions(),
 			"huaweicloud_swr_repository":               swr.ResourceSWRRepository(),

--- a/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_agency_test.go
+++ b/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_agency_test.go
@@ -1,0 +1,26 @@
+package swr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccSwrAgency_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testSwrAgency_basic,
+			},
+		},
+	})
+}
+
+const testSwrAgency_basic = `resource "huaweicloud_swr_agency" "test" {}`

--- a/huaweicloud/services/swr/resource_huaweicloud_swr_agency.go
+++ b/huaweicloud/services/swr/resource_huaweicloud_swr_agency.go
@@ -1,0 +1,118 @@
+package swr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SWR POST /v2/manage/agency
+// @API SWR GET /v2/manage/agency
+func ResourceSwrAgency() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSwrAgencyCreate,
+		ReadContext:   resourceSwrAgencyRead,
+		DeleteContext: resourceSwrAgencyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceSwrAgencyCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	// precheck whether the agency is exist, because the agency can be created once
+	// or a 409 HTTP response code will be returned
+	isAgency, err := getSWRAgency(client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if isAgency {
+		log.Println("[WARN] agency already exist")
+	} else {
+		createHttpUrl := "v2/manage/agency"
+		createPath := client.Endpoint + createHttpUrl
+		createOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				204,
+			},
+		}
+
+		_, err = client.Request("POST", createPath, &createOpt)
+		if err != nil {
+			return diag.Errorf("error creating SWR agency: %s", err)
+		}
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	return nil
+}
+
+func getSWRAgency(client *golangsdk.ServiceClient) (bool, error) {
+	getHttpUrl := "v2/manage/agency"
+	getPath := client.Endpoint + getHttpUrl
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return false, fmt.Errorf("error getting SWR agency: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return false, fmt.Errorf("error flattening SWR agency response: %s", err)
+	}
+
+	isAgency := utils.PathSearch("is_agency", getRespBody, nil)
+	if isAgency == nil {
+		return false, errors.New("error finding is_agency in API response")
+	}
+
+	return isAgency.(bool), nil
+}
+
+func resourceSwrAgencyRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSwrAgencyDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting SWR agency is not supported. The resource is only removed from the state " +
+		"and the agency still remains in the cloud"
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to create agency
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to create agency
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/swr' TESTARGS='-run TestAccSwrAgency_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccSwrAgency_basic -timeout 360m -parallel 4
=== RUN   TestAccSwrAgency_basic
=== PAUSE TestAccSwrAgency_basic
=== CONT  TestAccSwrAgency_basic
--- PASS: TestAccSwrAgency_basic (11.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       11.595s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
