### PR TITLE
feat(dns): add a new resource to manage resolver access log

### DIFF
--- a/docs/resources/dns_resolver_access_log.md
+++ b/docs/resources/dns_resolver_access_log.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Domain Name Service (DNS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dns_resolver_access_log"
+description: |-
+  Manages a DNS resolver access log resource within HuaweiCloud.
+---
+
+# huaweicloud_dns_resolver_access_log
+
+Manages a DNS resolver access log resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "lts_group_id" {}
+variable "lts_stream_id" {}
+variable "vpc_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_dns_resolver_access_log" "test" {
+  lts_group_id = var.lts_group_id
+  lts_topic_id = var.lts_stream_id
+  vpc_ids      = var.vpc_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the resolver access log is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `lts_group_id` - (Required, String, NonUpdatable) Specifies the ID of the log group.
+
+* `lts_topic_id` - (Required, String, NonUpdatable) Specifies the ID of the log stream.
+
+* `vpc_ids` - (Required, List) Specifies the list of VPC IDs associated with the resolver access log.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+Resolver access log can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dns_resolver_access_log.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3088,6 +3088,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_private_zone_associate":    dns.ResourceDNSPrivateZoneAssociate(),
 			"huaweicloud_dns_endpoint_assignment":       dns.ResourceEndpointAssignment(),
 			"huaweicloud_dns_endpoint":                  dns.ResourceDNSEndpoint(),
+			"huaweicloud_dns_resolver_access_log":       dns.ResourceResolverAccessLog(),
 			"huaweicloud_dns_resolver_rule":             dns.ResourceResolverRule(),
 			"huaweicloud_dns_resolver_rule_associate":   dns.ResourceResolverRuleAssociate(),
 			"huaweicloud_dns_line_group":                dns.ResourceLineGroup(),

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_resolver_access_log_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_resolver_access_log_test.go
@@ -1,0 +1,105 @@
+package dns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dns"
+)
+
+func getResolverAccessLog(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("dns_region", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DNS client: %s", err)
+	}
+
+	return dns.GetResolverAccessLog(client, state.Primary.ID)
+}
+
+func TestAccResolverAccessLog_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_dns_resolver_access_log.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getResolverAccessLog)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResolverAccessLog_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "lts_group_id",
+						"huaweicloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "lts_topic_id",
+						"huaweicloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttr(rName, "vpc_ids.#", "3"),
+				),
+			},
+			{
+				Config: testAccResolverAccessLog_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "vpc_ids.#", "2"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccResolverAccessLog_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_group" "test" {
+  group_name  = "%[1]s"
+  ttl_in_days = 30
+}
+
+resource "huaweicloud_lts_stream" "test" {
+  group_id    = huaweicloud_lts_group.test.id
+  stream_name = "%[1]s"
+}
+
+resource "huaweicloud_vpc" "test" {
+  count = 4
+
+  name = "%[1]s_${count.index}"
+  cidr = "192.168.0.0/16"
+}`, name)
+}
+
+func testAccResolverAccessLog_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dns_resolver_access_log" "test" {
+  lts_group_id = huaweicloud_lts_group.test.id
+  lts_topic_id = huaweicloud_lts_stream.test.id
+  vpc_ids      = slice(huaweicloud_vpc.test[*].id, 0, 3)
+}`, testAccResolverAccessLog_base(name))
+}
+
+func testAccResolverAccessLog_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dns_resolver_access_log" "test" {
+  lts_group_id = huaweicloud_lts_group.test.id
+  lts_topic_id = huaweicloud_lts_stream.test.id
+  vpc_ids      = slice(huaweicloud_vpc.test[*].id, 2, 4)
+}`, testAccResolverAccessLog_base(name))
+}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_resolver_access_log.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_resolver_access_log.go
@@ -1,0 +1,281 @@
+package dns
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var resolverAccessLogNonUpdatableParams = []string{"lts_group_id", "lts_topic_id"}
+
+// @API DNS POST /v2/resolver/queryloggingconfig
+// @API DNS GET /v2/resolver/queryloggingconfig/{id}
+// @API DNS POST /v2/resolver/queryloggingconfig/{id}/associatevpc
+// @API DNS POST /v2/resolver/queryloggingconfig/{id}/disassociatevpc
+// @API DNS DELETE /v2/resolver/queryloggingconfig/{id}
+func ResourceResolverAccessLog() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceResolverAccessLogCreate,
+		ReadContext:   resourceResolverAccessLogRead,
+		UpdateContext: resourceResolverAccessLogUpdate,
+		DeleteContext: resourceResolverAccessLogDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(resolverAccessLogNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the resolver access log is located.`,
+			},
+			"lts_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the log group.`,
+			},
+			"lts_topic_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the log stream.`,
+			},
+			"vpc_ids": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of VPC IDs associated with the resolver access log.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildResolverAccessLogVpc(vpcId string) map[string]interface{} {
+	return map[string]interface{}{
+		"vpc_id": vpcId,
+	}
+}
+
+func buildResolverAccessLogBodyParams(d *schema.ResourceData, vpcId string) map[string]interface{} {
+	return map[string]interface{}{
+		"lts_group_id": d.Get("lts_group_id"),
+		"lts_topic_id": d.Get("lts_topic_id"),
+		"vpc":          buildResolverAccessLogVpc(vpcId),
+	}
+}
+
+func resourceResolverAccessLogCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		httpUrl = "v2/resolver/queryloggingconfig"
+		vpcIds  = d.Get("vpc_ids").(*schema.Set)
+	)
+	client, err := cfg.NewServiceClient("dns_region", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildResolverAccessLogBodyParams(d, vpcIds.List()[0].(string))),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating resolver access log: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	accessLogId := utils.PathSearch("resolver_query_log_config.id", respBody, "").(string)
+	if accessLogId == "" {
+		return diag.Errorf("unable to find resolver access log ID from API response")
+	}
+
+	d.SetId(accessLogId)
+
+	// Because the first item is the VPC associated when creating, it has been associated successfully.
+	// So start from the second item, associate the VPC.
+	if vpcIds.Len() > 1 {
+		if err = associateResolverAccessLogVpcIds(client, accessLogId, vpcIds.List()[1:]); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceResolverAccessLogRead(ctx, d, meta)
+}
+
+func GetResolverAccessLog(client *golangsdk.ServiceClient, accessLogId string) (interface{}, error) {
+	httpUrl := "v2/resolver/queryloggingconfig/{id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{id}", accessLogId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("resolver_query_log_config", respBody, nil), nil
+}
+
+func resourceResolverAccessLogRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dns_region", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	accessLogId := d.Id()
+	respBody, err := GetResolverAccessLog(client, accessLogId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving resolver access log (%s): %s", accessLogId, err))
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("lts_group_id", utils.PathSearch("lts_group_id", respBody, nil)),
+		d.Set("lts_topic_id", utils.PathSearch("lts_topic_id", respBody, nil)),
+		d.Set("vpc_ids", utils.PathSearch("vpc_ids", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateResolverAccessLogVpcBodyParams(vpcId string) golangsdk.RequestOpts {
+	return golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"vpc": buildResolverAccessLogVpc(vpcId),
+		},
+	}
+}
+
+func associateResolverAccessLogVpcIds(client *golangsdk.ServiceClient, accessLogId string, vpcIds []interface{}) error {
+	httpUrl := "v2/resolver/queryloggingconfig/{id}/associatevpc"
+	associatePath := client.Endpoint + httpUrl
+	associatePath = strings.ReplaceAll(associatePath, "{id}", accessLogId)
+	for _, vpcId := range vpcIds {
+		associateOpt := buildUpdateResolverAccessLogVpcBodyParams(vpcId.(string))
+		if _, err := client.Request("POST", associatePath, &associateOpt); err != nil {
+			return fmt.Errorf("error associating VPC (%v) to resolver access log (%s): %s", vpcId, accessLogId, err)
+		}
+	}
+
+	return nil
+}
+
+func disassociateResolverAccessLogVpcIds(client *golangsdk.ServiceClient, accessLogId string, vpcIds []interface{}) error {
+	httpUrl := "v2/resolver/queryloggingconfig/{id}/disassociatevpc"
+	associatePath := client.Endpoint + httpUrl
+	associatePath = strings.ReplaceAll(associatePath, "{id}", accessLogId)
+	for _, vpcId := range vpcIds {
+		associateOpt := buildUpdateResolverAccessLogVpcBodyParams(vpcId.(string))
+		_, err := client.Request("POST", associatePath, &associateOpt)
+		if err != nil {
+			return fmt.Errorf("error disassociating VPC (%v) from resolver access log (%s): %s", vpcId, accessLogId, err)
+		}
+	}
+
+	return nil
+}
+
+func resourceResolverAccessLogUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dns_region", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	accessLogId := d.Id()
+	oldVal, newVal := d.GetChange("vpc_ids")
+	rmRaw := oldVal.(*schema.Set).Difference(newVal.(*schema.Set))
+	addRaw := newVal.(*schema.Set).Difference(oldVal.(*schema.Set))
+	if rmRaw.Len() > 0 {
+		if err = disassociateResolverAccessLogVpcIds(client, accessLogId, rmRaw.List()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if addRaw.Len() > 0 {
+		if err = associateResolverAccessLogVpcIds(client, accessLogId, addRaw.List()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceResolverAccessLogRead(ctx, d, meta)
+}
+
+func resourceResolverAccessLogDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		accessLogId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("dns_region", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	respBody, err := GetResolverAccessLog(client, accessLogId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error getting vpc ids associated with resolver access log (%s): %s",
+			accessLogId, err))
+	}
+
+	// If the resolver access log is associated with more than one VPC, the remaining VPCs must be unbound before the resource can be deleted.
+	if vpcIds := utils.PathSearch("vpc_ids", respBody, make([]interface{}, 0)).([]interface{}); len(vpcIds) > 1 {
+		if err = disassociateResolverAccessLogVpcIds(client, accessLogId, vpcIds[1:]); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	err = deleteResolverAccessLog(client, accessLogId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting DNS resolver access log (%s): %s", accessLogId, err))
+	}
+	return nil
+}
+
+func deleteResolverAccessLog(client *golangsdk.ServiceClient, accessLogId string) error {
+	httpUrl := "v2/resolver/queryloggingconfig/{id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{id}", accessLogId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource(`huaweicloud_dns_resolver_access_log`) to manage resolver access log.

The bound VPC region must be consistent with the region where the access logs are located; therefore, the `vpc.vpc_region`parameter is meaningless and is not used.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new resource.
2. add corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o dns -f TestAccResolverAccessLog_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccResolverAccessLog_basic -timeout 360m -parallel 10
=== RUN   TestAccResolverAccessLog_basic
=== PAUSE TestAccResolverAccessLog_basic
=== CONT  TestAccResolverAccessLog_basic
--- PASS: TestAccResolverAccessLog_basic (54.69s)
PASS
coverage: 5.0% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       54.829s coverage: 5.0% of statements in ./huaweicloud/services/dns
```
<img width="898" height="507" alt="image" src="https://github.com/user-attachments/assets/22c72531-265f-4269-92e6-2a5b19ebe531" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1320" height="915" alt="image" src="https://github.com/user-attachments/assets/c165052e-b3b4-4392-a6d9-511be1d2a68a" />
    
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
     <img width="1330" height="774" alt="image" src="https://github.com/user-attachments/assets/a77d0dd4-9261-417d-b8f4-cf0cf8f06d10" />

      <img width="1291" height="810" alt="image" src="https://github.com/user-attachments/assets/36f9d3a2-82ee-4887-acec-4714d666f53c" />



    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
