### PR TITLE
refactor(iam/v5_asymmetric_signature_switch): optimize resource code

### DIFF
--- a/docs/resources/identityv5_asymmetric_signature_switch.md
+++ b/docs/resources/identityv5_asymmetric_signature_switch.md
@@ -3,14 +3,16 @@ subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identityv5_asymmetric_signature_switch"
 description: |-
-  Enable or disable the asymmetric signature function for the account within HuaweiCloud.
+  Use this resource to enable or disable the asymmetric signature function for the account within HuaweiCloud.
 ---
 
 # huaweicloud_identityv5_asymmetric_signature_switch
 
-Enable or disable the asymmetric signature function for the account within HuaweiCloud.
+Use this resource to enable or disable the asymmetric signature function for the account within HuaweiCloud.
 
-->**Note** The asymmetric signature switch can not be destroyed.
+-> This resource is a one-time action resource used to enable or disable the asymmetric signature function. Deleting
+   this resource will not clear the corresponding request record, but will only remove the resource information from
+   the tf state file.
 
 ## Example Usage
 
@@ -22,8 +24,16 @@ resource "huaweicloud_identityv5_asymmetric_signature_switch" "test" {
 
 ## Argument Reference
 
-* `asymmetric_signature_switch` - (Required, Bool) Specifies the asymmetric signature switch.
+* `asymmetric_signature_switch` - (Required, Bool) Specifies Whether to enable the asymmetric signature function.
 
 ## Attribute Reference
 
-* `id` - Resource ID in format `<domain_id>`.
+* `id` - The ID of the resource, which is the domain ID.
+
+## Import
+
+The resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_identityv5_asymmetric_signature_switch.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3397,7 +3397,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identityv5_access_key":                  iam.ResourceIdentityAccessKey(),
 			"huaweicloud_identityv5_resource_tag":                iam.ResourceIdentityV5ResourceTag(),
 			"huaweicloud_identityv5_service_linked_agency":       iam.ResourceIdentityv5ServiceLinkedAgency(),
-			"huaweicloud_identityv5_asymmetric_signature_switch": iam.ResourceIdentityV5AsymmetricSignatureSwitch(),
+			"huaweicloud_identityv5_asymmetric_signature_switch": iam.ResourceV5AsymmetricSignatureSwitch(),
 
 			"huaweicloud_identitycenter_instance":                               identitycenter.ResourceIdentityCenterInstance(),
 			"huaweicloud_identitycenter_registered_region":                      identitycenter.ResourceIdentityCenterRegisteredRegion(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_asymmetric_signature_switch_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_asymmetric_signature_switch_test.go
@@ -8,14 +8,12 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-// Please ensure that the user executing the acceptance test has 'admin' permission.
 func TestAccV5AsymmetricSignatureSwitch_basic(t *testing.T) {
 	rName := "huaweicloud_identityv5_asymmetric_signature_switch.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_asymmetric_signature_switch.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_asymmetric_signature_switch.go
@@ -13,15 +13,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// ResourceIdentityV5AsymmetricSignatureSwitch
 // @API IAM PUT /v5/asymmetric-signature-switch
 // @API IAM GET /v5/asymmetric-signature-switch
-func ResourceIdentityV5AsymmetricSignatureSwitch() *schema.Resource {
+func ResourceV5AsymmetricSignatureSwitch() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIdentityV5AsymmetricSignatureSwitchUpdate,
-		ReadContext:   resourceIdentityV5AsymmetricSignatureSwitchRead,
-		UpdateContext: resourceIdentityV5AsymmetricSignatureSwitchUpdate,
-		DeleteContext: resourceIdentityV5AsymmetricSignatureSwitchDelete,
+		CreateContext: resourceV5AsymmetricSignatureSwitchUpdate,
+		ReadContext:   resourceV5AsymmetricSignatureSwitchRead,
+		UpdateContext: resourceV5AsymmetricSignatureSwitchUpdate,
+		DeleteContext: resourceV5AsymmetricSignatureSwitchDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -29,14 +28,15 @@ func ResourceIdentityV5AsymmetricSignatureSwitch() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"asymmetric_signature_switch": {
-				Type:     schema.TypeBool,
-				Required: true,
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: `Whether to enable the asymmetric signature function.`,
 			},
 		},
 	}
 }
 
-func resourceIdentityV5AsymmetricSignatureSwitchUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV5AsymmetricSignatureSwitchUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
 	if err != nil {
@@ -45,7 +45,8 @@ func resourceIdentityV5AsymmetricSignatureSwitchUpdate(ctx context.Context, d *s
 
 	path := iamClient.Endpoint + "v5/asymmetric-signature-switch"
 	reqOpts := golangsdk.RequestOpts{
-		OkCodes: []int{204},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+		OkCodes:     []int{204},
 		JSONBody: map[string]interface{}{
 			"asymmetric_signature": map[string]interface{}{
 				"asymmetric_signature_switch": d.Get("asymmetric_signature_switch").(bool),
@@ -54,13 +55,14 @@ func resourceIdentityV5AsymmetricSignatureSwitchUpdate(ctx context.Context, d *s
 	}
 	_, err = iamClient.Request("PUT", path, &reqOpts)
 	if err != nil {
-		return diag.Errorf("error set IAM asymmetric signature switch: %s", err)
+		return diag.Errorf("unable to set the asymmetric signature switch: %s", err)
 	}
+
 	d.SetId(cfg.DomainID)
-	return resourceIdentityV5AsymmetricSignatureSwitchRead(ctx, d, meta)
+	return resourceV5AsymmetricSignatureSwitchRead(ctx, d, meta)
 }
 
-func resourceIdentityV5AsymmetricSignatureSwitchRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV5AsymmetricSignatureSwitchRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
 	if err != nil {
@@ -70,19 +72,23 @@ func resourceIdentityV5AsymmetricSignatureSwitchRead(_ context.Context, d *schem
 	path := iamClient.Endpoint + "v5/asymmetric-signature-switch"
 	reqOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
 	resp, err := iamClient.Request("GET", path, &reqOpts)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error get IAM asymmetric signature switch")
+		return common.CheckDeletedDiag(d, err, "error getting the asymmetric signature switch")
 	}
+
 	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
 	asymmetricSignatureSwitch := utils.PathSearch("asymmetric_signature.asymmetric_signature_switch", respBody, nil)
 	if asymmetricSignatureSwitch == nil {
-		return diag.Errorf("error getting IAM asymmetric signature switch: asymmetric_signature_switch is not found in response")
+		return diag.Errorf("unable to find the asymmetric signature switch in the API response")
 	}
+
 	err = d.Set("asymmetric_signature_switch", asymmetricSignatureSwitch)
 	if err != nil {
 		return diag.Errorf("error setting asymmetric_signature_switch fields: %s", err)
@@ -90,9 +96,9 @@ func resourceIdentityV5AsymmetricSignatureSwitchRead(_ context.Context, d *schem
 	return nil
 }
 
-func resourceIdentityV5AsymmetricSignatureSwitchDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	errorMsg := "Deleting asymmetric signature switch is not supported. " +
-		"The asymmetric signature switch is only removed from the state, but it remains in the cloud."
+func resourceV5AsymmetricSignatureSwitchDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to enable or disable the asymmetric signature function.
+Deleting this resource will not clear the corresponding request record, but will only remove the resource information from the tf state file.`
 	return diag.Diagnostics{
 		diag.Diagnostic{
 			Severity: diag.Warning,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The current code has the following design issues and needs optimization:

- Redundant method naming
- Fields in the schema lack descriptions
- Common logic is not reused
- Some error messages are inaccurate
- There are some useless comments
- Some content in the documentation is inaccurately described

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update functions naming
2. add a description to each field in the schema
3. correcting inaccurate error messages
4. remove usless comments
5. improve and optimize the document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV5AsymmetricSignatureSwitch_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5AsymmetricSignatureSwitch_basic -timeout 360m -parallel 10
=== RUN   TestAccV5AsymmetricSignatureSwitch_basic
=== PAUSE TestAccV5AsymmetricSignatureSwitch_basic
=== CONT  TestAccV5AsymmetricSignatureSwitch_basic
--- PASS: TestAccV5AsymmetricSignatureSwitch_basic (31.88s)
PASS
coverage: 2.2% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       32.013s coverage: 2.2% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
