### PR TITLE
test(iam): optimize the acceptance case design for group role assignment datasource

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_check_group_role_assigment_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_check_group_role_assigment_test.go
@@ -9,112 +9,122 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccIdentityCheckGroupRoleAssignment_basic(t *testing.T) {
+func TestAccDataCheckGroupRoleAssignment_basic(t *testing.T) {
 	var (
-		groupName1           = acceptance.RandomAccResourceName()
-		dataSourceDomain     = "data.huaweicloud_identity_check_group_role_assignment.test_domain"
-		dataSourceProject    = "data.huaweicloud_identity_check_group_role_assignment.test_project"
-		dataSourceProjectAll = "data.huaweicloud_identity_check_group_role_assignment.test_project_all"
-		dataSourceDomainNot  = "data.huaweicloud_identity_check_group_role_assignment.test_domain_not"
+		name = acceptance.RandomAccResourceName()
+
+		byDomain   = "data.huaweicloud_identity_check_group_role_assignment.filter_by_domain"
+		dcByDomain = acceptance.InitDataSourceCheck(byDomain)
+
+		byProject   = "data.huaweicloud_identity_check_group_role_assignment.filter_by_project"
+		dcByProject = acceptance.InitDataSourceCheck(byProject)
+
+		byProjectAll   = "data.huaweicloud_identity_check_group_role_assignment.filter_by_project_all"
+		dcByProjectAll = acceptance.InitDataSourceCheck(byProjectAll)
+
+		byDomainNot   = "data.huaweicloud_identity_check_group_role_assignment.filter_by_domain_not"
+		dcByDomainNot = acceptance.InitDataSourceCheck(byDomainNot)
 	)
-	dcDomain := acceptance.InitDataSourceCheck(dataSourceDomain)
-	dcProject := acceptance.InitDataSourceCheck(dataSourceProject)
-	dcProjectAll := acceptance.InitDataSourceCheck(dataSourceProjectAll)
-	dcDomainNot := acceptance.InitDataSourceCheck(dataSourceDomainNot)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPrecheckDomainId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityCheckGroupRoleAssignment(groupName1),
+				Config: testAccDataCheckGroupRoleAssignment_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					dcDomain.CheckResourceExists(),
-					dcProject.CheckResourceExists(),
-					dcProjectAll.CheckResourceExists(),
-					dcDomainNot.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceDomain, "result", "true"),
-					resource.TestCheckResourceAttr(dataSourceProject, "result", "true"),
-					resource.TestCheckResourceAttr(dataSourceProjectAll, "result", "true"),
-					resource.TestCheckResourceAttr(dataSourceDomainNot, "result", "false"),
+					dcByDomain.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byDomain, "result", "true"),
+					dcByProject.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byProject, "result", "true"),
+					dcByProjectAll.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byProjectAll, "result", "true"),
+					dcByDomainNot.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byDomainNot, "result", "false"),
 				),
 			},
 		},
 	})
 }
 
