### PR TITLE
fix(evs): avoid panic when tags are map[string]interface{}

### DIFF
--- a/huaweicloud/services/evs/data_source_huaweicloud_evs_volumes.go
+++ b/huaweicloud/services/evs/data_source_huaweicloud_evs_volumes.go
@@ -558,7 +558,14 @@ func filterEvsVolumes(allVolumes []interface{}, d *schema.ResourceData) []interf
 
 	rst := make([]interface{}, 0, len(allVolumes))
 	for _, v := range allVolumes {
-		remoteTags := utils.PathSearch("tags", v, make(map[string]string)).(map[string]string)
+		rawTags := utils.PathSearch("tags", v, nil)
+		remoteTags := make(map[string]string)
+		switch tags := rawTags.(type) {
+		case map[string]string:
+			remoteTags = tags
+		case map[string]interface{}:
+			remoteTags = utils.ExpandToStringMap(tags)
+		}
 		if utils.HasMapContains(remoteTags, localTags) {
 			rst = append(rst, v)
 		}
@@ -566,3 +573,4 @@ func filterEvsVolumes(allVolumes []interface{}, d *schema.ResourceData) []interf
 
 	return rst
 }
+


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixes a panic in `filterEvsVolumes` when `tags` are decoded as `map[string]interface{}`. I hit this while using the SberCloud provider (which vendors this code) — `data.sbercloud_evs_volumes` crashed with `Plugin did not respond`, and the stack trace points to `data_source_huaweicloud_evs_volumes.go:561`. The root cause is a hard type assertion to `map[string]string` while the JSON decoder produces `map[string]interface{}`.

**Which issue this PR fixes**:
https://github.com/sbercloud-terraform/terraform-provider-sbercloud/issues/399

**Special notes for your reviewer**:
Reproduced in SberCloud (sbercloud provider) via `data.sbercloud_evs_volumes`. The crash stack trace points to this file and line in huaweicloud provider. Fix is type-safe conversion; behavior otherwise unchanged.

**Release note**:
```release-note
Fix panic in EVS volumes data source when tags are returned as map[string]interface{}.
```

PR Checklist
 
- [ ] Tests added/passed.
- [ ]  Documentation updated.
- [ ]  Schema updated.
- [ ]  CheckDeleted.