### PR TITLE
feat: test(iam): agency supports omit the role assignment and description

### DIFF
--- a/docs/resources/identity_agency.md
+++ b/docs/resources/identity_agency.md
@@ -63,11 +63,6 @@ The following arguments are supported:
 * `enterprise_project_roles` - (Optional, List) Specifies an array of one or more roles and enterprise projects which
   are used to grant permissions to agency on project. The structure is documented below.
 
--> **NOTE**
-At least one of `project_role`, `domain_roles`, `all_resources_roles` and `enterprise_project_roles` must be specified
-when creating an agency. We can get all **System-Defined Roles** from
-[HuaweiCloud](https://support.huaweicloud.com/intl/en-us/usermanual-permissions/iam_01_0001.html).
-
 The `project_role` block supports:
 
 * `project` - (Required, String) Specifies the name of project.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20251223022605-afc4ab0a25d5
+	github.com/chnsz/golangsdk v0.0.0-20260122034805-35f0d96c773e
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20251223022605-afc4ab0a25d5 h1:LaIwc+PTMiOHNJiOA8FdBefYbWZi8W4ZwWtnZHa1OC4=
-github.com/chnsz/golangsdk v0.0.0-20251223022605-afc4ab0a25d5/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
+github.com/chnsz/golangsdk v0.0.0-20260122034805-35f0d96c773e h1:HfEwKj3CmV/x0FPK12YsZUj1IwM8Il6sRI5xTHOOpM0=
+github.com/chnsz/golangsdk v0.0.0-20260122034805-35f0d96c773e/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_temporary_access_key_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_temporary_access_key_test.go
@@ -48,6 +48,16 @@ func TestAccIdentityTemporaryAccessKey_basic(t *testing.T) {
 	})
 }
 
+func testAccTemporaryAccessKey_basic_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_agency" "test" {
+  name                  = "%[1]s_create_with_role_assignments"
+  description           = "Created by terraform acceptance test"
+  delegated_domain_name = "%[2]s"
+}
+`, name, acceptance.HW_DOMAIN_NAME)
+}
+
 func AccIdentityTemporaryAccessKeyByAgency(agencyName, userName, initPassword string) string {
 	policy := "{\"Version\":\"1.1\",\"Statement\":[{\"Effect\":\"Allow\"," +
 		"\"Action\":[\"obs:object:GetObject\"],\"Resource\":[\"OBS:*:*:object:*\"]}]}"
@@ -63,7 +73,7 @@ resource "huaweicloud_identity_temporary_access_key" "test" {
   domain_name = huaweicloud_identity_agency.test.delegated_domain_name
   policy      = "%[3]s"
 }
-`, testAccIdentityAgency_domain(agencyName), testAccIdentityUserToken_basic(userName, initPassword), policy)
+`, testAccTemporaryAccessKey_basic_base(agencyName), testAccIdentityUserToken_basic(userName, initPassword), policy)
 }
 
 func AccIdentityTemporaryAccessKeyByToken(userName, initPassword string) string {

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_agency.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_agency.go
@@ -79,7 +79,6 @@ func ResourceIAMAgencyV3() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 			"duration": {
 				Type:             schema.TypeString,

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/v3/agency/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/v3/agency/requests.go
@@ -35,7 +35,8 @@ func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult)
 
 type UpdateOpts struct {
 	DelegatedDomain string `json:"trust_domain_name,omitempty"`
-	Description     string `json:"description,omitempty"`
+	// The description of the agency, which supports update with an empty string.
+	Description string `json:"description"`
 	// the duration can be string("FOREVER", "ONEDAY") or specific days in int(1, 2, 3...)
 	Duration interface{} `json:"duration,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20251223022605-afc4ab0a25d5
+# github.com/chnsz/golangsdk v0.0.0-20260122034805-35f0d96c773e
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Some feature of agency resource are difference with the API:
- POST API supports omit role assignments
- PUT API supports omit description

Also acceptance test should be redesigned according to the above changes and these following items:

- Hard-coding
- Redundant naming
- Insufficiently precise checks
- Test scenarios no enough

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. agency allows creation without roles assignment
2. agency description supports update with the empty string
3. optimize the acceptance case design for agency
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccAgency_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccAgency_basic -timeout 360m -parallel 10
=== RUN   TestAccAgency_basic
=== PAUSE TestAccAgency_basic
=== CONT  TestAccAgency_basic
--- PASS: TestAccAgency_basic (212.18s)
PASS
coverage: 8.0% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       212.270s        coverage: 8.0% of statements in ./huaweicloud/services/iam
```

* [x Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
