### PR TITLE
feat(hss): support `hss_image_baseline_change_ewp` resource

### DIFF
--- a/docs/resources/hss_image_baseline_change_ewp.md
+++ b/docs/resources/hss_image_baseline_change_ewp.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_image_baseline_change_ewp"
+description: |-
+  Using this resource to update the extended-weak-password configuration of the HSS image baseline within HuaweiCloud.
+---
+
+# huaweicloud_hss_image_baseline_change_ewp
+
+Using this resource to update the extended weak password configuration of the HSS image baseline within HuaweiCloud.
+
+-> This is a one-time action resource used to update the extended-weak-password configuration of the HSS image baseline.
+  Deleting this resource will not clear the corresponding request record, but will only remove the resource information
+  from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "extended_weak_password" {
+  type = list(string)
+}
+
+resource "huaweicloud_hss_image_baseline_change_ewp" "test" {
+  extended_weak_password = var.extended_weak_password
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `extended_weak_password` - (Optional, List, NonUpdatable) Specifies the extended-weak-password string list.  
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3288,6 +3288,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_event_alarm_white_list_delete":                  hss.ResourceEventAlarmWhiteListDelete(),
 			"huaweicloud_hss_event_login_white_list":                         hss.ResourceEventLoginWhiteList(),
 			"huaweicloud_hss_image_batch_scan":                               hss.ResourceImageBatchScan(),
+			"huaweicloud_hss_image_baseline_change_ewp":                      hss.ResourceImageBaselineChangeEWP(),
 			"huaweicloud_hss_login_common_location":                          hss.ResourceLoginCommonLocation(),
 			"huaweicloud_hss_login_white_ip":                                 hss.ResourceLoginWhiteIp(),
 			"huaweicloud_hss_change_host_ignore_status":                      hss.ResourceChangeHostIgnoreStatus(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_image_baseline_change_ewp_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_image_baseline_change_ewp_test.go
@@ -1,0 +1,55 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccImageBaselineChangeEWP_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testImageBaselineChangeEWP_basic(),
+			},
+		},
+	})
+}
+
+func testImageBaselineChangeEWP_basic() string {
+	return `
+resource "huaweicloud_hss_image_baseline_change_ewp" "test" {
+  extended_weak_password = ["11"]
+}
+`
+}
+
+func TestAccImageBaselineChangeEWP_empty(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testImageBaselineChangeEWP_empty(),
+			},
+		},
+	})
+}
+
+func testImageBaselineChangeEWP_empty() string {
+	return `
+resource "huaweicloud_hss_image_baseline_change_ewp" "test" {
+  extended_weak_password = []
+}
+`
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_image_baseline_change_ewp.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_image_baseline_change_ewp.go
@@ -1,0 +1,113 @@
+package hss
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS POST /v5/{project_id}/image/baseline/extended-weak-password
+func ResourceImageBaselineChangeEWP() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceImageBaselineChangeEWPCreate,
+		ReadContext:   resourceImageBaselineChangeEWPRead,
+		UpdateContext: resourceImageBaselineChangeEWPUpdate,
+		DeleteContext: resourceImageBaselineChangeEWPDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{"extended_weak_password"}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			// `extended_weak_password` can be set to an empty list.
+			"extended_weak_password": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildImageBaselineChangeEWPBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"extended_weak_password": utils.ExpandToStringList(d.Get("extended_weak_password").([]interface{})),
+	}
+}
+
+func resourceImageBaselineChangeEWPCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		httpUrl = "v5/{project_id}/image/baseline/extended-weak-password"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+		JSONBody:         buildImageBaselineChangeEWPBodyParams(d),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error updating HSS image baseline extended-weak-password: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return resourceImageBaselineChangeEWPRead(ctx, d, meta)
+}
+
+func resourceImageBaselineChangeEWPRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceImageBaselineChangeEWPUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceImageBaselineChangeEWPDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This is a one-time action resource used to update the extended-weak-password configuration of the
+    HSS image baseline. Deleting this resource will not clear the corresponding request record, but will only remove the
+    resource information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_image_baseline_change_ewp` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_image_baseline_change_ewp` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccImageBaselineChangeEWP_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccImageBaselineChangeEWP_ -timeout 360m -parallel 4
=== RUN   TestAccImageBaselineChangeEWP_basic
=== PAUSE TestAccImageBaselineChangeEWP_basic
=== RUN   TestAccImageBaselineChangeEWP_empty
=== PAUSE TestAccImageBaselineChangeEWP_empty
=== CONT  TestAccImageBaselineChangeEWP_basic
=== CONT  TestAccImageBaselineChangeEWP_empty
--- PASS: TestAccImageBaselineChangeEWP_empty (13.60s)
--- PASS: TestAccImageBaselineChangeEWP_basic (14.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       14.241s

```
<img width="925" height="36" alt="image" src="https://github.com/user-attachments/assets/36d79ad9-05b3-46b8-a538-c78867043c5e" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
