### PR TITLE
fix(CCE): change node pool and node root_volumes to optional

### DIFF
--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -343,7 +343,7 @@ The following arguments are supported:
   + `throughput` - (Optional, Int, NonUpdatable) Specifies the throughput of the disk in MiB/s,
     required when `volumetype` is **GPSSD2**.
 
-* `data_volumes` - (Required, List, NonUpdatable) Specifies the configurations of the data disk.
+* `data_volumes` - (Optional, List, NonUpdatable) Specifies the configurations of the data disk.
 
   + `size` - (Required, Int, NonUpdatable) Specifies the disk size in GB.
 

--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -370,7 +370,7 @@ The following arguments are supported:
 * `root_volume` - (Required, List) Specifies the configuration of the system disk.
   The [root_volume](#root_volume_struct) structure is documented below.
 
-* `data_volumes` - (Required, List) Specifies the configuration of the data disks.
+* `data_volumes` - (Optional, List) Specifies the configuration of the data disks.
   The [data_volumes](#data_volumes_struct) structure is documented below.
 
 * `charging_mode` - (Optional, String, NonUpdatable) Specifies the charging mode of the CCE node pool. Valid values are

--- a/huaweicloud/services/cce/common.go
+++ b/huaweicloud/services/cce/common.go
@@ -367,9 +367,6 @@ func resourceNodeDataVolume() *schema.Schema {
 		Type:     schema.TypeList,
 		Optional: true,
 		Computed: true,
-		Description: utils.SchemaDesc("", utils.SchemaDescInput{
-			Required: true,
-		}),
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"size": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  change node pool and node root_volumes to optional
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  change node pool and node root_volumes to optional
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/cce/ TESTARGS='-run TestAccNodePool_without_data_volumes'        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce/ -v -run TestAccNodePool_without_data_volumes -timeout 360m -parallel 4
=== RUN   TestAccNodePool_without_data_volumes
=== PAUSE TestAccNodePool_without_data_volumes
=== CONT  TestAccNodePool_without_data_volumes
--- PASS: TestAccNodePool_without_data_volumes (816.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       816.968s

make testacc TEST=./huaweicloud/services/acceptance/cce/ TESTARGS='-run TestAccNode_without_data_volumes'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce/ -v -run TestAccNode_without_data_volumes -timeout 360m -parallel 4
=== RUN   TestAccNode_without_data_volumes
=== PAUSE TestAccNode_without_data_volumes
=== CONT  TestAccNode_without_data_volumes
--- PASS: TestAccNode_without_data_volumes (1307.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1307.641s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
