### PR TITLE
test(iam): optimize the acceptance case design for group

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_group_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_group_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getIdentityGroupResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getGroupResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := c.IdentityV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
@@ -21,15 +21,15 @@ func getIdentityGroupResourceFunc(c *config.Config, state *terraform.ResourceSta
 	return groups.Get(client, state.Primary.ID).Extract()
 }
 
-func TestAccIdentityGroup_basic(t *testing.T) {
-	var group groups.Group
-	groupName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_identity_group.group_1"
+func TestAccGroup_basic(t *testing.T) {
+	var (
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&group,
-		getIdentityGroupResourceFunc,
+		resourceName = "huaweicloud_identity_group.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getGroupResourceFunc)
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -41,11 +41,19 @@ func TestAccIdentityGroup_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityGroup_basic(groupName),
+				Config: testAccGroup_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", groupName),
-					resource.TestCheckResourceAttr(resourceName, "description", "An ACC test group"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
+				),
+			},
+			{
+				Config: testAccGroup_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by terraform script"),
 				),
 			},
 			{
@@ -53,32 +61,24 @@ func TestAccIdentityGroup_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
-				Config: testAccIdentityGroup_update(groupName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", groupName),
-					resource.TestCheckResourceAttr(resourceName, "description", "An ACC update group"),
-				),
-			},
 		},
 	})
 }
 
-func testAccIdentityGroup_basic(groupName string) string {
+func testAccGroup_basic_step1(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identity_group" "group_1" {
-  name        = "%s"
-  description = "An ACC test group"
+resource "huaweicloud_identity_group" "test" {
+  name        = "%[1]s"
+  description = "Created by terraform script"
 }
-`, groupName)
+`, name)
 }
 
-func testAccIdentityGroup_update(groupName string) string {
+func testAccGroup_basic_step2(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identity_group" "group_1" {
-  name        = "%s"
-  description = "An ACC update group"
+resource "huaweicloud_identity_group" "test" {
+  name        = "%[1]s"
+  description = "Updated by terraform script"
 }
-`, groupName)
+`, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

- Hard-coding
- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the group role assignment resource's test
2. update the check items and function naming
3. combine some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccGroup_basic
=== PAUSE TestAccGroup_basic
=== CONT  TestAccGroup_basic
--- PASS: TestAccGroup_basic (20.90s)
PASS
coverage: 2.4% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       20.986s coverage: 2.4% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