-func testAccIdentityCheckGroupRoleAssignment(groupName string) string {
+func testAccDataCheckGroupRoleAssignment_base(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identity_group" "test" {
-  name = "%s"
+data "huaweicloud_identity_projects" "test" {
+  name = "%[1]s"
 }
 
-data "huaweicloud_identity_role" "role_1" {
+resource "huaweicloud_identity_group" "test" {
+  name = "%[2]s"
+}
+
+data "huaweicloud_identity_role" "aad_full_access" {
   display_name = "AAD FullAccess"
 }
 
-data "huaweicloud_identity_role" "role_2" {
+data "huaweicloud_identity_role" "aad_read_only_access" {
   display_name = "AAD ReadOnlyAccess"
 }
 
-data "huaweicloud_identity_role" "role_3" {
-  display_name = "AND ReadOnlyAccess"
-}
-
-data "huaweicloud_identity_role" "role_4" {
+data "huaweicloud_identity_role" "api_administrator" {
   display_name = "APIG Administrator"
 }
 
-resource "huaweicloud_identity_group_role_assignment" "test_domain" {
+resource "huaweicloud_identity_group_role_assignment" "test_with_domain" {
   group_id  = huaweicloud_identity_group.test.id
-  role_id   = data.huaweicloud_identity_role.role_1.id
-  domain_id = "%s"
+  role_id   = data.huaweicloud_identity_role.aad_full_access.id
+  domain_id = "%[3]s"
 }
 
-resource "huaweicloud_identity_group_role_assignment" "test_project" {
+resource "huaweicloud_identity_group_role_assignment" "test_with_project" {
   group_id   = huaweicloud_identity_group.test.id
-  role_id    = data.huaweicloud_identity_role.role_2.id
-  project_id = "%s"
+  role_id    = data.huaweicloud_identity_role.aad_read_only_access.id
+  project_id = try(data.huaweicloud_identity_projects.test.projects[0].id, "NOT_FOUND")
 }
 
-resource "huaweicloud_identity_group_role_assignment" "test_project_all" {
+resource "huaweicloud_identity_group_role_assignment" "test_with_project_all" {
   group_id   = huaweicloud_identity_group.test.id
-  role_id    = data.huaweicloud_identity_role.role_3.id
+  role_id    = data.huaweicloud_identity_role.api_administrator.id
   project_id = "all"
 }
+`, acceptance.HW_REGION_NAME, name, acceptance.HW_DOMAIN_ID)
+}
 
-data "huaweicloud_identity_check_group_role_assignment" "test_domain" {
+func testAccDataCheckGroupRoleAssignment_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_identity_check_group_role_assignment" "filter_by_domain" {
   group_id  = huaweicloud_identity_group.test.id
-  role_id   = data.huaweicloud_identity_role.role_1.id
-  domain_id = "%s"
+  role_id   = data.huaweicloud_identity_role.aad_full_access.id
+  domain_id = "%[2]s"
 
-  depends_on = [huaweicloud_identity_group_role_assignment.test_domain]
+  depends_on = [huaweicloud_identity_group_role_assignment.test_with_domain]
 }
 
-data "huaweicloud_identity_check_group_role_assignment" "test_project" {
+data "huaweicloud_identity_check_group_role_assignment" "filter_by_project" {
   group_id   = huaweicloud_identity_group.test.id
-  role_id    = data.huaweicloud_identity_role.role_2.id
-  project_id = "%s"
+  role_id    = data.huaweicloud_identity_role.aad_read_only_access.id
+  project_id = try(data.huaweicloud_identity_projects.test.projects[0].id, "NOT_FOUND")
 
-  depends_on = [huaweicloud_identity_group_role_assignment.test_project]
+  depends_on = [huaweicloud_identity_group_role_assignment.test_with_project]
 }
 
-data "huaweicloud_identity_check_group_role_assignment" "test_project_all" {
+data "huaweicloud_identity_check_group_role_assignment" "filter_by_project_all" {
   group_id   = huaweicloud_identity_group.test.id
-  role_id    = data.huaweicloud_identity_role.role_3.id
+  role_id    = data.huaweicloud_identity_role.api_administrator.id
   project_id = "all"
 
-  depends_on = [huaweicloud_identity_group_role_assignment.test_project_all]
+  depends_on = [huaweicloud_identity_group_role_assignment.test_with_project_all]
 }
 
-data "huaweicloud_identity_check_group_role_assignment" "test_domain_not" {
+data "huaweicloud_identity_check_group_role_assignment" "filter_by_domain_not" {
   group_id  = huaweicloud_identity_group.test.id
-  role_id   = data.huaweicloud_identity_role.role_4.id
-  domain_id = "%s"
+  role_id   = data.huaweicloud_identity_role.aad_full_access.id
+  domain_id = "%[2]s"
 }
-`, groupName, acceptance.HW_DOMAIN_ID, acceptance.HW_PROJECT_ID,
-		acceptance.HW_DOMAIN_ID, acceptance.HW_PROJECT_ID, acceptance.HW_DOMAIN_ID)
+`, testAccDataCheckGroupRoleAssignment_base(name), acceptance.HW_DOMAIN_ID)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

  1. Redundant code
  2. Insufficiently function name

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. remove the redundant code for the group role assignment datasource's test
2. update function naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataSourceCheckGroupRoleAssignment_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCheckGroupRoleAssignment_basic
=== PAUSE TestAccDataSourceCheckGroupRoleAssignment_basic
=== CONT  TestAccDataSourceCheckGroupRoleAssignment_basic
--- PASS: TestAccDataSourceCheckGroupRoleAssignment_basic (16.05s)
PASS
coverage: 4.9% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       16.191s coverage: 4.9% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.
