### PR TITLE
test(iam): optimize test for query v5 access key and feature status

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_account_feature_status_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_account_feature_status_test.go
@@ -8,27 +8,29 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityV5AccountFeatureStatus_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identityv5_account_feature_status.test"
+func TestAccDataAccountFeatureStatus_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_identityv5_account_feature_status.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIdentityV5AccountFeatureStatus_basic(),
+				Config: testAccDataV5AccountFeatureStatus_basic,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "feature_status"),
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dcName, "feature_status"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceIdentityV5AccountFeatureStatus_basic() string {
-	return `
+const testAccDataV5AccountFeatureStatus_basic = `
 data "huaweicloud_identityv5_account_feature_status" "test" {
-	feature_name = "v5_console"
+  feature_name = "v5_console"
 }
 `
-}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

- Redundant naming
- Insufficiently precise checks

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the check items and function naming
2. optimize test scenario of user resources and their reference
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccDataV5AccessKey_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5AccessKey_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5AccessKey_basic
=== PAUSE TestAccDataV5AccessKey_basic
=== CONT  TestAccDataV5AccessKey_basic
--- PASS: TestAccDataV5AccessKey_basic (26.68s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       26.809s coverage: 4.5% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccDataAccountFeatureStatus_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataAccountFeatureStatus_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAccountFeatureStatus_basic
=== PAUSE TestAccDataAccountFeatureStatus_basic
=== CONT  TestAccDataAccountFeatureStatus_basic
--- PASS: TestAccDataAccountFeatureStatus_basic (16.27s)
PASS
coverage: 2.0% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       16.428s coverage: 2.0% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
