### PR TITLE
test(iam): optimize the acceptance case for v5 service link agency

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -56,9 +56,11 @@ var (
 	HW_SECURITY_GROUP_ID             = os.Getenv("HW_SECURITY_GROUP_ID")
 	HW_ENTERPRISE_PROJECT_ID         = os.Getenv("HW_ENTERPRISE_PROJECT_ID")
 	HW_ENTERPRISE_PROJECT_NAME       = os.Getenv("HW_ENTERPRISE_PROJECT_NAME")
-	HW_ADMIN                         = os.Getenv("HW_ADMIN")
-	HW_IAM_V5                        = os.Getenv("HW_IAM_V5")
-	HW_RUNNER_PUBLIC_IP              = os.Getenv("HW_RUNNER_PUBLIC_IP")
+
+	HW_ADMIN                               = os.Getenv("HW_ADMIN")
+	HW_IAM_V5                              = os.Getenv("HW_IAM_V5")
+	HW_IAM_SERVICE_LINKED_AGENCY_PRINCIPAL = os.Getenv("HW_IAM_SERVICE_LINKED_AGENCY_PRINCIPAL")
+	HW_RUNNER_PUBLIC_IP                    = os.Getenv("HW_RUNNER_PUBLIC_IP")
 
 	// CBR environment
 	HW_CBR_ECS_BACKUP_ID          = os.Getenv("HW_CBR_ECS_BACKUP_ID")          // The ECS backup ID.
@@ -1628,6 +1630,13 @@ func TestAccPreCheckAdminOnly(t *testing.T) {
 func TestAccPreCheckIAMV5(t *testing.T) {
 	if HW_IAM_V5 == "" {
 		t.Skip("This environment does not support IAM v5 tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckServiceLinkedAgencyPrincipal(t *testing.T) {
+	if HW_IAM_SERVICE_LINKED_AGENCY_PRINCIPAL == "" {
+		t.Skip("HW_IAM_SERVICE_LINKED_AGENCY_PRINCIPAL must be set for this acceptance test")
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

- Hard-coding
- Redundant naming

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the huaweicloud_identityv5_service_linked_agency resource's test
2. update the check items and function naming
3. add an environment variable HW_IAM_SERVICE_LINKED_AGENCY_PRINCIPAL as the service principal
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV5ServiceLinkedService_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5ServiceLinkedService_basic -timeout 360m -parallel 10
=== RUN   TestAccV5ServiceLinkedService_basic
=== PAUSE TestAccV5ServiceLinkedService_basic
=== CONT  TestAccV5ServiceLinkedService_basic
--- PASS: TestAccV5ServiceLinkedService_basic (28.97s)
PASS
coverage: 2.2% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       29.242s coverage: 2.2% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
