### PR TITLE
feat(BMS): bms instance support os change and add reinstall resource

### DIFF
--- a/docs/resources/bms_instance.md
+++ b/docs/resources/bms_instance.md
@@ -86,14 +86,15 @@ The following arguments are supported:
 * `name` - (Required, String) Specifies a unique name for the instance. The name consists of 1 to 63 characters,
   including letters, digits, underscores (_), hyphens (-), and periods (.).
 
-* `image_id` - (Required, String, ForceNew) Specifies the image ID of the desired image for the instance. Changing this
-  creates a new instance.
+* `image_id` - (Required, String) Specifies the image ID of the desired image for the instance. Only a stopped BMS or a
+  BMS on which changing the OS failed supports changing OS. And when changing this parameter, the instance will be
+  shutdown first if the `power_action` is not **OFF**.
 
 * `flavor_id` - (Required, String, ForceNew) Specifies the flavor ID of the desired flavor for the instance. Changing
   this creates a new instance.
 
-* `user_id` - (Required, String, ForceNew) Specifies the user ID. You can obtain the user ID from My Credential on the
-  management console. Changing this creates a new instance.
+* `user_id` - (Required, String) Specifies the user ID. You can obtain the user ID from My Credential on the management
+  console. It can only be modified when `image_id` is modified.
 
 * `availability_zone` - (Required, String, ForceNew) Specifies the availability zone in which to create the instance.
   Please following [reference](https://developer.huaweicloud.com/intl/en-us/endpoint?BMS)
@@ -105,21 +106,21 @@ The following arguments are supported:
 * `nics` - (Required, List) Specifies an array of one or more networks to attach to the instance. The network
   object structure is documented below.
 
-* `admin_pass` - (Optional, String, ForceNew) Specifies the login password of the administrator for logging in to the
-  BMS using password authentication. Changing this creates a new instance. The password must meet the following
+* `admin_pass` - (Optional, String) Specifies the login password of the administrator for logging in to the BMS using
+  password authentication. It can only be modified when `image_id` is modified. The password must meet the following
   complexity requirements:
   + Contains 8 to 26 characters.
   + Contains at least three of the following character types: uppercase letters, lowercase letters, digits, and special
     characters !@$%^-_=+[{}]:,./?
   + Cannot contain the username or the username in reverse.
 
-* `key_pair` - (Optional, String, ForceNew) Specifies the name of a key pair for logging in to the BMS using key pair
+* `key_pair` - (Optional, String) Specifies the name of a key pair for logging in to the BMS using key pair
   authentication. The key pair must already be created and associated with the tenant's account. The parameter is
-  required when using a Windows image to create a BMS. Changing this creates a new instance.
+  required when using a Windows image to create a BMS. It can only be modified when `image_id` is modified.
 
-* `user_data` - (Optional, String, ForceNew) Specifies the user data to be injected during the instance creation. Text
-  and text files can be injected. `user_data` can come from a variety of sources: inline, read in from the *file*
-  function. The content of `user_data` can be plaint text or encoded with base64. Changing this creates a new instance.
+* `user_data` - (Optional, String) Specifies the user data to be injected during the instance creation. Text and text
+  files can be injected. `user_data` can come from a variety of sources: inline, read in from the **file** function. The
+  content of `user_data` can be plaint text or encoded with base64. It can only be modified when `image_id` is modified.
 
 -> **NOTE:** 1. If the `user_data` field is specified for a Linux BMS that is created using an image with Cloud-Init
   installed, the `admin_pass` field becomes invalid.
@@ -243,5 +244,5 @@ The `nics_struct` block supports:
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 30 minutes.
-* `update` - Default is 30 minutes.
+* `update` - Default is 60 minutes.
 * `delete` - Default is 30 minutes.

--- a/docs/resources/bms_os_reinstall.md
+++ b/docs/resources/bms_os_reinstall.md
@@ -1,0 +1,101 @@
+---
+subcategory: "Bare Metal Server (BMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_bms_os_reinstall"
+description: |-
+  Manages a BMS OS reinstall resource within HuaweiCloud.
+---
+
+# huaweicloud_bms_os_reinstall
+
+Manages a BMS OS reinstall resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "server_id" {}
+variable "key_name" {}
+variable "user_id" {}
+
+resource "huaweicloud_bms_os_reinstall" "test" {
+  server_id = var.server_id
+
+  os_reinstall{
+    key_name = var.key_name
+    user_id  = var.user_id
+
+    metadata {
+      __system__encrypted = "0"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `server_id` - (Required, String, NonUpdatable) Specifies the BMS ID.
+
+* `os_reinstall` - (Required, List, NonUpdatable) Specifies the operation of reinstalling the BMS OS.
+  The [os_reinstall](#os_reinstall_struct) structure is documented below.
+
+<a name="os_reinstall_struct"></a>
+The `os_reinstall` block supports:
+
+* `admin_pass` - (Optional, String, NonUpdatable) Specifies the initial password of the BMS administrator account. The
+  Linux administrator is **root**, and the Windows administrator is **Administrator**. Recommended password complexity
+  requirements are as follows:
+  + The password contains 8 to 26 characters.
+  + Contains at least three of the following character types: uppercase letters, lowercase letters, digits, and special
+    characters **!@$%^-_=+[{}]:,./?**.
+  + The password cannot contain the username or the username in reverse.
+
+-> **NOTE:**
+  1.For Windows BMSs, the password cannot contain more than two consecutive characters in the username.
+  <br/>2.For Linux BMSs, `user_data` can be used to inject a password. In this case, `admin_pass` is invalid.
+  <br/>3.Either `admin_pass` or `key_name` can be set.
+  <br/>4.If both `admin_pass` and `key_name` are empty, `user_data` in metadata must be set.
+
+* `key_name` - (Optional, String, NonUpdatable) Specifies the key pair name.
+
+* `user_id` - (Optional, String, NonUpdatable) Specifies the user ID.
+
+* `metadata` - (Optional, List, NonUpdatable) Specifies the BMS metadata.
+  The [metadata](#os_reinstall_metadata_struct) structure is documented below.
+
+<a name="os_reinstall_metadata_struct"></a>
+The `metadata` block supports:
+
+* `user_data` - (Optional, String, NonUpdatable) Specifies the Linux image root password injected during the BMS OS
+  reinstallation. It is a user-defined initial password. The password change script must be encoded using Base64.
+  Recommended password complexity requirements are as follows:
+  + Contains 8 to 26 characters.
+  + Contains at least three of the following character types: uppercase letters, lowercase letters, digits, and special
+    **characters !@$%^-_=+[{}]:,./?**.
+
+* `__system__encrypted` - (Optional, String, NonUpdatable) Specifies whether the system disk is encrypted. The value can
+  be **0 (not encrypted)** or **1 (encrypted)**.
+  + If this parameter is not specified, the system disk will not be encrypted by default.
+  + If this parameter is set to **0**, `__system__cmkid` will be invalid.
+
+* `__system__cmkid` - (Optional, String, NonUpdatable) Specifies the CMK ID which is used for encryption. This parameter
+  is used with `__system__encrypted`.
+
+* `__system__encryption_algorithm` - (Optional, String, NonUpdatable) Specifies the encryption algorithms for encrypted
+  volumes. Value options: **AES_256**, **SM4**. Defaults to **AES_256**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is the instance ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2639,6 +2639,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_bms_volume_attach":            bms.ResourceVolumeAttach(),
 			"huaweicloud_bms_instance_password_reset":  bms.ResourceInstancePasswordReset(),
 			"huaweicloud_bms_instance_password_delete": bms.ResourceInstancePasswordDelete(),
+			"huaweicloud_bms_os_reinstall":             bms.ResourceBmsOsReinstall(),
 
 			"huaweicloud_bcs_instance": bcs.ResourceInstance(),
 

--- a/huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_os_reinstall_test.go
+++ b/huaweicloud/services/acceptance/bms/resource_huaweicloud_bms_os_reinstall_test.go
@@ -1,0 +1,90 @@
+package bms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBmsOsReinstall_Basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckUserId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBmsOsReinstall_basic(rName),
+			},
+		},
+	})
+}
+
+func testAccBmsOsReinstall_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_bms_instance" "test" {
+  security_groups   = [huaweicloud_networking_secgroup.test.id]
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  flavor_id         = data.huaweicloud_bms_flavors.test.flavors[0].id
+  key_pair          = huaweicloud_kps_keypair.test.name
+  image_id          = try(local.x86_images[0], "")
+  name              = "%[2]s"
+  user_id           = "%[3]s"
+  system_disk_type  = "GPSSD"
+  system_disk_size  = 150
+  power_action      = "OFF"
+
+  user_data = <<EOF
+#!/bin/bash 
+sudo mkdir /example
+EOF
+
+  nics {
+    subnet_id = huaweicloud_vpc_subnet.test.id
+  }
+
+  metadata = {
+    foo1 = "bar1"
+    key1 = "value1"
+  }
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = "1"
+  auto_renew    = "false"
+}
+`, testAccBmsInstance_base(rName), rName, acceptance.HW_USER_ID)
+}
+
+func testAccBmsOsReinstall_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_bms_os_reinstall" "test" {
+  server_id = huaweicloud_bms_instance.test.id
+
+  os_reinstall {
+    key_name = huaweicloud_kps_keypair.test.name
+    user_id  = "%[2]s"
+
+    metadata {
+      user_data = <<EOF
+#!/bin/bash 
+sudo mkdir /example
+EOF
+      __system__encrypted = "0"
+    }
+  }
+}
+`, testAccBmsOsReinstall_base(rName), acceptance.HW_USER_ID)
+}

