### PR TITLE
fix(eps): eliminate potential vulnerabilities in the datasource migrate records

### DIFF
--- a/docs/data-sources/enterprise_project_migrate_record.md
+++ b/docs/data-sources/enterprise_project_migrate_record.md
@@ -3,38 +3,34 @@ subcategory: "Enterprise Project Management Service (EPS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_enterprise_project_migrate_record"
 description: |-
-  Use this data source to get the resource move record of EPS within HuaweiCloud.
+  Use this data source to get the resource move records of EPS within HuaweiCloud.
 ---
 
 # huaweicloud_enterprise_project_migrate_record
 
-Use this data source to get the resource move record of EPS within HuaweiCloud.
+Use this data source to get the resource move records of EPS within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
-data "huaweicloud_enterprise_project_migrate_record" "test" {
-  start_time  = "2020-10-10 01:00:00"
-  end_time    = "2025-11-19 15:30:00"
-  resource_id = "3dde353d-0117-4e1a-a09c-4750f61a3c5d"
-}
+data "huaweicloud_enterprise_project_migrate_record" "test" {}
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `resource_id` - (Optional, String) Specifies the resource id.  
+* `resource_id` - (Optional, String) Specifies the resource ID.
   If omitted, the migration record of all resources will be queried.
 
-* `start_time` - (Optional, String) Specifies the start time.  
-  This parameter needs to be used in conjunction with end_time.  
-  If omitted, the migration record for the most recent week will be queried.  
+* `start_time` - (Optional, String) Specifies the start time.
+  This parameter needs to be used in conjunction with `end_time`.
+  If omitted, the migration record for the most recent week will be queried.
   The time format is **YYYY-MM-DD hh:mm:ss**.
 
-* `end_time` - (Optional, String) Specifies the end time.  
-  This parameter needs to be used in conjunction with start_time.  
-  If omitted, the migration record for the most recent week will be queried.  
+* `end_time` - (Optional, String) Specifies the end time.
+  This parameter needs to be used in conjunction with `start_time`.
+  If omitted, the migration record for the most recent week will be queried.
   The time format is **YYYY-MM-DD hh:mm:ss**.
 
 ## Attribute Reference
