### PR TITLE
test(iam): optimize the acceptance case for v5 policy group attach

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_policy_group_attach_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_policy_group_attach_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 )
 
-func getIdentityV5PolicyGroupAttachResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getV5PolicyGroupAttachResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := cfg.NewServiceClient("iam", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
@@ -22,13 +22,13 @@ func getIdentityV5PolicyGroupAttachResourceFunc(cfg *config.Config, state *terra
 	return iam.GetGroupAttachedIdentityV5Policy(client, state.Primary.Attributes["group_id"], state.Primary.Attributes["policy_id"])
 }
 
-func TestAccIdentityV5PolicyGroupAttach_basic(t *testing.T) {
+func TestAccV5PolicyGroupAttach_basic(t *testing.T) {
 	var (
 		name = acceptance.RandomAccResourceName()
 
 		obj   interface{}
 		rName = "huaweicloud_identityv5_policy_group_attach.test"
-		rc    = acceptance.InitResourceCheck(rName, &obj, getIdentityV5PolicyGroupAttachResourceFunc)
+		rc    = acceptance.InitResourceCheck(rName, &obj, getV5PolicyGroupAttachResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -39,7 +39,7 @@ func TestAccIdentityV5PolicyGroupAttach_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityV5PolicyGroupAttach_basic(name),
+				Config: testAccV5PolicyGroupAttach_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "policy_id", "huaweicloud_identity_policy.test", "id"),
@@ -54,13 +54,13 @@ func TestAccIdentityV5PolicyGroupAttach_basic(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccIdentityV5PolicyGroupAttachImportState(rName),
+				ImportStateIdFunc: testAccV5PolicyGroupAttachImportState(rName),
 			},
 		},
 	})
 }
 
-func testAccIdentityV5PolicyGroupAttach_basic(rName string) string {
+func testAccV5PolicyGroupAttach_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_policy" "test" {
   name            = "%[1]s"
@@ -88,7 +88,7 @@ resource "huaweicloud_identityv5_policy_group_attach" "test" {
 `, rName)
 }
 
-func testAccIdentityV5PolicyGroupAttachImportState(rName string) resource.ImportStateIdFunc {
+func testAccV5PolicyGroupAttachImportState(rName string) resource.ImportStateIdFunc {
 	return func(state *terraform.State) (string, error) {
 		rs, ok := state.RootModule().Resources[rName]
 		if !ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Standardize the methods naming in the `huaweicloud_identityv5_policy_group_attach` resource test.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. standardize the methods naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o iam -f TestAccV5PolicyGroupAttach_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5PolicyGroupAttach_basic -timeout 360m -parallel 10
=== RUN   TestAccV5PolicyGroupAttach_basic
=== PAUSE TestAccV5PolicyGroupAttach_basic
=== CONT  TestAccV5PolicyGroupAttach_basic
--- PASS: TestAccV5PolicyGroupAttach_basic (31.27s)
PASS
coverage: 4.8% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       31.503s coverage: 4.8% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
