### PR TITLE
test(iam): optimize tests for v5 query registered_services and service_principals

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_registered_services_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_registered_services_test.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,25 +9,27 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityV5RegisteredServices_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identityv5_registered_services.services"
+func TestAccDataV5RegisteredServices_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_identityv5_registered_services.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIdentityV5RegisteredServices_basic(),
+				Config: testAccDataV5RegisteredServices_basic,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "service_codes.0"),
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "service_codes.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceIdentityV5RegisteredServices_basic() string {
-	return `
-data "huaweicloud_identityv5_registered_services" "services" {}
+const testAccDataV5RegisteredServices_basic = `
+data "huaweicloud_identityv5_registered_services" "test" {}
 `
-}

--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_service_principals_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_service_principals_test.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,21 +9,44 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityV5ServicePrincipals_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+func TestAccDataV5ServicePrincipals_basic(t *testing.T) {
+	var (
+		byLanguageWithZhCn   = "data.huaweicloud_identityv5_service_principals.filter_by_language_with_zh_cn"
+		dcByLanguageWithZhCn = acceptance.InitDataSourceCheck(byLanguageWithZhCn)
+
+		byLanguageWithEnUs   = "data.huaweicloud_identityv5_service_principals.filter_by_language_with_en_us"
+		dcByLanguageWithEnUs = acceptance.InitDataSourceCheck(byLanguageWithEnUs)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIdentityV5ServicePrincipals_basic,
+				Config: testAccDataV5ServicePrincipals_basic,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.huaweicloud_identityv5_service_principals.test", "service_principals.#"),
+					dcByLanguageWithZhCn.CheckResourceExists(),
+					resource.TestMatchResourceAttr(byLanguageWithZhCn, "service_principals.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(byLanguageWithZhCn, "service_principals.0.service_principal"),
+					resource.TestCheckResourceAttrSet(byLanguageWithZhCn, "service_principals.0.description"),
+					resource.TestCheckResourceAttrSet(byLanguageWithZhCn, "service_principals.0.display_name"),
+					resource.TestCheckResourceAttrSet(byLanguageWithZhCn, "service_principals.0.service_catalog"),
+					dcByLanguageWithEnUs.CheckResourceExists(),
+					resource.TestMatchResourceAttr(byLanguageWithEnUs, "service_principals.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(byLanguageWithEnUs, "service_principals.0.display_name", regexp.MustCompile(`^[a-zA-Z]`)),
+					resource.TestMatchResourceAttr(byLanguageWithEnUs, "service_principals.0.description", regexp.MustCompile(`^[a-zA-Z]`)),
 				),
 			},
 		},
 	})
 }
 
-var testAccDataSourceIdentityV5ServicePrincipals_basic = `
-data "huaweicloud_identityv5_service_principals" "test" {}
+const testAccDataV5ServicePrincipals_basic = `
+# Filter by 'language' parameter with 'zh-cn', Default value is 'zh-cn'.
+data "huaweicloud_identityv5_service_principals" "filter_by_language_with_zh_cn" {}
+
+# Filter by 'language' parameter with 'en-us'.
+data "huaweicloud_identityv5_service_principals" "filter_by_language_with_en_us" {
+  language = "en-us"
+}
 `


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

The huaweicloud_identityv5_user_attached_policies, huaweicloud_identityv5_agency_attached_policies and huaweicloud_identityv5_group_attached_policies old test cases suffer from several design problems:

- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well


**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for data source tests
2. update the check items and function naming
3. improve some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
 ./scripts/coverage.sh -o iam -f TestAccDataV5ServicePrincipals_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5ServicePrincipals_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5ServicePrincipals_basic
=== PAUSE TestAccDataV5ServicePrincipals_basic
=== CONT  TestAccDataV5ServicePrincipals_basic
--- PASS: TestAccDataV5ServicePrincipals_basic (25.08s)
PASS
coverage: 2.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       25.298s coverage: 2.3% of statements in ./huaweicloud/services/iam
```
```
 ./scripts/coverage.sh -o iam -f TestAccDataV5RegisteredServices_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5RegisteredServices_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5RegisteredServices_basic
=== PAUSE TestAccDataV5RegisteredServices_basic
=== CONT  TestAccDataV5RegisteredServices_basic
--- PASS: TestAccDataV5RegisteredServices_basic (21.50s)
PASS
coverage: 2.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       21.628s coverage: 2.3% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
