### PR TITLE
test(iam): optimize the acceptance case for v5 login policy

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_login_policy_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_login_policy_test.go
@@ -1,7 +1,6 @@
 package iam
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -15,8 +14,61 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+func getV5LoginPolicy(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v5/login-policy"
+	getPath := client.Endpoint + httpUrl
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the login policy values are not the default values, means the login policy is not destroyed.
+	if utils.PathSearch("login_policy.user_validity_period", respBody, float64(0)).(float64) != 0 ||
+		utils.PathSearch("login_policy.custom_info_for_login", respBody, "").(string) != "" ||
+		utils.PathSearch("login_policy.lockout_duration", respBody, float64(0)).(float64) != 15 ||
+		utils.PathSearch("login_policy.login_failed_times", respBody, float64(0)).(float64) != 5 ||
+		utils.PathSearch("login_policy.period_with_login_failures", respBody, float64(0)).(float64) != 15 ||
+		utils.PathSearch("login_policy.session_timeout", respBody, float64(0)).(float64) != 60 ||
+		utils.PathSearch("login_policy.show_recent_login_info", respBody, false).(bool) ||
+		utils.PathSearch("length(login_policy.allow_address_netmasks)", respBody, float64(0)).(float64) != 0 ||
+		utils.PathSearch("length(login_policy.allow_ip_ranges)", respBody, float64(0)).(float64) != 1 ||
+		utils.PathSearch("login_policy.allow_ip_ranges[0].ip_range", respBody, "").(string) != "0.0.0.0-255.255.255.255" ||
+		utils.PathSearch("login_policy.allow_ip_ranges[0].description", respBody, "").(string) != "" ||
+		utils.PathSearch("length(login_policy.allow_ip_ranges_ipv6)", respBody, float64(0)).(float64) != 1 ||
+		utils.PathSearch("login_policy.allow_ip_ranges_ipv6[0].ip_range", respBody, "").(string) !=
+			"0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF" ||
+		utils.PathSearch("login_policy.allow_ip_ranges_ipv6[0].description", respBody, "").(string) != "" {
+		return respBody, nil
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func getV5LoginPolicyFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("iam", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IAM client: %s", err)
+	}
+
+	return getV5LoginPolicy(client)
+}
+
+// Please ensure that the user executing the acceptance test has 'admin' permission.
 func TestAccV5LoginPolicy_basic(t *testing.T) {
-	resourceName := "huaweicloud_identityv5_login_policy.test"
+	var (
+		rName = "huaweicloud_identityv5_login_policy.test"
+		obj   interface{}
+		rc    = acceptance.InitResourceCheck(rName, &obj, getV5LoginPolicyFunc)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -24,53 +76,57 @@ func TestAccV5LoginPolicy_basic(t *testing.T) {
 			acceptance.TestAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccV5CheckLoginPolicyDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccV5LoginPolicy_basic(),
+				Config: testAccV5LoginPolicy_basic_step1,
 				Check: resource.ComposeTestCheckFunc(
-					testAccV5CheckLoginPolicyExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "user_validity_period", "20"),
-					resource.TestCheckResourceAttr(resourceName, "lockout_duration", "30"),
-					resource.TestCheckResourceAttr(resourceName, "login_failed_times", "10"),
-					resource.TestCheckResourceAttr(resourceName, "period_with_login_failures", "30"),
-					resource.TestCheckResourceAttr(resourceName, "session_timeout", "120"),
-					resource.TestCheckResourceAttr(resourceName, "show_recent_login_info", "true"),
-					resource.TestCheckResourceAttr(resourceName, "custom_info_for_login", "hello Terraform"),
-					resource.TestCheckResourceAttr(resourceName, "allow_address_netmasks.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "allow_address_netmasks.0.address_netmask", "255.0.0.0/1"),
-					resource.TestCheckResourceAttr(resourceName, "allow_address_netmasks.0.description", "terraform test"),
-					resource.TestCheckResourceAttr(resourceName, "allow_ip_ranges.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allow_ip_ranges_ipv6.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "allow_ip_ranges_ipv6.0.ip_range",
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "user_validity_period", "20"),
+					resource.TestCheckResourceAttr(rName, "lockout_duration", "30"),
+					resource.TestCheckResourceAttr(rName, "login_failed_times", "10"),
+					resource.TestCheckResourceAttr(rName, "period_with_login_failures", "30"),
+					resource.TestCheckResourceAttr(rName, "session_timeout", "120"),
+					resource.TestCheckResourceAttr(rName, "show_recent_login_info", "true"),
+					resource.TestCheckResourceAttr(rName, "custom_info_for_login", "hello Terraform"),
+					resource.TestCheckResourceAttr(rName, "allow_address_netmasks.#", "1"),
+					resource.TestCheckResourceAttr(rName, "allow_address_netmasks.0.address_netmask", "255.0.0.0/1"),
+					resource.TestCheckResourceAttr(rName, "allow_address_netmasks.0.description", "terraform test"),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges.#", "2"),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges.0.ip_range", "0.0.0.0-255.255.255.254"),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges.0.description", ""),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges.1.ip_range", "0.0.0.0-255.255.255.100"),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges.1.description", "terraform test2"),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges_ipv6.#", "1"),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges_ipv6.0.ip_range",
 						"0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFF0"),
-					resource.TestCheckResourceAttr(resourceName, "allow_ip_ranges_ipv6.0.description", "terraform test"),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges_ipv6.0.description", "terraform test"),
 				),
 			},
 			{
-				Config: testAccV5LoginPolicy_update(),
+				Config: testAccV5LoginPolicy_basic_step2,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "user_validity_period", "0"),
-					resource.TestCheckResourceAttr(resourceName, "lockout_duration", "20"),
-					resource.TestCheckResourceAttr(resourceName, "login_failed_times", "6"),
-					resource.TestCheckResourceAttr(resourceName, "period_with_login_failures", "20"),
-					resource.TestCheckResourceAttr(resourceName, "session_timeout", "90"),
-					resource.TestCheckResourceAttr(resourceName, "show_recent_login_info", "false"),
-					resource.TestCheckResourceAttr(resourceName, "custom_info_for_login", ""),
-					resource.TestCheckResourceAttr(resourceName, "allow_address_netmasks.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "allow_address_netmasks.0.address_netmask", "100.0.0.0/1"),
-					resource.TestCheckResourceAttr(resourceName, "allow_address_netmasks.0.description", "terraform test"),
-					resource.TestCheckResourceAttr(resourceName, "allow_ip_ranges.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "allow_ip_ranges.0.ip_range", "0.0.0.0-255.255.255.100"),
-					resource.TestCheckResourceAttr(resourceName, "allow_ip_ranges.0.description", "terraform test"),
-					resource.TestCheckResourceAttr(resourceName, "allow_ip_ranges_ipv6.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "allow_ip_ranges_ipv6.0.ip_range",
+					resource.TestCheckResourceAttr(rName, "user_validity_period", "0"),
+					resource.TestCheckResourceAttr(rName, "lockout_duration", "20"),
+					resource.TestCheckResourceAttr(rName, "login_failed_times", "6"),
+					resource.TestCheckResourceAttr(rName, "period_with_login_failures", "20"),
+					resource.TestCheckResourceAttr(rName, "session_timeout", "90"),
+					resource.TestCheckResourceAttr(rName, "show_recent_login_info", "false"),
+					resource.TestCheckResourceAttr(rName, "custom_info_for_login", ""),
+					resource.TestCheckResourceAttr(rName, "allow_address_netmasks.#", "1"),
+					resource.TestCheckResourceAttr(rName, "allow_address_netmasks.0.address_netmask", "100.0.0.0/1"),
+					resource.TestCheckResourceAttr(rName, "allow_address_netmasks.0.description", ""),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges.#", "1"),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges.0.ip_range", "0.0.0.0-255.255.255.100"),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges.0.description", "terraform test"),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges_ipv6.#", "1"),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges_ipv6.0.ip_range",
 						"0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFF1"),
-					resource.TestCheckResourceAttr(resourceName, "allow_ip_ranges_ipv6.0.description", "terraform test"),
+					resource.TestCheckResourceAttr(rName, "allow_ip_ranges_ipv6.0.description", ""),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -78,89 +134,7 @@ func TestAccV5LoginPolicy_basic(t *testing.T) {
 	})
 }
 
-func testAccV5CheckLoginPolicyExists(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("resource not found: %s", n)
-		}
-		if rs.Primary.ID == "" {
-			return errors.New("resource ID is not set")
-		}
-
-		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
-		region := acceptance.HW_REGION_NAME
-		getLoginPolicyClient, err := cfg.IAMNoVersionClient(region)
-		if err != nil {
-			return fmt.Errorf("error creating IAM Client: %s", err)
-		}
-
-		getLoginPolicyHttpUrl := "v5/login-policy"
-		getLoginPolicyPath := getLoginPolicyClient.Endpoint + getLoginPolicyHttpUrl
-		getLoginPolicyOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-		}
-
-		_, err = getLoginPolicyClient.Request("GET", getLoginPolicyPath, &getLoginPolicyOpt)
-		if err != nil {
-			return fmt.Errorf("error retrieving IAM login policy: %s", err)
-		}
-		return err
-	}
-}
-
-func testAccV5CheckLoginPolicyDestroy(s *terraform.State) error {
-	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
-	region := acceptance.HW_REGION_NAME
-	getLoginPolicyClient, err := cfg.IAMNoVersionClient(region)
-	if err != nil {
-		return fmt.Errorf("error creating IAM Client: %s", err)
-	}
-
-	getLoginPolicyHttpUrl := "v5/login-policy"
-	getLoginPolicyPath := getLoginPolicyClient.Endpoint + getLoginPolicyHttpUrl
-	getLoginPolicyOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_identityv5_login_policy" {
-			continue
-		}
-
-		getLoginPolicyResp, err := getLoginPolicyClient.Request("GET", getLoginPolicyPath, &getLoginPolicyOpt)
-		if err != nil {
-			return fmt.Errorf("error retrieving IAM login policy: %s", err)
-		}
-
-		getLoginPolicyRespBody, err := utils.FlattenResponse(getLoginPolicyResp)
-		if err != nil {
-			return err
-		}
-
-		if utils.PathSearch("login_policy.user_validity_period", getLoginPolicyRespBody, float64(0)).(float64) != 0 ||
-			utils.PathSearch("login_policy.custom_info_for_login", getLoginPolicyRespBody, "").(string) != "" ||
-			utils.PathSearch("login_policy.lockout_duration", getLoginPolicyRespBody, float64(0)).(float64) != 15 ||
-			utils.PathSearch("login_policy.login_failed_times", getLoginPolicyRespBody, float64(0)).(float64) != 5 ||
-			utils.PathSearch("login_policy.period_with_login_failures", getLoginPolicyRespBody, float64(0)).(float64) != 15 ||
-			utils.PathSearch("login_policy.session_timeout", getLoginPolicyRespBody, float64(0)).(float64) != 60 ||
-			utils.PathSearch("login_policy.show_recent_login_info", getLoginPolicyRespBody, false).(bool) ||
-			utils.PathSearch("length(login_policy.allow_address_netmasks)", getLoginPolicyRespBody, float64(0)).(float64) != 0 ||
-			utils.PathSearch("length(login_policy.allow_ip_ranges)", getLoginPolicyRespBody, float64(0)).(float64) != 1 ||
-			utils.PathSearch("login_policy.allow_ip_ranges[0].ip_range", getLoginPolicyRespBody, "").(string) != "0.0.0.0-255.255.255.255" ||
-			utils.PathSearch("login_policy.allow_ip_ranges[0].description", getLoginPolicyRespBody, "").(string) != "" ||
-			utils.PathSearch("length(login_policy.allow_ip_ranges_ipv6)", getLoginPolicyRespBody, float64(0)).(float64) != 1 ||
-			utils.PathSearch("login_policy.allow_ip_ranges_ipv6[0].ip_range", getLoginPolicyRespBody, "").(string) !=
-				"0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF" ||
-			utils.PathSearch("login_policy.allow_ip_ranges_ipv6[0].description", getLoginPolicyRespBody, "").(string) != "" {
-			return errors.New("the login policy failed to reset to defaults")
-		}
-	}
-	return nil
-}
-
-func testAccV5LoginPolicy_basic() string {
-	return `
+const testAccV5LoginPolicy_basic_step1 = `
 resource "huaweicloud_identityv5_login_policy" "test" {
   user_validity_period       = 20
   lockout_duration           = 30
@@ -169,28 +143,28 @@ resource "huaweicloud_identityv5_login_policy" "test" {
   session_timeout            = 120
   show_recent_login_info     = true
   custom_info_for_login      = "hello Terraform"
+
   allow_address_netmasks {
     address_netmask = "255.0.0.0/1"
     description     = "terraform test"
   }
+
   allow_ip_ranges {
     ip_range    = "0.0.0.0-255.255.255.254"
-    description = "terraform test1"
   }
   allow_ip_ranges {
     ip_range    = "0.0.0.0-255.255.255.100"
     description = "terraform test2"
   }
+
   allow_ip_ranges_ipv6 {
     ip_range    = "0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFF0"
     description = "terraform test"
   }
 }
 `
-}
 
-func testAccV5LoginPolicy_update() string {
-	return `
+const testAccV5LoginPolicy_basic_step2 = `
 resource "huaweicloud_identityv5_login_policy" "test" {
   user_validity_period       = 0
   lockout_duration           = 20
@@ -198,19 +172,18 @@ resource "huaweicloud_identityv5_login_policy" "test" {
   period_with_login_failures = 20
   session_timeout            = 90
   show_recent_login_info     = false
-  custom_info_for_login      = ""
+
   allow_address_netmasks {
     address_netmask = "100.0.0.0/1"
-    description     = "terraform test"
   }
+
   allow_ip_ranges {
     ip_range    = "0.0.0.0-255.255.255.100"
-    description = "terraform test"
+	description = "terraform test"
   }
+
   allow_ip_ranges_ipv6 {
-    ip_range    = "0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFF1"
-    description = "terraform test"
+    ip_range = "0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFF1"
   }
 }
 `
-}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

- Hard-coding
- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the v5 login policy resource's test
2. update function naming
3. for logic that checks if a resource exists, use the existing style instead of the old one.
4. combine some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV5LoginPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5LoginPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccV5LoginPolicy_basic
=== PAUSE TestAccV5LoginPolicy_basic
=== CONT  TestAccV5LoginPolicy_basic
--- PASS: TestAccV5LoginPolicy_basic (58.60s)
PASS
coverage: 2.4% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       58.772s coverage: 2.4% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
