### PR TITLE
test(iam): optimize the acceptance case design for keystone metadata file datasource

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_keystone_metadata_file_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_keystone_metadata_file_test.go
@@ -8,9 +8,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityKeystoneMetadataFile_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_identity_keystone_metadata_file.test"
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccDataKeystoneMetadataFile_basic(t *testing.T) {
+	var (
+		check = "data.huaweicloud_identity_keystone_metadata_file.test"
+		dc    = acceptance.InitDataSourceCheck(check)
+
+		byUnsigned   = "data.huaweicloud_identity_keystone_metadata_file.test_with_unsigned"
+		dcByUnsigned = acceptance.InitDataSourceCheck(byUnsigned)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -19,28 +24,22 @@ func TestAccDataSourceIdentityKeystoneMetadataFile_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testTestDataSourceIdentityKeystoneMetadataFile,
+				Config: testAccDataKeystoneMetadataFile_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSourceName, "metadata_file"),
-				),
-			},
-			{
-				Config: testTestDataSourceIdentityKeystoneMetadataFileWithUnsigned,
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSourceName, "metadata_file"),
+					resource.TestCheckResourceAttrSet(check, "metadata_file"),
+					dcByUnsigned.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(byUnsigned, "metadata_file"),
 				),
 			},
 		},
 	})
 }
 
-const testTestDataSourceIdentityKeystoneMetadataFile = `
+const testAccDataKeystoneMetadataFile_basic = `
 data "huaweicloud_identity_keystone_metadata_file" "test" {}
-`
-const testTestDataSourceIdentityKeystoneMetadataFileWithUnsigned = `
-data "huaweicloud_identity_keystone_metadata_file" "test" {
+
+data "huaweicloud_identity_keystone_metadata_file" "test_with_unsigned" {
   unsigned = true
 }
 `


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

  1. Redundant code

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. remove the redundant code for the keystone metadata file datasource‘s test
2. update the check items and function naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataSourceKeystoneMetadataFile_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceKeystoneMetadataFile_basic
=== PAUSE TestAccDataSourceKeystoneMetadataFile_basic
=== CONT  TestAccDataSourceKeystoneMetadataFile_basic
--- PASS: TestAccDataSourceKeystoneMetadataFile_basic (21.51s)
PASS
coverage: 2.0% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       21.637s coverage: 2.0% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.