### PR TITLE
feat(dns): add a new data source to get resolver access log list

### DIFF
--- a/docs/data-sources/dns_resolver_access_logs.md
+++ b/docs/data-sources/dns_resolver_access_logs.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Domain Name Service (DNS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dns_resolver_access_logs"
+description: |-
+  Use this data source to get the list of DNS resolver access logs within HuaweiCloud.
+---
+
+# huaweicloud_dns_resolver_access_logs
+
+Use this data source to get the list of DNS resolver access logs within HuaweiCloud.
+
+## Example Usage
+
+### Query all resolver access logs
+
+```hcl
+data "huaweicloud_dns_resolver_access_logs" "test" {}
+```
+
+### Query resolver access logs by the specified VPC ID
+
+```hcl
+variable "vpc_id" {}
+
+data "huaweicloud_dns_resolver_access_logs" "test" {
+  vpc_id = var.vpc_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the resolver access logs are located.  
+  If omitted, the provider-level region will be used.
+
+* `vpc_id` - (Optional, String) Specifies the ID of the VPC to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `access_logs` - The list of resolver access logs that match the filter parameters.  
+  The [access_logs](#resolver_access_logs_struct) structure is documented below.
+
+<a name="resolver_access_logs_struct"></a>
+The `access_logs` block supports:
+
+* `id` - The ID of the resolver access log.
+
+* `lts_group_id` - The ID of the log group.
+
+* `lts_topic_id` - The ID of the log stream.
+
+* `vpc_ids` - The list of VPC IDs associated with the resolver access log.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1186,6 +1186,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_nameservers":                  dns.DataSourceNameservers(),
 			"huaweicloud_dns_quotas":                       dns.DataSourceQuotas(),
 			"huaweicloud_dns_recordsets":                   dns.DataSourceRecordsets(),
+			"huaweicloud_dns_resolver_access_logs":         dns.DataSourceResolverAccessLogs(),
 			"huaweicloud_dns_resolver_rules":               dns.DataSourceDNSResolverRules(),
 			"huaweicloud_dns_system_lines":                 dns.DataSourceSystemLines(),
 			"huaweicloud_dns_zones":                        dns.DataSourceZones(),

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_resolver_access_logs_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_resolver_access_logs_test.go
@@ -1,0 +1,101 @@
+package dns
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataResolverAccessLogs_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dns_resolver_access_logs.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byVpcId   = "data.huaweicloud_dns_resolver_access_logs.filter_by_vpc_id"
+		dcByVpcId = acceptance.InitDataSourceCheck(byVpcId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceResolverAccessLogs_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Filter without any parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "access_logs.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "access_logs.0.id"),
+					resource.TestCheckResourceAttrSet(all, "access_logs.0.lts_group_id"),
+					resource.TestCheckResourceAttrSet(all, "access_logs.0.lts_topic_id"),
+					resource.TestMatchResourceAttr(all, "access_logs.0.vpc_ids.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'vpc_id' parameter.
+					dcByVpcId.CheckResourceExists(),
+					resource.TestCheckOutput("is_vpc_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataResolverAccessLogs_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_group" "test" {
+  group_name  = "%[1]s"
+  ttl_in_days = 7
+}
+
+resource "huaweicloud_lts_stream" "test" {
+  group_id    = huaweicloud_lts_group.test.id
+  stream_name = "%[1]s"
+}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/24"
+}
+
+resource "huaweicloud_dns_resolver_access_log" "test" {
+  lts_group_id = huaweicloud_lts_group.test.id
+  lts_topic_id = huaweicloud_lts_stream.test.id
+  vpc_ids      = [huaweicloud_vpc.test.id]
+}`, name)
+}
+
+func testAccDataSourceResolverAccessLogs_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Filter without any parameters.
+data "huaweicloud_dns_resolver_access_logs" "test" {
+  depends_on = [huaweicloud_dns_resolver_access_log.test]
+}
+
+# Filter by 'vpc_id' parameter.
+locals {
+  vpc_id = huaweicloud_vpc.test.id
+}
+
+data "huaweicloud_dns_resolver_access_logs" "filter_by_vpc_id" {
+  vpc_id = local.vpc_id
+
+  depends_on = [huaweicloud_dns_resolver_access_log.test]
+}
+
+locals {
+  filter_result_by_vpc_id = [for v in data.huaweicloud_dns_resolver_access_logs.filter_by_vpc_id.access_logs[*].vpc_ids :
+  contains(v, local.vpc_id)]
+}
+
+output "is_vpc_id_filter_useful" {
+  value = length(local.filter_result_by_vpc_id) > 0 && alltrue(local.filter_result_by_vpc_id)
+}`, testAccDataResolverAccessLogs_base(name))
+}

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_resolver_access_logs.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_resolver_access_logs.go
@@ -1,0 +1,168 @@
+package dns
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DNS GET /v2/resolver/queryloggingconfig
+func DataSourceResolverAccessLogs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceResolverAccessLogsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the resolver access logs are located.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the VPC to be queried.`,
+			},
+			"access_logs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the resolver access log.`,
+						},
+						"lts_group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the log group.`,
+						},
+						"lts_topic_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the log stream.`,
+						},
+						"vpc_ids": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of VPC IDs associated with the resolver access log.`,
+						},
+					},
+				},
+				Description: `The list of resolver access logs that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildListResolverAccessLogsQueryParams(d *schema.ResourceData, limit int) string {
+	queryParam := fmt.Sprintf("?limit=%d", limit)
+	if v, ok := d.GetOk("vpc_id"); ok {
+		queryParam = fmt.Sprintf("%s&vpc_id=%v", queryParam, v)
+	}
+
+	return queryParam
+}
+
+func listResolverAccessLogs(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/resolver/queryloggingconfig"
+		result  = make([]interface{}, 0)
+		limit   = 500
+		marker  = ""
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath += buildListResolverAccessLogsQueryParams(d, limit)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s&marker=%s", listPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", listPathWithMarker, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		accessLogs := utils.PathSearch("resolver_query_log_configs", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, accessLogs...)
+		if len(accessLogs) < limit {
+			break
+		}
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func dataSourceResolverAccessLogsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dns_region", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	accessLogs, err := listResolverAccessLogs(client, d)
+	if err != nil {
+		return diag.Errorf("error querying resolver access logs: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("access_logs", flattenResolverAccessLogs(accessLogs)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenResolverAccessLogs(accessLogs []interface{}) []map[string]interface{} {
+	if len(accessLogs) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(accessLogs))
+	for _, item := range accessLogs {
+		result = append(result, map[string]interface{}{
+			"id":           utils.PathSearch("id", item, nil),
+			"lts_group_id": utils.PathSearch("lts_group_id", item, nil),
+			"lts_topic_id": utils.PathSearch("lts_topic_id", item, nil),
+			"vpc_ids":      utils.PathSearch("vpc_ids", item, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source (`huaweicloud_dns_resolver_access_logs`) to get resolver access log list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
add corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o dns -f TestAccDataResolverAccessLogs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDataResolverAccessLogs_basic -timeout 360m -parallel 10
=== RUN   TestAccDataResolverAccessLogs_basic
=== PAUSE TestAccDataResolverAccessLogs_basic
=== CONT  TestAccDataResolverAccessLogs_basic
--- PASS: TestAccDataResolverAccessLogs_basic (36.30s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       36.406s coverage: 5.1% of statements in ./huaweicloud/services/dns
```

<img width="938" height="271" alt="image" src="https://github.com/user-attachments/assets/2ec319c1-e599-4326-91f6-a20f5fcd8c59" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
