### PR TITLE
test(iam): optimize the acceptance case design for catalog datasource

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_catalog_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_catalog_test.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,35 +10,83 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccIdentityCatalogDataSource_basic(t *testing.T) {
-	userName := acceptance.RandomAccResourceName()
-	initPassword := acceptance.RandomPassword()
-	resourceName := "data.huaweicloud_identity_catalog.test"
-	dc := acceptance.InitDataSourceCheck(resourceName)
+func TestAccDataCatalog_basic(t *testing.T) {
+	var (
+		userName = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_identity_catalog.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPrecheckDomainName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source: "hashicorp/random",
+				// The version of the random provider must be greater than 3.3.0 to support the 'numeric' parameter.
+				VersionConstraint: "3.3.0",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityCatalogDataSource_basic(userName, initPassword),
+				Config: testAccDataCatalog_basic(userName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(resourceName, "catalog.#"),
+					resource.TestMatchResourceAttr(all, "catalog.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "catalog.0.id"),
+					resource.TestCheckResourceAttrSet(all, "catalog.0.name"),
+					resource.TestCheckResourceAttrSet(all, "catalog.0.type"),
 				),
 			},
 		},
 	})
 }
 
-func testAccIdentityCatalogDataSource_basic(userName, initPassword string) string {
+func testAccDataCatalog_base(name string) string {
+	return fmt.Sprintf(`
+resource "random_string" "test" {
+  length           = 10
+  min_numeric      = 1
+  min_special      = 1
+  min_lower        = 1
+  override_special = "@!"
+}
+
+resource "huaweicloud_identity_user" "test" {
+  name        = "%[1]s"
+  password    = random_string.test.result
+  enabled     = true
+  email       = "%[1]s@abc.com"
+
+  login_protect_verification_method = "email"
+}
+
+resource "huaweicloud_identity_user_token" "test" {
+  user_name    = huaweicloud_identity_user.test.name
+  password     = random_string.test.result
+  account_name = "%[2]s"
+  project_name = "%[3]s"
+
+  # Waiting for the user to be created.
+  depends_on = [huaweicloud_identity_user.test]
+}
+`, name, acceptance.HW_DOMAIN_NAME, acceptance.HW_REGION_NAME)
+}
+
+func testAccDataCatalog_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-data "huaweicloud_identity_catalog" "test" {
+data "huaweicloud_identity_catalog" "all" {
   project_token = huaweicloud_identity_user_token.test.token
+
+  # The token is created asynchronously, so we need to depend on it.
+  depends_on = [huaweicloud_identity_user_token.test]
 }
-`, testAccIdentityUserToken_project(userName, initPassword))
+`, testAccDataCatalog_base(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:
  1. Redundant naming
  2. Insufficiently precise checks

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. update the check items and function naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataSourceCatalog_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCatalog_basic
=== PAUSE TestAccDataSourceCatalog_basic
=== CONT  TestAccDataSourceCatalog_basic
--- PASS: TestAccDataSourceCatalog_basic (14.48s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       14.612s coverage: 3.7% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.