### PR TITLE
feat(dns): add a new data source to query system lines

### DIFF
--- a/docs/data-sources/dns_system_lines.md
+++ b/docs/data-sources/dns_system_lines.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Domain Name Service (DNS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dns_system_lines"
+description: |-
+  Use this data source to get the list of DNS system lines within HuaweiCloud.
+---
+
+# huaweicloud_dns_system_lines
+
+Use this data source to get the list of DNS system lines within HuaweiCloud.
+
+## Example Usage
+
+### Query system lines (Chinese)
+
+```hcl
+data "huaweicloud_dns_system_lines" "test" {}
+```
+
+### Query system lines (English)
+
+```hcl
+data "huaweicloud_dns_system_lines" "test" {
+  locale = "en-us"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the system lines are located.  
+  If omitted, the default value is the provider-level region.
+
+* `locale` - (Optional, String) Specifies the display language.  
+  The valid values are as follows:
+  + **zh-cn**
+  + **en-us**
+  + **es-us**
+  + **pt-br**
+
+  If omitted, the default value is **zh-cn**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `lines` - The list of system lines that match the filter parameters.  
+  The [lines](#system_lines) structure is documented below.
+
+<a name="system_lines"></a>
+The `lines` block supports:
+
+* `id` - The ID of the system line.
+
+* `name` - The name of the system line.
+
+* `father_id` - The ID of the parent line.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1185,6 +1185,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_quotas":                       dns.DataSourceQuotas(),
 			"huaweicloud_dns_recordsets":                   dns.DataSourceRecordsets(),
 			"huaweicloud_dns_resolver_rules":               dns.DataSourceDNSResolverRules(),
+			"huaweicloud_dns_system_lines":                 dns.DataSourceSystemLines(),
 			"huaweicloud_dns_zones":                        dns.DataSourceZones(),
 			"huaweicloud_dns_zone_nameservers":             dns.DataSourceZoneNameservers(),
 			"huaweicloud_dns_public_zone_detection_status": dns.DataSourcePublicZoneDetectionStatus(),

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_system_lines_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_system_lines_test.go
@@ -1,0 +1,62 @@
+package dns
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSystemLines_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dns_system_lines.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byLocale   = "data.huaweicloud_dns_system_lines.filter_by_locale"
+		dcByLocale = acceptance.InitDataSourceCheck(byLocale)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSystemLines_basic,
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "lines.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "lines.0.id"),
+					resource.TestCheckResourceAttrSet(all, "lines.0.name"),
+					resource.TestCheckResourceAttrSet(all, "lines.0.father_id"),
+					// Filter by 'locale' parameter.
+					dcByLocale.CheckResourceExists(),
+					resource.TestCheckOutput("is_locale_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSystemLines_basic = `
+# Without any filter parameters.
+data "huaweicloud_dns_system_lines" "test" {}
+
+# Filter by 'locale' parameter.
+data "huaweicloud_dns_system_lines" "filter_by_locale" {
+  locale = "en-us"
+}
+
+locals {
+  filter_result_by_locale = [for v in data.huaweicloud_dns_system_lines.filter_by_locale.lines[*].name :
+  length(try(regex("^[A-Za-z]", v), "")) > 0]
+}
+
+output "is_locale_filter_useful" {
+  value = length(local.filter_result_by_locale) > 0 && alltrue(local.filter_result_by_locale)
+}
+`

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_system_lines.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_system_lines.go
@@ -1,0 +1,155 @@
+package dns
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DNS GET /v2.1/system-lines
+func DataSourceSystemLines() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSystemLinesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the system lines are located.`,
+			},
+			"locale": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The display language.`,
+			},
+			"lines": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the system line.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the system line.`,
+						},
+						"father_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the parent line.`,
+						},
+					},
+				},
+				Description: `The list of system lines that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildListSystemLinesQueryParams(d *schema.ResourceData, limit int) string {
+	queryParams := fmt.Sprintf("?limit=%d", limit)
+
+	if v, ok := d.GetOk("locale"); ok {
+		queryParams = fmt.Sprintf("%s&locale=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func listSystemLines(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2.1/system-lines"
+		limit   = 1000
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath += buildListSystemLinesQueryParams(d, limit)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		lines := utils.PathSearch("lines", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, lines...)
+		if len(lines) < limit {
+			break
+		}
+
+		offset += len(lines)
+	}
+
+	return result, nil
+}
+
+func dataSourceSystemLinesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dns", region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	lines, err := listSystemLines(client, d)
+	if err != nil {
+		return diag.Errorf("error querying system lines: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("lines", flattenSystemLines(lines)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSystemLines(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"id":        utils.PathSearch("id", item, nil),
+			"name":      utils.PathSearch("name", item, nil),
+			"father_id": utils.PathSearch("father_id", item, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source (`huaweicloud_dns_system_lines`) to query system line list.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding acceptance test and documentaion.

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDataSystemLines_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDataSystemLines_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSystemLines_basic
=== PAUSE TestAccDataSystemLines_basic
=== CONT  TestAccDataSystemLines_basic
--- PASS: TestAccDataSystemLines_basic (24.62s)
PASS
coverage: 3.2% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       24.761s coverage: 3.2% of statements in ./huaweicloud/services/dns
```
<img width="924" height="293" alt="image" src="https://github.com/user-attachments/assets/70692903-f341-4bde-8845-44760e41b918" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
