### PR TITLE
feat(dns): add new data source to get public email or website recordsets

### DIFF
--- a/docs/data-sources/dns_public_zone_recordsets.md
+++ b/docs/data-sources/dns_public_zone_recordsets.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Domain Name Service (DNS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dns_public_zone_recordsets"
+description: |-
+  Use this data source to get the list of email or website recordsets of the public zone within HuaweiCloud.
+---
+
+# huaweicloud_dns_public_zone_recordsets
+
+Use this data source to get the list of email or website recordsets of the public zone within HuaweiCloud.
+
+## Example Usage
+
+### Query email recordsets
+
+```hcl
+variable "zone_id" {}
+
+data "huaweicloud_dns_public_zone_recordsets" "test" {
+  zone_id = var.zone_id
+  type    = "email"
+}
+```
+
+### Query website recordsets
+
+```hcl
+data "huaweicloud_dns_public_zone_recordsets" "test" {
+  zone_id = var.zone_id
+  type    = "website"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone_id` - (Required, String) Specifies the ID of the public zone to be queried.
+
+* `type` - (Required, String) Specifies the type of the domain name to be queried.  
+  The valid values are as follows:
+  + **email**
+  + **website**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `recordsets` - The list of recordsets.  
+  The [recordsets](#public_zone_recordsets) structure is documented below.
+
+<a name="public_zone_recordsets"></a>
+The `recordsets` block supports:
+
+* `id` - The ID of the recordset.
+
+* `name` - The name of the recordset.
+
+* `zone_id` - The ID of the zone to which the recordset belongs.
+
+* `type` - The type of the recordset.
+
+* `default` - Whether the recordset is default.
+
+* `created_at` - The creation time of the recordset, in RFC3339 format.
+
+* `updated_at` - The update time of the recordset, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1192,6 +1192,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_zone_nameservers":             dns.DataSourceZoneNameservers(),
 			"huaweicloud_dns_public_zone_detection_status": dns.DataSourcePublicZoneDetectionStatus(),
 			"huaweicloud_dns_public_zone_lines":            dns.DataSourceDNSPublicZoneLines(),
+			"huaweicloud_dns_public_zone_recordsets":       dns.DataSourcePublicZoneRecordsets(),
 			"huaweicloud_dns_tags":                         dns.DataSourceDNSTags(),
 			"huaweicloud_dns_tags_filter":                  dns.DataSourceDNSTagsFilter(),
 			"huaweicloud_dns_endpoints":                    dns.DataSourceDNSEndpoints(),

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_public_zone_recordsets_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_public_zone_recordsets_test.go
@@ -1,0 +1,97 @@
+package dns
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataPublicZoneRecordsets_basic(t *testing.T) {
+	var (
+		name = fmt.Sprintf("tf.test.zone-%s.com.", acctest.RandString(5))
+
+		emailName = "data.huaweicloud_dns_public_zone_recordsets.email"
+		dcEmail   = acceptance.InitDataSourceCheck(emailName)
+
+		websiteName = "data.huaweicloud_dns_public_zone_recordsets.website"
+		dcWebsite   = acceptance.InitDataSourceCheck(websiteName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataPublicZoneRecordsets_notFound(),
+				ExpectError: regexp.MustCompile(`This zone does not exist`),
+			},
+			{
+				Config: testAccDataPublicZoneRecordsets_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Query email recordsets.
+					dcEmail.CheckResourceExists(),
+					resource.TestMatchResourceAttr(emailName, "recordsets.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					resource.TestCheckResourceAttrSet(emailName, "recordsets.0.id"),
+					resource.TestCheckResourceAttrSet(emailName, "recordsets.0.name"),
+					resource.TestCheckResourceAttrSet(emailName, "recordsets.0.zone_id"),
+					resource.TestCheckResourceAttrSet(emailName, "recordsets.0.type"),
+					resource.TestCheckResourceAttrSet(emailName, "recordsets.0.default"),
+					resource.TestMatchResourceAttr(emailName, "recordsets.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(emailName, "recordsets.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Query website recordsets.
+					dcWebsite.CheckResourceExists(),
+					resource.TestMatchResourceAttr(websiteName, "recordsets.#", regexp.MustCompile(`[1-9][0-9]*`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataPublicZoneRecordsets_notFound() string {
+	randomId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dns_public_zone_recordsets" "test" {
+  zone_id = replace("%[1]s", "-", "")
+  type    = "email"
+}
+`, randomId)
+}
+
+func testAccDataPublicZoneRecordsets_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dns_zone" "test" {
+  name      = "%[1]s"
+  zone_type = "public"
+}
+
+resource "huaweicloud_dns_recordset" "test" {
+  zone_id     = huaweicloud_dns_zone.test.id
+  name        = "pop3.${huaweicloud_dns_zone.test.name}"
+  type        = "CNAME"
+  records     = ["pop3.sparkspace.huaweicloud.com."]
+}
+
+# Query email recordsets.
+data "huaweicloud_dns_public_zone_recordsets" "email" {
+  zone_id = huaweicloud_dns_zone.test.id
+  type    = "email"
+
+  depends_on = [huaweicloud_dns_recordset.test]
+}
+
+# Query website recordsets.
+data "huaweicloud_dns_public_zone_recordsets" "website" {
+  zone_id = huaweicloud_dns_zone.test.id
+  type    = "website"
+}`, name)
+}

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_public_zone_recordsets.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_public_zone_recordsets.go
@@ -1,0 +1,175 @@
+package dns
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DNS GET /v2.1/zones/{zone_id}/email-recordsets
+// @API DNS GET /v2.1/zones/{zone_id}/website-recordsets
+func DataSourcePublicZoneRecordsets() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePublicZoneRecordsetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the public zone.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the domain name to be queried.`,
+			},
+			"recordsets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the recordset.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the recordset.`,
+						},
+						"zone_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the zone to which the recordset belongs.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the recordset.`,
+						},
+						"default": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the recordset is default.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the recordset, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The update time of the recordset, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `The list of recordsets.`,
+			},
+		},
+	}
+}
+
+func listPublicZoneRecordsets(client *golangsdk.ServiceClient, zoneId, queryType string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2.1/zones/{zone_id}/{type}-recordsets"
+		limit   = 500
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{type}", queryType)
+	listPath = strings.ReplaceAll(listPath, "{zone_id}", zoneId)
+	listPath = fmt.Sprintf("%s?limit=%d", listPath, limit)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		recordsets := utils.PathSearch("recordsets", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, recordsets...)
+
+		if len(recordsets) < limit {
+			break
+		}
+		offset += len(recordsets)
+	}
+
+	return result, nil
+}
+
+func dataSourcePublicZoneRecordsetsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg = meta.(*config.Config)
+	)
+	client, err := cfg.NewServiceClient("dns", "")
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	zoneId := d.Get("zone_id").(string)
+	queryType := d.Get("type").(string)
+	recordsets, err := listPublicZoneRecordsets(client, zoneId, queryType)
+	if err != nil {
+		return diag.Errorf("error querying public zone %s recordsets: %s", queryType, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("recordsets", flattenPublicZoneRecordsets(recordsets)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPublicZoneRecordsets(recordsets []interface{}) []map[string]interface{} {
+	if len(recordsets) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(recordsets))
+	for _, item := range recordsets {
+		result = append(result, map[string]interface{}{
+			"id":      utils.PathSearch("id", item, nil),
+			"name":    utils.PathSearch("name", item, nil),
+			"zone_id": utils.PathSearch("zone_id", item, nil),
+			"type":    utils.PathSearch("type", item, nil),
+			"default": utils.PathSearch("default", item, nil),
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_at",
+				item, "").(string), "2006-01-02T15:04:05")/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("update_at",
+				item, "").(string), "2006-01-02T15:04:05")/1000, false),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_dns_public_zone_recordsets`) to get the list of email or website recordsets of the public zone.

The API returns nil for the fields `description`, `ttl`, `records`, `status`, `zone_name`, `records`, and `project_id`. Therefore they are currently being integrated.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dns -f TestAccDataPublicZoneRecordsets_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccDataPublicZoneRecordsets_basic -timeout 360m -parallel 10
=== RUN   TestAccDataPublicZoneRecordsets_basic
=== PAUSE TestAccDataPublicZoneRecordsets_basic
=== CONT  TestAccDataPublicZoneRecordsets_basic
--- PASS: TestAccDataPublicZoneRecordsets_basic (47.03s)
PASS
coverage: 11.5% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       47.122s coverage: 11.5% of statements in ./huaweicloud/services/dns
```
<img width="955" height="211" alt="image" src="https://github.com/user-attachments/assets/3c1f1fd6-fb9f-4a45-9439-14ba59502924" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
