### PR TITLE
refactor(iam/v5_access_key): optimize code of the data source and resource

### DIFF
--- a/docs/data-sources/identityv5_access_key.md
+++ b/docs/data-sources/identityv5_access_key.md
@@ -3,27 +3,20 @@ subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identityv5_access_key"
 description: |-
-  Use this data source to get the list of access key in the Identity and Access Management V5 service.
+  Use this data source to get the first available access key under the specified user within HuaweiCloud.
 ---
 
 # huaweicloud_identityv5_access_key
 
-Use this data source to get the list of access key in the Identity and Access Management V5 service.
+Use this data source to get the first available access key under the specified user within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
-resource "huaweicloud_identityv5_user" "user_1" {
-  name = "Test_accessKey"
-}
-
-resource "huaweicloud_identityv5_access_key" "key_1" {
-  user_id = huaweicloud_identityv5_user.user_1.id
-  status  = "inactive"
-}
+variable "user_id" {}
 
 data "huaweicloud_identityv5_access_key" "test" {
-  user_id = huaweicloud_identityv5_access_key.key_1.user_id
+  user_id = var.user_id
 }
 ```
 
@@ -37,10 +30,14 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `access_key_id` - Indicates the ID of the access key.
+* `id` - The ID of the data source.
 
-* `status` - Indicates the status of the access key. The value can be `active` or `inactive`.
+* `access_key_id` - The ID of the access key.
 
-* `created_at` - Indicates the time when the access key was created.
+* `status` - The status of the access key.  
+  + **active**
+  + **inactive**
 
-* `last_used_at` - Indicates the time when the access key was last used.
+* `created_at` - The creation time of the access key.
+
+* `last_used_at` - The time when the access key was last used.

--- a/docs/resources/identityv5_access_key.md
+++ b/docs/resources/identityv5_access_key.md
@@ -3,25 +3,20 @@ subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identityv5_access_key"
 description: |-
-  Manages a permanent Access Key resource within HuaweiCloud IAM V5 service.
+  Manages a permanent access key resource within HuaweiCloud.
 ---
 
 # huaweicloud_identityv5_access_key
 
-Manages a permanent Access Key resource within HuaweiCloud IAM V5 service.
+Manages a permanent access key resource within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
-variable "name" {}
+variable "user_id" {}
 
-resource "huaweicloud_identityv5_user" "user_1" {
-  name        = var.name
-  description = "tested by terraform"
-}
-
-resource "huaweicloud_identityv5_access_key" "key_1" {
-  user_id = huaweicloud_identityv5_user.user_1.id
+resource "huaweicloud_identityv5_access_key" "test" {
+  user_id = var.user_id
 }
 ```
 
