### PR TITLE
test(iam): optimize the acceptance case for v5 user password

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_user_password_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_user_password_test.go
@@ -9,35 +9,87 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccIdentityV5UserPassword_basic(t *testing.T) {
-	password := "TestPassword#$%111"
-	originalPassword := "TestPassword#$%"
-	resourceName := "huaweicloud_identityv5_user_password.test"
+func TestAccV5UserPassword_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		rName = "huaweicloud_identityv5_user_password.test"
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      nil,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source: "hashicorp/random",
+				// The version of the random provider must be greater than 3.3.0 to support the 'numeric' parameter.
+				VersionConstraint: "3.3.0",
+			},
+		},
+		// This is a one-time resource without delete logic.
+		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityV5UserPassword_basic(password, originalPassword),
+				Config: testAccV5UserPassword_basic_step1(name),
+			},
+			{
+				Config: testAccV5UserPassword_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "new_password", password),
-					resource.TestCheckResourceAttr(resourceName, "old_password", originalPassword),
+					resource.TestCheckResourceAttrPair(rName, "old_password", "random_string.test.0", "result"),
+					resource.TestCheckResourceAttrPair(rName, "new_password", "random_string.test.1", "result"),
 				),
 			},
 		},
 	})
 }
 
-func testAccIdentityV5UserPassword_basic(newPassword, oldPassword string) string {
+func testAccV5UserPassword_basic_step1(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identityv5_user_password" "test" {
-  new_password = "%[1]s"
-  old_password = "%[2]s"
+resource "huaweicloud_identityv5_user" "test" {
+  name = "%[1]s"
 }
-`, newPassword, oldPassword)
+
+resource "huaweicloud_identityv5_access_key" "test" {
+  user_id = huaweicloud_identityv5_user.test.id
+}
+
+resource "random_string" "test" {
+  count = 2
+
+  length           = 10
+  min_numeric      = 1
+  min_special      = 2
+  min_lower        = 1
+  override_special = "@!#&"
+}
+
+resource "huaweicloud_identityv5_login_profile" "test" {
+  user_id  = huaweicloud_identityv5_user.test.id
+  password = random_string.test[0].result
+}
+`, name)
+}
+
+// lintignore:AT004
+func testAccV5UserPassword_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+provider "huaweicloud" {
+  alias  = "new_user"
+  region = "%[2]s"
+
+  access_key = huaweicloud_identityv5_access_key.test.id
+  secret_key = huaweicloud_identityv5_access_key.test.secret_access_key
+}
+
+resource "huaweicloud_identityv5_user_password" "test" {
+  provider = huaweicloud.new_user
+
+  new_password = random_string.test[1].result
+  old_password = huaweicloud_identityv5_login_profile.test.password
+
+  depends_on = [huaweicloud_identityv5_login_profile.test]
+}
+`, testAccV5UserPassword_basic_step1(name), acceptance.HW_REGION_NAME)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

- Hard-coding
- Redundant naming
- Insufficiently precise checks


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the  huaweicloud_identityv5_user_password resource's test
2. update the check items and function naming
3. optimize test scenario of user resources and their reference
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
huawei@wuzhuanhong-dev:~/go/src/terraform-provider-huaweicloud$ ./scripts/coverage.sh -o iam -f TestAccV5UserPassword_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5UserPassword_basic -timeout 360m -parallel 10
=== RUN   TestAccV5UserPassword_basic
=== PAUSE TestAccV5UserPassword_basic
=== CONT  TestAccV5UserPassword_basic
--- PASS: TestAccV5UserPassword_basic (48.18s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       48.323s coverage: 5.1% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
