### PR TITLE
test(iam): optimize the acceptance case design for group datasource

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_group_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_group_test.go
@@ -9,10 +9,13 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccIdentityGroupDataSource_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identity_group.test"
-	rName := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccDataGroup_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_identity_group.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -20,87 +23,68 @@ func TestAccIdentityGroupDataSource_basic(t *testing.T) {
 			acceptance.TestAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source: "hashicorp/random",
+				// The version of the random provider must be greater than 3.3.0 to support the 'numeric' parameter.
+				VersionConstraint: "3.3.0",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityGroupDataSource_by_name(rName),
+				Config: testAccDataGroup_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
-					resource.TestCheckResourceAttr(dataSourceName, "users.#", "0"),
+					resource.TestCheckResourceAttr(all, "name", name),
+					resource.TestCheckResourceAttr(all, "users.#", "2"),
+					resource.TestCheckResourceAttrSet(all, "users.0.id"),
+					resource.TestCheckResourceAttrSet(all, "users.0.name"),
+					resource.TestCheckResourceAttrSet(all, "users.0.enabled"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccIdentityGroupDataSource_with_user(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identity_group.test"
-	rName := acceptance.RandomAccResourceName()
-	password := acceptance.RandomPassword()
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckAdminOnly(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccIdentityGroupDataSource_with_user(rName, password),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
-					resource.TestCheckResourceAttr(dataSourceName, "users.#", "2"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "users.0.id"),
-				),
-			},
-		},
-	})
-}
-
-func testAccIdentityGroupDataSource_by_name(rName string) string {
+func testAccDataGroup_base(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identity_group" "test" {
-  name        = "%s"
-  description = "An ACC test group"
+resource "random_string" "test" {
+  length           = 10
+  min_numeric      = 1
+  min_special      = 1
+  min_lower        = 1
+  override_special = "@!"
 }
 
-data "huaweicloud_identity_group" "test" {
-  name = huaweicloud_identity_group.test.name
-  
-  depends_on = [
-    huaweicloud_identity_group.test
-  ]
-}
-`, rName)
-}
-
-func testAccIdentityGroupDataSource_with_user(rName, password string) string {
-	return fmt.Sprintf(`
 resource "huaweicloud_identity_group" "test" {
   name        = "%[1]s"
-  description = "An ACC test group"
 }
 
 resource "huaweicloud_identity_user" "test" {
   count    = 2
   name     = "%[1]s-${count.index}"
-  password = "%[2]s"
+  password = random_string.test.result
   enabled  = true
 }
 
 resource "huaweicloud_identity_group_membership" "test" {
   group = huaweicloud_identity_group.test.id
-  users = huaweicloud_identity_user.test.*.id
+  users = huaweicloud_identity_user.test[*].id
+}
+`, name)
 }
 
-data "huaweicloud_identity_group" "test" {
+func testAccDataGroup_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_identity_group" "all" {
   name = huaweicloud_identity_group.test.name
 
+  # Waiting for the group membership to be created
   depends_on = [
     huaweicloud_identity_group_membership.test
   ]
 }
-`, rName, password)
+`, testAccDataGroup_base(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

  1. Redundant code
  2. Insufficiently precise checks

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. remove the redundant code for the group datasource‘s test
2. update the check items and function naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataSourceGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceGroup_basic
=== PAUSE TestAccDataSourceGroup_basic
=== CONT  TestAccDataSourceGroup_basic
--- PASS: TestAccDataSourceGroup_basic (25.46s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       25.602s coverage: 4.2% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.