@@ -29,9 +24,13 @@ resource "huaweicloud_identityv5_access_key" "key_1" {
 
 The following arguments are supported:
 
-* `user_id` - (Required, String， NonUpdatable) Specifies the ID of the user.
+* `user_id` - (Required, String, NonUpdatable) Specifies the ID of the user.
 
-* `status` - (Optional, String) Specifies the status of the access key can be *active* or *inactive*.
+* `status` - (Optional, String) Specifies the status of the access key.  
+  Defaults to **active**.  
+  The valid values are as follows:
+  + **active**
+  + **inactive**
 
 ## Attribute Reference
 
@@ -39,19 +38,38 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The access key ID.
 
-* `created_at` - Indicates access key creation time.
+* `access_key_id` - The ID of the generated access key.
 
-* `last_used_at` - Indicates the last usage time of the access key. If it does not exist,
-  it indicates that it has never been used.
+* `secret_access_key` - The generated secret access key.  
 
-* `access_key_id` - Indicates the access key ID.
+* `created_at` - The creation time of the access key.
 
-* `secret_access_key` - Indicates the access secret key.  
+* `last_used_at` - The time when the access key was last used.  
+  If it is an empty string, it means that the AK and SK have never been used.
 
 ## Import
 
-The IAM v5 access key can be imported using the user_id and access_key_id separated by a slash, e.g:
+The IAM v5 access key can be imported using the `user_id` and `id` ( also the `access_key_id`),
+separated by a slash, e.g.
 
 ```bash
-$ terraform import huaweicloud_identityv5_access_key.access_key <user_id>/<id>
+$ terraform import huaweicloud_identityv5_access_key.test <user_id>/<id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `secret_access_key`.
+It is generally recommended running `terraform plan` after importing the resource. You can then decide
+if changes should be applied to the resource, or the resource definition should be updated to align with the resource.
+Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_identityv5_access_key" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      secret_access_key,
+    ]
+  }
+}
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1665,7 +1665,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identityv5_group_attached_policies":  iam.DataSourceV5GroupAttachedPolicies(),
 			"huaweicloud_identityv5_authorization_schema":     iam.DataSourceIdentityV5AuthorizationSchema(),
 			"huaweicloud_identityv5_user_attached_policies":   iam.DataSourceV5UserAttachedPolicies(),
-			"huaweicloud_identityv5_access_key":               iam.DataSourceIdentityV5AccessKey(),
+			"huaweicloud_identityv5_access_key":               iam.DataSourceV5AccessKey(),
 
 			"huaweicloud_identitycenter_access_control_attribute_configurations": identitycenter.DataSourceAccessControlAttributeConfigurations(),
 			"huaweicloud_identitycenter_account_assignments":                     identitycenter.DataSourceIdentityCenterAccountAssignments(),
@@ -3421,7 +3421,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identityv5_virtual_mfa_device":          iam.ResourceV5VirtualMfaDevice(),
 			"huaweicloud_identityv5_group":                       iam.ResourceIdentityV5Group(),
 			"huaweicloud_identityv5_group_membership":            iam.ResourceV5GroupMembership(),
-			"huaweicloud_identityv5_access_key":                  iam.ResourceIdentityAccessKey(),
+			"huaweicloud_identityv5_access_key":                  iam.ResourceV5AccessKey(),
 			"huaweicloud_identityv5_resource_tag":                iam.ResourceV5ResourceTag(),
 			"huaweicloud_identityv5_service_linked_agency":       iam.ResourceIdentityv5ServiceLinkedAgency(),
 			"huaweicloud_identityv5_asymmetric_signature_switch": iam.ResourceIdentityV5AsymmetricSignatureSwitch(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_access_key_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_access_key_test.go
@@ -2,17 +2,14 @@ package iam
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 )
 
 func getV5AccessKeyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -20,26 +17,8 @@ func getV5AccessKeyResourceFunc(cfg *config.Config, state *terraform.ResourceSta
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
-	getAccessKeyHttpUrl := "v5/users/{user_id}/access-keys"
-	getAccessKeyPath := client.Endpoint + getAccessKeyHttpUrl
-	getAccessKeyPath = strings.ReplaceAll(getAccessKeyPath, "{user_id}", state.Primary.Attributes["user_id"])
-	getAccessKeyOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	getAccessKeyResp, err := client.Request("GET", getAccessKeyPath, &getAccessKeyOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving IAM access key: %s", err)
-	}
-	getAccessKeyRespBody, err := utils.FlattenResponse(getAccessKeyResp)
-	if err != nil {
-		return nil, err
-	}
 
-	accessKey := utils.PathSearch(fmt.Sprintf("access_keys[?access_key_id=='%s']|[0]", state.Primary.ID), getAccessKeyRespBody, nil)
-	if accessKey == nil {
-		return nil, golangsdk.ErrDefault404{}
-	}
-	return accessKey, nil
+	return iam.GetV5AccessKeyById(client, state.Primary.Attributes["user_id"], state.Primary.ID)
 }
 
 // Please ensure that the user executing the acceptance test has 'admin' permission.

--- a/huaweicloud/services/iam/data_source_huaweicloud_identityv5_access_key.go
+++ b/huaweicloud/services/iam/data_source_huaweicloud_identityv5_access_key.go
@@ -2,14 +2,12 @@ package iam
 
 import (
 	"context"
-	"fmt"
+	"log"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -17,64 +15,73 @@ import (
 
 // @API IAM GET /v5/users/{user_id}/access-keys
 // @API IAM GET /v5/users/{user_id}/access-keys/{access_key_id}/last-used
-func DataSourceIdentityV5AccessKey() *schema.Resource {
+func DataSourceV5AccessKey() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceIdentityV5AccessKeyRead,
+		ReadContext: dataSourceV5AccessKeyRead,
 
 		Schema: map[string]*schema.Schema{
 			"user_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the IAM user.`,
 			},
 			"access_key_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the access key.`,
 			},
 			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the access key.`,
 			},
 			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the access key.`,
 			},
 			"last_used_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the access key was last used.`,
 			},
 		},
 	}
 }
 
