### PR TITLE
feat(waf): alarm notification resource support deletion API

### DIFF
--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_alarm_notification_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_alarm_notification_test.go
@@ -48,7 +48,7 @@ func TestAccAlarmNotification_basic(t *testing.T) {
 			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      nil,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAlarmNotification_basic(name),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

alarm notification resource support deletion API

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o waf -f TestAccAlarmNotification_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/waf" -v -coverprofile="./huaweicloud/services/acceptance/waf/waf_coverage.cov" -coverpkg="./huaweicloud/services/waf" -run TestAccAlarmNotification_basic -timeout 360m -parallel 10=== RUN   TestAccAlarmNotification_basic
=== PAUSE TestAccAlarmNotification_basic
=== CONT  TestAccAlarmNotification_basic
--- PASS: TestAccAlarmNotification_basic (33.10s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/waf
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       33.200s coverage: 4.6% of statements in ./huaweicloud/services/waf
```
<img width="1327" height="84" alt="image" src="https://github.com/user-attachments/assets/1823c2d1-894a-4181-b465-301a59e92cc3" />
<img width="1129" height="550" alt="image" src="https://github.com/user-attachments/assets/d1f50314-cfad-4313-a6ed-669442e6221f" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
