### PR TITLE
fix(eps): eliminate potential vulnerabilities datasource services

### DIFF
--- a/docs/data-sources/enterprise_project_services.md
+++ b/docs/data-sources/enterprise_project_services.md
@@ -22,17 +22,19 @@ The following arguments are supported:
 
 * `locale` - (Optional, String) Specifies the display language.
 
-* `service` - (Optional, String) Specifies the cloud service name.  
+* `service` - (Optional, String) Specifies the cloud service name.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `services` - Indicates the cloud services.
-  The [service](#service) structure is documented below.
+* `id` - The data source ID.
 
-<a name="service"></a>
-The `service` block supports:
+* `services` - Indicates the cloud services.
+  The [services](#service_struct) structure is documented below.
+
+<a name="service_struct"></a>
+The `services` block supports:
 
 * `service` - Indicates the cloud service name.
 
@@ -40,16 +42,16 @@ The `service` block supports:
   locale parameter.
 
 * `resource_types` - Indicates the resource type list.
-  The [resource type](#resource_type) structure is documented below.
+  The [resource_types](#resource_types_struct) structure is documented below.
 
-<a name="resource_type"></a>
-The `resource type` block supports:
+<a name="resource_types_struct"></a>
+The `resource_types` block supports:
 
 * `resource_type` - Indicates the name of the resource type.
 
 * `resource_type_i18n_display_name` - Indicates the display name of the resource type. You can set the language by
   setting the locale parameter.
 
-* `global` - Specifies whether the resource is a global resource.
+* `global` - Whether the resource is a global resource.
 
 * `regions` - Indicates regions supported.

--- a/huaweicloud/services/acceptance/eps/data_source_huaweicloud_enterprise_project_services_test.go
+++ b/huaweicloud/services/acceptance/eps/data_source_huaweicloud_enterprise_project_services_test.go
@@ -9,8 +9,10 @@ import (
 )
 
 func TestAccDataEnterpriseProjectServices_basic(t *testing.T) {
-	all := "data.huaweicloud_enterprise_project_services.test"
-	dc := acceptance.InitDataSourceCheck(all)
+	var (
+		dataSourceName = "data.huaweicloud_enterprise_project_services.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -20,14 +22,14 @@ func TestAccDataEnterpriseProjectServices_basic(t *testing.T) {
 				Config: testAccDataEnterpriseProjectServices_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(all, "services.#"),
-					resource.TestCheckResourceAttrSet(all, "services.0.service"),
-					resource.TestCheckResourceAttrSet(all, "services.0.service_i18n_display_name"),
-					resource.TestCheckResourceAttrSet(all, "services.0.resource_types.#"),
-					resource.TestCheckResourceAttrSet(all, "services.0.resource_types.0.resource_type"),
-					resource.TestCheckResourceAttrSet(all, "services.0.resource_types.0.resource_type_i18n_display_name"),
-					resource.TestCheckResourceAttrSet(all, "services.0.resource_types.0.regions.#"),
-					resource.TestCheckOutput("huaweicloud_enterprise_project_services", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "services.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "services.0.service"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "services.0.service_i18n_display_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "services.0.resource_types.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "services.0.resource_types.0.resource_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "services.0.resource_types.0.resource_type_i18n_display_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "services.0.resource_types.0.regions.#"),
+
 					resource.TestCheckOutput("huaweicloud_enterprise_project_services_locale", "true"),
 					resource.TestCheckOutput("huaweicloud_enterprise_project_services_service", "true"),
 				),

--- a/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project_services.go
+++ b/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project_services.go
@@ -29,156 +29,163 @@ func DataSourceEpsServices() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
-			// Attributes.
 			"services": {
 				Type:     schema.TypeList,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"service": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"service_i18n_display_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"resource_types": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"resource_type": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"resource_type_i18n_display_name": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"global": {
-										Type:     schema.TypeBool,
-										Computed: true,
-									},
-									"regions": {
-										Type:     schema.TypeList,
-										Computed: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-								},
-							},
-						},
-					},
-				},
+				Elem:     buildEpsServicesSchema(),
 			},
 		},
 	}
 }
 
+func buildEpsServicesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"service": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_i18n_display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     buildEpsResourceTypeSchema(),
+			},
+		},
+	}
+}
+
+func buildEpsResourceTypeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"resource_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_type_i18n_display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"global": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"regions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func buildEpsServicesQueryParams(d *schema.ResourceData, offset int) string {
+	rst := "?limit=200"
+
+	if v, ok := d.GetOk("locale"); ok {
+		rst += fmt.Sprintf("&locale=%v", v)
+	}
+
+	if v, ok := d.GetOk("service"); ok {
+		rst += fmt.Sprintf("&provider=%v", v)
+	}
+
+	if offset > 0 {
+		rst += fmt.Sprintf("&offset=%d", offset)
+	}
+
+	return rst
+}
+
 func dataSourceEpsServicesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1.0/enterprise-projects/providers"
