### PR TITLE
fix(ram): the `ram_permission_versions` dataSource quality improvement

### DIFF
--- a/docs/data-sources/ram_permission_versions.md
+++ b/docs/data-sources/ram_permission_versions.md
@@ -3,20 +3,20 @@ subcategory: "Resource Access Manager (RAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ram_permission_versions"
 description: |
-  Use this data source to list permission versions in Resource Access Manager.
+  Use this data source to get the list of all versions with specified permission in Resource Access Manager.
 ---
 
-# huaweicloud_ram_resource_permissions_versions
+# huaweicloud_ram_permission_versions
 
-Use this data source to list permission versions in Resource Access Manager.
+Use this data source to get the list of all versions with specified permission in Resource Access Manager.
 
 ## Example Usage
 
 ```hcl
-variable "resource_type" {}
+variable "permission_id" {}
 
-data "huaweicloud_ram_resource_permissions_versions" "test" {
-  resource_type = var.resource_type
+data "huaweicloud_ram_permission_versions" "test" {
+  permission_id = var.permission_id
 }
 ```
 
@@ -24,11 +24,7 @@ data "huaweicloud_ram_resource_permissions_versions" "test" {
 
 The following arguments are supported:
 
-* `resource_type` - (Optional, String) Specifies the resource type of RAM permission.
-
-* `permission_type` - (Optional, String) Specifies the type of the permission.
-
-* `name` - (Optional, String) Specifies the name of RAM permission.
+* `permission_id` - (Required, String) Specifies the ID of the shared resource permission.
 
 ## Attribute Reference
 
@@ -36,13 +32,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `permissions` - Indicates the list of the RAM permissions
-  The [permissions](#RAM_Permissions) structure is documented below.
+* `permissions` - The detailed information list of shared resource permissions.
 
-<a name="RAM_Permissions"></a>
+  The [permissions](#RAM_permissions) structure is documented below.
+
+<a name="RAM_permissions"></a>
 The `permissions` block supports:
 
-* `id` - Indicates the id of RAM permission.
+* `id` - Indicates the ID of RAM permission.
 
 * `name` - Indicates the name of RAM permission.
 
@@ -50,7 +47,7 @@ The `permissions` block supports:
 
 * `is_resource_type_default` - Whether the RAM permission resource type is default.
 
-* `created_at` - Indicates the RAM permission create time.
+* `created_at` - Indicates the RAM permission creation time.
 
 * `updated_at` - Indicates the RAM permission last update time.
 

--- a/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_permission_versions_test.go
+++ b/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_permission_versions_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceRAMListPermissionVersions_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_ram_permission_versions.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataSourcePermissionVersions_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_ram_permission_versions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -21,31 +23,31 @@ func TestAccDataSourceRAMListPermissionVersions_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceRAMListPermissionVersions_basic(acceptance.HW_RAM_PERMISSION_ID),
+				Config: testDataSourcePermissionVersions_basic(acceptance.HW_RAM_PERMISSION_ID),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSource, "permissions.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.created_at"),
-					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.default_version"),
 					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.id"),
-					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.is_resource_type_default"),
 					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.name"),
-					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.permission_type"),
-					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.permission_urn"),
 					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.resource_type"),
-					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.is_resource_type_default"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.created_at"),
 					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.updated_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.permission_urn"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.permission_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.default_version"),
 					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.version"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.status"),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceRAMListPermissionVersions_basic(permissionId string) string {
+func testDataSourcePermissionVersions_basic(permissionId string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_ram_permission_versions" "test" {
-	permission_id = "%[1]s"
+  permission_id = "%[1]s"
 }
 `, permissionId)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Modify incorrect MD document name.
2. Modify parameter errors and Example Usage errors in the MD document.
3. Optimize variable names and code in resource files.
4. Adjust the field order in the MD document, test file, and resource file to be consistent with the API document.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
6. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

the `ram_permission_versions` dataSource quality improvement

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ram" TESTARGS="-run TestAccDataSourcePermissionVersions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccDataSourcePermissionVersions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePermissionVersions_basic
=== PAUSE TestAccDataSourcePermissionVersions_basic
=== CONT  TestAccDataSourcePermissionVersions_basic
--- PASS: TestAccDataSourcePermissionVersions_basic (10.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       10.947s

```
<img width="910" height="37" alt="image" src="https://github.com/user-attachments/assets/fcea3be2-b760-4b7d-ab4c-d9c9577ed3a2" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