@@ -43,7 +39,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `records` - The list of the resource move record.
+* `records` - The list of the resource move records.
   The [migrate-record](#migrate_record) structure is documented below.
 
 <a name="migrate_record"></a>
@@ -51,38 +47,38 @@ The `migrate-record` block supports:
 
 * `associated` - Whether associated resources are moved.
 
-* `code` - Response code.
+* `code` - The response code.
 
-* `message` - Response information.
+* `message` - The response information.
 
-* `project_id` - Project ID.
+* `project_id` - The project ID.
 
-* `project_name` - Project name.
+* `project_name` - The project name.
 
-* `region_id` - Region ID.
+* `region_id` - The region ID.
 
-* `event_time` - Event time.
+* `event_time` - The event time.
 
-* `user_name` - User name.
+* `user_name` - The user name.
 
-* `operate_type` - Move type.
+* `operate_type` - The move type.
 
-* `resource_id` - Resource ID.
+* `resource_id` - The resource ID.
 
-* `resource_name` - Resource name.
+* `resource_name` - The resource name.
 
-* `resource_type` - Resource type.
+* `resource_type` - The resource type.
 
-* `initiate_ep_id` - ID of the enterprise project that initiates a resource move.
+* `initiate_ep_id` - The ID of the enterprise project that initiates a resource move.
 
-* `initiate_ep_name` - Name of the enterprise project that initiates a resource move.
+* `initiate_ep_name` - The name of the enterprise project that initiates a resource move.
 
-* `origin_ep_id` - ID of the source enterprise project.
+* `origin_ep_id` - The ID of the source enterprise project.
 
-* `origin_ep_name` - Name of the source enterprise project.
+* `origin_ep_name` - The name of the source enterprise project.
 
-* `target_ep_id` - ID of the destination enterprise project.
+* `target_ep_id` - The ID of the destination enterprise project.
 
-* `target_ep_name` - Name of the destination enterprise project.
+* `target_ep_name` - The name of the destination enterprise project.
 
 * `exist_failed` - Whether there are failed tasks.

--- a/huaweicloud/services/acceptance/eps/data_source_huaweicloud_enterprise_migration_record_test.go
+++ b/huaweicloud/services/acceptance/eps/data_source_huaweicloud_enterprise_migration_record_test.go
@@ -1,6 +1,7 @@
 package eps
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,34 +10,80 @@ import (
 )
 
 func TestAccDataEnterpriseProjectMigrationRecord_basic(t *testing.T) {
-	all := "data.huaweicloud_enterprise_project_migrate_record.test"
-	dc := acceptance.InitDataSourceCheck(all)
+	var (
+		dataSourceName = "data.huaweicloud_enterprise_project_migrate_record.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		name           = acceptance.RandomAccResourceName()
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMigrateEpsID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataEnterpriseProjectMigrationRecord_basic_test(),
+				Config: testAccDataEnterpriseProjectMigrationRecord_base(name),
+			},
+			{
+				Config: testAccDataEnterpriseProjectMigrationRecord_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(all, "records.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.event_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.operate_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.project_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.region_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.resource_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.resource_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.user_name"),
+
+					resource.TestCheckOutput("resource_id_filter_is_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataEnterpriseProjectMigrationRecord_basic_test() string {
-	return `
-data "huaweicloud_enterprise_project_migrate_record" "test" {
-  start_time  = "2020-01-01 00:00:00"
-  end_time    = "2025-11-19 15:30:30"
-  resource_id = "3dde353d-0117-4e1a-a09c-4750f61a3c5d"
+func testAccDataEnterpriseProjectMigrationRecord_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cc_connection" "test" {
+  name                  = "%s"
+  enterprise_project_id = "%s"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
-output "huaweicloud_enterprise_project_migrate_record" {
-  value = data.huaweicloud_enterprise_project_migrate_record.test
+func testAccDataEnterpriseProjectMigrationRecord_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cc_connection" "test" {
+  name                  = "%s"
+  enterprise_project_id = "%s"
 }
-`
+
+data "huaweicloud_enterprise_project_migrate_record" "test" {
+  depends_on = [huaweicloud_cc_connection.test]
+}
+
+# Filter by resource_id
+locals {
+  resource_id = data.huaweicloud_enterprise_project_migrate_record.test.records[0].resource_id
+}
+
+data "huaweicloud_enterprise_project_migrate_record" "filter_by_resource_id" {
+  resource_id = local.resource_id
+}
+
+locals {
+  resource_id_filter_result = [
+    for v in data.huaweicloud_enterprise_project_migrate_record.filter_by_resource_id.records[*].resource_id : v == local.resource_id
+  ]
+}
+
+output "resource_id_filter_is_useful" {
+  value = alltrue(local.resource_id_filter_result) && length(local.resource_id_filter_result) > 0
+}
+
+`, name, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project_migrate_record.go
+++ b/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project_migrate_record.go
@@ -34,134 +34,185 @@ func DataSourceMigrateRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
-			// Attributes.
 			"records": {
 				Type:     schema.TypeList,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"associated": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"code": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"message": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"project_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"project_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"region_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"event_time": {
-							Type:     schema.TypeFloat,
-							Computed: true,
-						},
-						"user_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"operate_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"resource_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"resource_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"resource_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"initiate_ep_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"initiate_ep_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"origin_ep_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"origin_ep_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"target_ep_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"target_ep_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"exist_failed": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-					},
-				},
+				Elem:     buildMigrateRecordSchema(),
 			},
 		},
 	}
 }
 
+func buildMigrateRecordSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"associated": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"message": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			// The API documentation describes this field `event_time` as a string type, but it is actually a float type.
+			"event_time": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"operate_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"initiate_ep_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"initiate_ep_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"origin_ep_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"origin_ep_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_ep_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_ep_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			// The API documentation describes this field `exist_failed` as a string type, but it is actually a boolean type.
+			"exist_failed": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildMigrateRecordQueryParams(d *schema.ResourceData, startTime, endTime, offset string) string {
+	rst := ""
+	if v, ok := d.GetOk("resource_id"); ok {
+		rst += fmt.Sprintf("&resource_id=%s", v)
+	}
+
+	if startTime != "" {
+		rst += fmt.Sprintf("&start_time=%s", startTime)
+	}
+
+	if endTime != "" {
+		rst += fmt.Sprintf("&end_time=%s", endTime)
+	}
+
+	if offset != "" {
+		rst += fmt.Sprintf("&offset=%s", offset)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+// Convert the time string to the corresponding timestamp (in millisecond).
+func convertTimeQueryParam(time string) (string, error) {
+	if time == "" {
+		return "", nil
+	}
+
+	timestamp, err := utils.FormatUTCTimeStamp(time)
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatInt(timestamp*1000, 10), nil
+}
+
 func dataSourceMigrateRecordRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1.0/enterprise-projects/migrate-record/list"
+		allResults = make([]interface{}, 0)
+		offset     = ""
 	)
 	client, err := cfg.NewServiceClient("eps", region)
 	if err != nil {
 		return diag.Errorf("error creating EPS client: %s", err)
 	}
 
-	httpUrl, err := buildMigrateRecordQueryParameter(d)
+	startTime, err := convertTimeQueryParam(d.Get("start_time").(string))
 	if err != nil {
-		return diag.Errorf("error build EPS migrate record url: %s", err)
+		return diag.Errorf("error converting start_time: %s", err)
 	}
 
-	listPathBase := client.Endpoint + httpUrl
+	endTime, err := convertTimeQueryParam(d.Get("end_time").(string))
+	if err != nil {
+		return diag.Errorf("error converting end_time: %s", err)
+	}
 
-	opt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
 	}
 
-	res := make([]interface{}, 0)
-	offset := ""
 	for {
-		listPath := listPathBase + buildOffsetPath(offset)
-		getResp, err := client.Request("GET", listPath, &opt)
+		requestPathWithQueryParams := requestPath + buildMigrateRecordQueryParams(d, startTime, endTime, offset)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
 		if err != nil {
-			return diag.Errorf("error retrieving EPS migrate record: %s", err)
+			return diag.Errorf("error retrieving EPS migrate records: %s", err)
 		}
-		getRespBody, err := utils.FlattenResponse(getResp)
+
+		respBody, err := utils.FlattenResponse(resp)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		res = append(res, flattenListMigrateRecordResponseBody(getRespBody)...)
-		offset = utils.PathSearch("offset", getRespBody, "").(string)
+
+		records := utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{})
+		if len(records) == 0 {
+			break
+		}
+
+		allResults = append(allResults, records...)
+		offset = utils.PathSearch("offset", respBody, "").(string)
 		if offset == "" {
 			break
 		}
@@ -174,55 +225,20 @@ func dataSourceMigrateRecordRead(_ context.Context, d *schema.ResourceData, meta
 	d.SetId(randUUID)
 
 	mErr := multierror.Append(nil,
-		d.Set("records", res),
+		d.Set("records", flattenListMigrateRecordResponseBody(allResults)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func buildMigrateRecordQueryParameter(d *schema.ResourceData) (string, error) {
-	httpUrl := "v1.0/enterprise-projects/migrate-record/list?limit=10"
-
-	if d.Get("resource_id") != nil {
-		httpUrl += fmt.Sprintf("&resource_id=%s", d.Get("resource_id"))
-	}
-
-	if begTime, ok := d.GetOk("start_time"); ok {
-		earlierTime, err := utils.FormatUTCTimeStamp(begTime.(string))
-		if err != nil {
-			return "", fmt.Errorf("unable to parse start_time: %s", err)
-		}
-		httpUrl += fmt.Sprintf("&start_time=%s", strconv.FormatInt(earlierTime*1000, 10))
-	}
-
-	if endTime, ok := d.GetOk("end_time"); ok {
-		laterTime, err := utils.FormatUTCTimeStamp(endTime.(string))
-		if err != nil {
-			return "", fmt.Errorf("unable to parse end_time: %s", err)
-		}
-		httpUrl += fmt.Sprintf("&end_time=%s", strconv.FormatInt(laterTime*1000, 10))
-	}
-
-	return httpUrl, nil
-}
-
-func buildOffsetPath(offset string) string {
-	res := ""
-	if offset != "" {
-		res += fmt.Sprintf("&offset=%s", offset)
-	}
-	return res
-}
-
-func flattenListMigrateRecordResponseBody(resp interface{}) []interface{} {
-	if resp == nil {
+func flattenListMigrateRecordResponseBody(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
 		return nil
 	}
-	curJson := utils.PathSearch("records", resp, make([]interface{}, 0))
-	curArray := curJson.([]interface{})
-	res := make([]interface{}, 0)
-	for _, v := range curArray {
-		res = append(res, map[string]interface{}{
+
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
 			"associated":       utils.PathSearch("associated", v, nil),
 			"code":             utils.PathSearch("code", v, nil),
 			"message":          utils.PathSearch("message", v, nil),
@@ -244,5 +260,5 @@ func flattenListMigrateRecordResponseBody(resp interface{}) []interface{} {
 			"exist_failed":     utils.PathSearch("exist_failed", v, nil),
 		})
 	}
-	return res
+	return rst
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

eliminate potential vulnerabilities in the datasource migrate records
- Remove magic values ​​from test cases.
- Make test case execution logic more robust.
- Refactor the datasource code.
- Improve document content quality.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Filter parameters `start_time` and `end_time` were tested separately.
<img width="937" height="1081" alt="image" src="https://github.com/user-attachments/assets/0d5a88da-e230-4454-bd6d-c60f6a17b933" />

- The pagination logic, with limit=1, was tested separately and passed.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o eps -f TestAccDataEnterpriseProjectMigrationRecord_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eps" -v -coverprofile="./huaweicloud/services/acceptance/eps/eps_coverage.cov" -coverpkg="./huaweicloud/services/eps" -run TestAccDataEnterpriseProjectMigrationRecord_basic -timeout 360m -parallel 10
=== RUN   TestAccDataEnterpriseProjectMigrationRecord_basic
=== PAUSE TestAccDataEnterpriseProjectMigrationRecord_basic
=== CONT  TestAccDataEnterpriseProjectMigrationRecord_basic
--- PASS: TestAccDataEnterpriseProjectMigrationRecord_basic (39.82s)
PASS
coverage: 14.1% of statements in ./huaweicloud/services/eps
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eps       39.932s coverage: 14.1% of statements in ./huaweicloud/services/eps
```
<img width="1312" height="57" alt="image" src="https://github.com/user-attachments/assets/2f308b96-d5c1-4a35-8a00-998a153fbda1" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
