### PR TITLE
test(iam): optimize the acceptance case for v5 user

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_user_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_user_test.go
@@ -9,15 +9,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/identity/v3.0/users"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getIdentityUserResourceFuncV5(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.NewServiceClient("iam_no_version", acceptance.HW_REGION_NAME)
+func getV5UserResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("iam", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
@@ -34,17 +33,15 @@ func getIdentityUserResourceFuncV5(cfg *config.Config, state *terraform.Resource
 	return utils.FlattenResponse(getUserResp)
 }
 
-func TestAccIdentityV5User_basic(t *testing.T) {
-	var user users.User
-	userName := acceptance.RandomAccResourceName()
-	userNameUpdate := acceptance.RandomAccResourceName()
+// Please ensure that the user executing the acceptance test has 'admin' permission.
+func TestAccV5User_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
 
-	resourceName := "huaweicloud_identityv5_user.user_1"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&user,
-		getIdentityUserResourceFuncV5,
+		obj   interface{}
+		rName = "huaweicloud_identityv5_user.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getV5UserResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -56,57 +53,78 @@ func TestAccIdentityV5User_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityV5User_basic(userName),
+				Config: testAccV5User_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", userName),
-					resource.TestCheckResourceAttr(resourceName, "description", "tested by terraform"),
-					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
-					resource.TestCheckResourceAttrSet(resourceName, "is_root_user"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "urn"),
-					resource.TestCheckResourceAttrSet(resourceName, "tags.#"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "tested by terraform"),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
+					// Check attributes.
+					resource.TestCheckResourceAttrSet(rName, "is_root_user"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "urn"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				Config: testAccV5User_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "update by terraform"),
+					resource.TestCheckResourceAttr(rName, "enabled", "false"),
+					resource.TestCheckResourceAttr(rName, "tags.#", "0"),
+				),
+			},
+			// Only used to check the 'tags' attribute.
+			{
+				Config: testAccV5User_basic_step3(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(rName, "tags.0.tag_key", "foo"),
+					resource.TestCheckResourceAttr(rName, "tags.0.tag_value", "bar"),
+				),
+			},
+			{
+				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-			{
-				Config: testAccIdentityV5User_update(userNameUpdate),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", userNameUpdate),
-					resource.TestCheckResourceAttr(resourceName, "description", "update by terraform"),
-					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "is_root_user"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "urn"),
-					resource.TestCheckResourceAttrSet(resourceName, "tags.#"),
-				),
 			},
 		},
 	})
 }
 
-func testAccIdentityV5User_basic(name string) string {
+func testAccV5User_basic_step1(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identityv5_user" "user_1" {
- name        = "%[1]s"
- description = "tested by terraform"
+resource "huaweicloud_identityv5_user" "test" {
+  name        = "%[1]s"
+  description = "tested by terraform"
 }
 `, name)
 }
 
-func testAccIdentityV5User_update(name string) string {
+func testAccV5User_basic_step2(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identityv5_user" "user_1" {
+resource "huaweicloud_identityv5_user" "test" {
   name        = "%[1]s"
   enabled     = false
   description = "update by terraform"
 }
+
+resource "huaweicloud_identityv5_resource_tag" "test" {
+  resource_type = "user"
+  resource_id   = huaweicloud_identityv5_user.test.id
+
+  tags = {
+    foo = "bar"
+  }
+}
 `, name)
+}
+
+// Only used to check the 'tags' attribute.
+// In step two, a tag is added to the user, but 'tags' is only an attribute,
+// so the value of 'tags' can only be obtained after refreshing the resource in step three.
+func testAccV5User_basic_step3(name string) string {
+	return testAccV5User_basic_step2(name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

- Hard-coding
- Redundant naming
- Insufficiently precise checks


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the user resource's test
2. update the check items and function naming
3. optimize test scenario of user resources and their reference
4. supplement some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV5User_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5User_basic -timeout 360m -parallel 10
=== RUN   TestAccV5User_basic
=== PAUSE TestAccV5User_basic
=== CONT  TestAccV5User_basic
--- PASS: TestAccV5User_basic (64.20s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       64.294s coverage: 4.2% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
