### PR TITLE
feat(mrs/cluster): the cluster resource scaling nodes

### DIFF
--- a/docs/resources/mapreduce_cluster.md
+++ b/docs/resources/mapreduce_cluster.md
@@ -374,8 +374,9 @@ The following arguments are supported:
 * `name` - (Required, String) Specifies the name of the MapReduce cluster. The name can contain 2 to 64
   characters, which may consist of letters, digits, underscores (_) and hyphens (-).
 
-* `version` - (Required, String, ForceNew) Specifies the MapReduce cluster version. The valid values are `MRS 1.9.2`
-  , `MRS 3.0.5` and `MRS 3.1.0`. Changing this will create a new MapReduce cluster resource.
+* `version` - (Required, String, ForceNew) Specifies the MapReduce cluster version.  
+Changing this will create a new MapReduce cluster resource.  
+For the versions supported by the cluster, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/bulletin-mrs/mrs_13_000014.html#section3).
 
 * `component_list` - (Required, List, ForceNew) Specifies the list of component names. For the components supported by
   the cluster, please following [reference](https://support.huaweicloud.com/intl/en-us/productdesc-mrs/mrs_08_0005.html)
@@ -515,8 +516,9 @@ The `master_nodes` block supports:
 * `flavor` - (Required, String, ForceNew) Specifies the instance specifications for each nodes in node group.
   Changing this will create a new MapReduce cluster resource.
 
-* `node_number` - (Required, Int, ForceNew) Specifies the number of nodes for the node group.  
-  Changing this will create a new MapReduce cluster resource.
+* `node_number` - (Required, Int) Specifies the number of nodes for the node group.  
+
+  -> Master nodes support expansion only, shrinking is not allowed.
 
 * `root_volume_type` - (Required, String, ForceNew) Specifies the system disk flavor of the nodes. Changing this will
   create a new MapReduce cluster resource.
@@ -556,6 +558,18 @@ The `master_nodes` block supports:
 
   -> `DBService` is a basic component of a cluster. Components such as Hive, Hue, Oozie, Loader, and Redis, and Loader
    store their metadata in DBService, and provide the metadata backup and restoration functions by using DBService.
+
+* `skip_bootstrap_scripts` - (Optional, Bool) Specifies whether to skip bootstrap scripts when the cluster
+  is expanded.  
+  Defaults to **true**.
+  + **true**: Skip bootstrap scripts.
+  + **false**: Do not skip bootstrap scripts.
+
+* `scale_without_start` - (Optional, Bool) Specifies whether to start the components on the node after it has
+  been expanded.  
+  Defaults to **false**.
+  + **true**: Do not start the components on the node after it has been expanded.
+  + **false**: Start the components on the node after it has been expanded.
   
 * `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the cluster.  
   Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.  
@@ -631,6 +645,23 @@ The `analysis_core_nodes` and `streaming_core_nodes` blocks support:
   -> `DBService` is a basic component of a cluster. Components such as Hive, Hue, Oozie, Loader, and Redis, and Loader
    store their metadata in DBService, and provide the metadata backup and restoration functions by using DBService.
 
+* `resource_ids` - (Optional, List) Specifies the resource node IDs to be shrunk.  
+  Only ECS nodes with abnormal status can be deleted.
+
+  -> When the `resource_ids` parameter is specified for shrinking, the `node_count` parameter in each node group is invalid.
+
+* `skip_bootstrap_scripts` - (Optional, Bool) Specifies whether to skip bootstrap scripts when the cluster
+  is expanded.  
+  Defaults to **true**.
+  + **true**: Skip bootstrap scripts.
+  + **false**: Do not skip bootstrap scripts.
+
+* `scale_without_start` - (Optional, Bool) Specifies whether to start the components on the node after it has
+  been expanded.  
+  Defaults to **false**.
+  + **true**: Do not start the components on the node after it has been expanded.
+  + **false**: Start the components on the node after it has been expanded.
+
   + `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the cluster.  
   Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.  
   Changing this parameter will create a new MapReduce cluster resource.
@@ -705,6 +736,23 @@ The `analysis_task_nodes` and `streaming_task_nodes` blocks support:
   -> `DBService` is a basic component of a cluster. Components such as Hive, Hue, Oozie, Loader, and Redis, and Loader
    store their metadata in DBService, and provide the metadata backup and restoration functions by using DBService.
 
+* `resource_ids` - (Optional, List) Specifies the resource node IDs to be shrunk.  
+  Only ECS nodes with abnormal status can be deleted.
+
+  -> When the `resource_ids` parameter is specified for shrinking, the `node_count` parameter in each node group is invalid.
+
+* `skip_bootstrap_scripts` - (Optional, Bool) Specifies whether to skip bootstrap scripts when the cluster
+  is expanded.  
+  Defaults to **true**.
+  + **true**: Skip bootstrap scripts.
+  + **false**: Do not skip bootstrap scripts.
+
+* `scale_without_start` - (Optional, Bool) Specifies whether to start the components on the node after it has
+  been expanded.  
+  Defaults to **false**.
+  + **true**: Do not start the components on the node after it has been expanded.
+  + **false**: Start the components on the node after it has been expanded.
+
 <a name="v2_mapreduce_cluster_custom_nodes"></a>
 The `custom_nodes` block supports:
 
@@ -714,8 +762,7 @@ The `custom_nodes` block supports:
 * `flavor` - (Required, String, ForceNew) Specifies the instance specifications for each nodes in node group.
   Changing this will create a new MapReduce cluster resource.
 
-* `node_number` - (Required, Int, ForceNew) Specifies the number of nodes for the node group.  
-  Changing this will create a new MapReduce cluster resource.
+* `node_number` - (Required, Int) Specifies the number of nodes for the node group.  
 
 * `root_volume_type` - (Required, String, ForceNew) Specifies the system disk flavor of the nodes. Changing this will
   create a new MapReduce cluster resource.
@@ -755,6 +802,23 @@ The `custom_nodes` block supports:
 
   -> `DBService` is a basic component of a cluster. Components such as Hive, Hue, Oozie, Loader, and Redis, and Loader
    store their metadata in DBService, and provide the metadata backup and restoration functions by using DBService.
+
+* `resource_ids` - (Optional, List) Specifies the resource node IDs to be shrunk.  
+  Only ECS nodes with abnormal status can be deleted.
+
+  -> When the `resource_ids` parameter is specified for shrinking, the `node_count` parameter in each node group is invalid.
+
+* `skip_bootstrap_scripts` - (Optional, Bool) Specifies whether to skip bootstrap scripts when the cluster
+  is expanded.  
+  Defaults to **true**.
+  + **true**: Skip bootstrap scripts.
+  + **false**: Do not skip bootstrap scripts.
+
+* `scale_without_start` - (Optional, Bool) Specifies whether to start the components on the node after it has
+  been expanded.  
+  Defaults to **false**.
+  + **true**: Do not start the components on the node after it has been expanded.
+  + **false**: Start the components on the node after it has been expanded.
 
 * `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the cluster.  
   Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.  
@@ -914,11 +978,20 @@ terraform import huaweicloud_mapreduce_cluster.test <id>
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
 `manager_admin_pass`, `node_admin_pass`,`template_id`, `assigned_roles`, `external_datasources`, `component_configs`,
-`smn_notify`, `charging_mode`, `period`, `period_unit`, `auto_renew`, `streaming_core_nodes.0.charging_mode`,
-`streaming_core_nodes.0.period`, `streaming_core_nodes.0.period_unit`, `streaming_core_nodes.0.auto_renew`,
+`smn_notify`, `charging_mode`, `period`, `period_unit`, `auto_renew`, `master_nodes.0.charging_mode`,
+`master_nodes.0.period`, `master_nodes.0.period_unit`, `master_nodes.0.auto_renew`,
+`master_nodes.0.skip_bootstrap_scripts`, `master_nodes.0.scale_without_start`, `streaming_core_nodes.0.charging_mode`,
+`streaming_core_nodes.0.resource_ids`, `streaming_core_nodes.0.skip_bootstrap_scripts`,
+`streaming_core_nodes.0.scale_without_start`, `streaming_task_nodes.0.resource_ids`,
+`streaming_task_nodes.0.skip_bootstrap_scripts`, `streaming_task_nodes.0.scale_without_start`,
 `analysis_core_nodes.0.charging_mode`, `analysis_core_nodes.0.period`, `analysis_core_nodes.0.period_unit`,
-`analysis_core_nodes.0.auto_renew`, `custom_nodes.0.charging_mode`, `custom_nodes.0.period`, `custom_nodes.0.period_unit`
-and `custom_nodes.0.auto_renew`. It is generally recommended running `terraform plan` after importing a cluster.
+`analysis_core_nodes.0.auto_renew`, `analysis_core_nodes.0.resource_ids`,
+`analysis_core_nodes.0.skip_bootstrap_scripts`, `analysis_core_nodes.0.scale_without_start`,
+`analysis_task_nodes.0.resource_ids`, `analysis_task_nodes.0.skip_bootstrap_scripts`,
+`analysis_task_nodes.0.scale_without_start`, `custom_nodes.0.charging_mode`, `custom_nodes.0.period`,
+`custom_nodes.0.period_unit`, `custom_nodes.0.auto_renew`, `custom_nodes.0.resource_ids`,
+`custom_nodes.0.skip_bootstrap_scripts` and `custom_nodes.0.scale_without_start`,
+It is generally recommended running `terraform plan` after importing a cluster.
 You can then decide if changes should be applied to the cluster, or the resource definition
 should be updated to align with the cluster. Also you can ignore changes as below.
 
@@ -928,11 +1001,50 @@ resource "huaweicloud_mapreduce_cluster" "test" {
 
   lifecycle {
     ignore_changes = [
-      manager_admin_pass, node_admin_pass, template_id, assigned_roles, external_datasources, component_configs, smn_notify,
-      charging_mode, period, period_unit, auto_renew, master_nodes.0.charging_mode, master_nodes.0.period, master_nodes.0.period_unit,
-      master_nodes.0.auto_renew, streaming_core_nodes.0.charging_mode, streaming_core_nodes.0.period, streaming_core_nodes.0.period_unit,
-      streaming_core_nodes.0.auto_renew, analysis_core_nodes.0.charging_mode, analysis_core_nodes.0.period, analysis_core_nodes.0.period_unit,
-      analysis_core_nodes.0.auto_renew, custom_nodes.0.charging_mode, custom_nodes.0.period, custom_nodes.0.period_unit, custom_nodes.0.auto_renew
+      manager_admin_pass,
+      node_admin_pass,
+      template_id,
+      assigned_roles,
+      external_datasources,
+      component_configs,
+      smn_notify,
+      charging_mode,
+      period,
+      period_unit,
+      auto_renew,
+      master_nodes.0.charging_mode,
+      master_nodes.0.period,
+      master_nodes.0.period_unit,
+      master_nodes.0.auto_renew,
+      master_nodes.0.skip_bootstrap_scripts,
+      master_nodes.0.scale_without_start,
+      streaming_core_nodes.0.charging_mode,
+      streaming_core_nodes.0.period,
+      streaming_core_nodes.0.period_unit,
+      streaming_core_nodes.0.auto_renew,
+      streaming_core_nodes.0.resource_ids,
+      streaming_core_nodes.0.skip_bootstrap_scripts,
+      streaming_core_nodes.0.scale_without_start,
+      streaming_task_nodes.0.resource_ids,
+      streaming_task_nodes.0.skip_bootstrap_scripts,
+      streaming_task_nodes.0.scale_without_start,
+      analysis_core_nodes.0.charging_mode,
+      analysis_core_nodes.0.period,
+      analysis_core_nodes.0.period_unit,
+      analysis_core_nodes.0.auto_renew,
+      analysis_core_nodes.0.resource_ids,
+      analysis_core_nodes.0.skip_bootstrap_scripts,
+      analysis_core_nodes.0.scale_without_start,
+      analysis_task_nodes.0.resource_ids,
+      analysis_task_nodes.0.skip_bootstrap_scripts,
+      analysis_task_nodes.0.scale_without_start,
+      custom_nodes.0.resource_ids,
+      custom_nodes.0.skip_bootstrap_scripts,
+      custom_nodes.0.scale_without_start
+      custom_nodes.0.charging_mode,
+      custom_nodes.0.period,
+      custom_nodes.0.period_unit,
+      custom_nodes.0.auto_renew,
     ]
   }
 }

--- a/docs/resources/mapreduce_cluster.md
+++ b/docs/resources/mapreduce_cluster.md
@@ -375,8 +375,8 @@ The following arguments are supported:
   characters, which may consist of letters, digits, underscores (_) and hyphens (-).
 
 * `version` - (Required, String, ForceNew) Specifies the MapReduce cluster version.  
-Changing this will create a new MapReduce cluster resource.  
-For the versions supported by the cluster, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/bulletin-mrs/mrs_13_000014.html#section3).
+  Changing this will create a new MapReduce cluster resource.  
+  For the versions supported by the cluster, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/bulletin-mrs/mrs_13_000014.html#section3).
 
 * `component_list` - (Required, List, ForceNew) Specifies the list of component names. For the components supported by
   the cluster, please following [reference](https://support.huaweicloud.com/intl/en-us/productdesc-mrs/mrs_08_0005.html)
@@ -485,8 +485,8 @@ The EIP must have been created and must be in the same region as the cluster.
   The [object](#BootstrapScripts) structure is documented below.
   Changing this will create a new MapReduce cluster resource.
 
-* `smn_notify` - (Optional, List, ForceNew) Specifies the alarm configuration of the cluster. The [smn_notify](#SMNNotify)
-  structure is documented below.
+* `smn_notify` - (Optional, List, ForceNew) Specifies the alarm configuration of the cluster.  
+  The [smn_notify](#SMNNotify) block is documented below.  
   Changing this will create a new MapReduce cluster resource.
 
 * `mrs_ecs_default_agency` - (Optional, String, ForceNew) Specifies the default agency name bound to the cluster node.  
@@ -609,10 +609,14 @@ The `analysis_core_nodes` and `streaming_core_nodes` blocks support:
 
 * `data_volume_count` - (Required, Int, ForceNew) Specifies the data disk number of the nodes. The number configuration
   of each node are as follows:
-  + **analysis_core_nodes**: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
-  + **streaming_core_nodes**: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
-  + **analysis_task_nodes**: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
-  + **streaming_task_nodes**: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
+  + **analysis_core_nodes**: minimum is one and the maximum is subject to the configuration of
+    the corresponding flavor.
+  + **streaming_core_nodes**: minimum is one and the maximum is subject to the configuration of
+    the corresponding flavor.
+  + **analysis_task_nodes**: minimum is one and the maximum is subject to the configuration of
+    the corresponding flavor.
+  + **streaming_task_nodes**: minimum is one and the maximum is subject to the configuration of
+    the corresponding flavor.
 
   Changing this will create a new MapReduce cluster resource.
   
@@ -648,7 +652,8 @@ The `analysis_core_nodes` and `streaming_core_nodes` blocks support:
 * `resource_ids` - (Optional, List) Specifies the resource node IDs to be shrunk.  
   Only ECS nodes with abnormal status can be deleted.
 
-  -> When the `resource_ids` parameter is specified for shrinking, the `node_count` parameter in each node group is invalid.
+  -> When the `resource_ids` parameter is specified for shrinking, the `node_count` parameter in
+     each node group is invalid.
 
 * `skip_bootstrap_scripts` - (Optional, Bool) Specifies whether to skip bootstrap scripts when the cluster
   is expanded.  
@@ -700,10 +705,14 @@ The `analysis_task_nodes` and `streaming_task_nodes` blocks support:
 
 * `data_volume_count` - (Required, Int, ForceNew) Specifies the data disk number of the nodes. The number configuration
   of each node are as follows:
-  + **analysis_core_nodes**: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
-  + **streaming_core_nodes**: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
-  + **analysis_task_nodes**: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
-  + **streaming_task_nodes**: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
+  + **analysis_core_nodes**: minimum is one and the maximum is subject to the configuration of
+    the corresponding flavor.
+  + **streaming_core_nodes**: minimum is one and the maximum is subject to the configuration of
+    the corresponding flavor.
+  + **analysis_task_nodes**: minimum is one and the maximum is subject to the configuration of
+    the corresponding flavor.
+  + **streaming_task_nodes**: minimum is one and the maximum is subject to the configuration of
+    the corresponding flavor.
 
   Changing this will create a new MapReduce cluster resource.
   
@@ -739,7 +748,8 @@ The `analysis_task_nodes` and `streaming_task_nodes` blocks support:
 * `resource_ids` - (Optional, List) Specifies the resource node IDs to be shrunk.  
   Only ECS nodes with abnormal status can be deleted.
 
-  -> When the `resource_ids` parameter is specified for shrinking, the `node_count` parameter in each node group is invalid.
+  -> When the `resource_ids` parameter is specified for shrinking, the `node_count` parameter in
+     each node group is invalid.
 
 * `skip_bootstrap_scripts` - (Optional, Bool) Specifies whether to skip bootstrap scripts when the cluster
   is expanded.  
@@ -806,7 +816,8 @@ The `custom_nodes` block supports:
 * `resource_ids` - (Optional, List) Specifies the resource node IDs to be shrunk.  
   Only ECS nodes with abnormal status can be deleted.
 
-  -> When the `resource_ids` parameter is specified for shrinking, the `node_count` parameter in each node group is invalid.
+  -> When the `resource_ids` parameter is specified for shrinking, the `node_count` parameter in
+     each node group is invalid.
 
 * `skip_bootstrap_scripts` - (Optional, Bool) Specifies whether to skip bootstrap scripts when the cluster
   is expanded.  
@@ -864,7 +875,8 @@ The `configs` block supports:
 <a name="ExternalDatasources"></a>
 The `external_datasources` block supports:
 
-* `component_name` - (Required, String, ForceNew) Specifies the component name. The valid values are `Hive` and `Ranger`.
+* `component_name` - (Required, String, ForceNew) Specifies the component name.  
+  The valid values are `Hive` and `Ranger`.  
   Changing this will create a new MapReduce cluster resource.
 
 * `role_type` - (Required, String, ForceNew) Specifies the component role type.

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster.go
@@ -335,7 +335,7 @@ func nodeGroupSchemaResource(groupName string) *schema.Resource {
 				ForceNew: true,
 			},
 			"assigned_roles": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Schema{
@@ -646,7 +646,8 @@ func buildNodeGroupOpts(d *schema.ResourceData, optsRaw []interface{}, defaultNa
 		nodeGroup.DataVolumeCount = golangsdk.IntToPointer(volumeCount)
 		// This parameter is mandatory when the cluster type is CUSTOM. Specifies the roles deployed in a node group.
 		if clusterType := d.Get("type").(string); clusterType == typeCustom {
-			for _, v := range opts["assigned_roles"].([]interface{}) {
+			assignedRoles := utils.PathSearch("assigned_roles", opts, schema.NewSet(schema.HashString, nil)).(*schema.Set)
+			for _, v := range assignedRoles.List() {
 				nodeGroup.AssignedRoles = append(nodeGroup.AssignedRoles, v.(string))
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. The cluster resource supports expanding and shrinking nodes.
   + Master nodes support expansion only, shrinking is not allowed.
   + The `PUT /v1.1/{project_id}/cluster_infos/{cluster_id}` interface does not support scaling up master nodes, so new APIs are used instead.
2. Change the type of `assigned_roles` to Set.
     +  The order in the script is inconsistent with the order returned by the API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o mrs -f TestAccMrsMapReduceCluster_hybrid
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccMrsMapReduceCluster_hybrid -timeout 360m -parallel 10
=== RUN   TestAccMrsMapReduceCluster_hybrid
=== PAUSE TestAccMrsMapReduceCluster_hybrid
=== CONT  TestAccMrsMapReduceCluster_hybrid
--- PASS: TestAccMrsMapReduceCluster_hybrid (2350.28s)
PASS
coverage: 28.1% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       2350.431s       coverage: 28.1% of statements in ./huaweicloud/services/mrs
```
```
./scripts/coverage.sh -o mrs -f TestAccCluster_custom_compact
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccCluster_custom_compact -timeout 360m -parallel 10
=== RUN   TestAccCluster_custom_compact
=== PAUSE TestAccCluster_custom_compact
=== CONT  TestAccCluster_custom_compact
--- PASS: TestAccCluster_custom_compact (2098.65s)
PASS
coverage: 30.2% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       2098.749s       coverage: 30.2% of statements in ./huaweicloud/services/mrs
```
```
./scripts/coverage.sh -o mrs -f TestAccCluster_prepaid_custom
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccCluster_prepaid_custom -timeout 360m -parallel 10
=== RUN   TestAccCluster_prepaid_custom
=== PAUSE TestAccCluster_prepaid_custom
=== CONT  TestAccCluster_prepaid_custom
--- PASS: TestAccCluster_prepaid_custom (1372.02s)
PASS
coverage: 28.6% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       1372.179s       coverage: 28.6% of statements in ./huaweicloud/services/mrs
```

 ```
./scripts/coverage.sh -o mrs -f TestAccClusterNodeBatchShrink_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccClusterNodeBatchShrink_basic -timeout 360m -parallel 10
=== RUN   TestAccClusterNodeBatchShrink_basic
=== PAUSE TestAccClusterNodeBatchShrink_basic
=== CONT  TestAccClusterNodeBatchShrink_basic
--- PASS: TestAccClusterNodeBatchShrink_basic (458.12s)
PASS
coverage: 10.7% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       458.298s        coverage: 10.7% of statements in ./huaweicloud/services/mrs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
