### PR TITLE
fix(ram): the `ram_tags` dataSource quality improvement

### DIFF
--- a/docs/data-sources/ram_tags.md
+++ b/docs/data-sources/ram_tags.md
@@ -3,12 +3,12 @@ subcategory: "Resource Access Manager (RAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ram_tags"
 description: |-
-  Use this data source to list tags in Resource Access Manager.
+  Use this data source to get the list of tags that have been used in Resource Access Manager.
 ---
 
-# huaweicloud_ram_types
+# huaweicloud_ram_tags
 
-Use this data source to list tags in Resource Access Manager.
+Use this data source to get the list of tags that have been used in Resource Access Manager.
 
 ## Example Usage
 
@@ -28,9 +28,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `tags` - The list of tags.
 
-  The [tags](#tags) structure is documented below.
+  The [tags](#tags_struct) structure is documented below.
 
-<a name="tags"></a>
+<a name="tags_struct"></a>
 The `tags` block supports:
 
 * `key` - The key of tags.

--- a/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_tags_test.go
+++ b/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_tags_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceRAMListTags_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_ram_tags.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataSourceTags_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_ram_tags.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -19,7 +21,7 @@ func TestAccDataSourceRAMListTags_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceRAMListTags_basic(),
+				Config: testDataSourceTags_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSource, "tags.#"),
@@ -31,7 +33,7 @@ func TestAccDataSourceRAMListTags_basic(t *testing.T) {
 	})
 }
 
-func testDataSourceRAMListTags_basic() string {
+func testDataSourceTags_basic() string {
 	return `
   data "huaweicloud_ram_tags" "test" {}
 `


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Modify resource name errors in MD document.
2. Optimize code snippets and MD document descriptions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

the `ram_tags` dataSource quality improvement

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ram" TESTARGS="-run TestAccDataSourceTags_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccDataSourceTags_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceTags_basic
=== PAUSE TestAccDataSourceTags_basic
=== CONT  TestAccDataSourceTags_basic
--- PASS: TestAccDataSourceTags_basic (11.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       11.467s
```
<img width="807" height="33" alt="image" src="https://github.com/user-attachments/assets/3aac46c8-1825-416f-a442-88d7470dbb52" />


* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