-func dataSourceIdentityV5AccessKeyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceV5AccessKeyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.NewServiceClient("iam", region)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
 	userId := d.Get("user_id").(string)
-
-	accessKey, err := getAccessKeyV5(client, userId)
+	accessKeys, err := listV5AccessKeys(client, userId)
 	if err != nil {
-		return diag.Errorf("error retrieving access key: %s", err)
-	}
-	if accessKey == nil {
-		return diag.Errorf("not found access key : %s", err)
+		return diag.Errorf("error retrieving access key of the user (%s): %s", userId, err)
 	}
 
+	accessKey := utils.PathSearch("[0]", accessKeys, nil)
 	accessKeyId := utils.PathSearch("access_key_id", accessKey, "").(string)
-
-	lastUsedAt, err := getAccessKeyLastUsedV5(client, userId, accessKeyId)
-	if err != nil {
-		return diag.Errorf("error retrieving access key last used time: %s", err)
+	if accessKeyId == "" {
+		return diag.Errorf("unable to find the access key ID from the API response: %s", err)
 	}
 
-	id, _ := uuid.GenerateUUID()
-	d.SetId(id)
+	lastUsedAt, err := getV5AccessKeyLastUsedAt(client, userId, accessKeyId)
+	if err != nil {
+		// To avoid the error of this interface, causing the data source to fail to use normally, use log to record the error.
+		log.Printf("[ERROR] error retrieving last used time of the access key (%s): %s", accessKeyId, err)
+	}
 
-	mErr := multierror.Append(nil,
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomId)
+
+	mErr := multierror.Append(
 		d.Set("access_key_id", accessKeyId),
 		d.Set("status", utils.PathSearch("status", accessKey, nil)),
 		d.Set("created_at", utils.PathSearch("created_at", accessKey, nil)),
@@ -82,50 +89,4 @@ func dataSourceIdentityV5AccessKeyRead(_ context.Context, d *schema.ResourceData
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
-}
-
-func getAccessKeyV5(client *golangsdk.ServiceClient, userId string) (interface{}, error) {
-	path := client.Endpoint + "v5/users/" + userId + "/access-keys"
-	reqOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	r, err := client.Request("GET", path, &reqOpt)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := utils.FlattenResponse(r)
-	if err != nil {
-		return nil, err
-	}
-
-	accessKey := utils.PathSearch("access_keys", resp, make([]interface{}, 0)).([]interface{})
-	if len(accessKey) < 1 {
-		return nil, nil
-	}
-
-	return accessKey[0], nil
-}
-
-func getAccessKeyLastUsedV5(client *golangsdk.ServiceClient, userId, accessKeyId string) (string, error) {
-	path := client.Endpoint + "v5/users/" + userId + "/access-keys/" + accessKeyId + "/last-used"
-	reqOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	r, err := client.Request("GET", path, &reqOpt)
-	if err != nil {
-		if errCode, ok := err.(golangsdk.ErrDefault404); ok {
-			fmt.Printf("Access key last used info not found: %s\n", errCode.Error())
-			return "", nil
-		}
-		return "", err
-	}
-
-	resp, err := utils.FlattenResponse(r)
-	if err != nil {
-		return "", err
-	}
-
-	lastUsedAt := utils.PathSearch("access_key_last_used.last_used_at", resp, "").(string)
-	return lastUsedAt, nil
 }

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_access_key.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_access_key.go
@@ -2,13 +2,14 @@ package iam
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -17,137 +18,214 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var v5AccessKeyNonUpdatableParams = []string{"user_id"}
+
 // @API IAM POST /v5/users/{user_id}/access-keys
-// @API IAM DELETE /v5/users/{user_id}/access-keys/{access_key_id}
 // @API IAM GET /v5/users/{user_id}/access-keys
 // @API IAM GET /v5/users/{user_id}/access-keys/{access_key_id}/last-used
 // @API IAM PUT /v5/users/{user_id}/access-keys/{access_key_id}
-var accessKeyV5NonUpdatableParams = []string{"user_id"}
-
-func ResourceIdentityAccessKey() *schema.Resource {
+// @API IAM DELETE /v5/users/{user_id}/access-keys/{access_key_id}
+func ResourceV5AccessKey() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIdentityV5AccessKeyCreate,
-		ReadContext:   resourceIdentityV5AccessKeyRead,
-		UpdateContext: resourceIdentityV5AccessKeyUpdate,
-		DeleteContext: resourceIdentityV5AccessKeyDelete,
+		CreateContext: resourceV5AccessKeyCreate,
+		ReadContext:   resourceV5AccessKeyRead,
+		UpdateContext: resourceV5AccessKeyUpdate,
+		DeleteContext: resourceV5AccessKeyDelete,
 
-		CustomizeDiff: config.FlexibleForceNew(accessKeyV5NonUpdatableParams),
+		CustomizeDiff: config.FlexibleForceNew(v5AccessKeyNonUpdatableParams),
 
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceIdentityV5AccessKeyImportState,
+			StateContext: resourceV5AccessKeyImportState,
 		},
 		Schema: map[string]*schema.Schema{
 			"user_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the user.`,
 			},
 			"status": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The status of the access key.`,
 			},
 			"access_key_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the generated access key.`,
 			},
 			"secret_access_key": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: `The generated secret access key.`,
 			},
 			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the access key.`,
 			},
 			"last_used_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the access key was last used.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
 			},
 		},
 	}
 }
 
-func resourceIdentityV5AccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV5AccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+	client, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
 	userId := d.Get("user_id").(string)
-	createAccessKeyHttpUrl := "v5/users/{user_id}/access-keys"
-	createAccessKeyPath := iamClient.Endpoint + createAccessKeyHttpUrl
-	createAccessKeyPath = strings.ReplaceAll(createAccessKeyPath, "{user_id}", userId)
-	createAccessKeyOpt := golangsdk.RequestOpts{
+	httpUrl := "v5/users/{user_id}/access-keys"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{user_id}", userId)
+	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
-	createAccessKeyResp, err := iamClient.Request("POST", createAccessKeyPath, &createAccessKeyOpt)
+	createAccessKeyResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating IAM access key for user (%s): %s", userId, err)
+	}
+
+	resp, err := utils.FlattenResponse(createAccessKeyResp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	createAccessKeyBody, err := utils.FlattenResponse(createAccessKeyResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	accessKeyId := utils.PathSearch("access_key.access_key_id", createAccessKeyBody, "").(string)
+
+	accessKeyId := utils.PathSearch("access_key.access_key_id", resp, "").(string)
 	if accessKeyId == "" {
-		return diag.Errorf("error getting IAM access key id: %s", err)
+		return diag.Errorf("unable to find the IAM access key ID from the API response: %s", err)
 	}
+
 	d.SetId(accessKeyId)
-	mErr := multierror.Append(nil,
-		d.Set("secret_access_key", utils.PathSearch("access_key.secret_access_key", createAccessKeyBody, "").(string)),
+
+	mErr := multierror.Append(
+		d.Set("secret_access_key", utils.PathSearch("access_key.secret_access_key", resp, "").(string)),
 	)
 	if err = mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error setting IAM access key fields: %s", err)
+		return diag.Errorf("error saving secret access key field to state: %s", err)
 	}
 
 	if v, ok := d.GetOk("status"); ok && v.(string) != "active" {
-		updateAccessKeyHttpUrl := "v5/users/{user_id}/access-keys/{access_key_id}"
-		updateAccessKeyPath := iamClient.Endpoint + updateAccessKeyHttpUrl
-		updateAccessKeyPath = strings.ReplaceAll(updateAccessKeyPath, "{user_id}", userId)
-		updateAccessKeyPath = strings.ReplaceAll(updateAccessKeyPath, "{access_key_id}", accessKeyId)
-		updateAccessKeyOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-			JSONBody: map[string]interface{}{
-				"status": d.Get("status").(string),
-			},
-		}
-		_, err := iamClient.Request("PUT", updateAccessKeyPath, &updateAccessKeyOpt)
+		err = updateV5AccessKeyStatus(client, userId, accessKeyId, v.(string))
 		if err != nil {
-			return diag.Errorf("error updating IAM access key: %s", err)
+			return diag.Errorf("error updating status of access key for user (%s): %s", userId, err)
 		}
 	}
-	return resourceIdentityV5AccessKeyRead(ctx, d, meta)
+
+	return resourceV5AccessKeyRead(ctx, d, meta)
 }
 
-func resourceIdentityV5AccessKeyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateV5AccessKeyStatus(client *golangsdk.ServiceClient, userId string, accessKeyId string, status string) error {
+	httpUrl := "v5/users/{user_id}/access-keys/{access_key_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{user_id}", userId)
+	updatePath = strings.ReplaceAll(updatePath, "{access_key_id}", accessKeyId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"status": status,
+		},
+	}
+	_, err := client.Request("PUT", updatePath, &opt)
+	return err
+}
+
+func listV5AccessKeys(client *golangsdk.ServiceClient, userId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v5/users/{user_id}/access-keys"
+		result  = make([]interface{}, 0)
+		marker  = ""
+		// The default limit is 200, maximum is 200.
+		limit = 200
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{user_id}", userId)
+	listPath += fmt.Sprintf("?limit=%d", limit)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s&marker=%s", listPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", listPathWithMarker, &getOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		accessKeys := utils.PathSearch("access_keys", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, accessKeys...)
+		if len(accessKeys) < limit {
+			break
+		}
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func GetV5AccessKeyById(client *golangsdk.ServiceClient, userId string, accessKeyId string) (interface{}, error) {
+	accessKeys, err := listV5AccessKeys(client, userId)
+	if err != nil {
+		return nil, err
+	}
+
+	accessKey := utils.PathSearch(fmt.Sprintf("[?access_key_id=='%s']|[0]", accessKeyId), accessKeys, nil)
+	if accessKey == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v5/users/{user_id}/access-keys",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the IAM access key (%s) for user (%s) does not exist", accessKeyId, userId)),
+			},
+		}
+	}
+
+	return accessKey, nil
+}
+
+func resourceV5AccessKeyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+	client, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
 	userId := d.Get("user_id").(string)
-	getAccessKeyHttpUrl := "v5/users/{user_id}/access-keys"
-	getAccessKeyPath := iamClient.Endpoint + getAccessKeyHttpUrl
-	getAccessKeyPath = strings.ReplaceAll(getAccessKeyPath, "{user_id}", userId)
-	getAccessKeyOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	getAccessKeyResp, err := iamClient.Request("GET", getAccessKeyPath, &getAccessKeyOpt)
+	accessKey, err := GetV5AccessKeyById(client, userId, d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error get IAM user access key")
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving IAM access key of the user (%s)", userId))
 	}
 
-	getAccessKeyRespBody, err := utils.FlattenResponse(getAccessKeyResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	accessKey := utils.PathSearch(fmt.Sprintf("access_keys[?access_key_id=='%s']|[0]", d.Id()), getAccessKeyRespBody, nil)
-	if accessKey == nil {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
-	}
-	mErr := multierror.Append(nil,
+	mErr := multierror.Append(
 		d.Set("access_key_id", utils.PathSearch("access_key_id", accessKey, nil)),
 		d.Set("created_at", utils.PathSearch("created_at", accessKey, "").(string)),
 		d.Set("status", utils.PathSearch("status", accessKey, "").(string)),
@@ -157,89 +235,89 @@ func resourceIdentityV5AccessKeyRead(_ context.Context, d *schema.ResourceData, 
 	}
 
 	accessKeyId := utils.PathSearch("access_key_id", accessKey, "").(string)
-	if accessKeyId != "" {
-		getLastUsedHttpUrl := "v5/users/{user_id}/access-keys/{access_key_id}/last-used"
-		getLastUsedPath := iamClient.Endpoint + getLastUsedHttpUrl
-		getLastUsedPath = strings.ReplaceAll(getLastUsedPath, "{user_id}", userId)
-		getLastUsedPath = strings.ReplaceAll(getLastUsedPath, "{access_key_id}", accessKeyId)
-		getLastUsedOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-		}
-		getLastUsedResp, err := iamClient.Request("GET", getLastUsedPath, &getLastUsedOpt)
-		if err != nil {
-			return diag.Errorf("error get IAM User last login time: %s", err)
-		}
-		lastUsed, err := utils.FlattenResponse(getLastUsedResp)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		if e := d.Set("last_used_at", utils.PathSearch("access_key_last_used.last_used_at", lastUsed, nil)); e != nil {
-			return diag.FromErr(e)
-		}
+	if accessKeyId == "" {
+		return nil
 	}
-	return nil
+
+	lastUsedAt, err := getV5AccessKeyLastUsedAt(client, userId, accessKeyId)
+	if err != nil {
+		log.Printf("[ERROR] error retrieving last used time of the access key (%s): %s", accessKeyId, err)
+	}
+
+	return diag.FromErr(d.Set("last_used_at", lastUsedAt))
 }
 
-func resourceIdentityV5AccessKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
-	if err != nil {
-		return diag.Errorf("error creating IAM client: %s", err)
-	}
-
-	accessKeyId := d.Id()
-	if d.HasChanges("status") {
-		updateAccessKeyHttpUrl := "v5/users/{user_id}/access-keys/{access_key_id}"
-		updateAccessKeyPath := iamClient.Endpoint + updateAccessKeyHttpUrl
-		updateAccessKeyPath = strings.ReplaceAll(updateAccessKeyPath, "{user_id}", d.Get("user_id").(string))
-		updateAccessKeyPath = strings.ReplaceAll(updateAccessKeyPath, "{access_key_id}", accessKeyId)
-		updateAccessKeyOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-			JSONBody: map[string]interface{}{
-				"status": d.Get("status").(string),
-			},
-		}
-		_, err := iamClient.Request("PUT", updateAccessKeyPath, &updateAccessKeyOpt)
-		if err != nil {
-			return diag.Errorf("error updating IAM access key: %s", err)
-		}
-	}
-	return resourceIdentityV5AccessKeyRead(ctx, d, meta)
-}
-
-func resourceIdentityV5AccessKeyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
-	if err != nil {
-		return diag.Errorf("error creating IAM client: %s", err)
-	}
-	deleteAccessKeyHttpUrl := "v5/users/{user_id}/access-keys/{access_key_id}"
-	deleteAccessKeyPath := iamClient.Endpoint + deleteAccessKeyHttpUrl
-	deleteAccessKeyPath = strings.ReplaceAll(deleteAccessKeyPath, "{user_id}", d.Get("user_id").(string))
-	deleteAccessKeyPath = strings.ReplaceAll(deleteAccessKeyPath, "{access_key_id}", d.Id())
-	deleteAccessKeyOpt := golangsdk.RequestOpts{
+func getV5AccessKeyLastUsedAt(client *golangsdk.ServiceClient, userId, accessKeyId string) (string, error) {
+	path := client.Endpoint + "v5/users/" + userId + "/access-keys/" + accessKeyId + "/last-used"
+	reqOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
-	_, err = iamClient.Request("DELETE", deleteAccessKeyPath, &deleteAccessKeyOpt)
+	r, err := client.Request("GET", path, &reqOpt)
 	if err != nil {
-		return diag.Errorf("error deleting IAM access key: %s", err)
+		return "", err
 	}
+
+	resp, err := utils.FlattenResponse(r)
+	if err != nil {
+		return "", err
+	}
+
+	return utils.PathSearch("access_key_last_used.last_used_at", resp, "").(string), nil
+}
+
+func resourceV5AccessKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		userId      = d.Get("user_id").(string)
+		accessKeyId = d.Id()
+	)
+
+	client, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	err = updateV5AccessKeyStatus(client, userId, accessKeyId, d.Get("status").(string))
+	if err != nil {
+		return diag.Errorf("error updating status of access key for user (%s): %s", userId, err)
+	}
+
+	return resourceV5AccessKeyRead(ctx, d, meta)
+}
+
+func resourceV5AccessKeyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		userId = d.Get("user_id").(string)
+	)
+
+	client, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	httpUrl := "v5/users/{user_id}/access-keys/{access_key_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{user_id}", userId)
+	deletePath = strings.ReplaceAll(deletePath, "{access_key_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting access key for user (%s): %s", userId, err)
+	}
+
 	return nil
 }
 
-func resourceIdentityV5AccessKeyImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
-	[]*schema.ResourceData, error) {
-	parts := strings.Split(d.Id(), "/")
+func resourceV5AccessKeyImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
 	if len(parts) != 2 {
-		return nil, errors.New("invalid format of import ID, must be <user_id>/<id>")
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<user_id>/<id>', but got '%s'", importedId)
 	}
 
 	d.SetId(parts[1])
-	mErr := multierror.Append(nil,
-		d.Set("user_id", parts[0]),
-	)
-	if err := mErr.ErrorOrNil(); err != nil {
-		return nil, fmt.Errorf("failed to set value to state when import, %s", err)
-	}
-	return []*schema.ResourceData{d}, nil
+	return []*schema.ResourceData{d}, d.Set("user_id", parts[0])
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The current code has the following design issues and needs optimization:

- Redundant method naming
- Fields in the schema lack descriptions
- Common logic is not reused
- Missing `enable_force_new` in resource
- Some error messages are inaccurate
- Some content in the documentation is inaccurately described

Nonupdatable feature:
<img width="823" height="561" alt="image" src="https://github.com/user-attachments/assets/2e49fde3-46eb-45db-887b-1b09171fb4b1" />

ForceNew enabled:
<img width="988" height="559" alt="image" src="https://github.com/user-attachments/assets/0018f1d9-31a2-465e-970c-c5069fc20d12" />

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update functions naming
2. add missing 'enable_force_new' internal parameter
3. add a description to each field in the schema
4. correcting inaccurate error messages
5. improve and optimize the document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV5AccessKey_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5AccessKey_basic -timeout 360m -parallel 10
=== RUN   TestAccV5AccessKey_basic
=== PAUSE TestAccV5AccessKey_basic
=== CONT  TestAccV5AccessKey_basic
--- PASS: TestAccV5AccessKey_basic (46.10s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       46.234s coverage: 4.2% of statements in ./huaweicloud/services/iam
```
```
/scripts/coverage.sh -o iam -f TestAccDataV5AccessKey_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5AccessKey_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5AccessKey_basic
=== PAUSE TestAccDataV5AccessKey_basic
=== CONT  TestAccDataV5AccessKey_basic
--- PASS: TestAccDataV5AccessKey_basic (21.70s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       21.858s coverage: 4.5% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
     <img width="1207" height="841" alt="image" src="https://github.com/user-attachments/assets/110572e4-a045-468d-9e56-45f6426f5c81" />
    
    ab. Related resources (parent resources) not found
     <img width="1129" height="753" alt="image" src="https://github.com/user-attachments/assets/169b5a28-09bb-4640-8590-b85119fc5057" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
