### PR TITLE
feat(dns): add a new data source to query DNS servers of the public zone

### DIFF
--- a/docs/data-sources/dns_public_zone_servers.md
+++ b/docs/data-sources/dns_public_zone_servers.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Domain Name Service (DNS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dns_public_zone_servers"
+description: |-
+  Use this data source to query the DNS server addresses of the public zone within HuaweiCloud.
+---
+
+# huaweicloud_dns_public_zone_servers
+
+Use this data source to query the DNS server addresses of the public zone within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "domain_name" {}
+
+data "huaweicloud_dns_public_zone_servers" "test" {
+  domain_name = var.domain_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required, String) Specifies the domain name of the public zone.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `all_hw_dns` - Whether all servers are HuaweiCloud DNS servers.
+
+* `include_hw_dns` - Whether HuaweiCloud DNS servers are included.
+
+* `dns_servers` - The list of DNS server addresses.
+
+* `expected_dns_servers` - The list of expected DNS server addresses.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1196,6 +1196,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_public_zone_detection_status": dns.DataSourcePublicZoneDetectionStatus(),
 			"huaweicloud_dns_public_zone_lines":            dns.DataSourceDNSPublicZoneLines(),
 			"huaweicloud_dns_public_zone_recordsets":       dns.DataSourcePublicZoneRecordsets(),
+			"huaweicloud_dns_public_zone_servers":          dns.DataSourcePublicZoneServers(),
 			"huaweicloud_dns_tags":                         dns.DataSourceDNSTags(),
 			"huaweicloud_dns_tags_filter":                  dns.DataSourceDNSTagsFilter(),
 			"huaweicloud_dns_endpoints":                    dns.DataSourceDNSEndpoints(),

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_public_zone_servers_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_public_zone_servers_test.go
@@ -1,0 +1,45 @@
+package dns
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// The HW_DNS_ZONE_NAMES provided must be purchased from a domain registrar.
+func TestAccDataPublicZoneServers_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_dns_public_zone_servers.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDnsZoneNames(t, 1)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataPublicZoneServers_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dcName, "include_hw_dns", "true"),
+					resource.TestMatchResourceAttr(dcName, "dns_servers.#", regexp.MustCompile(`^[1-9][0-9]*$`)),
+					resource.TestMatchResourceAttr(dcName, "expected_dns_servers.#", regexp.MustCompile(`^[1-9][0-9]*$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataPublicZoneServers_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dns_public_zone_servers" "test" {
+  domain_name = split(",", "%[1]s")[0]
+}`, acceptance.HW_DNS_ZONE_NAMES)
+}

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_public_zone_servers.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_public_zone_servers.go
@@ -1,0 +1,96 @@
+package dns
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DNS GET /v2/public-zones/dns-servers/{domain_name}
+func DataSourcePublicZoneServers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePublicZoneServersRead,
+
+		Schema: map[string]*schema.Schema{
+			"domain_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The domain name of the public zone.`,
+			},
+			"all_hw_dns": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether all servers are HuaweiCloud DNS servers.`,
+			},
+			"include_hw_dns": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether HuaweiCloud DNS servers are included.`,
+			},
+			"dns_servers": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of DNS server addresses.`,
+			},
+			"expected_dns_servers": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of expected DNS server addresses.`,
+			},
+		},
+	}
+}
+
+func getPublicZoneServers(client *golangsdk.ServiceClient, domainName string) (interface{}, error) {
+	httpUrl := "v2/public-zones/dns-servers/{domain_name}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{domain_name}", domainName)
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+	requestResp, err := client.Request("GET", getPath, &reqOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func dataSourcePublicZoneServersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dns", "")
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	respBody, err := getPublicZoneServers(client, d.Get("domain_name").(string))
+	if err != nil {
+		return diag.Errorf("error querying public zone DNS servers: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("all_hw_dns", utils.PathSearch("all_hw_dns", respBody, nil)),
+		d.Set("include_hw_dns", utils.PathSearch("include_hw_dns", respBody, nil)),
+		d.Set("dns_servers", utils.PathSearch("dns_servers", respBody, nil)),
+		d.Set("expected_dns_servers", utils.PathSearch("expected_dns_servers", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source (`huaweicloud_dns_public_zone_servers`) to query DNS servers of the public zone.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding acceptance test and documentaion.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDataPublicZoneServers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDataPublicZoneServers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataPublicZoneServers_basic
=== PAUSE TestAccDataPublicZoneServers_basic
=== CONT  TestAccDataPublicZoneServers_basic
--- PASS: TestAccDataPublicZoneServers_basic (18.69s)
PASS
coverage: 2.5% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       18.803s coverage: 2.5% of statements in ./huaweicloud/services/dns
```
<img width="894" height="224" alt="image" src="https://github.com/user-attachments/assets/0030232d-f1d8-4c4b-81cf-5c2d69948ea2" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
