### PR TITLE
fix(eps): eliminate potential vulnerabilities datasource resources mapping

### DIFF
--- a/docs/data-sources/enterprise_project_resources_mapping.md
+++ b/docs/data-sources/enterprise_project_resources_mapping.md
@@ -22,4 +22,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `resource_mapping` - The resource type mapping of EPS.
+* `resource_mapping` - The resource type mapping of EPS. This field is a key-value pair type.

--- a/huaweicloud/services/acceptance/eps/data_source_huaweicloud_enterprise_project_resources_mapping_test.go
+++ b/huaweicloud/services/acceptance/eps/data_source_huaweicloud_enterprise_project_resources_mapping_test.go
@@ -9,8 +9,10 @@ import (
 )
 
 func TestAccDataEnterpriseProjectResourcesMapping_basic(t *testing.T) {
-	all := "data.huaweicloud_enterprise_project_resources_mapping.test"
-	dc := acceptance.InitDataSourceCheck(all)
+	var (
+		dataSourceName = "data.huaweicloud_enterprise_project_resources_mapping.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -20,8 +22,7 @@ func TestAccDataEnterpriseProjectResourcesMapping_basic(t *testing.T) {
 				Config: testAccDataEnterpriseProjectResourcesMapping_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(all, "resource_mapping.vpcs", "vpc"),
-					resource.TestCheckOutput("huaweicloud_enterprise_project_resources_mapping", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "resource_mapping.%"),
 				),
 			},
 		},
@@ -30,8 +31,4 @@ func TestAccDataEnterpriseProjectResourcesMapping_basic(t *testing.T) {
 
 const testAccDataEnterpriseProjectResourcesMapping_basic = `
 data "huaweicloud_enterprise_project_resources_mapping" "test" {}
-
-output "huaweicloud_enterprise_project_resources_mapping" {
-  value = length(data.huaweicloud_enterprise_project_resources_mapping.test.resource_mapping) > 0
-}
 `


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

eliminate potential vulnerabilities datasource resources mapping

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o eps -f TestAccDataEnterpriseProjectResourcesMapping_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eps" -v -coverprofile="./huaweicloud/services/acceptance/eps/eps_coverage.cov" -coverpkg="./huaweicloud/services/eps" -run TestAccDataEnterpriseProjectResourcesMapping_basic -timeout 360m -parallel 10
=== RUN   TestAccDataEnterpriseProjectResourcesMapping_basic
=== PAUSE TestAccDataEnterpriseProjectResourcesMapping_basic
=== CONT  TestAccDataEnterpriseProjectResourcesMapping_basic
--- PASS: TestAccDataEnterpriseProjectResourcesMapping_basic (12.11s)
PASS
coverage: 7.2% of statements in ./huaweicloud/services/eps
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eps       12.255s coverage: 7.2% of statements in ./huaweicloud/services/eps
```
<img width="1374" height="57" alt="image" src="https://github.com/user-attachments/assets/1b88e546-c876-427a-bb9f-5a7b7351a860" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
