### PR TITLE
test(iam): optimize test for v5 query agencies data source

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_agencies_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_agencies_test.go
@@ -2,6 +2,7 @@ package iam_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,46 +10,131 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityV5Agencies_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identityv5_agencies.test"
-	rName := acceptance.RandomAccResourceName()
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+func TestAccV5Agencies_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_identityv5_agencies.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byAgencyId   = "data.huaweicloud_identityv5_agencies.filter_by_agency_id"
+		dcByAgencyId = acceptance.InitDataSourceCheck(byAgencyId)
+
+		byPathPrefix   = "data.huaweicloud_identityv5_agencies.filter_by_path_prefix"
+		dcByPathPrefix = acceptance.InitDataSourceCheck(byPathPrefix)
+
+		byAgencyIdWithoutPath   = "data.huaweicloud_identityv5_agencies.filter_by_agency_id_without_path"
+		dcByAgencyIdWithoutPath = acceptance.InitDataSourceCheck(byAgencyIdWithoutPath)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckServiceLinkedAgencyPrincipal(t)
+			acceptance.TestAccPrecheckDomainName(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIdentityV5Agencies_basic,
+				Config: testAccV5Agencies_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "agencies.#"),
-				),
-			},
-			{
-				Config: testAccDataSourceIdentityV5AgenciesWithId_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "agencies.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "agencies.0.agency_name", rName),
-					resource.TestCheckResourceAttr(dataSourceName, "agencies.0.description", "test for terraform"),
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "agencies.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'agency_id' parameter.
+					dcByAgencyId.CheckResourceExists(),
+					resource.TestCheckOutput("is_agency_id_filter_useful", "true"),
+					resource.TestCheckResourceAttrPair(byAgencyId, "agencies.0.agency_id",
+						"huaweicloud_identityv5_service_linked_agency.test", "id"),
+					resource.TestCheckResourceAttrPair(byAgencyId, "agencies.0.agency_name",
+						"huaweicloud_identityv5_service_linked_agency.test", "agency_name"),
+					resource.TestCheckResourceAttrPair(byAgencyId, "agencies.0.path",
+						"huaweicloud_identityv5_service_linked_agency.test", "path"),
+					resource.TestCheckResourceAttrPair(byAgencyId, "agencies.0.urn",
+						"huaweicloud_identityv5_service_linked_agency.test", "urn"),
+					resource.TestCheckResourceAttrPair(byAgencyId, "agencies.0.description",
+						"huaweicloud_identityv5_service_linked_agency.test", "description"),
+					resource.TestCheckResourceAttrPair(byAgencyId, "agencies.0.max_session_duration",
+						"huaweicloud_identityv5_service_linked_agency.test", "max_session_duration"),
+					resource.TestCheckResourceAttrSet(byAgencyId, "agencies.0.created_at"),
+					// Filter by 'path_prefix' parameter.
+					dcByPathPrefix.CheckResourceExists(),
+					resource.TestCheckOutput("is_path_prefix_filter_useful", "true"),
+					// Filter by 'agency_id' parameter without path.
+					dcByAgencyIdWithoutPath.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(byAgencyIdWithoutPath, "agencies.0.trust_domain_id"),
+					resource.TestCheckResourceAttrPair(byAgencyIdWithoutPath, "agencies.0.trust_domain_name",
+						"huaweicloud_identity_agency.test", "delegated_domain_name"),
 				),
 			},
 		},
 	})
 }
 
-var testAccDataSourceIdentityV5Agencies_basic = `
-data "huaweicloud_identityv5_agencies" "test" {}
-`
-
-func testAccDataSourceIdentityV5AgenciesWithId_basic(trustAgencyName string) string {
+func testAccV5Agencies_base() string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identity_service_agency" "test" {
-  name                   = "%s"
-  delegated_service_name = "service.APIG"
-  policy_names           = ["NATReadOnlyPolicy"]
-  description            = "test for terraform"
+# Create a service-linked agency, it will return the 'path' field.
+resource "huaweicloud_identityv5_service_linked_agency" "test" {
+  service_principal = "%[1]s"
+  description       = "Create by terraform script"
 }
 
-data "huaweicloud_identityv5_agencies" "test" {
-  agency_id = huaweicloud_identity_service_agency.test.id
+# Create a agency, it will not return the 'path' field.
+resource "huaweicloud_identity_agency" "test" {
+  name                  = "%[2]s"
+  delegated_domain_name = "%[3]s"
+  description           = "Create by terraform script"
+  duration              = "30"
 }
-`, trustAgencyName)
+`, acceptance.HW_IAM_SERVICE_LINKED_AGENCY_PRINCIPAL, acceptance.RandomAccResourceName(), acceptance.HW_DOMAIN_NAME)
+}
+
+func testAccV5Agencies_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_identityv5_agencies" "test" {
+  depends_on = [huaweicloud_identityv5_service_linked_agency.test]
+}
+
+# Filter by 'agency_id' parameter.
+locals {
+  agency_id = huaweicloud_identityv5_service_linked_agency.test.id
+}
+
+data "huaweicloud_identityv5_agencies" "filter_by_agency_id" {
+  agency_id = local.agency_id
+}
+
+locals {
+  agency_id_filter_result = [for v in data.huaweicloud_identityv5_agencies.filter_by_agency_id.agencies[*].agency_id :
+  v == local.agency_id]
+}
+
+output "is_agency_id_filter_useful" {
+  value = length(local.agency_id_filter_result) > 0 && alltrue(local.agency_id_filter_result)
+}
+
+# Filter by 'path_prefix' parameter.
+locals {
+  path_prefix = huaweicloud_identityv5_service_linked_agency.test.path
+}
+
+data "huaweicloud_identityv5_agencies" "filter_by_path_prefix" {
+  path_prefix = huaweicloud_identityv5_service_linked_agency.test.path
+}
+
+locals {
+  path_prefix_filter_result = [for v in data.huaweicloud_identityv5_agencies.filter_by_path_prefix.agencies[*].path :
+  strcontains(v, local.path_prefix)]
+}
+
+output "is_path_prefix_filter_useful" {
+  value = length(local.path_prefix_filter_result) > 0 && alltrue(local.path_prefix_filter_result)
+}
+
+# It will not return the 'path' field, but will return the 'trust_domain_id' and 'trust_domain_name' fields.
+data "huaweicloud_identityv5_agencies" "filter_by_agency_id_without_path" {
+  agency_id = huaweicloud_identity_agency.test.id
+}
+`, testAccV5Agencies_base())
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

- Hard-coding
- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the huaweicloud_identityv5_agencies  data source's test
2. update the check items and function naming
3. supplement some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV5Agencies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5Agencies_basic -timeout 360m -parallel 10
=== RUN   TestAccV5Agencies_basic
=== PAUSE TestAccV5Agencies_basic
=== CONT  TestAccV5Agencies_basic
--- PASS: TestAccV5Agencies_basic (26.88s)
PASS
coverage: 5.0% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       27.001s coverage: 5.0% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
