### PR TITLE
feat(SWR): support to get sync regions

### DIFF
--- a/docs/data-sources/swr_sync_regions.md
+++ b/docs/data-sources/swr_sync_regions.md
@@ -1,0 +1,32 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_swr_sync_regions"
+description: |-
+  Use this data source to get the list of regions which is available to synchronize images.
+---
+
+# huaweicloud_swr_sync_regions
+
+Use this data source to get the list of regions which are available to synchronize images.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_swr_sync_regions" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `sync_regions` - The region IDs that are available to synchronize images.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2105,6 +2105,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_sfs_turbo_quotas":      sfsturbo.DataSourceSfsTurboQuotas(),
 			"huaweicloud_sfs_turbo_mounted_ips": sfsturbo.DataSourceSfsTurboMountedIps(),
 
+			"huaweicloud_swr_sync_regions":              swr.DataSourceSyncRegions(),
 			"huaweicloud_swr_organizations":             swr.DataSourceOrganizations(),
 			"huaweicloud_swr_repositories":              swr.DataSourceRepositories(),
 			"huaweicloud_swrv3_repositories":            swr.DataSourceSwrv3Repositories(),

--- a/huaweicloud/services/acceptance/swr/data_source_huaweicloud_swr_sync_regions_test.go
+++ b/huaweicloud/services/acceptance/swr/data_source_huaweicloud_swr_sync_regions_test.go
@@ -1,0 +1,32 @@
+package swr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSwrSyncRegions_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_swr_sync_regions.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSwrSyncRegions_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "sync_regions.#"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceSwrSyncRegions_basic = `data "huaweicloud_swr_sync_regions" "test" {}`

--- a/huaweicloud/services/swr/data_source_huaweicloud_swr_sync_regions.go
+++ b/huaweicloud/services/swr/data_source_huaweicloud_swr_sync_regions.go
@@ -1,0 +1,78 @@
+package swr
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SWR GET /v2/manage/regions
+func DataSourceSyncRegions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSyncRegionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"sync_regions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceSyncRegionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	getHttpUrl := "v2/manage/regions"
+	getPath := client.Endpoint + getHttpUrl
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error getting SWR sync regions: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.Errorf("error flattening SWR sync regions response: %s", err)
+	}
+
+	syncRegions := utils.PathSearch("[].regionID", getRespBody, nil)
+	if syncRegions == nil {
+		return diag.Errorf("error finding region IDs in API response")
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("sync_regions", syncRegions),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support to get sync regions
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support to get sync regions
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/swr' TESTARGS='-run TestAccDataSourceSwrSyncRegions_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccDataSourceSwrSyncRegions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSwrSyncRegions_basic
=== PAUSE TestAccDataSourceSwrSyncRegions_basic
=== CONT  TestAccDataSourceSwrSyncRegions_basic
--- PASS: TestAccDataSourceSwrSyncRegions_basic (12.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       12.668s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
