### PR TITLE
fix(ram): the `ram_distinct_shared_resources` dataSource quality improvement

### DIFF
--- a/docs/data-sources/ram_distinct_shared_resources.md
+++ b/docs/data-sources/ram_distinct_shared_resources.md
@@ -2,11 +2,11 @@
 subcategory: "Resource Access Manager (RAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ram_distinct_shared_resources"
-description: |
+description: |-
   Use this data source to get the list of RAM distinct shared resources.
 ---
 
-# huaweicloud_ram_shared_resources
+# huaweicloud_ram_distinct_shared_resources
 
 Use this data source to get the list of RAM distinct shared resources.
 
@@ -14,18 +14,9 @@ Use this data source to get the list of RAM distinct shared resources.
 
 ```hcl
 variable resource_owner {}
-variable resource_ids {}
-variable principle {}
-variable resource_region {}
-variable resource_urn {}
-
 
 data "huaweicloud_ram_distinct_shared_resources" "test" {
-  resource_owner  = var.resource_owner
-  resource_ids    = var.resource_ids
-  principle       = var.principle
-  resource_region = var.resource_region
-  resource_urn    = var.resource_urn
+  resource_owner = var.resource_owner
 }
 ```
 
@@ -35,8 +26,8 @@ The following arguments are supported:
 
 * `resource_owner` - (Required, String) Specifies the owner associated with the RAM share.
   Value options are as follows:
-    + **self**: Shared to other users by myself.
-    + **other-accounts**: Shared to me by other users.
+  + **self**: Shared to other users by myself.
+  + **other-accounts**: Shared to me by other users.
 
 * `resource_ids` - (Optional, List) Specifies the list of resource IDs associated with the RAM share.
 
@@ -59,16 +50,15 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `distinct_shared_resources` - The list of distinct shared resources.
-  The [distinct_shared_resources](#distinct_shared_resources) structure is documented below.
+* `distinct_shared_resources` - The list of information on different resources.
 
-<a name="distinct_shared_resources"></a>
+  The [distinct_shared_resources](#distinct_shared_resources_struct) structure is documented below.
+
+<a name="distinct_shared_resources_struct"></a>
 The `distinct_shared_resources` block supports:
 
-* `resource_type` - The resource type associated with the RAM share.
+* `resource_urn` - The unified resource name for resources.
 
-* `resource_urn` - The resource urn associated with the RAM share.
+* `resource_type` - The resource type.
 
-* `status` - The status of the RAM share.
-
-* `updated_at` - The latest update time of the RAM share.
+* `updated_at` - The last time the resource sharing instance was updated.

--- a/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_distinct_shared_resources_test.go
+++ b/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_distinct_shared_resources_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourceRAMDistinctSharedResources_basic(t *testing.T) {
+func TestAccDataSourceDistinctSharedResources_basic(t *testing.T) {
 	var (
-		rName = "data.huaweicloud_ram_distinct_shared_resources.test"
-		dc    = acceptance.InitDataSourceCheck(rName)
+		dataSource = "data.huaweicloud_ram_distinct_shared_resources.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -21,22 +21,41 @@ func TestAccDatasourceRAMDistinctSharedResources_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceRAMDistinctSharedReources_base(),
+				Config: testDataSourceDistinctSharedReources_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(rName, "distinct_shared_resources.0.resource_urn"),
-					resource.TestCheckResourceAttrSet(rName, "distinct_shared_resources.0.resource_type"),
-					resource.TestCheckResourceAttrSet(rName, "distinct_shared_resources.0.updated_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "distinct_shared_resources.0.resource_urn"),
+					resource.TestCheckResourceAttrSet(dataSource, "distinct_shared_resources.0.resource_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "distinct_shared_resources.0.updated_at"),
+
+					resource.TestCheckOutput("is_resource_urns_filter_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDatasourceRAMDistinctSharedReources_base() string {
+func testDataSourceDistinctSharedReources_basic() string {
 	return `
 data "huaweicloud_ram_distinct_shared_resources" "test" {
-	resource_owner = "self"
+  resource_owner = "self"
+}
+
+# Filter using resource_urns.
+locals {
+  resource_urn = data.huaweicloud_ram_distinct_shared_resources.test.distinct_shared_resources[0].resource_urn
+}
+
+data "huaweicloud_ram_distinct_shared_resources" "resource_urns_filter" {
+  resource_owner = "self"
+  resource_urns  = [local.resource_urn]
+}
+
+output "is_resource_urns_filter_useful" {
+  value = length(data.huaweicloud_ram_distinct_shared_resources.resource_urns_filter.distinct_shared_resources) > 0 && alltrue(
+    [for v in data.huaweicloud_ram_distinct_shared_resources.resource_urns_filter.distinct_shared_resources[*].resource_urn : v
+    == local.resource_urn]
+  )
 }
 `
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Fix errors in pagination queries.
2. Optimize code snippets and MD document descriptions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

the `ram_distinct_shared_resources` dataSource quality improvement

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ram" TESTARGS="-run TestAccDataSourceDistinctSharedResources_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccDataSourceDistinctSharedResources_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDistinctSharedResources_basic
=== PAUSE TestAccDataSourceDistinctSharedResources_basic
=== CONT  TestAccDataSourceDistinctSharedResources_basic
--- PASS: TestAccDataSourceDistinctSharedResources_basic (12.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       12.858s
```
<img width="931" height="35" alt="image" src="https://github.com/user-attachments/assets/e8332013-20e8-4a96-9a47-2ea35a6d297c" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
