### PR TITLE
feat(hss): support `hss_ransomware_backups` data source

### DIFF
--- a/docs/data-sources/hss_ransomware_backups.md
+++ b/docs/data-sources/hss_ransomware_backups.md
@@ -1,0 +1,87 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_ransomware_backups"
+description: |-
+  Use this data source to get the list of HSS ransomware backups within HuaweiCloud.
+---
+
+# huaweicloud_hss_ransomware_backups
+
+Use this data source to get the list of HSS ransomware backups within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "host_id" {}
+
+data "huaweicloud_hss_ransomware_backups" "test" {
+  host_id = var.host_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `host_id` - (Required, String) Specifies the host ID to query ransomware backups.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `status` - (Optional, String) Specifies the backup status. Valid values are:
+  + **available**: Available.
+  + **protecting**: Protecting.
+  + **deleting**: Deleting.
+  + **restoring**: Restoring.
+  + **error**: Error.
+  + **waiting_protect**: Waiting protect.
+  + **waiting_delete**: Waiting delete.
+  + **waiting_restore**: Waiting restore.
+
+* `name` - (Optional, String) Specifies the backup name.
+
+* `last_days` - (Optional, Int) Specifies the query time range in days. Valid values are `1` - `30`.  
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_num` - The total number of ransomware backup records.
+
+* `data_list` - The list of ransomware backup data.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `backup_id` - The backup ID.
+
+* `backup_name` - The backup name.
+
+* `backup_status` - The backup status.
+
+* `create_time` - The backup creation time.
+
+* `os_images_data` - The list of backup registered image IDs.
+
+  The [os_images_data](#os_images_data_struct) structure is documented below.
+
+* `backup_tag` - The backup tag. Valid values are:
+  + **0**: Scheduled backup.
+  + **1**: Ransomware encryption backup.
+
+<a name="os_images_data_struct"></a>
+The `os_images_data` block supports:
+
+* `image_id` - The backup registration image ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1520,6 +1520,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_ransomware_backup_operation_logs":           hss.DataSourceRansomwareBackupOperationLogs(),
 			"huaweicloud_hss_ransomware_backup_vaults":                   hss.DataSourceRansomwareBackupVaults(),
 			"huaweicloud_hss_ransomware_backup_policies":                 hss.DataSourceRansomwareBackupPolicies(),
+			"huaweicloud_hss_ransomware_backups":                         hss.DataSourceRansomwareBackups(),
 			"huaweicloud_hss_ransomware_protection_policies":             hss.DataSourceRansomwareProtectionPolicies(),
 			"huaweicloud_hss_ransomware_protection_servers":              hss.DataSourceRansomwareProtectionServers(),
 			"huaweicloud_hss_rasp_events":                                hss.DataSourceRaspEvents(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_ransomware_backups_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_ransomware_backups_test.go
@@ -1,0 +1,77 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRansomwareBackups_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_ransomware_backups.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test requires setting a host ID with ransomware protection enabled and generating a backup.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceRansomwareBackups_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.backup_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.backup_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.backup_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.create_time"),
+
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_enterprise_project_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceRansomwareBackups_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_hss_ransomware_backups" "test" {
+  host_id = "%[1]s"
+}
+
+# Filter using name.
+locals {
+  name = data.huaweicloud_hss_ransomware_backups.test.data_list[0].backup_name
+}
+
+data "huaweicloud_hss_ransomware_backups" "name_filter" {
+  host_id = "%[1]s"
+  name    = local.name
+}
+
+output "is_name_filter_useful" {
+  value = length(data.huaweicloud_hss_ransomware_backups.name_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_ransomware_backups.name_filter.data_list[*].backup_name : v == local.name]
+  )
+}
+
+# Filter using enterprise_project_id.
+data "huaweicloud_hss_ransomware_backups" "enterprise_project_id_filter" {
+  host_id               = "%[1]s"
+  enterprise_project_id = "all_granted_eps"
+}
+
+output "is_enterprise_project_id_filter_useful" {
+  value = length(data.huaweicloud_hss_ransomware_backups.enterprise_project_id_filter.data_list) > 0
+}
+`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_ransomware_backups.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_ransomware_backups.go
@@ -1,0 +1,222 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/ransomware/backup/{host_id}
+func DataSourceRansomwareBackups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRansomwareBackupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"last_days": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceRansomwareBackupsDataListSchema(),
+			},
+		},
+	}
+}
+
+func dataSourceRansomwareBackupsDataListSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"backup_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"backup_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			// In the API documentation, it is `backup_status`, but it actually returns `status`.
+			"backup_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			// `create_time` in API documentation as an int type, but it actually returns a string type.
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"os_images_data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"image_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"backup_tag": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildRansomwareBackupsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		queryParams = fmt.Sprintf("%s&status=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		queryParams = fmt.Sprintf("%s&name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("last_days"); ok {
+		queryParams = fmt.Sprintf("%s&last_days=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceRansomwareBackupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "hss"
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		result   = make([]interface{}, 0)
+		offset   = 0
+		totalNum float64
+		httpUrl  = "v5/{project_id}/ransomware/backup/{host_id}"
+		hostId   = d.Get("host_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{host_id}", hostId)
+	requestPath += buildRansomwareBackupsQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS ransomware backups: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalNum = utils.PathSearch("total_num", respBody, float64(0)).(float64)
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", totalNum),
+		d.Set("data_list", flattenRansomwareBackupsDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRansomwareBackupsDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"backup_id":     utils.PathSearch("backup_id", v, nil),
+			"backup_name":   utils.PathSearch("backup_name", v, nil),
+			"backup_status": utils.PathSearch("status", v, nil),
+			"create_time":   utils.PathSearch("create_time", v, nil),
+			"os_images_data": flattenRansomwareBackupsOsImagesData(
+				utils.PathSearch("os_images_data", v, make([]interface{}, 0)).([]interface{})),
+			"backup_tag": utils.PathSearch("backup_tag", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenRansomwareBackupsOsImagesData(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"image_id": utils.PathSearch("image_id", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_ransomware_backups` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_ransomware_backups` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceRansomwareBackups_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceRansomwareBackups_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRansomwareBackups_basic
=== PAUSE TestAccDataSourceRansomwareBackups_basic
=== CONT  TestAccDataSourceRansomwareBackups_basic
--- PASS: TestAccDataSourceRansomwareBackups_basic (14.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       14.861s

```
<img width="899" height="34" alt="image" src="https://github.com/user-attachments/assets/95d8687e-6d48-4c34-ba1b-2599ccfa7a98" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
