### PR TITLE
feat(waf): new resource to batch update whiteblackip rules

### DIFF
--- a/docs/resources/waf_batch_update_whiteblackip_rules.md
+++ b/docs/resources/waf_batch_update_whiteblackip_rules.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_batch_update_whiteblackip_rules"
+description: |-
+  Manages a resource to batch update white-black IP rules within HuaweiCloud WAF.
+---
+
+# huaweicloud_waf_batch_update_whiteblackip_rules
+
+Manages a resource to batch update white-black IP rules within HuaweiCloud WAF.
+
+-> All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be used.
+
+-> This resource is a one-time action resource for batch updating white-black IP rules. Deleting this resource
+   will not remove the created rules, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_waf_batch_update_whiteblackip_rules" "test" {
+  name        = "test"
+  white       = 1
+  addr        = "127.0.0.1"
+  description = "test description"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the white-black IP rule.
+
+* `white` - (Required, Int, NonUpdatable) Specifies the protection action.
+  The value can be:
+  + `0`: block
+  + `1`: allow
+  + `2`: log only
+
+* `policy_rule_ids` - (Required, List, NonUpdatable) Specifies an array of policies and rule IDs to associate protection
+  policies with their corresponding rule sets.
+  The [policy_rule_ids](#Rule_policy_rule_ids) structure is documented below.
+
+* `addr` - (Optional, String, NonUpdatable) Specifies the IP address or CIDR block.
+  This parameter and `ip_group_id` are alternative.
+
+* `ip_group_id` - (Optional, String, NonUpdatable) Specifies the IP address group ID.
+  This parameter and `addr` are alternative.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the rule.
+
+* `time_mode` - (Optional, String, NonUpdatable) Specifies the time mode.
+  The value can be:
+  + **permanent**: The rule takes effect immediately (default).
+  + **customize**: The rule takes effect during the specified time period.
+
+* `start` - (Optional, Int, NonUpdatable) Specifies the start timestamp.
+  This field is valid only when `time_mode` is set to **customize**.
+
+* `terminal` - (Optional, Int, NonUpdatable) Specifies the end timestamp.
+  This field is valid only when `time_mode` is set to **customize**.
+
+<a name="Rule_policy_rule_ids"></a>
+The `policy_rule_ids` block supports:
+
+* `policy_id` - (Required, String, NonUpdatable) Specifies the policy ID.
+
+* `rule_ids` - (Required, List, NonUpdatable) Specifies the rule IDs.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3935,6 +3935,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_batch_create_ip_reputation_rules":    waf.ResourceWafBatchCreateIpReputationRules(),
 			"huaweicloud_waf_batch_create_privacy_rules":          waf.ResourceWafBatchCreatePrivacyRules(),
 			"huaweicloud_waf_batch_delete_alarm_notifications":    waf.ResourceWafBatchDeleteAlarmNotifications(),
+			"huaweicloud_waf_batch_update_whiteblackip_rules":     waf.ResourceWafBatchUpdateWhiteblackipRules(),
 			"huaweicloud_waf_migrate_domain":                      waf.ResourceMigrateDomain(),
 			"huaweicloud_waf_policy":                              waf.ResourceWafPolicy(),
 			"huaweicloud_waf_policies_batch_delete":               waf.ResourcePoliciesBatchDelete(),

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_update_whiteblackip_rules_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_batch_update_whiteblackip_rules_test.go
@@ -1,0 +1,51 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchUpdateWhiteBlackIpRules_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	cidr := acceptance.RandomCidr()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckWafPolicyId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchUpdateWhiteBlackIpRules_basic(name, cidr),
+			},
+		},
+	})
+}
+
+func testAccBatchUpdateWhiteBlackIpRules_basic(name, cidr string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_rule_blacklist" "test" {
+  name       = "%[1]s"
+  action     = 1
+  policy_id  = "%[2]s"
+  ip_address = "%[3]s"
+}
+
+resource "huaweicloud_waf_batch_update_whiteblackip_rules" "test" {
+  name  = "%[1]s"
+  white = 1
+  addr  = "%[3]s"
+
+  policy_rule_ids {
+    policy_id = "%[2]s"
+    rule_ids  = [huaweicloud_waf_rule_blacklist.test.id]
+  }
+}
+`, name, acceptance.HW_WAF_POLICY_ID, cidr)
+}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_batch_update_whiteblackip_rules.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_batch_update_whiteblackip_rules.go
@@ -1,0 +1,205 @@
+package waf
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF POST /v1/{project_id}/waf/rule/whiteblackip/batch-update
+func ResourceWafBatchUpdateWhiteblackipRules() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafBatchUpdateWhiteblackipRulesCreate,
+		ReadContext:   resourceWafBatchUpdateWhiteblackipRulesRead,
+		UpdateContext: resourceWafBatchUpdateWhiteblackipRulesUpdate,
+		DeleteContext: resourceWafBatchUpdateWhiteblackipRulesDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"name",
+			"white",
+			"policy_rule_ids",
+			"policy_rule_ids.*.policy_id",
+			"policy_rule_ids.*.rule_ids",
+			"addr",
+			"description",
+			"ip_group_id",
+			"time_mode",
+			"start",
+			"terminal",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"white": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"policy_rule_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     buildBatchUpdateWhiteblackipRulesPolicyRuleIdsSchema(),
+			},
+			"addr": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"time_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"start": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"terminal": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildBatchUpdateWhiteblackipRulesPolicyRuleIdsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rule_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func buildBatchUpdateWhiteblackipRulesPolicyRuleIds(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"policy_id": rawMap["policy_id"],
+			"rule_ids":  rawMap["rule_ids"],
+		})
+	}
+
+	return rst
+}
+
+func buildBatchUpdateWhiteblackipRulesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":            d.Get("name"),
+		"white":           d.Get("white"),
+		"policy_rule_ids": buildBatchUpdateWhiteblackipRulesPolicyRuleIds(d.Get("policy_rule_ids").([]interface{})),
+		"addr":            utils.ValueIgnoreEmpty(d.Get("addr")),
+		"description":     utils.ValueIgnoreEmpty(d.Get("description")),
+		"ip_group_id":     utils.ValueIgnoreEmpty(d.Get("ip_group_id")),
+		"time_mode":       utils.ValueIgnoreEmpty(d.Get("time_mode")),
+		"start":           utils.ValueIgnoreEmpty(d.Get("start")),
+		"terminal":        utils.ValueIgnoreEmpty(d.Get("terminal")),
+	}
+
+	return bodyParams
+}
+
+func resourceWafBatchUpdateWhiteblackipRulesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/waf/rule/whiteblackip/batch-update"
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: utils.RemoveNil(buildBatchUpdateWhiteblackipRulesBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error batch updating WAF white-black IP rules: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(id)
+
+	return resourceWafBatchUpdateWhiteblackipRulesRead(ctx, d, meta)
+}
+
+func resourceWafBatchUpdateWhiteblackipRulesRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchUpdateWhiteblackipRulesUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is an action resource.
+	return nil
+}
+
+func resourceWafBatchUpdateWhiteblackipRulesDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch update white-black IP rules. Deleting this resource
+    will not remove the created rules, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to batch update whiteblackip rules

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccBatchUpdateWhiteBlackIpRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccBatchUpdateWhiteBlackIpRules_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchUpdateWhiteBlackIpRules_basic
=== PAUSE TestAccBatchUpdateWhiteBlackIpRules_basic
=== CONT  TestAccBatchUpdateWhiteBlackIpRules_basic
--- PASS: TestAccBatchUpdateWhiteBlackIpRules_basic (13.15s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       13.252s coverage: 4.5% of statements in ./huaweicloud/services/waf
```
<img width="1327" height="81" alt="image" src="https://github.com/user-attachments/assets/bddc4b15-2989-482e-b4f2-0d0a023284d8" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
