### PR TITLE
test(iam): optimize the acceptance case design for agency role assignment datasource

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_check_agency_role_assigment_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_check_agency_role_assigment_test.go
@@ -9,102 +9,118 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccIdentityCheckAgencyRoleAssignment_basic(t *testing.T) {
+func TestAccDataCheckAgencyRoleAssignment_basic(t *testing.T) {
 	var (
-		agencyName1          = acceptance.RandomAccResourceName()
-		dataSourceDomain     = "data.huaweicloud_identity_check_agency_role_assignment.test_domain"
-		dataSourceProject    = "data.huaweicloud_identity_check_agency_role_assignment.test_project"
-		dataSourceProjectAll = "data.huaweicloud_identity_check_agency_role_assignment.test_project_all"
-		dataSourceDomainNot  = "data.huaweicloud_identity_check_agency_role_assignment.test_domain_not"
+		name = acceptance.RandomAccResourceName()
+
+		byDomain   = "data.huaweicloud_identity_check_agency_role_assignment.filter_by_domain"
+		dcByDomain = acceptance.InitDataSourceCheck(byDomain)
+
+		byProject   = "data.huaweicloud_identity_check_agency_role_assignment.filter_by_project"
+		dcByProject = acceptance.InitDataSourceCheck(byProject)
+
+		byProjectAll   = "data.huaweicloud_identity_check_agency_role_assignment.filter_by_project_all"
+		dcByProjectAll = acceptance.InitDataSourceCheck(byProjectAll)
+
+		byDomainNot   = "data.huaweicloud_identity_check_agency_role_assignment.filter_by_domain_not"
+		dcByDomainNot = acceptance.InitDataSourceCheck(byDomainNot)
 	)
-	dcDomain := acceptance.InitDataSourceCheck(dataSourceDomain)
-	dcProject := acceptance.InitDataSourceCheck(dataSourceProject)
-	dcProjectAll := acceptance.InitDataSourceCheck(dataSourceProjectAll)
-	dcDomainNot := acceptance.InitDataSourceCheck(dataSourceDomainNot)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPrecheckDomainId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityCheckAgencyRoleAssignmentDomain(agencyName1),
+				Config: testAccDataCheckAgencyRoleAssignment_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
-					dcDomain.CheckResourceExists(),
-					dcProject.CheckResourceExists(),
-					dcProjectAll.CheckResourceExists(),
-					dcDomainNot.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceDomain, "result", "true"),
-					resource.TestCheckResourceAttr(dataSourceProject, "result", "true"),
-					resource.TestCheckResourceAttr(dataSourceProjectAll, "result", "true"),
-					resource.TestCheckResourceAttr(dataSourceDomainNot, "result", "false"),
+					dcByDomain.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byDomain, "result", "true"),
+					dcByProject.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byProject, "result", "true"),
+					dcByProjectAll.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byProjectAll, "result", "true"),
+					dcByDomainNot.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byDomainNot, "result", "false"),
 				),
 			},
 		},
 	})
 }
 
-func testAccIdentityCheckAgencyRoleAssignmentDomain(agencyName string) string {
+func testAccDataCheckAgencyRoleAssignment_base(name string) string {
 	return fmt.Sprintf(`
+data "huaweicloud_identity_projects" "test" {
+  name = "%[1]s"
+}
+
 resource "huaweicloud_identity_agency" "test" {
-  name                  = "%s"
-  description           = "This is a test agency"
-  delegated_domain_name = "%s"
+  name                  = "%[2]s"
+  description           = "Test by terraform"
+  delegated_domain_name = "%[3]s"
 
   project_role {
-    project = "%s"
+    project = try(data.huaweicloud_identity_projects.test.projects[0].id, "NOT_FOUND")
     roles   = ["CCE Administrator"]
   }
+
   domain_roles = [
     "Server Administrator",
     "Anti-DDoS Administrator",
   ]
+
   all_resources_roles = [
     "VPC Administrator"
   ]
 }
 
-data "huaweicloud_identity_role" "role_1" {
-  display_name = "Server Administrator"
+variable "role_names" {
+  type = list(string)
+  default = [
+    "Server Administrator",
+    "CCE Administrator",
+    "VPC Administrator",
+    "AAD FullAccess",
+  ]
 }
 
-data "huaweicloud_identity_role" "role_2" {
-  display_name = "CCE Administrator"
+data "huaweicloud_identity_role" "test" {
+  count = length(var.role_names)
+
+  display_name = var.role_names[count.index]
+}
+`, acceptance.HW_REGION_NAME, name, acceptance.HW_DOMAIN_NAME)
 }
 
-data "huaweicloud_identity_role" "role_3" {
-  display_name = "VPC Administrator"
-}
+func testAccDataCheckAgencyRoleAssignment_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
 
-data "huaweicloud_identity_role" "role_4" {
-  display_name = "AAD FullAccess"
-}
-
-data "huaweicloud_identity_check_agency_role_assignment" "test_domain" {
+data "huaweicloud_identity_check_agency_role_assignment" "filter_by_domain" {
   agency_id = huaweicloud_identity_agency.test.id
-  role_id   = data.huaweicloud_identity_role.role_1.id
-  domain_id = "%s"
+  role_id   = data.huaweicloud_identity_role.test[0].id
+  domain_id = "%[2]s"
 }
 
-data "huaweicloud_identity_check_agency_role_assignment" "test_project" {
+data "huaweicloud_identity_check_agency_role_assignment" "filter_by_project" {
   agency_id  = huaweicloud_identity_agency.test.id
-  role_id    = data.huaweicloud_identity_role.role_2.id
-  project_id = "%s"
+  role_id    = data.huaweicloud_identity_role.test[1].id
+  project_id = try(data.huaweicloud_identity_projects.test.projects[0].id, "NOT_FOUND")
 }
 
-data "huaweicloud_identity_check_agency_role_assignment" "test_project_all" {
+data "huaweicloud_identity_check_agency_role_assignment" "filter_by_project_all" {
   agency_id  = huaweicloud_identity_agency.test.id
-  role_id    = data.huaweicloud_identity_role.role_3.id
+  role_id    = data.huaweicloud_identity_role.test[2].id
   project_id = "all"
 }
 
-data "huaweicloud_identity_check_agency_role_assignment" "test_domain_not" {
+data "huaweicloud_identity_check_agency_role_assignment" "filter_by_domain_not" {
   agency_id = huaweicloud_identity_agency.test.id
-  role_id   = data.huaweicloud_identity_role.role_4.id
-  domain_id = "%s"
+  role_id   = data.huaweicloud_identity_role.test[3].id
+  domain_id = "%[2]s"
 }
-`, agencyName, acceptance.HW_DOMAIN_NAME, acceptance.HW_REGION_NAME,
-		acceptance.HW_DOMAIN_ID, acceptance.HW_PROJECT_ID, acceptance.HW_DOMAIN_ID)
+`, testAccDataCheckAgencyRoleAssignment_base(name), acceptance.HW_DOMAIN_ID)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

  1. Redundant code

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. remove the redundant code for the agency role assignment datasource‘s test
2. update the check items and function naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataSourceCheckAgencyRoleAssignment_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCheckAgencyRoleAssignment_basic
=== PAUSE TestAccDataSourceCheckAgencyRoleAssignment_basic
=== CONT  TestAccDataSourceCheckAgencyRoleAssignment_basic
--- PASS: TestAccDataSourceCheckAgencyRoleAssignment_basic (20.84s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       20.974s coverage: 6.1% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.