### PR TITLE
test(iam): optimize the acceptance case design for enterprise project groups datasource

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_enterprise_project_groups_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_enterprise_project_groups_test.go
@@ -9,31 +9,47 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccIdentityEnterpriseProjectGroups_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identity_enterprise_project_groups.test"
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccDataEnterpriseProjectGroups_basic(t *testing.T) {
+	all := "data.huaweicloud_identity_enterprise_project_groups.all"
+	dc := acceptance.InitDataSourceCheck(all)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityEnterpriseProjectGroups(),
+				Config: testAccDataEnterpriseProjectGroups_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSourceName, "groups.#"),
+					resource.TestCheckOutput("is_enterprise_project_id_filter_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccIdentityEnterpriseProjectGroups() string {
+func testAccDataEnterpriseProjectGroups_basic() string {
 	return fmt.Sprintf(`
-data "huaweicloud_identity_enterprise_project_groups" "test" {
- 	enterprise_project_id = "%s"
+# All
+locals {
+  enterprise_project_id = "%[1]s"
 }
-`, acceptance.HW_ENTERPRISE_PROJECT_ID)
+
+data "huaweicloud_identity_enterprise_project_groups" "all" {
+  enterprise_project_id = local.enterprise_project_id
+}
+
+locals {
+  enterprise_project_id_filter_result = [
+    for v in data.huaweicloud_identity_enterprise_project_groups.all.groups[*].enterprise_project_id : v == local.enterprise_project_id
+  ]
+}
+
+output "is_enterprise_project_id_filter_useful" {
+  value = length(local.enterprise_project_id_filter_result) > 0 && alltrue(local.enterprise_project_id_filter_result)
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

  1. Redundant code

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. remove the redundant code for the enterprise project groups datasource‘s test
2. update function naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataSourceEnterpriseProjectGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceEnterpriseProjectGroups_basic
=== PAUSE TestAccDataSourceEnterpriseProjectGroups_basic
=== CONT  TestAccDataSourceEnterpriseProjectGroups_basic
--- PASS: TestAccDataSourceEnterpriseProjectGroups_basic (12.18s)
PASS
coverage: 2.4% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       12.305s coverage: 2.4% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.
