### PR TITLE
feat(secmaster): new datasource to query pipe index

### DIFF
--- a/docs/data-sources/secmaster_pipe_index.md
+++ b/docs/data-sources/secmaster_pipe_index.md
@@ -1,0 +1,40 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_pipe_index"
+description: |-
+  Use this data source to get the list of SecMaster pipe index.
+---
+
+# huaweicloud_secmaster_pipe_index
+
+Use this data source to get the list of SecMaster pipe index.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_secmaster_pipe_index" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+* `pipe_id` - (Required, String) Specifies the pipe ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `mapping` - The mapping information in JSON format of the pipe index.
+
+* `status` - The status of the pipe index. Valid values are **open** and **closed**.
+
+* `timestamp_field` - The timestamp field of the pipe index.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2047,6 +2047,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_notes":                         secmaster.DataSourceNotes(),
 			"huaweicloud_secmaster_operation_connections":         secmaster.DataSourceOperationConnections(),
 			"huaweicloud_secmaster_pipes":                         secmaster.DataSourceSecmasterPipes(),
+			"huaweicloud_secmaster_pipe_index":                    secmaster.DataSourcePipeIndex(),
 			"huaweicloud_secmaster_playbook_action_instances":     secmaster.DataSourceSecmasterPlaybookActionInstances(),
 			"huaweicloud_secmaster_playbook_actions":              secmaster.DataSourceSecmasterPlaybookActions(),
 			"huaweicloud_secmaster_playbook_approvals":            secmaster.DataSourcePlaybookApprovals(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_pipe_index_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_pipe_index_test.go
@@ -1,0 +1,44 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcePipeIndex_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_secmaster_pipe_index.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+			acceptance.TestAccPreCheckSecMasterPipeId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePipeIndex_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "mapping"),
+					resource.TestCheckResourceAttrSet(dataSource, "status"),
+					resource.TestCheckResourceAttrSet(dataSource, "timestamp_field"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePipeIndex_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_pipe_index" "test" {
+  workspace_id = "%[1]s"
+  pipe_id      = "%[2]s"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_PIPE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_pipe_index.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_pipe_index.go
@@ -1,0 +1,99 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/siem/pipes/{pipe_id}/index
+func DataSourcePipeIndex() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePipeIndexRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"pipe_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// String value in JSON format
+			"mapping": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"timestamp_field": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePipeIndexRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/siem/pipes/{pipe_id}/index"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestPath = strings.ReplaceAll(requestPath, "{pipe_id}", d.Get("pipe_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving SecMaster pipe index: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("mapping", utils.JsonToString(utils.PathSearch("mapping", respBody, nil))),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("timestamp_field", utils.PathSearch("timestamp_field", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query pipe index

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourcePipeIndex_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourcePipeIndex_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourcePipeIndex_basic
=== PAUSE TestAccDataSourcePipeIndex_basic
=== CONT  TestAccDataSourcePipeIndex_basic
--- PASS: TestAccDataSourcePipeIndex_basic (15.34s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 15.483s coverage: 3.8% of statements in ./huaweicloud/services/secmaster
```
<img width="1380" height="88" alt="image" src="https://github.com/user-attachments/assets/6d961b80-cf92-4784-b7c4-1806cc3ff240" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
