### PR TITLE
refactor: test(iam): provider supports omit protocol and optimize protocol test

### DIFF
--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -66,8 +66,11 @@ The following arguments are supported:
   The name is unique, it is recommended to include domain name information.
   Changing this creates a new resource.
 
-* `protocol` - (Required, String, ForceNew) Specifies the protocol of the identity provider.
+* `protocol` - (Optional, String, ForceNew) Specifies the protocol of the identity provider.
   Valid values are **saml** and **oidc**. Changing this creates a new resource.
+  This parameter can be omitted during creation and using `huaweicloud_identity_provider_conversion` and
+  `huaweicloud_identity_provider_protocol` resources to manage it. At the same time, please use
+  `lifecycle.ignore_changes` to ignore changes to `conversion_rules` under this management way.
 
 * `status` - (Optional, Bool) Enabled status for the identity provider. Defaults to true.
 

--- a/docs/resources/identity_provider_protocol.md
+++ b/docs/resources/identity_provider_protocol.md
@@ -17,19 +17,25 @@ specified in `huaweicloud_identity_provider_protocol`, it will try to update the
 ## Example Usage
 
 ```hcl
-variable "provider_id" {}
-variable "mapping_id" {}
+variable "provider_name" {}
 
-resource "huaweicloud_identity_provider_protocol" "protocol" {
-  provider_id = var.provider_id
-  protocol_id = "saml"
-  mapping_id  = var.mapping_id
+# Without protocol setting
+resource "huaweicloud_identity_provider" "test" {
+  name = var.provider_name
 }
 
-resource "huaweicloud_identity_provider_protocol" "protocol" {
-  provider_id = var.provider_id
+resource "huaweicloud_identity_provider_conversion" "test" {
+  provider_id = huaweicloud_identity_provider.test.id
+
+  conversion_rules {
+    ...
+  }
+}
+
+resource "huaweicloud_identity_provider_protocol" "test" {
+  provider_id = huaweicloud_identity_provider.test.id
   protocol_id = "saml"
-  mapping_id  = var.mapping_id
+  mapping_id  = huaweicloud_identity_provider_conversion.conversion.id
 }
 ```
 

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_protocol_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_protocol_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers"
-
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iam/v3/model"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -26,24 +24,19 @@ func getProviderProtocolFunc(c *config.Config, state *terraform.ResourceState) (
 	}
 	response, err := iamV3Client.KeystoneShowProtocol(request)
 	if err != nil {
-		return fmt.Errorf("KeystoneShowProtocol error : %s", err), err
+		return nil, err
 	}
 	return response.Protocol, nil
 }
 
-func generateTestMappingID(providerID string) string {
-	return "test_" + providerID
-}
+func TestAccProviderProtocol_basic(t *testing.T) {
+	var (
+		obj interface{}
 
-func TestAccIdentityProviderProtocol_basic(t *testing.T) {
-	var provider providers.Provider
-	var randomName = acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_identity_provider_protocol.protocol"
+		resourceName = "huaweicloud_identity_provider_protocol.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getProviderProtocolFunc)
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&provider,
-		getProviderProtocolFunc,
+		name = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -54,12 +47,12 @@ func TestAccIdentityProviderProtocol_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityProviderProtocolCreate(randomName),
+				Config: testAccProviderProtocol_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "provider_id", randomName),
+					resource.TestCheckResourceAttr(resourceName, "provider_id", name),
 					resource.TestCheckResourceAttr(resourceName, "protocol_id", "saml"),
-					resource.TestCheckResourceAttr(resourceName, "mapping_id", "mapping_"+generateTestMappingID(randomName)),
+					resource.TestCheckResourceAttrPair(resourceName, "mapping_id", "huaweicloud_identity_provider_conversion.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "links.#", "1"),
 				),
 			},
@@ -72,33 +65,34 @@ func TestAccIdentityProviderProtocol_basic(t *testing.T) {
 	})
 }
 
-// huaweicloud_identity_provider创建一个saml协议的idp，mapping_id为mapping_{provider_id}
-// huaweicloud_identity_provider_conversion创建一个新的mapping，mapping_id为mapping_generateTestMappingID(name)
-// huaweicloud_identity_provider_protocol更新协议，修改mapping为mapping_generateTestMappingID(name)
-func testAccIdentityProviderProtocolCreate(name string) string {
+func testAccProviderProtocol_basic_step1(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identity_provider" "provider1" {
-  name     = "%s"
-  protocol = "saml"
+resource "huaweicloud_identity_provider" "test" {
+  name = "%[1]s"
+
+  lifecycle {
+    ignore_changes = [conversion_rules]
+  }
 }
 
-resource "huaweicloud_identity_provider_conversion" "conversion" {
-  provider_id = "%s"
+resource "huaweicloud_identity_provider_conversion" "test" {
+  provider_id = huaweicloud_identity_provider.test.id
 
   conversion_rules {
     local {
       username = "Tom"
     }
+
     remote {
       attribute = "Tom"
     }
   }
 }
 
-resource "huaweicloud_identity_provider_protocol" "protocol" {
-  provider_id = huaweicloud_identity_provider.provider1.id
+resource "huaweicloud_identity_provider_protocol" "test" {
+  provider_id = huaweicloud_identity_provider.test.id
   protocol_id = "saml"
-  mapping_id  = huaweicloud_identity_provider_conversion.conversion.id
+  mapping_id  = huaweicloud_identity_provider_conversion.test.id
 }
-`, name, generateTestMappingID(name))
+`, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The protocol of provider resource can be omitted.

The old test cases suffer from several design problems:

- Hard-coding
- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the IAM resource's test
2. update the check items and function naming
3. combine some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccProviderProtocol_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccProviderProtocol_basic -timeout 360m -parallel 10
=== RUN   TestAccProviderProtocol_basic
=== PAUSE TestAccProviderProtocol_basic
=== CONT  TestAccProviderProtocol_basic
--- PASS: TestAccProviderProtocol_basic (14.17s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       14.264s coverage: 5.1% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccProviderProtocol_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccProviderProtocol_basic -timeout 360m -parallel 10
=== RUN   TestAccProviderProtocol_basic
=== PAUSE TestAccProviderProtocol_basic
=== CONT  TestAccProviderProtocol_basic
--- PASS: TestAccProviderProtocol_basic (15.49s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       15.629s coverage: 5.1% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
