### PR TITLE
test(iam): optimize test for some v5 data sources

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_account_summary_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_account_summary_test.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,9 +9,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIamIdentityV5AccountSummary_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_identityv5_account_summary.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataV5AccountSummary_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_identityv5_account_summary.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -19,29 +22,29 @@ func TestAccDataSourceIamIdentityV5AccountSummary_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceIamIdentityV5AccountSummary_basic,
+				Config: testAccDataV5AccountSummary_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "agencies_quota"),
-					resource.TestCheckResourceAttrSet(dataSource, "attached_policies_per_agency_quota"),
-					resource.TestCheckResourceAttrSet(dataSource, "attached_policies_per_group_quota"),
-					resource.TestCheckResourceAttrSet(dataSource, "attached_policies_per_user_quota"),
-					resource.TestCheckResourceAttrSet(dataSource, "groups_quota"),
-					resource.TestCheckResourceAttrSet(dataSource, "policies"),
-					resource.TestCheckResourceAttrSet(dataSource, "policies_quota"),
-					resource.TestCheckResourceAttrSet(dataSource, "groups"),
-					resource.TestCheckResourceAttrSet(dataSource, "policy_size_quota"),
-					resource.TestCheckResourceAttrSet(dataSource, "root_user_mfa_enabled"),
-					resource.TestCheckResourceAttrSet(dataSource, "users"),
-					resource.TestCheckResourceAttrSet(dataSource, "users_quota"),
-					resource.TestCheckResourceAttrSet(dataSource, "versions_per_policy_quota"),
-					resource.TestCheckResourceAttrSet(dataSource, "agencies"),
+					resource.TestCheckResourceAttrSet(dcName, "agencies_quota"),
+					resource.TestCheckResourceAttrSet(dcName, "attached_policies_per_agency_quota"),
+					resource.TestCheckResourceAttrSet(dcName, "attached_policies_per_group_quota"),
+					resource.TestCheckResourceAttrSet(dcName, "attached_policies_per_user_quota"),
+					resource.TestCheckResourceAttrSet(dcName, "groups_quota"),
+					resource.TestMatchResourceAttr(dcName, "policies", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dcName, "policies_quota"),
+					resource.TestMatchResourceAttr(dcName, "groups", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dcName, "policy_size_quota"),
+					resource.TestCheckResourceAttrSet(dcName, "root_user_mfa_enabled"),
+					resource.TestMatchResourceAttr(dcName, "users", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dcName, "users_quota"),
+					resource.TestCheckResourceAttrSet(dcName, "versions_per_policy_quota"),
+					resource.TestCheckResourceAttrSet(dcName, "agencies"),
 				),
 			},
 		},
 	})
 }
 
-const testDataSourceDataSourceIamIdentityV5AccountSummary_basic = `
+const testAccDataV5AccountSummary_basic = `
 data "huaweicloud_identityv5_account_summary" "test" {}
 `

--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_authorization_schema_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_authorization_schema_test.go
@@ -1,6 +1,7 @@
 package iam_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,35 +9,45 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityV5AuthorizationSchema_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identityv5_authorization_schema.schema"
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
-	resource.Test(t, resource.TestCase{
+func TestAccDataV5AuthorizationSchema_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_identityv5_authorization_schema.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIdentityV5AuthorizationSchema_basic(),
+				Config: testAccDataV5AuthorizationSchema_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet("data.huaweicloud_identityv5_authorization_schema.schema", "actions.#"),
-					resource.TestCheckResourceAttrSet("data.huaweicloud_identityv5_authorization_schema.schema", "conditions.#"),
-					resource.TestCheckResourceAttrSet("data.huaweicloud_identityv5_authorization_schema.schema", "operations.#"),
-					resource.TestCheckResourceAttrSet("data.huaweicloud_identityv5_authorization_schema.schema", "resources.#"),
-					resource.TestCheckResourceAttrSet("data.huaweicloud_identityv5_authorization_schema.schema", "version"),
+					resource.TestMatchResourceAttr(all, "actions.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "actions.0.name"),
+					resource.TestCheckResourceAttrSet(all, "actions.0.access_level"),
+					resource.TestMatchResourceAttr(all, "actions.0.description.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(all, "conditions.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "conditions.0.key"),
+					resource.TestCheckResourceAttrSet(all, "conditions.0.value_type"),
+					resource.TestCheckResourceAttrSet(all, "conditions.0.multi_valued"),
+					resource.TestMatchResourceAttr(all, "conditions.0.description.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(all, "operations.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "operations.0.operation_action"),
+					resource.TestCheckResourceAttrSet(all, "operations.0.operation_id"),
+					resource.TestMatchResourceAttr(all, "resources.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "resources.0.urn_template"),
+					resource.TestCheckResourceAttrSet(all, "resources.0.type_name"),
+					resource.TestCheckResourceAttrSet(all, "version"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceIdentityV5AuthorizationSchema_basic() string {
-	return `
-data "huaweicloud_identityv5_authorization_schema" "schema" {
-	service_code = "iam"	
+const testAccDataV5AuthorizationSchema_basic = `
+data "huaweicloud_identityv5_authorization_schema" "test" {
+  service_code = "iam"
 }
 `
-}

--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_resource_tags_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identityv5_resource_tags_test.go
@@ -9,23 +9,29 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityv5ResourceTags_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identityv5_resource_tags.test"
-	rName := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccDataV5ResourceTags_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_identityv5_resource_tags.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceIdentityv5Tags_basic(rName),
+				Config: testAccDataV5Tags_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSourceName, "resource_id"),
-					resource.TestCheckResourceAttr(dataSourceName, "resource_type", "user"),
-					resource.TestCheckResourceAttr(dataSourceName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(dataSourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(all, "resource_id"),
+					resource.TestCheckResourceAttr(all, "resource_type", "user"),
+					resource.TestCheckResourceAttr(all, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(all, "tags.key", "value"),
 				),
 			},
 		},
@@ -50,7 +56,7 @@ resource "huaweicloud_identityv5_resource_tag" "test" {
 `, name)
 }
 
-func testDataSourceIdentityv5Tags_basic(name string) string {
+func testAccDataV5Tags_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The `huaweicloud_identityv5_account_summary`, `huaweicloud_identityv5_resource_tags` and `huaweicloud_identityv5_authorization_schema` old test cases suffer from several design problems:

- Hard-coding
- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the  data source's test
2. update the check items and function naming
3. supplement some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccDataV5AccountSummary_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5AccountSummary_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5AccountSummary_basic
=== PAUSE TestAccDataV5AccountSummary_basic
=== CONT  TestAccDataV5AccountSummary_basic
--- PASS: TestAccDataV5AccountSummary_basic (17.70s)
PASS
coverage: 2.0% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       17.859s coverage: 2.0% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccDataV5AuthorizationSchema_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5AuthorizationSchema_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5AuthorizationSchema_basic
=== PAUSE TestAccDataV5AuthorizationSchema_basic
=== CONT  TestAccDataV5AuthorizationSchema_basic
--- PASS: TestAccDataV5AuthorizationSchema_basic (19.71s)
PASS
coverage: 2.9% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       19.858s coverage: 2.9% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccDataV5ResourceTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5ResourceTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5ResourceTags_basic
=== PAUSE TestAccDataV5ResourceTags_basic
=== CONT  TestAccDataV5ResourceTags_basic
--- PASS: TestAccDataV5ResourceTags_basic (20.03s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       20.155s coverage: 4.3% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
