### PR TITLE
feat(waf): new datasource to query dns domains

### DIFF
--- a/docs/data-sources/waf_dns_domains.md
+++ b/docs/data-sources/waf_dns_domains.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_dns_domains"
+description: |-
+  Use this data source to get the list of DNS domains.
+---
+
+# huaweicloud_waf_dns_domains
+
+Use this data source to get the list of DNS domains.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+
+data "huaweicloud_waf_dns_domains" "test" {
+  enterprise_project_id = var.enterprise_project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the DNS domain belongs.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `items` - The list of DNS domains.
+
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `id` - The ID of the DNS domain.
+
+* `domain` - The domain name of the DNS domain.
+
+* `servers` - The list of servers.
+
+  The [servers](#servers_struct) structure is documented below.
+
+* `protect_port` - The protected port of the DNS domain.
+
+<a name="servers_struct"></a>
+The `servers` block supports:
+
+* `type` - The type of the server.
+
+* `address` - The address of the server.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2310,6 +2310,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_dedicated_domains":                    waf.DataSourceWafDedicatedDomains(),
 			"huaweicloud_waf_dedicated_instance_tags":              waf.DataSourceWafDedicatedInstanceTags(),
 			"huaweicloud_waf_dedicated_instances":                  waf.DataSourceWafDedicatedInstances(),
+			"huaweicloud_waf_dns_domains":                          waf.DataSourceDNSDomains(),
 			"huaweicloud_waf_domain_status":                        waf.DataSourceWafDomainStatus(),
 			"huaweicloud_waf_domains":                              waf.DataSourceWafDomains(),
 			"huaweicloud_waf_event_logs":                           waf.DataSourceWafEventLogs(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_dns_domains_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_dns_domains_test.go
@@ -1,0 +1,38 @@
+package waf
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDNSDomains_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_waf_dns_domains.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDNSDomains_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.domain"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.0.servers.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceDNSDomains_basic = `
+data "huaweicloud_waf_dns_domains" "test" {}
+`

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_dns_domains.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_dns_domains.go
@@ -1,0 +1,160 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/dns-domain
+func DataSourceDNSDomains() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDNSDomainsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"servers": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"address": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"protect_port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildDNSDomainsQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	return ""
+}
+
+func dataSourceDNSDomainsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{projectid}/waf/dns-domain"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("waf", region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{projectid}", client.ProjectID)
+	requestPath += buildDNSDomainsQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving WAF DNS domains: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("items", flattenDNSDomains(utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDNSDomains(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"id":           utils.PathSearch("id", v, nil),
+			"domain":       utils.PathSearch("domain", v, nil),
+			"servers":      flattenDNSDomainsServers(utils.PathSearch("servers", v, make([]interface{}, 0)).([]interface{})),
+			"protect_port": utils.PathSearch("protect_port", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenDNSDomainsServers(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"type":    utils.PathSearch("type", v, nil),
+			"address": utils.PathSearch("address", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query dns domains

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccDataSourceDNSDomains_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccDataSourceDNSDomains_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDNSDomains_basic
=== PAUSE TestAccDataSourceDNSDomains_basic
=== CONT  TestAccDataSourceDNSDomains_basic
--- PASS: TestAccDataSourceDNSDomains_basic (19.25s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       19.363s coverage: 4.0% of statements in ./huaweicloud/services/waf
```
<img width="1370" height="86" alt="image" src="https://github.com/user-attachments/assets/322719e4-b882-4726-92e7-b1b20f3d3042" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
