### PR TITLE
test(iam): optimize the acceptance case for v5 resource tag

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_resource_tags_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_resource_tags_test.go
@@ -32,15 +32,33 @@ func TestAccDataSourceIdentityv5ResourceTags_basic(t *testing.T) {
 	})
 }
 
+func testAccDataV5Tags_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identityv5_user" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_identityv5_resource_tag" "test" {
+  resource_type = "user"
+  resource_id   = huaweicloud_identityv5_user.test.id
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, name)
+}
+
 func testDataSourceIdentityv5Tags_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 data "huaweicloud_identityv5_resource_tags" "test" {
   resource_type = "user"
-  resource_id   = huaweicloud_identityv5_user.user_1.id
+  resource_id   = huaweicloud_identityv5_user.test.id
   
   depends_on = [huaweicloud_identityv5_resource_tag.test]
 }
-`, testAccV5ResourceTag_basic(name))
+`, testAccDataV5Tags_base(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:
- Redundant naming

 
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Standardize variables and methods naming for huaweicloud_identityv5_resource_tag resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o iam -f TestAccV5ResourceTag_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5ResourceTag_basic -timeout 360m -parallel 10
=== RUN   TestAccV5ResourceTag_basic
=== PAUSE TestAccV5ResourceTag_basic
=== CONT  TestAccV5ResourceTag_basic
--- PASS: TestAccV5ResourceTag_basic (53.32s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       53.506s coverage: 4.3% of statements in ./huaweicloud/services/iam
```

```
./scripts/coverage.sh -o iam -f TestAccDataSourceIdentityv5ResourceTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataSourceIdentityv5ResourceTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceIdentityv5ResourceTags_basic
=== PAUSE TestAccDataSourceIdentityv5ResourceTags_basic
=== CONT  TestAccDataSourceIdentityv5ResourceTags_basic
--- PASS: TestAccDataSourceIdentityv5ResourceTags_basic (18.99s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       19.100s coverage: 4.3% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
