### PR TITLE
test(iam): optimize the acceptance case design for policy, project and provider

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_policy_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_policy_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getIdentityPolicyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getPolicyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := cfg.NewServiceClient("iam_no_version", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
@@ -35,44 +35,41 @@ func getIdentityPolicyResourceFunc(cfg *config.Config, state *terraform.Resource
 	return utils.FlattenResponse(getPolicyResp)
 }
 
-func TestAccIdentityPolicy_basic(t *testing.T) {
-	var object interface{}
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_identity_policy.test"
+func TestAccPolicy_basic(t *testing.T) {
+	var (
+		object interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&object,
-		getIdentityPolicyResourceFunc,
+		resourceName = "huaweicloud_identity_policy.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &object, getPolicyResourceFunc)
+
+		name = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckAdminOnly(t)
-			acceptance.TestAccPreCheckIAMV5(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityPolicy_basic(rName),
+				Config: testAccPolicy_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "description", "test for terraform"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
 					resource.TestCheckResourceAttr(resourceName, "policy_type", "custom"),
 					resource.TestCheckResourceAttr(resourceName, "default_version_id", "v1"),
 					resource.TestCheckResourceAttr(resourceName, "version_ids.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "attachment_count"),
-					resource.TestCheckResourceAttrSet(resourceName, "version_ids"),
 					resource.TestCheckResourceAttrSet(resourceName, "urn"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 				),
 			},
 			{
-				Config: testAccIdentityPolicy_update(rName),
+				Config: testAccPolicy_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "default_version_id", "v2"),
@@ -88,11 +85,11 @@ func TestAccIdentityPolicy_basic(t *testing.T) {
 	})
 }
 
-func testAccIdentityPolicy_basic(rName string) string {
+func testAccPolicy_basic_step1(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_policy" "test" {
-  name            = "%s"
-  description     = "test for terraform"
+  name            = "%[1]s"
+  description     = "Created by terraform script"
   policy_document = jsonencode(
     {
       Statement = [
@@ -105,14 +102,14 @@ resource "huaweicloud_identity_policy" "test" {
     }
   )
 }
-`, rName)
+`, name)
 }
 
-func testAccIdentityPolicy_update(rName string) string {
+func testAccPolicy_basic_step2(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_policy" "test" {
-  name            = "%s"
-  description     = "test for terraform"
+  name            = "%[1]s"
+  description     = "Created by terraform script"
   policy_document = jsonencode(
     {
       Statement = [
@@ -125,5 +122,5 @@ resource "huaweicloud_identity_policy" "test" {
     }
   )
 }
-`, rName)
+`, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

- Hard-coding
- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the IAM resource's test
2. update the check items and function naming
3. combine some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccProject_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccProject_basic -timeout 360m -parallel 10
=== RUN   TestAccProject_basic
=== PAUSE TestAccProject_basic
=== CONT  TestAccProject_basic
--- PASS: TestAccProject_basic (24.08s)
PASS
coverage: 2.6% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       24.165s coverage: 2.6% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccPolicy_basic
=== PAUSE TestAccPolicy_basic
=== CONT  TestAccPolicy_basic
--- PASS: TestAccPolicy_basic (24.37s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       24.480s coverage: 3.5% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccProtectionPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccProtectionPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccProtectionPolicy_basic
=== PAUSE TestAccProtectionPolicy_basic
=== CONT  TestAccProtectionPolicy_basic
--- PASS: TestAccProtectionPolicy_basic (34.93s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       35.021s coverage: 2.7% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccProviderConversion_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccProviderConversion_basic -timeout 360m -parallel 10
=== RUN   TestAccProviderConversion_basic
=== PAUSE TestAccProviderConversion_basic
=== CONT  TestAccProviderConversion_basic
--- PASS: TestAccProviderConversion_basic (23.13s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       23.221s coverage: 4.7% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccProviderMapping_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccProviderMapping_basic -timeout 360m -parallel 10
=== RUN   TestAccProviderMapping_basic
=== PAUSE TestAccProviderMapping_basic
=== CONT  TestAccProviderMapping_basic
--- PASS: TestAccProviderMapping_basic (23.39s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       23.494s coverage: 4.7% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