+		offset     = 0
+		allResults = make([]interface{}, 0)
 	)
 	client, err := cfg.NewServiceClient("eps", region)
 	if err != nil {
 		return diag.Errorf("error creating EPS client: %s", err)
 	}
 
-	listPathBase := client.Endpoint + buildEpsServicesQueryParameter(d)
-
-	opt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders: map[string]string{
 			"Content-Type": "application/json",
 		},
 	}
 
-	res := make([]interface{}, 0)
-	offset := ""
 	for {
-		listPath := listPathBase + buildEpsServicesOffsetPath(offset)
-		getResp, err := client.Request("GET", listPath, &opt)
+		requestPathWithOffset := requestPath + buildEpsServicesQueryParams(d, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpt)
 		if err != nil {
 			return diag.Errorf("error retrieving EPS services: %s", err)
 		}
-		getRespBody, err := utils.FlattenResponse(getResp)
+
+		respBody, err := utils.FlattenResponse(resp)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		res = append(res, flattenListEpsServicesResponseBody(getRespBody)...)
-		offset = utils.PathSearch("offset", getRespBody, "").(string)
-		if offset == "" {
+
+		providers := utils.PathSearch("providers", respBody, make([]interface{}, 0)).([]interface{})
+		if len(providers) == 0 {
 			break
 		}
+
+		allResults = append(allResults, providers...)
+		offset += len(providers)
 	}
 
 	randUUID, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
+
 	d.SetId(randUUID)
 
 	mErr := multierror.Append(nil,
-		d.Set("services", res),
+		d.Set("services", flattenListEpsServicesResponseBody(allResults)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func buildEpsServicesQueryParameter(d *schema.ResourceData) string {
-	httpUrl := "v1.0/enterprise-projects/providers?limit=200"
-
-	if d.Get("locale") != "" {
-		httpUrl += fmt.Sprintf("&locale=%s", d.Get("locale"))
-	}
-
-	if d.Get("service") != "" {
-		httpUrl += fmt.Sprintf("&provider=%s", d.Get("service"))
-	}
-
-	return httpUrl
-}
-
-func buildEpsServicesOffsetPath(offset string) string {
-	res := ""
-	if offset != "" {
-		res += fmt.Sprintf("&offset=%s", offset)
-	}
-	return res
-}
-
-func flattenListEpsServicesResponseBody(resp interface{}) []interface{} {
-	if resp == nil {
+func flattenListEpsServicesResponseBody(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
 		return nil
 	}
-	curJson := utils.PathSearch("providers", resp, make([]interface{}, 0))
-	curArray := curJson.([]interface{})
-	res := make([]interface{}, 0)
-	for _, v := range curArray {
-		res = append(res, map[string]interface{}{
+
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		resourceTypes := utils.PathSearch("resource_types", v, make([]interface{}, 0)).([]interface{})
+		rst = append(rst, map[string]interface{}{
 			"service":                   utils.PathSearch("provider", v, nil),
 			"service_i18n_display_name": utils.PathSearch("provider_i18n_display_name", v, nil),
-			"resource_types":            flattenResourceTypeBody(utils.PathSearch("resource_types", v, nil)),
+			"resource_types":            flattenResourceTypeBody(resourceTypes),
 		})
 	}
-	return res
+	return rst
 }
 
-func flattenResourceTypeBody(resourceTypeBody interface{}) []interface{} {
-	if resourceTypeBody == nil {
+func flattenResourceTypeBody(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
 		return nil
 	}
-	resourceTypeArray := resourceTypeBody.([]interface{})
-	res := make([]interface{}, 0)
-	for _, v := range resourceTypeArray {
-		res = append(res, map[string]interface{}{
+
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
 			"resource_type":                   utils.PathSearch("resource_type", v, nil),
 			"resource_type_i18n_display_name": utils.PathSearch("resource_type_i18n_display_name", v, nil),
 			"global":                          utils.PathSearch("global", v, nil),
 			"regions":                         utils.PathSearch("regions", v, nil),
 		})
 	}
-	return res
+	return rst
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

eliminate potential vulnerabilities datasource services

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o eps -f TestAccDataEnterpriseProjectServices_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eps" -v -coverprofile="./huaweicloud/services/acceptance/eps/eps_coverage.cov" -coverpkg="./huaweicloud/services/eps" -run TestAccDataEnterpriseProjectServices_basic -timeout 360m -parallel 10
=== RUN   TestAccDataEnterpriseProjectServices_basic
=== PAUSE TestAccDataEnterpriseProjectServices_basic
=== CONT  TestAccDataEnterpriseProjectServices_basic
--- PASS: TestAccDataEnterpriseProjectServices_basic (32.70s)
PASS
coverage: 14.2% of statements in ./huaweicloud/services/eps
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eps       32.782s coverage: 14.2% of statements in ./huaweicloud/services/eps
```
<img width="1310" height="55" alt="image" src="https://github.com/user-attachments/assets/f63e820b-fbec-4d97-a7c7-a24ff3e84bc0" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
