### PR TITLE
test(iam): optimize the acceptance case design for endpoints datasource

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_endpoints_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_endpoints_test.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,12 +9,15 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccIdentityEndpointDataSource_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_identity_endpoints.test"
-	dataSourceById := "data.huaweicloud_identity_endpoints.test1"
+func TestAccDataEndpoints_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_identity_endpoints.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
-	config := testAccIdentityEndpoints_basic()
-	configWithId := testAccIdentityEndpointsById_basic()
+		byId   = "data.huaweicloud_identity_endpoints.filter_by_endpoint_id"
+		dcById = acceptance.InitDataSourceCheck(byId)
+	)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
@@ -21,35 +25,39 @@ func TestAccIdentityEndpointDataSource_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithId,
+				Config: testAccDataEndpoints_basic,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceById, "endpoints.#"),
-					resource.TestCheckResourceAttr(dataSourceById, "endpoints.0.enabled", "true"),
-				),
-			},
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSource, "endpoints.#"),
-					resource.TestCheckResourceAttr(dataSource, "endpoints.0.enabled", "true"),
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "endpoints.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(all, "endpoints.0.enabled", "true"),
+					dcById.CheckResourceExists(),
+					resource.TestCheckOutput("is_endpoint_id_filter_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccIdentityEndpoints_basic() string {
-	return `
-data "huaweicloud_identity_endpoints" "test" {}
-`
+const testAccDataEndpoints_basic = `
+# All
+data "huaweicloud_identity_endpoints" "all" {}
+
+# Filter by endpoint ID
+locals {
+  endpoint_id = try(data.huaweicloud_identity_endpoints.all.endpoints.0.id, "NOT_FOUND")
 }
 
-func testAccIdentityEndpointsById_basic() string {
-	return `
-data "huaweicloud_identity_endpoints" "test" {}
+data "huaweicloud_identity_endpoints" "filter_by_endpoint_id" {
+  endpoint_id = local.endpoint_id
+}
 
-data "huaweicloud_identity_endpoints" "test1" {
-  endpoint_id = data.huaweicloud_identity_endpoints.test.endpoints.0.id
+locals {
+  endpoint_id_filter_result = [
+    for v in data.huaweicloud_identity_endpoints.filter_by_endpoint_id.endpoints[*].id : v == local.endpoint_id
+  ]
+}
+
+output "is_endpoint_id_filter_useful" {
+  value = length(local.endpoint_id_filter_result) > 0 && alltrue(local.endpoint_id_filter_result)
 }
 `
-}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

  1. Redundant code

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. remove the redundant code for the endpoints datasource‘s test
2. update function naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataSourceEndpoints_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceEndpoints_basic
=== PAUSE TestAccDataSourceEndpoints_basic
=== CONT  TestAccDataSourceEndpoints_basic
--- PASS: TestAccDataSourceEndpoints_basic (25.99s)
PASS
coverage: 2.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       26.120s coverage: 2.3% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.