### PR TITLE
fix(eps): eliminate potential vulnerabilities in the datasource configs

### DIFF
--- a/docs/data-sources/enterprise_project_configs.md
+++ b/docs/data-sources/enterprise_project_configs.md
@@ -22,10 +22,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `support_item` - The configurations of EPS.
-  The [configuration](#eps_config) structure is documented below.
+* `support_item_attribute` - The configurations of EPS.
+  The [support_item_attribute](#support_item_attribute_struct) structure is documented below.
 
-<a name="eps_config"></a>
-The `configuration` block supports:
+<a name="support_item_attribute_struct"></a>
+The `support_item_attribute` block supports:
 
-* `delete_ep_support` - Whether enterprise projects can be deleted.
+* `delete_ep_support_attribute` - Whether enterprise projects can be deleted.

--- a/huaweicloud/services/acceptance/eps/data_source_huaweicloud_enterprise_project_configs_test.go
+++ b/huaweicloud/services/acceptance/eps/data_source_huaweicloud_enterprise_project_configs_test.go
@@ -9,8 +9,10 @@ import (
 )
 
 func TestAccDataEnterpriseProjectConfigs_basic(t *testing.T) {
-	all := "data.huaweicloud_enterprise_project_configs.test"
-	dc := acceptance.InitDataSourceCheck(all)
+	var (
+		dataSourceName = "data.huaweicloud_enterprise_project_configs.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -20,7 +22,8 @@ func TestAccDataEnterpriseProjectConfigs_basic(t *testing.T) {
 				Config: testAccDataEnterpriseProjectConfigs_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckOutput("huaweicloud_enterprise_project_configs", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "support_item_attribute.0.delete_ep_support_attribute"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "support_item.delete_ep_support"),
 				),
 			},
 		},
@@ -29,8 +32,4 @@ func TestAccDataEnterpriseProjectConfigs_basic(t *testing.T) {
 
 const testAccDataEnterpriseProjectConfigs_basic = `
 data "huaweicloud_enterprise_project_configs" "test" {}
-
-output "huaweicloud_enterprise_project_configs" {
-  value = data.huaweicloud_enterprise_project_configs.test.support_item.delete_ep_support == true
-}
 `


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

eliminate potential vulnerabilities in the datasource configs
- Modify the data structure of the parameter fields to align with the API documentation.
- Refactor the code in the code files and test case files.
- Improve document content quality.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o eps -f TestAccDataEnterpriseProjectConfigs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eps" -v -coverprofile="./huaweicloud/services/acceptance/eps/eps_coverage.cov" -coverpkg="./huaweicloud/services/eps" -run TestAccDataEnterpriseProjectConfigs_basic -timeout 360m -parallel 10
=== RUN   TestAccDataEnterpriseProjectConfigs_basic
=== PAUSE TestAccDataEnterpriseProjectConfigs_basic
=== CONT  TestAccDataEnterpriseProjectConfigs_basic
--- PASS: TestAccDataEnterpriseProjectConfigs_basic (12.08s)
PASS
coverage: 6.8% of statements in ./huaweicloud/services/eps
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eps       12.159s coverage: 6.8% of statements in ./huaweicloud/services/eps
```
<img width="1329" height="66" alt="image" src="https://github.com/user-attachments/assets/f4dc1b89-ffde-4fd8-97d2-1fdb84c6e571" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
