### PR TITLE
test(iam): optimize tests for v5 attached policies data sources (user/agency/group)

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_agency_attached_policies_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_agency_attached_policies_test.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,32 +10,67 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityV5AgencyAttachedPolicies_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identityv5_agency_attached_policies.test"
-	rName := acceptance.RandomAccResourceName()
+// Please ensure that the user executing the acceptance test has 'admin' permission.
+func TestAccDataV5AgencyAttachedPolicies_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
 
-	resource.Test(t, resource.TestCase{
+		all = "data.huaweicloud_identityv5_agency_attached_policies.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIdentityV5AgencyAttachedPolicies_basic(rName),
+				Config: testAccDataV5AgencyAttachedPolicies_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "agency_id"),
-					resource.TestCheckResourceAttr(dataSourceName, "attached_policies.0.policy_id", "NATReadOnlyPolicy"),
-					resource.TestCheckResourceAttr(dataSourceName, "attached_policies.0.policy_name", "NATReadOnlyPolicy"),
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "attached_policies.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "attached_policies.0.policy_id"),
+					resource.TestCheckResourceAttrSet(all, "attached_policies.0.policy_name"),
+					resource.TestCheckResourceAttrSet(all, "attached_policies.0.urn"),
+					resource.TestCheckResourceAttrSet(all, "attached_policies.0.attached_at"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceIdentityV5AgencyAttachedPolicies_basic(agencyName string) string {
+func testAccDataV5AgencyAttachedPolicies_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_trust_agency" "test" {
+  name         = "%[1]s"
+  policy_names = ["NATReadOnlyPolicy"]
+  trust_policy = jsonencode(
+    {
+      Statement = [
+        {
+          Action = [
+            "sts:agencies:assume",
+          ]
+          Effect = "Allow"
+          Principal = {
+            Service = [
+              "service.OBS",
+            ]
+          }
+        },
+      ]
+      Version = "5.0"
+    }
+  )
+}
+`, name)
+}
+
+func testAccDataV5AgencyAttachedPolicies_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 data "huaweicloud_identityv5_agency_attached_policies" "test" {
   agency_id = huaweicloud_identity_trust_agency.test.id
 }
-`, testAccIdentityTrustAgency_basic(agencyName))
+`, testAccDataV5AgencyAttachedPolicies_base(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The `huaweicloud_identityv5_user_attached_policies`, `huaweicloud_identityv5_agency_attached_policies` and `huaweicloud_identityv5_group_attached_policies` old test cases suffer from several design problems:

- Hard-coding
- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for data source tests
2. update the check items and function naming
3. optimize test scenario of user resources and their reference
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccDataV5UserAttachedPolicies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5UserAttachedPolicies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5UserAttachedPolicies_basic
=== PAUSE TestAccDataV5UserAttachedPolicies_basic
=== CONT  TestAccDataV5UserAttachedPolicies_basic
--- PASS: TestAccDataV5UserAttachedPolicies_basic (22.63s)
PASS
coverage: 5.6% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       22.787s coverage: 5.6% of statements in ./huaweicloud/services/iam
```

```
./scripts/coverage.sh -o iam -f TestAccDataV5GroupAttachedPolicies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5GroupAttachedPolicies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5GroupAttachedPolicies_basic
=== PAUSE TestAccDataV5GroupAttachedPolicies_basic
=== CONT  TestAccDataV5GroupAttachedPolicies_basic
--- PASS: TestAccDataV5GroupAttachedPolicies_basic (24.76s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       24.893s coverage: 5.3% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccDataV5AgencyAttachedPolicies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5AgencyAttachedPolicies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5AgencyAttachedPolicies_basic
=== PAUSE TestAccDataV5AgencyAttachedPolicies_basic
=== CONT  TestAccDataV5AgencyAttachedPolicies_basic
--- PASS: TestAccDataV5AgencyAttachedPolicies_basic (30.48s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       30.591s coverage: 4.6% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
