### PR TITLE
test(iam): optimize the acceptance case for v5 password policy

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_password_policy_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_password_policy_test.go
@@ -1,7 +1,6 @@
 package iam
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -15,8 +14,52 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+func getV5PasswordPolicy(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v5/password-policy"
+	getPath := client.Endpoint + httpUrl
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if utils.PathSearch("password_policy.maximum_consecutive_identical_chars", respBody, float64(0)).(float64) != 0 ||
+		utils.PathSearch("password_policy.minimum_password_age", respBody, float64(0)).(float64) != 0 ||
+		utils.PathSearch("password_policy.minimum_password_length", respBody, float64(0)).(float64) != 8 ||
+		utils.PathSearch("password_policy.password_reuse_prevention", respBody, float64(0)).(float64) != 1 ||
+		!utils.PathSearch("password_policy.password_not_username_or_invert", respBody, false).(bool) ||
+		utils.PathSearch("password_policy.password_validity_period", respBody, float64(0)).(float64) != 0 ||
+		utils.PathSearch("password_policy.password_char_combination", respBody, float64(0)).(float64) != 2 ||
+		!utils.PathSearch("password_policy.allow_user_to_change_password", respBody, false).(bool) {
+		return respBody, nil
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func getV5PasswordPolicyFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("iam", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IAM client: %s", err)
+	}
+
+	return getV5PasswordPolicy(client)
+}
+
+// Please ensure that the user executing the acceptance test has 'admin' permission.
 func TestAccV5PasswordPolicy_basic(t *testing.T) {
-	resourceName := "huaweicloud_identityv5_password_policy.enhanced"
+	var (
+		obj   interface{}
+		rName = "huaweicloud_identityv5_password_policy.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getV5PasswordPolicyFunc)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -24,37 +67,38 @@ func TestAccV5PasswordPolicy_basic(t *testing.T) {
 			acceptance.TestAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccV5CheckPasswordPolicyDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccV5PasswordPolicy_basic(),
+				Config: testAccV5PasswordPolicy_basic_step1,
 				Check: resource.ComposeTestCheckFunc(
-					testAccV5CheckPasswordPolicyExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "maximum_consecutive_identical_chars", "1"),
-					resource.TestCheckResourceAttr(resourceName, "minimum_password_age", "30"),
-					resource.TestCheckResourceAttr(resourceName, "minimum_password_length", "10"),
-					resource.TestCheckResourceAttr(resourceName, "password_reuse_prevention", "2"),
-					resource.TestCheckResourceAttr(resourceName, "password_not_username_or_invert", "false"),
-					resource.TestCheckResourceAttr(resourceName, "password_validity_period", "90"),
-					resource.TestCheckResourceAttr(resourceName, "password_char_combination", "3"),
-					resource.TestCheckResourceAttr(resourceName, "allow_user_to_change_password", "false"),
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "maximum_consecutive_identical_chars", "1"),
+					resource.TestCheckResourceAttr(rName, "minimum_password_age", "30"),
+					resource.TestCheckResourceAttr(rName, "minimum_password_length", "10"),
+					resource.TestCheckResourceAttr(rName, "password_reuse_prevention", "2"),
+					resource.TestCheckResourceAttr(rName, "password_not_username_or_invert", "false"),
+					resource.TestCheckResourceAttr(rName, "password_validity_period", "90"),
+					resource.TestCheckResourceAttr(rName, "password_char_combination", "3"),
+					resource.TestCheckResourceAttr(rName, "allow_user_to_change_password", "false"),
 				),
 			},
 			{
-				Config: testAccV5PasswordPolicy_update(),
+				Config: testAccV5PasswordPolicy_basic_step2,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "maximum_consecutive_identical_chars", "2"),
-					resource.TestCheckResourceAttr(resourceName, "minimum_password_age", "60"),
-					resource.TestCheckResourceAttr(resourceName, "minimum_password_length", "20"),
-					resource.TestCheckResourceAttr(resourceName, "password_reuse_prevention", "4"),
-					resource.TestCheckResourceAttr(resourceName, "password_not_username_or_invert", "true"),
-					resource.TestCheckResourceAttr(resourceName, "password_validity_period", "120"),
-					resource.TestCheckResourceAttr(resourceName, "password_char_combination", "4"),
-					resource.TestCheckResourceAttr(resourceName, "allow_user_to_change_password", "true"),
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "maximum_consecutive_identical_chars", "2"),
+					resource.TestCheckResourceAttr(rName, "minimum_password_age", "60"),
+					resource.TestCheckResourceAttr(rName, "minimum_password_length", "20"),
+					resource.TestCheckResourceAttr(rName, "password_reuse_prevention", "4"),
+					resource.TestCheckResourceAttr(rName, "password_not_username_or_invert", "true"),
+					resource.TestCheckResourceAttr(rName, "password_validity_period", "120"),
+					resource.TestCheckResourceAttr(rName, "password_char_combination", "4"),
+					resource.TestCheckResourceAttr(rName, "allow_user_to_change_password", "true"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -62,78 +106,8 @@ func TestAccV5PasswordPolicy_basic(t *testing.T) {
 	})
 }
 
