### PR TITLE
feat(hss): support `hss_honeypot_port_support_list` data source

### DIFF
--- a/docs/data-sources/hss_honeypot_port_support_list.md
+++ b/docs/data-sources/hss_honeypot_port_support_list.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_honeypot_port_support_list"
+description: |-
+  Use this data source to get the list of HSS honeypot port support host list within HuaweiCloud.
+---
+
+# huaweicloud_hss_honeypot_port_support_list
+
+Use this data source to get the list of HSS honeypot port support host list within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_honeypot_port_support_list" "test" {
+  os_type = "Linux"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `os_type` - (Required, String) Specifies the operating system type. Valid values are:
+  + **Linux**: Linux.
+  + **Windows**: Windows.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `ports` - (Optional, String) Specifies the port numbers to set, separated by commas.
+
+* `policy_id` - (Optional, String) Specifies the policy ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `total_num` - The total number.
+
+* `data_list` - The list of honeypot port support host.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `host_id` - The server (host) unique identifier ID.
+
+* `host_name` - The server name.
+
+* `private_ip` - The server private IP.
+
+* `agent_id` - The agent ID.
+
+* `conflict_port` - The conflicting ports.
+
+* `os_type` - The operating system type.
+
+* `group_name` - The group name.
+
+* `group_id` - The group ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1482,6 +1482,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_files_statistic":                            hss.DataSourceFilesStatistic(),
 			"huaweicloud_hss_honeypot_port_hosts":                        hss.DataSourceHoneypotPortHosts(),
 			"huaweicloud_hss_honeypot_port_policies":                     hss.DataSourceHoneypotPortPolicies(),
+			"huaweicloud_hss_honeypot_port_support_list":                 hss.DataSourceHoneypotPortSupportList(),
 			"huaweicloud_hss_host_groups":                                hss.DataSourceHostGroups(),
 			"huaweicloud_hss_host_statistics":                            hss.DataSourceHostStatistics(),
 			"huaweicloud_hss_host_vulnerabilities":                       hss.DataSourceHssHostVulnerabilities(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_honeypot_port_support_list_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_honeypot_port_support_list_test.go
@@ -1,0 +1,49 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceHoneypotPortSupportList_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_honeypot_port_support_list.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires the existence of a host with flagship version host protection enabled.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceHoneypotPortSupportList_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.host_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.host_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.private_ip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.agent_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.os_type"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceHoneypotPortSupportList_basic() string {
+	return `
+data "huaweicloud_hss_honeypot_port_support_list" "test" {
+  os_type               = "Linux"
+  enterprise_project_id = "all_granted_eps"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_honeypot_port_support_list.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_honeypot_port_support_list.go
@@ -1,0 +1,198 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/honeypot-port/support-list
+func DataSourceHoneypotPortSupportList() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceHoneypotPortSupportListRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"os_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ports": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceHoneypotPortSupportListDataListSchema(),
+			},
+		},
+	}
+}
+
+func dataSourceHoneypotPortSupportListDataListSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"host_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"agent_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"conflict_port": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"os_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildHoneypotPortSupportListQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := fmt.Sprintf("?limit=200&os_type=%v", d.Get("os_type"))
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("ports"); ok {
+		queryParams = fmt.Sprintf("%s&ports=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("policy_id"); ok {
+		queryParams = fmt.Sprintf("%s&policy_id=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceHoneypotPortSupportListRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "hss"
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		result   = make([]interface{}, 0)
+		offset   = 0
+		totalNum float64
+		httpUrl  = "v5/{project_id}/honeypot-port/support-list"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildHoneypotPortSupportListQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS honeypot port support list: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalNum = utils.PathSearch("total_num", respBody, float64(0)).(float64)
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", totalNum),
+		d.Set("data_list", flattenHoneypotPortSupportListDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenHoneypotPortSupportListDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"host_id":       utils.PathSearch("host_id", v, nil),
+			"host_name":     utils.PathSearch("host_name", v, nil),
+			"private_ip":    utils.PathSearch("private_ip", v, nil),
+			"agent_id":      utils.PathSearch("agent_id", v, nil),
+			"conflict_port": utils.ExpandToIntList(utils.PathSearch("conflict_port", v, make([]interface{}, 0)).([]interface{})),
+			"os_type":       utils.PathSearch("os_type", v, nil),
+			"group_name":    utils.PathSearch("group_name", v, nil),
+			"group_id":      utils.PathSearch("group_id", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_honeypot_port_support_list` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_honeypot_port_support_list` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceHoneypotPortSupportList_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceHoneypotPortSupportList_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceHoneypotPortSupportList_basic
=== PAUSE TestAccDataSourceHoneypotPortSupportList_basic
=== CONT  TestAccDataSourceHoneypotPortSupportList_basic
--- PASS: TestAccDataSourceHoneypotPortSupportList_basic (12.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.455s
```
<img width="932" height="34" alt="image" src="https://github.com/user-attachments/assets/dd1da223-8842-4627-aa82-a3beb62b9e61" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
