### PR TITLE
test(iam): optimize the acceptance case for v5 asymmetric signature

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_asymmetric_signature_switch_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_asymmetric_signature_switch_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccIdentityV5AsymmetricSignatureSwitch_basic(t *testing.T) {
-	resourceName := "huaweicloud_identityv5_asymmetric_signature_switch.test"
+// Please ensure that the user executing the acceptance test has 'admin' permission.
+func TestAccV5AsymmetricSignatureSwitch_basic(t *testing.T) {
+	rName := "huaweicloud_identityv5_asymmetric_signature_switch.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -20,19 +21,19 @@ func TestAccIdentityV5AsymmetricSignatureSwitch_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityV5AsymmetricSignatureSwitch_basic,
+				Config: testAccV5AsymmetricSignatureSwitch_basic_step1,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "asymmetric_signature_switch", "true"),
+					resource.TestCheckResourceAttr(rName, "asymmetric_signature_switch", "true"),
 				),
 			},
 			{
-				Config: testAccIdentityV5AsymmetricSignatureSwitch_update,
+				Config: testAccV5AsymmetricSignatureSwitch_basic_step2,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "asymmetric_signature_switch", "false"),
+					resource.TestCheckResourceAttr(rName, "asymmetric_signature_switch", "false"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -40,13 +41,13 @@ func TestAccIdentityV5AsymmetricSignatureSwitch_basic(t *testing.T) {
 	})
 }
 
-var testAccIdentityV5AsymmetricSignatureSwitch_basic = `
+const testAccV5AsymmetricSignatureSwitch_basic_step1 = `
 resource "huaweicloud_identityv5_asymmetric_signature_switch" "test" {
   asymmetric_signature_switch = true
 }
 `
 
-var testAccIdentityV5AsymmetricSignatureSwitch_update = `
+const testAccV5AsymmetricSignatureSwitch_basic_step2 = `
 resource "huaweicloud_identityv5_asymmetric_signature_switch" "test" {
   asymmetric_signature_switch = false
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Unified variable and constant naming of the`huaweicloud_identityv5_asymmetric_signature_switch` resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

1. unified naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
/scripts/coverage.sh -o iam -f TestAccV5AsymmetricSignatureSwitch_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5AsymmetricSignatureSwitch_basic -timeout 360m -parallel 10
=== RUN   TestAccV5AsymmetricSignatureSwitch_basic
=== PAUSE TestAccV5AsymmetricSignatureSwitch_basic
=== CONT  TestAccV5AsymmetricSignatureSwitch_basic
--- PASS: TestAccV5AsymmetricSignatureSwitch_basic (31.28s)
PASS
coverage: 2.2% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       31.426s coverage: 2.2% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
