### PR TITLE
feat(dds): add data source to get whether parameter template name exist

### DIFF
--- a/docs/data-sources/dds_parameter_template_name_validation.md
+++ b/docs/data-sources/dds_parameter_template_name_validation.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Document Database Service (DDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dds_parameter_template_name_validation"
+description: |-
+  Use this data source to query whether the parameter template name exists.
+---
+
+# huaweicloud_dds_parameter_template_name_validation
+
+Use this data source to query whether the parameter template name exists.
+
+## Example Usage
+
+```hcl
+variable "param_template_name"  {}
+
+data "huaweicloud_dds_parameter_template_name_validation" "test" {
+  name = var.param_template_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Required, String) Specifies the parameter template name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `is_existed` - Whether the parameter template name exists.
+  The valid values are as follows:
+  + **true**: Indicates the parameter template name exists.
+  + **false**: Indicates the parameter template name does not exist.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1077,6 +1077,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_flavors":                                 dds.DataSourceDDSFlavorV3(),
 			"huaweicloud_dds_migrate_availability_zones":              dds.DataSourceDDSMigrateAvailabilityZones(),
 			"huaweicloud_dds_instances":                               dds.DataSourceDdsInstance(),
+			"huaweicloud_dds_parameter_template_name_validation":      dds.DataSourceParameterTemplateNameValidation(),
 			"huaweicloud_dds_parameter_templates":                     dds.DataSourceDdsParameterTemplates(),
 			"huaweicloud_dds_pt_applicable_instances":                 dds.DataSourceDdsPtApplicableInstances(),
 			"huaweicloud_dds_pt_application_records":                  dds.DataSourceDdsPtApplicationRecords(),

--- a/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_parameter_template_name_validation_test.go
+++ b/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_parameter_template_name_validation_test.go
@@ -1,0 +1,42 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceParameterTemplateNameValidation_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_dds_parameter_template_name_validation.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		name           = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceParameterTemplateNameValidation_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "is_existed"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceParameterTemplateNameValidation_basic(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_dds_parameter_template_name_validation" "test" {
+  name = "%s"
+}
+`, name)
+}

--- a/huaweicloud/services/dds/data_source_huaweicloud_dds_parameter_template_name_validation.go
+++ b/huaweicloud/services/dds/data_source_huaweicloud_dds_parameter_template_name_validation.go
@@ -1,0 +1,89 @@
+package dds
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DDS GET /v3/{project_id}/configurations/name-validation
+func DataSourceParameterTemplateNameValidation() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceParameterTemplateNameValidationRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"is_existed": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceParameterTemplateNameValidationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v3/{project_id}/configurations/name-validation"
+		templateName = d.Get("name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dds", region)
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = fmt.Sprintf("%s?name=%s", getPath, templateName)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the validation result: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("is_existed", utils.PathSearch("is_existed", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to get whether parameter template name exist.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDataSourceParameterTemplateNameValidation_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDataSourceParameterTemplateNameValidation_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceParameterTemplateNameValidation_basic
=== PAUSE TestAccDataSourceParameterTemplateNameValidation_basic
=== CONT  TestAccDataSourceParameterTemplateNameValidation_basic
--- PASS: TestAccDataSourceParameterTemplateNameValidation_basic (19.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       19.434s
```
<img width="1203" height="16" alt="image" src="https://github.com/user-attachments/assets/5d64a612-57b7-4387-abb3-0678036bd371" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
