### PR TITLE
test(iam): optimize the acceptance test for v5 query user

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_users_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_users_test.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,44 +10,172 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityV5Users_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identityv5_users.test"
-	name := acceptance.RandomAccResourceName()
+// Please ensure that the user executing the acceptance test has 'admin' permission.
+func TestAccDataV5Users_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_identityv5_users.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byGroupId   = "data.huaweicloud_identityv5_users.filter_by_group_id"
+		dcByGroupId = acceptance.InitDataSourceCheck(byGroupId)
+
+		byUserId   = "data.huaweicloud_identityv5_users.filter_by_user_id"
+		dcByUserId = acceptance.InitDataSourceCheck(byUserId)
+
+		byWithoutLoginProfile   = "data.huaweicloud_identityv5_users.filter_by_without_login_profile"
+		dcByWithoutLoginProfile = acceptance.InitDataSourceCheck(byWithoutLoginProfile)
+	)
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source: "hashicorp/random",
+				// The version of the random provider must be greater than 3.3.0 to support the 'numeric' parameter.
+				VersionConstraint: "3.3.0",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIdentityV5Users_basic(),
+				Config: testAccDataV5Users_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "users.#"),
-				),
-			},
-			{
-				Config: testAccDataSourceIdentityV5Users_showUser(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "users.#"),
+					// Without any filter parameter.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "users.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'group_id' parameter.
+					dcByGroupId.CheckResourceExists(),
+					resource.TestCheckOutput("is_group_id_filter_useful", "true"),
+					// Filter by 'user_id' parameter.
+					dcByUserId.CheckResourceExists(),
+					resource.TestCheckOutput("is_user_id_filter_useful", "true"),
+					// Check other attributes.
+					// Current user is new created, not logged in yet, so 'last_login_at' attribute is empty and not checked.
+					resource.TestCheckResourceAttrPair(byUserId, "users.0.user_id", "huaweicloud_identityv5_user.test.0", "id"),
+					resource.TestCheckResourceAttrPair(byUserId, "users.0.user_name", "huaweicloud_identityv5_user.test.0", "name"),
+					resource.TestCheckResourceAttrPair(byUserId, "users.0.enabled", "huaweicloud_identityv5_user.test.0", "enabled"),
+					resource.TestCheckResourceAttrPair(byUserId, "users.0.description", "huaweicloud_identityv5_user.test.0", "description"),
+					resource.TestCheckResourceAttrPair(byUserId, "users.0.is_root_user", "huaweicloud_identityv5_user.test.0", "is_root_user"),
+					resource.TestCheckResourceAttrPair(byUserId, "users.0.created_at", "huaweicloud_identityv5_user.test.0", "created_at"),
+					resource.TestCheckResourceAttrPair(byUserId, "users.0.urn", "huaweicloud_identityv5_user.test.0", "urn"),
+					resource.TestCheckResourceAttr(byUserId, "users.0.tags.0.tag_key", "owner"),
+					resource.TestCheckResourceAttr(byUserId, "users.0.tags.0.tag_value", "terraform"),
+					resource.TestCheckResourceAttrPair(byUserId, "users.0.password_reset_required",
+						"huaweicloud_identityv5_login_profile.test", "password_reset_required"),
+					resource.TestCheckResourceAttrPair(byUserId, "users.0.password_expires_at",
+						"huaweicloud_identityv5_login_profile.test", "password_expires_at"),
+					// To test the case of new users not setting login password.
+					dcByWithoutLoginProfile.CheckResourceExists(),
+					resource.TestCheckOutput("without_login_psw_validation_pass", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceIdentityV5Users_basic() string {
-	return `
-data "huaweicloud_identityv5_users" "test" {}
-`
-}
-
-func testAccDataSourceIdentityV5Users_showUser(name string) string {
+func testAccDataV5Users_base(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identityv5_user" "user_1" {
- name        = "%[1]s"
- description = "tested by terraform"
+resource "huaweicloud_identityv5_user" "test" {
+  count = 2
+
+  name        = "%[1]s${count.index}"
+  description = "created by terraform script"
+  enabled     = true
 }
 
-data "huaweicloud_identityv5_users" "test" {
-	user_id = huaweicloud_identityv5_user.user_1.id
+resource "huaweicloud_identityv5_group" "test" {
+  group_name = "%[1]s"
+}
+
+locals {
+  user_id = try(huaweicloud_identityv5_user.test[0].id, null)
+}
+
+resource "huaweicloud_identityv5_group_membership" "test" {
+  group_id     = huaweicloud_identityv5_group.test.id
+  user_id_list = [local.user_id]
+}
+
+resource "huaweicloud_identityv5_resource_tag" "test" {
+  resource_type = "user"
+  resource_id   = local.user_id
+
+  tags = {
+    owner = "terraform"
+  }
+}
+
+resource "random_string" "test" {
+  length           = 10
+  min_numeric      = 1
+  min_special      = 1
+  min_lower        = 1
+  override_special = "@!"
+}
+
+resource "huaweicloud_identityv5_login_profile" "test" {
+  user_id                 = local.user_id
+  password                = random_string.test.result
+  password_reset_required = true
 }
 `, name)
+}
+
+func testAccDataV5Users_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_identityv5_users" "test" {
+  depends_on = [huaweicloud_identityv5_user.test]
+}
+
+# Filter by 'group_id' parameter.
+locals {
+  group_id = huaweicloud_identityv5_group.test.id
+}
+
+data "huaweicloud_identityv5_users" "filter_by_group_id" {
+  group_id = local.group_id
+
+  depends_on = [huaweicloud_identityv5_group_membership.test]
+}
+
+output "is_group_id_filter_useful" {
+  value = contains(data.huaweicloud_identityv5_users.filter_by_group_id.users[*].user_id, local.user_id)
+}
+
+# Filter by 'user_id' parameter.
+data "huaweicloud_identityv5_users" "filter_by_user_id" {
+  user_id = local.user_id
+
+  depends_on = [
+    huaweicloud_identityv5_resource_tag.test,
+    huaweicloud_identityv5_login_profile.test,
+  ]
+}
+
+locals {
+  user_id_filter_result = [for v in data.huaweicloud_identityv5_users.filter_by_user_id.users[*].user_id :
+  v == local.user_id]
+}
+
+output "is_user_id_filter_useful" {
+  value = length(local.user_id_filter_result) > 0 && alltrue(local.user_id_filter_result)
+}
+
+# To test the case of new users not setting login password.
+data "huaweicloud_identityv5_users" "filter_by_without_login_profile" {
+  user_id = try(huaweicloud_identityv5_user.test[1].id, null)
+}
+
+output "without_login_psw_validation_pass" {
+  value = length(data.huaweicloud_identityv5_users.filter_by_without_login_profile.users) > 0
+}
+`, testAccDataV5Users_base(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the huaweicloud_identityv5_users data source's test
2. update the check items and function naming
3. supplement some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o iam -f TestAccDataV5Users_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5Users_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5Users_basic
=== PAUSE TestAccDataV5Users_basic
=== CONT  TestAccDataV5Users_basic
--- PASS: TestAccDataV5Users_basic (35.58s)
PASS
coverage: 7.7% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       35.782s coverage: 7.7% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