-func testAccV5CheckPasswordPolicyExists(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("resource not found: %s", n)
-		}
-		if rs.Primary.ID == "" {
-			return errors.New("resource ID is not set")
-		}
-
-		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
-		region := acceptance.HW_REGION_NAME
-		client, err := cfg.IAMNoVersionClient(region)
-		if err != nil {
-			return fmt.Errorf("error creating IAM client: %s", err)
-		}
-
-		getPasswordPolicyHttpUrl := "v5/password-policy"
-		getPasswordPolicyPath := client.Endpoint + getPasswordPolicyHttpUrl
-		getPasswordPolicyOpt := golangsdk.RequestOpts{KeepResponseBody: true}
-		_, err = client.Request("GET", getPasswordPolicyPath, &getPasswordPolicyOpt)
-		if err != nil {
-			return fmt.Errorf("error retrieving IAM password policy: %s", err)
-		}
-		return err
-	}
-}
-
-func testAccV5CheckPasswordPolicyDestroy(s *terraform.State) error {
-	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
-	region := acceptance.HW_REGION_NAME
-	client, err := cfg.IAMNoVersionClient(region)
-	if err != nil {
-		return fmt.Errorf("error creating IAM client: %s", err)
-	}
-
-	getPasswordPolicyHttpUrl := "v5/password-policy"
-	getPasswordPolicyPath := client.Endpoint + getPasswordPolicyHttpUrl
-	getPasswordPolicyOpt := golangsdk.RequestOpts{KeepResponseBody: true}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "huaweicloud_identityv5_password_policy" {
-			continue
-		}
-
-		getPasswordPolicyResp, err := client.Request("GET", getPasswordPolicyPath, &getPasswordPolicyOpt)
-		if err != nil {
-			return fmt.Errorf("error fetching the IAM account password policy: %s", err)
-		}
-
-		getPasswordPolicyBody, err := utils.FlattenResponse(getPasswordPolicyResp)
-		if err != nil {
-			return err
-		}
-
-		if utils.PathSearch("password_policy.maximum_consecutive_identical_chars", getPasswordPolicyBody, float64(0)).(float64) != 0 ||
-			utils.PathSearch("password_policy.minimum_password_age", getPasswordPolicyBody, float64(0)).(float64) != 0 ||
-			utils.PathSearch("password_policy.minimum_password_length", getPasswordPolicyBody, float64(0)).(float64) != 8 ||
-			utils.PathSearch("password_policy.password_reuse_prevention", getPasswordPolicyBody, float64(0)).(float64) != 1 ||
-			!utils.PathSearch("password_policy.password_not_username_or_invert", getPasswordPolicyBody, false).(bool) ||
-			utils.PathSearch("password_policy.password_validity_period", getPasswordPolicyBody, float64(0)).(float64) != 0 ||
-			utils.PathSearch("password_policy.password_char_combination", getPasswordPolicyBody, float64(0)).(float64) != 2 ||
-			!utils.PathSearch("password_policy.allow_user_to_change_password", getPasswordPolicyBody, false).(bool) {
-			return errors.New("the password policy failed to reset to defaults")
-		}
-	}
-	return nil
-}
-
-func testAccV5PasswordPolicy_basic() string {
-	return `
-resource "huaweicloud_identityv5_password_policy" "enhanced" {
+const testAccV5PasswordPolicy_basic_step1 = `
+resource "huaweicloud_identityv5_password_policy" "test" {
   maximum_consecutive_identical_chars = 1
   minimum_password_age                = 30
   minimum_password_length             = 10
@@ -144,11 +118,9 @@ resource "huaweicloud_identityv5_password_policy" "enhanced" {
   allow_user_to_change_password       = false
 }
 `
-}
 
-func testAccV5PasswordPolicy_update() string {
-	return `
-resource "huaweicloud_identityv5_password_policy" "enhanced" {
+const testAccV5PasswordPolicy_basic_step2 = `
+resource "huaweicloud_identityv5_password_policy" "test" {
   maximum_consecutive_identical_chars = 2
   minimum_password_age                = 60
   minimum_password_length             = 20
@@ -159,4 +131,3 @@ resource "huaweicloud_identityv5_password_policy" "enhanced" {
   allow_user_to_change_password       = true
 }
 `
-}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:
- Hard-coding
- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the v5 password policy resource's test
2. update the check items and function naming
3. remove redundant functions
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV5PasswordPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5PasswordPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccV5PasswordPolicy_basic
=== PAUSE TestAccV5PasswordPolicy_basic
=== CONT  TestAccV5PasswordPolicy_basic
--- PASS: TestAccV5PasswordPolicy_basic (58.47s)
PASS
coverage: 2.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       58.621s coverage: 2.3% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
