### PR TITLE
feat(secmaster): new resource to manage pipe consumption

### DIFF
--- a/docs/resources/secmaster_pipe_consumption.md
+++ b/docs/resources/secmaster_pipe_consumption.md
@@ -1,0 +1,61 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_pipe_consumption"
+description: |-
+  Manages a pipe consumption resource of SecMaster within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_pipe_consumption
+
+Manages a pipe consumption resource of SecMaster within HuaweiCloud.
+
+-> This resource is used to enable pipe consumption. Destroying this resource will disable pipe consumption.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "pipe_id" {}
+
+resource "huaweicloud_secmaster_pipe_consumption" "test" {
+  workspace_id = var.workspace_id
+  pipe_id      = var.pipe_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the ID of the workspace.
+
+* `pipe_id` - (Required, String, NonUpdatable) Specifies the pipe ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (pipe ID).
+
+* `access_point` - The access point.
+
+* `pipe_name` - The pipe name.
+
+* `status` - The status.
+
+* `subscription_name` - The subscription name.
+
+* `table_id` - The table ID.
+
+## Import
+
+The pipe consumption can be imported using the `workspace_id` and their `pipe_id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_secmaster_pipe_consumption.test <workspace_id>/<pipe_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3757,6 +3757,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_layout_field":                secmaster.ResourceLayoutField(),
 			"huaweicloud_secmaster_module":                      secmaster.ResourceModule(),
 			"huaweicloud_secmaster_operation_connection":        secmaster.ResourceOperationConnection(),
+			"huaweicloud_secmaster_pipe_consumption":            secmaster.ResourcePipeConsumption(),
 			"huaweicloud_secmaster_playbook_action":             secmaster.ResourcePlaybookAction(),
 			"huaweicloud_secmaster_playbook_approval":           secmaster.ResourcePlaybookApproval(),
 			"huaweicloud_secmaster_playbook_enable":             secmaster.ResourcePlaybookEnable(),

--- a/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_pipe_consumption_test.go
+++ b/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_pipe_consumption_test.go
@@ -1,0 +1,92 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/secmaster"
+)
+
+func getResourcePipeConsumptionFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("secmaster", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	return secmaster.GetPipeConsumptionByName(client, state.Primary.Attributes["workspace_id"], state.Primary.ID)
+}
+
+func TestAccResourcePipeConsumption_basic(t *testing.T) {
+	var (
+		rName  = "huaweicloud_secmaster_pipe_consumption.test"
+		object interface{}
+		rc     = acceptance.InitResourceCheck(
+			rName,
+			&object,
+			getResourcePipeConsumptionFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+			acceptance.TestAccPreCheckSecMasterPipeId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourcePipeConsumption_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_SECMASTER_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "pipe_id", acceptance.HW_SECMASTER_PIPE_ID),
+					resource.TestCheckResourceAttrSet(rName, "access_point"),
+					resource.TestCheckResourceAttrSet(rName, "pipe_name"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccPipeConsumptionImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccResourcePipeConsumption_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_secmaster_pipe_consumption" "test" {
+  workspace_id = "%[1]s"
+  pipe_id      = "%[2]s"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_PIPE_ID)
+}
+
+func testAccPipeConsumptionImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var workspaceId, pipeId string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", rName)
+		}
+
+		workspaceId = rs.Primary.Attributes["workspace_id"]
+		pipeId = rs.Primary.Attributes["pipe_id"]
+
+		if workspaceId == "" || pipeId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<pipe_id>', but got '%s/%s'",
+				workspaceId, pipeId)
+		}
+
+		return fmt.Sprintf("%s/%s", workspaceId, pipeId), nil
+	}
+}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_pipe_consumption.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_pipe_consumption.go
@@ -1,0 +1,224 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SecMaster POST /v1/{project_id}/workspaces/{workspace_id}/siem/pipes/{pipe_id}/consumption
+// @API SecMaster DELETE /v1/{project_id}/workspaces/{workspace_id}/siem/pipes/{pipe_id}/consumption
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/siem/pipes/{pipe_id}/consumption
+func ResourcePipeConsumption() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePipeConsumptionCreate,
+		ReadContext:   resourcePipeConsumptionRead,
+		UpdateContext: resourcePipeConsumptionUpdate,
+		DeleteContext: resourcePipeConsumptionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePipeConsumptionImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"workspace_id",
+			"pipe_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"pipe_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"access_point": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"pipe_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subscription_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"table_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourcePipeConsumptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		pipeId      = d.Get("pipe_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/siem/pipes/{pipe_id}/consumption"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{workspace_id}", workspaceId)
+	createPath = strings.ReplaceAll(createPath, "{pipe_id}", pipeId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"pipe_id": pipeId,
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster pipe consumption: %s", err)
+	}
+
+	d.SetId(pipeId)
+
+	return resourcePipeConsumptionRead(ctx, d, meta)
+}
+
+func GetPipeConsumptionByName(client *golangsdk.ServiceClient, workspaceId, pipeId string) (interface{}, error) {
+	createPath := client.Endpoint + "v1/{project_id}/workspaces/{workspace_id}/siem/pipes/{pipe_id}/consumption"
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{workspace_id}", workspaceId)
+	createPath = strings.ReplaceAll(createPath, "{pipe_id}", pipeId)
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", createPath, &createOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	status := utils.PathSearch("status", respBody, "disable").(string)
+	if status == "disable" {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return respBody, nil
+}
+
+func resourcePipeConsumptionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	respBody, err := GetPipeConsumptionByName(client, workspaceId, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving SecMaster pipe consumption")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("access_point", utils.PathSearch("access_point", respBody, nil)),
+		d.Set("pipe_name", utils.PathSearch("pipe_name", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("subscription_name", utils.PathSearch("subscription_name", respBody, nil)),
+		d.Set("table_id", utils.PathSearch("table_id", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourcePipeConsumptionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourcePipeConsumptionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/siem/pipes/{pipe_id}/consumption"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{workspace_id}", workspaceId)
+	createPath = strings.ReplaceAll(createPath, "{pipe_id}", d.Id())
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error deleting SecMaster pipe consumption: %s", err)
+	}
+
+	return nil
+}
+
+func resourcePipeConsumptionImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<pipe_id>', but got '%s'",
+			importedId)
+	}
+
+	d.SetId(parts[1])
+	mErr := multierror.Append(
+		d.Set("workspace_id", parts[0]),
+		d.Set("pipe_id", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage pipe consumption

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccResourcePipeConsumption_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccResourcePipeConsumption_basic -timeout 360m -parallel 10
=== RUN   TestAccResourcePipeConsumption_basic
=== PAUSE TestAccResourcePipeConsumption_basic
=== CONT  TestAccResourcePipeConsumption_basic
--- PASS: TestAccResourcePipeConsumption_basic (16.00s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 16.125s coverage: 4.3% of statements in ./huaweicloud/services/secmaster
```
<img width="1432" height="82" alt="image" src="https://github.com/user-attachments/assets/8bc17606-b9a5-473a-a78e-d6a42ffc0f6a" />


* [X] Documentation updated.
* [X] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="954" height="290" alt="image" src="https://github.com/user-attachments/assets/bf96468b-7a81-44c0-9d0f-381c9f0d6e59" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
