### PR TITLE
fix(dc): DC `virtual_interface` dataSource quality improvement

### DIFF
--- a/docs/data-sources/dc_virtual_interfaces.md
+++ b/docs/data-sources/dc_virtual_interfaces.md
@@ -2,7 +2,8 @@
 subcategory: "Direct Connect (DC)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_dc_virtual_interfaces"
-description: ""
+description: |-
+  Use this data source to get the list of DC virtual interfaces.
 ---
 
 # huaweicloud_dc_virtual_interfaces
@@ -32,11 +33,12 @@ The following arguments are supported:
 
 * `status` - (Optional, String) Specifies the status of the virtual interface.
 
-* `direct_connect_id` - (Optional, String) Specifies the ID of the direct connection associated with the virtual interface.
+* `direct_connect_id` - (Optional, String) Specifies the ID of the direct connection associated with the virtual
+  interface.
 
 * `vgw_id` - (Optional, String) Specifies the ID of the virtual gateway for the virtual interface.
 
-* `enterprise_project_id` - (Optional, String) Indicates the ID of the enterprise project
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project
   that the virtual interface belongs to.
 
 ## Attribute Reference
@@ -57,7 +59,7 @@ The `virtual_interfaces` block supports:
 
 * `bandwidth` - The bandwidth of the virtual interface.
 
-* `created_at` - The create time of the virtual interface.
+* `created_at` - The creation time of the virtual interface.
 
 * `description` - The description of the virtual interface.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

DC `virtual_interface` dataSource quality improvement, including modifying document descriptions, variable commands, and optimizing code style.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

DC `virtual_interface` dataSource quality improvement

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dc" TESTARGS="-run TestAccDatasourceVirtualInterface_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc -v -run TestAccDatasourceVirtualInterface_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceVirtualInterface_basic
=== PAUSE TestAccDatasourceVirtualInterface_basic
=== CONT  TestAccDatasourceVirtualInterface_basic
--- PASS: TestAccDatasourceVirtualInterface_basic (48.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        48.701s
```
<img width="877" height="33" alt="image" src="https://github.com/user-attachments/assets/d81c6ed2-fa33-4259-9039-f666ce955560" />


* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
