### PR TITLE
test(iam): optimize the acceptance case design for custom role datasource

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_custom_role_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_custom_role_test.go
@@ -9,33 +9,42 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccIdentityCustomRoleDataSource_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identity_custom_role.role_1"
-	rName := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccDataCustomRole_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		byName   = "data.huaweicloud_identity_custom_role.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byId   = "data.huaweicloud_identity_custom_role.filter_by_id"
+		dcById = acceptance.InitDataSourceCheck(byId)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPrecheckDomainId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityCustomRoleDataSource_basic(rName),
+				Config: testAccDataCustomRole_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(byName, "catalog"),
+					dcById.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(byId, "catalog"),
 				),
 			},
 		},
 	})
 }
 
-func testAccIdentityCustomRoleDataSource_basic(rName string) string {
+func testAccDataCustomRole_base(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identity_role" test {
-  name        = "%s"
+resource "huaweicloud_identity_role" "test" {
+  name        = "%[1]s"
   description = "created by terraform"
   type        = "AX"
   policy      = <<EOF
@@ -55,13 +64,35 @@ resource "huaweicloud_identity_role" test {
 }
 EOF
 }
-
-data "huaweicloud_identity_custom_role" "role_1" {
-  name = huaweicloud_identity_role.test.name
-
-  depends_on = [
-	huaweicloud_identity_role.test
-  ]
+`, name)
 }
-`, rName)
+
+func testAccDataCustomRole_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Filter by name
+locals {
+  name = huaweicloud_identity_role.test.name
+}
+
+data "huaweicloud_identity_custom_role" "filter_by_name" {
+  name = local.name
+
+  # Waiting for the role to be created.
+  depends_on = [huaweicloud_identity_role.test]
+}
+
+# Filter by ID
+locals {
+  id = huaweicloud_identity_role.test.id
+}
+
+data "huaweicloud_identity_custom_role" "filter_by_id" {
+  id = local.id
+
+  # Waiting for the role to be created.
+  depends_on = [huaweicloud_identity_role.test]
+}
+`, testAccDataCustomRole_base(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

  1. Redundant code
  2. Insufficiently precise checks

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. remove the redundant code for the custom role datasource's test
2. update the check items and function naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataSourceCustomRole_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCustomRole_basic
=== PAUSE TestAccDataSourceCustomRole_basic
=== CONT  TestAccDataSourceCustomRole_basic
--- PASS: TestAccDataSourceCustomRole_basic (14.17s)
PASS
coverage: 2.6% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       14.297s coverage: 2.6% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.