### PR TITLE
test(iam): optimize the acceptance test for v5 query virtual MFA devices

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_virtual_mfa_devices_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_virtual_mfa_devices_test.go
@@ -1,6 +1,8 @@
 package iam
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,28 +10,80 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityV5VirtualMfaDevices_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identityv5_virtual_mfa_devices.test"
+// Please ensure that the user executing the acceptance test has 'admin' permission.
+func TestAccDataV5VirtualMfaDevices_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_identityv5_virtual_mfa_devices.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byUserId   = "data.huaweicloud_identityv5_virtual_mfa_devices.filter_by_user_id"
+		dcByUserId = acceptance.InitDataSourceCheck(byUserId)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIdentityV5VirtualMfaDevices_basic(),
+				Config: testAccDataV5VirtualMfaDevices_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "devices.#"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.enabled"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.serial_number"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.user_id"),
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "devices.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'user_id' parameter.
+					dcByUserId.CheckResourceExists(),
+					resource.TestCheckOutput("is_user_id_filter_useful", "true"),
+					resource.TestCheckResourceAttrPair(byUserId, "devices.0.enabled",
+						"huaweicloud_identityv5_virtual_mfa_device.test", "enabled"),
+					resource.TestCheckResourceAttrPair(byUserId, "devices.0.serial_number",
+						"huaweicloud_identityv5_virtual_mfa_device.test", "id"),
+					resource.TestCheckResourceAttrPair(byUserId, "devices.0.user_id",
+						"huaweicloud_identityv5_virtual_mfa_device.test", "user_id"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceIdentityV5VirtualMfaDevices_basic() string {
-	return `
-data "huaweicloud_identityv5_virtual_mfa_devices" "test" {}
-`
+func testAccDataV5VirtualMfaDevices_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identityv5_user" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_identityv5_virtual_mfa_device" "test" {
+  name    = "%[1]s"
+  user_id = huaweicloud_identityv5_user.test.id
+}
+
+# Without any filter parameters.
+data "huaweicloud_identityv5_virtual_mfa_devices" "test" {
+  depends_on = [huaweicloud_identityv5_virtual_mfa_device.test]
+}
+
+# Filter by 'user_id' parameter.
+locals {
+  user_id = huaweicloud_identityv5_user.test.id
+}
+
+data "huaweicloud_identityv5_virtual_mfa_devices" "filter_by_user_id" {
+  user_id = local.user_id
+
+  depends_on = [huaweicloud_identityv5_virtual_mfa_device.test]
+}
+
+locals {
+  user_id_filter_result = [for v in data.huaweicloud_identityv5_virtual_mfa_devices.filter_by_user_id.devices[*].user_id :
+  v == local.user_id]
+}
+
+output "is_user_id_filter_useful" {
+  value = length(local.user_id_filter_result) > 0 && alltrue(local.user_id_filter_result)
+}
+`, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:
- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the huaweicloud_identityv5_virtual_mfa_devices data source's test
2. update the check items and function naming
3. supplement some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o iam -f TestAccDataV5VirtualMfaDevices_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5VirtualMfaDevices_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5VirtualMfaDevices_basic
=== PAUSE TestAccDataV5VirtualMfaDevices_basic
=== CONT  TestAccDataV5VirtualMfaDevices_basic
--- PASS: TestAccDataV5VirtualMfaDevices_basic (21.88s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       22.026s coverage: 4.2% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
