### PR TITLE
test(iam): optimize the test for v5 query groups and policy versions

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_groups_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_groups_test.go
@@ -1,6 +1,8 @@
 package iam
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,25 +10,86 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityV5Groups_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identityv5_groups.test"
+// Please ensure that the user executing the acceptance test has 'admin' permission.
+func TestAccDataV5Groups_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		all = "data.huaweicloud_identityv5_groups.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byUserId   = "data.huaweicloud_identityv5_groups.filter_by_user_id"
+		dcByUserId = acceptance.InitDataSourceCheck(byUserId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIdentityV5Groups_basic(),
+				Config: testAccDataV5Groups_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "groups.#"),
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "groups.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'user_id' parameter.
+					dcByUserId.CheckResourceExists(),
+					resource.TestCheckOutput("is_user_id_filter_useful", "true"),
+					resource.TestCheckResourceAttrPair(byUserId, "groups.0.group_id", "huaweicloud_identityv5_group.test", "id"),
+					resource.TestCheckResourceAttrPair(byUserId, "groups.0.group_name", "huaweicloud_identityv5_group.test", "group_name"),
+					resource.TestCheckResourceAttrPair(byUserId, "groups.0.urn", "huaweicloud_identityv5_group.test", "urn"),
+					resource.TestCheckResourceAttrPair(byUserId, "groups.0.description", "huaweicloud_identityv5_group.test", "description"),
+					resource.TestCheckResourceAttrSet(byUserId, "groups.0.created_at"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceIdentityV5Groups_basic() string {
-	return `
-data "huaweicloud_identityv5_groups" "test" {}
-`
+func testAccDataV5Groups_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identityv5_user" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_identityv5_group" "test" {
+  group_name  = "%[1]s"
+  description = "created by terraform script"
+}
+
+resource "huaweicloud_identityv5_group_membership" "test" {
+  group_id     = huaweicloud_identityv5_group.test.id
+  user_id_list = [huaweicloud_identityv5_user.test.id]
+}
+`, name)
+}
+
+func testAccDataV5Groups_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_identityv5_groups" "test" {
+  depends_on = [huaweicloud_identityv5_group.test]
+}
+
+# Filter by 'user_id' parameter.
+locals {
+  user_id = huaweicloud_identityv5_user.test.id
+}
+
+data "huaweicloud_identityv5_groups" "filter_by_user_id" {
+  user_id = local.user_id
+
+  depends_on = [huaweicloud_identityv5_group_membership.test]
+}
+
+# Created a new user and only associated with one group, so here only need to check if the first group ID is equal to the created group ID.
+output "is_user_id_filter_useful" {
+  value = data.huaweicloud_identityv5_groups.filter_by_user_id.groups[0].group_id == huaweicloud_identityv5_group.test.id
+}
+`, testAccDataV5Groups_base(name))
 }

--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_policy_versions_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_policy_versions_test.go
@@ -1,6 +1,8 @@
 package iam
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,41 +10,82 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityV5PolicyVersions_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identityv5_policy_versions.test"
-	resource.Test(t, resource.TestCase{
+func TestAccDataV5PolicyVersions_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_identityv5_policy_versions.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byVersionId   = "data.huaweicloud_identityv5_policy_versions.filter_by_version_id"
+		dcByVersionId = acceptance.InitDataSourceCheck(byVersionId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIdentityV5PolicyVersions_basic,
+				Config: testAccDataV5PolicyVersions_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "versions.#"),
-				),
-			},
-			{
-				Config: testAccDataSourceIdentityV5PolicyVersionsWithVersionId_basic,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "versions.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "versions.0.version_id", "v1"),
-					resource.TestCheckResourceAttr(dataSourceName, "versions.0.is_default", "false"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "versions.0.created_at"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "versions.0.document"),
+					// Without any filter parameter.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "versions.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'version_id' parameter.
+					dcByVersionId.CheckResourceExists(),
+					resource.TestCheckOutput("is_version_id_filter_useful", "true"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.version_id",
+						"huaweicloud_identity_policy.test", "default_version_id"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.document",
+						"huaweicloud_identity_policy.test", "policy_document"),
+					resource.TestCheckResourceAttr(byVersionId, "versions.0.is_default", "true"),
+					resource.TestCheckResourceAttrSet(byVersionId, "versions.0.created_at"),
 				),
 			},
 		},
 	})
 }
 
-var testAccDataSourceIdentityV5PolicyVersions_basic = `
-data "huaweicloud_identityv5_policy_versions" "test" {
-  policy_id = "NATReadOnlyPolicy"
+func testAccDataV5PolicyVersions_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_policy" "test" {
+  name            = "%[1]s"
+  description     = "created by terraform script"
+  policy_document = jsonencode(
+    {
+      Statement = [
+        {
+          Action = ["*"]
+          Effect = "Allow"
+        }
+      ]
+      Version = "5.0"
+    }
+  )
 }
-`
 
-var testAccDataSourceIdentityV5PolicyVersionsWithVersionId_basic = `
+# Without any filter parameter.
 data "huaweicloud_identityv5_policy_versions" "test" {
-  policy_id  = "NATReadOnlyPolicy"
-  version_id = "v1"
+  policy_id = huaweicloud_identity_policy.test.id
 }
-`
+
+# Filter by 'version_id' parameter.
+locals {
+  version_id = huaweicloud_identity_policy.test.default_version_id
+}
+
+data "huaweicloud_identityv5_policy_versions" "filter_by_version_id" {
+  policy_id  = huaweicloud_identity_policy.test.id
+  version_id = local.version_id
+}
+
+locals {
+  version_id_filter_result = [for v in data.huaweicloud_identityv5_policy_versions.filter_by_version_id.versions[*].version_id :
+  v == local.version_id]
+}
+
+output "is_version_id_filter_useful" {
+  value = length(local.version_id_filter_result) > 0 && alltrue(local.version_id_filter_result)
+}
+`, name)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The `huaweicloud_identityv5_groups` and `huaweicloud_identityv5_policy_versions` old test cases suffer from several design problems:

- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supplement some test scenarios
2. update the check items and function naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccDataV5Groups_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5Groups_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5Groups_basic
=== PAUSE TestAccDataV5Groups_basic
=== CONT  TestAccDataV5Groups_basic
--- PASS: TestAccDataV5Groups_basic (26.87s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       27.098s coverage: 5.1% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccDataSourceIdentityV5PolicyVersions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataSourceIdentityV5PolicyVersions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceIdentityV5PolicyVersions_basic
=== PAUSE TestAccDataSourceIdentityV5PolicyVersions_basic
=== CONT  TestAccDataSourceIdentityV5PolicyVersions_basic
--- PASS: TestAccDataSourceIdentityV5PolicyVersions_basic (19.31s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       19.462s coverage: 4.0% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
