### PR TITLE
feat(dds): add new data source to get instance disk information

### DIFF
--- a/docs/data-sources/dds_instance_disk_usage.md
+++ b/docs/data-sources/dds_instance_disk_usage.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Document Database Service (DDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dds_instance_disk_usage"
+description: |-
+  Use this data source to get the instance disk information.
+---
+
+# huaweicloud_dds_instance_disk_usage
+
+Use this data source to get the instance disk information.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_dds_instance_disk_usage" "test"{
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `volumes` - The instance disks information.
+
+  The [volumes](#volumes_struct) structure is documented below.
+
+<a name="volumes_struct"></a>
+The `volumes` block supports:
+
+* `entity_id` - Indicates the instance ID or group ID or node ID.
+
+* `entity_name` - Indicates the instance name or group name or node name.
+
+* `group_type` - Indicates the group type.
+  + **mongos**
+  + **shard**
+  + **config**
+  + **replica**
+  + **single**
+  + **readonly**
+
+* `used` - Indicates the instance disk capacity used, in GB.
+
+* `size` - Indicates the instance disk capacity, in GB.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1081,6 +1081,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_pt_applicable_instances":                 dds.DataSourceDdsPtApplicableInstances(),
 			"huaweicloud_dds_pt_application_records":                  dds.DataSourceDdsPtApplicationRecords(),
 			"huaweicloud_dds_pt_modification_records":                 dds.DataSourceDdsPtModificationRecords(),
+			"huaweicloud_dds_instance_disk_usage":                     dds.DataSourceInstanceDiskUsage(),
 			"huaweicloud_dds_instance_parameter_modification_records": dds.DataSourceDdsInstanceParameterModificationRecords(),
 			"huaweicloud_dds_databases":                               dds.DataSourceDdsDatabases(),
 			"huaweicloud_dds_database_users":                          dds.DateSourceDDSDatabaseUser(),

--- a/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_instance_disk_usage_test.go
+++ b/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_instance_disk_usage_test.go
@@ -1,0 +1,47 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceInstanceDiskUsage_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_dds_instance_disk_usage.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDDSInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceInstanceDiskUsage_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.entity_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.entity_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.group_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.used"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "volumes.0.size"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceInstanceDiskUsage_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dds_instance_disk_usage" "test" {
+  instance_id = "%[1]s"
+}
+`, acceptance.HW_DDS_INSTANCE_ID)
+}

--- a/huaweicloud/services/dds/data_source_huaweicloud_dds_instance_disk_usage.go
+++ b/huaweicloud/services/dds/data_source_huaweicloud_dds_instance_disk_usage.go
@@ -1,0 +1,131 @@
+package dds
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DDS GET /v3/{project_id}/instances/{instance_id}/disk-usage
+func DataSourceInstanceDiskUsage() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceDiskUsageRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"volumes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"entity_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"entity_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"group_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"used": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceInstanceDiskUsageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/disk-usage"
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dds", region)
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the instance disk information: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("volumes", flattenInstanceDiskUsage(
+			utils.PathSearch("volumes", getRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInstanceDiskUsage(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"entity_id":   utils.PathSearch("entity_id", v, nil),
+			"entity_name": utils.PathSearch("entity_name", v, nil),
+			"group_type":  utils.PathSearch("group_type", v, nil),
+			"used":        utils.PathSearch("used", v, nil),
+			"size":        utils.PathSearch("size", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get instance disk information.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDatasourceInstanceDiskUsage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDatasourceInstanceDiskUsage_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceInstanceDiskUsage_basic
=== PAUSE TestAccDatasourceInstanceDiskUsage_basic
=== CONT  TestAccDatasourceInstanceDiskUsage_basic
--- PASS: TestAccDatasourceInstanceDiskUsage_basic (16.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       16.997s
```
<img width="1203" height="16" alt="image" src="https://github.com/user-attachments/assets/fc4c9b12-f8be-479b-9dd8-6086e7342667" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
