### PR TITLE
fix(CCE): cce autopilot cluster log configs fix test and doc

### DIFF
--- a/docs/data-sources/cce_autopilot_cluster_log_configs.md
+++ b/docs/data-sources/cce_autopilot_cluster_log_configs.md
@@ -29,13 +29,16 @@ The following arguments are supported:
 
 * `cluster_id` - (Required, String) Specifies the cluster ID.
 
-* `type` - (Optional, String) Specifies the type of log config.
+* `type` - (Optional, String) Specifies the type of log config. Value options:
+  + **control**: specifies the logs of the control plane components.
+  + **audit**: specifies the audit logs on the control plane.
+  + **system-addon**: s ecifies the logs of the system add-ons.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `ttl_in_days` - The Storage duration.
+* `ttl_in_days` - The storage duration.
 
 * `log_configs` - Log config information.
 
@@ -46,6 +49,6 @@ The `log_configs` block supports:
 
 * `name` - Last config server name.
 
-* `enable` - Collected or not.
+* `enable` - Whether to enable log collection.
 
 * `type` - The type of log config.

--- a/huaweicloud/services/acceptance/cceautopilot/data_source_huaweicloud_cce_autopilot_cluster_log_configs_test.go
+++ b/huaweicloud/services/acceptance/cceautopilot/data_source_huaweicloud_cce_autopilot_cluster_log_configs_test.go
@@ -1,6 +1,7 @@
 package cceautopilot
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,33 +9,44 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceCceAutopilotClusterLogConfigs_basic(t *testing.T) {
+func TestAccDataSourceClusterLogConfigs_basic(t *testing.T) {
 	dataSource := "data.huaweicloud_cce_autopilot_cluster_log_configs.test"
 	dc := acceptance.InitDataSourceCheck(dataSource)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCceClusterId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceCceAutopilotClusterLogsConfigs_basic,
+				Config: testAccDataSourceClusterLogConfigs_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_results_not_empty", "true"),
+					resource.TestCheckResourceAttrSet(dataSource, "ttl_in_days"),
+					resource.TestCheckResourceAttrSet(dataSource, "log_configs.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "log_configs.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "log_configs.0.enable"),
+					resource.TestCheckResourceAttrSet(dataSource, "log_configs.0.name"),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-const testDataSourceCceAutopilotClusterLogsConfigs_basic = `
+func testAccDataSourceClusterLogConfigs_basic() string {
+	return fmt.Sprintf(`
 data "huaweicloud_cce_autopilot_cluster_log_configs" "test" {
-  cluster_id = "83a085fe-d4f1-11f0-80d0-0255ac10178d"
+  cluster_id = "%[1]s"
 }
-
-output "is_results_not_empty" {
-  value = length(data.huaweicloud_cce_autopilot_cluster_log_configs.test.log_configs) > 0
+data "huaweicloud_cce_autopilot_cluster_log_configs" "type_filter" {
+  cluster_id = "%[1]s"
+  type       = "control"
 }
-`
+output "type_filter_is_useful" {
+  value = length(data.huaweicloud_cce_autopilot_cluster_log_configs.type_filter.log_configs) > 0
+}
+`, acceptance.HW_CCE_CLUSTER_ID)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. fix test
2. fix docs error

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  cce autopilot cluster log configs fix test and doc
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/cceautopilot/ TESTARGS='-run TestAccDataSourceCceAutopilotClusterLogConfigs_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cceautopilot/ -v -run TestAccDataSourceCceAutopilotClusterLogConfigs_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCceAutopilotClusterLogConfigs_basic
=== PAUSE TestAccDataSourceCceAutopilotClusterLogConfigs_basic
=== CONT  TestAccDataSourceCceAutopilotClusterLogConfigs_basic
--- PASS: TestAccDataSourceCceAutopilotClusterLogConfigs_basic (40.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cceautopilot      40.898s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