--- a/huaweicloud/services/bms/resource_huaweicloud_bms_os_reinstall.go
+++ b/huaweicloud/services/bms/resource_huaweicloud_bms_os_reinstall.go
@@ -1,0 +1,224 @@
+package bms
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var osReinstallNonUpdatableParams = []string{"server_id", "os_reinstall", "os_reinstall.*.admin_pass",
+	"os_reinstall.*.key_name", "os_reinstall.*.user_id", "os_reinstall.*.metadata", "os_reinstall.*.metadata.*.user_data",
+	"os_reinstall.*.metadata.*.__system__encrypted", "os_reinstall.*.metadata.*.__system__cmkid",
+	"os_reinstall.*.metadata.*.__system__encrypted"}
+
+// @API BMS POST /v1/{project_id}/baremetalservers/{server_id}/reinstallos
+// @API BMS GET /v1/{project_id}/jobs/{job_id}
+func ResourceBmsOsReinstall() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBmsOsReinstallCreate,
+		ReadContext:   resourceBmsOsReinstallRead,
+		UpdateContext: resourceBmsOsReinstallUpdate,
+		DeleteContext: resourceBmsOsReinstallDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(osReinstallNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"server_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"os_reinstall": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem:     osReinstallSchema(),
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func osReinstallSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"admin_pass": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"key_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"user_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"metadata": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     osReinstallMetadataSchema(),
+			},
+		},
+	}
+}
+
+func osReinstallMetadataSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"user_data": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"__system__encrypted": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"__system__cmkid": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"__system__encryption_algorithm": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceBmsOsReinstallCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v1/{project_id}/baremetalservers/{server_id}/reinstallos"
+		product = "bms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating BMS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{server_id}", d.Get("server_id").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createOpt.JSONBody = buildOsReinstallBodyParams(d)
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating BMS OS reinstall: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(d.Get("server_id").(string))
+
+	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID from the API response")
+	}
+
+	err = waitForJobComplete(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for BMS OS reinstall: %s", err)
+	}
+
+	return nil
+}
+
+func buildOsReinstallBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"os-reinstall": utils.RemoveNil(buildOsReinstallOsReinstallBodyParams(d.Get("os_reinstall"))),
+	}
+	return bodyParams
+}
+
+func buildOsReinstallOsReinstallBodyParams(osReinstallRaw interface{}) map[string]interface{} {
+	if osReinstallRaw == nil || len(osReinstallRaw.([]interface{})) == 0 {
+		return nil
+	}
+
+	osReinstall := osReinstallRaw.([]interface{})[0]
+	if v, ok := osReinstall.(map[string]interface{}); ok {
+		bodyParams := map[string]interface{}{
+			"adminpass": utils.ValueIgnoreEmpty(v["admin_pass"]),
+			"keyname":   utils.ValueIgnoreEmpty(v["key_name"]),
+			"userid":    utils.ValueIgnoreEmpty(v["user_id"]),
+			"metadata":  buildOsReinstallOsReinstallMetadataBodyParams(v["metadata"]),
+		}
+		return bodyParams
+	}
+	return nil
+}
+
+func buildOsReinstallOsReinstallMetadataBodyParams(metadataRaw interface{}) map[string]interface{} {
+	if metadataRaw == nil || len(metadataRaw.([]interface{})) == 0 {
+		return nil
+	}
+
+	osReinstall := metadataRaw.([]interface{})[0]
+	if v, ok := osReinstall.(map[string]interface{}); ok {
+		userData := v["user_data"].(string)
+		if _, err := base64.StdEncoding.DecodeString(userData); err != nil {
+			userData = base64.StdEncoding.EncodeToString([]byte(userData))
+		}
+		bodyParams := map[string]interface{}{
+			"user_data":                      userData,
+			"__system__encrypted":            utils.ValueIgnoreEmpty(v["__system__encrypted"]),
+			"__system__cmkid":                utils.ValueIgnoreEmpty(v["__system__cmkid"]),
+			"__system__encryption_algorithm": utils.ValueIgnoreEmpty(v["__system__encryption_algorithm"]),
+		}
+		return bodyParams
+	}
+	return nil
+}
+
+func resourceBmsOsReinstallRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceBmsOsReinstallUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceBmsOsReinstallDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting BMS OS reinstall resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  bms instance support os change and add reinstall resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  bms instance support os change and add reinstall resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/bms/ TESTARGS='-run TestAccBmsInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/bms/ -v -run TestAccBmsInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccBmsInstance_basic
=== PAUSE TestAccBmsInstance_basic
=== CONT  TestAccBmsInstance_basic
--- PASS: TestAccBmsInstance_basic (1502.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/bms       1502.187s

make testacc TEST=./huaweicloud/services/acceptance/bms/ TESTARGS='-run TestAccBmsInstance_password_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/bms/ -v -run TestAccBmsInstance_password_basic -timeout 360m -parallel 4
=== RUN   TestAccBmsInstance_password_basic
=== PAUSE TestAccBmsInstance_password_basic
=== CONT  TestAccBmsInstance_password_basic
--- PASS: TestAccBmsInstance_password_basic (1254.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/bms       1254.771s

make testacc TEST=./huaweicloud/services/acceptance/bms/ TESTARGS='-run TestAccBmsInstance_power_action'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/bms/ -v -run TestAccBmsInstance_power_action -timeout 360m -parallel 4
=== RUN   TestAccBmsInstance_power_action
=== PAUSE TestAccBmsInstance_power_action
=== CONT  TestAccBmsInstance_power_action
--- PASS: TestAccBmsInstance_power_action (1087.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/bms       1087.820s

make testacc TEST=./huaweicloud/services/acceptance/bms/ TESTARGS='-run TestAccBmsOsReinstall_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/bms/ -v -run TestAccBmsOsReinstall_Basic -timeout 360m -parallel 4
=== RUN   TestAccBmsOsReinstall_Basic
=== PAUSE TestAccBmsOsReinstall_Basic
=== CONT  TestAccBmsOsReinstall_Basic
--- PASS: TestAccBmsOsReinstall_Basic (1166.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/bms       1166.614s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
