### PR TITLE
test(iam): optimize the acceptance case design for login protects datasource

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_login_protects_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_login_protects_test.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,11 +10,16 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceIdentityLoginProtects_basic(t *testing.T) {
-	userName := acceptance.RandomAccResourceName()
-	initPassword := acceptance.RandomPassword()
-	dataSourceName := "data.huaweicloud_identity_login_protects.test"
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccDataLoginProtects_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_identity_login_protects.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byUserId   = "data.huaweicloud_identity_login_protects.filter_by_user_id"
+		dcByUserId = acceptance.InitDataSourceCheck(byUserId)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -21,38 +27,76 @@ func TestAccDataSourceIdentityLoginProtects_basic(t *testing.T) {
 			acceptance.TestAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source: "hashicorp/random",
+				// The version of the random provider must be greater than 3.3.0 to support the 'numeric' parameter.
+				VersionConstraint: "3.3.0",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testTestDataSourceIdentityLoginProtects,
+				Config: testAccDataLoginProtects_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSourceName, "login_protects.#"),
-				),
-			},
-			{
-				Config: testTestDataSourceIdentityLoginProtectsWithUserId(userName, initPassword),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSourceName, "login_protects.#"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "login_protects.0.user_id"),
-					resource.TestCheckResourceAttr(dataSourceName, "login_protects.0.enabled", "true"),
-					resource.TestCheckResourceAttr(dataSourceName, "login_protects.0.verification_method", "email"),
+					resource.TestMatchResourceAttr(all, "login_protects.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByUserId.CheckResourceExists(),
+					resource.TestCheckOutput("is_filter_by_user_id_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-const testTestDataSourceIdentityLoginProtects = `
-data "huaweicloud_identity_login_protects" "test" {}
-`
+func testAccDataLoginProtects_base(name string) string {
+	return fmt.Sprintf(`
+resource "random_string" "test" {
+  length           = 10
+  min_numeric      = 1
+  min_special      = 1
+  min_lower        = 1
+  override_special = "@!"
+}
 
-func testTestDataSourceIdentityLoginProtectsWithUserId(name, password string) string {
+resource "huaweicloud_identity_user" "test" {
+  name        = "%[1]s"
+  password    = random_string.test.result
+  enabled     = true
+  email       = "%[1]s@abc.com"
+  description = "tested by terraform"
+
+  login_protect_verification_method = "email"
+}
+`, name)
+}
+
+func testAccDataLoginProtects_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-data "huaweicloud_identity_login_protects" "test" {
-  user_id = huaweicloud_identity_user.user_1.id
+# All
+data "huaweicloud_identity_login_protects" "all" {
+  # Waiting for the login protect to be created
+  depends_on = [huaweicloud_identity_user.test]
 }
-`, testAccIdentityUser_basic(name, password))
+
+# Filter by user ID
+locals {
+  user_id = huaweicloud_identity_user.test.id
+}
+
+data "huaweicloud_identity_login_protects" "filter_by_user_id" {
+  user_id = local.user_id
+}
+
+locals {
+  login_protects = data.huaweicloud_identity_login_protects.filter_by_user_id.login_protects
+}
+
+output "is_filter_by_user_id_useful" {
+  value = length(local.login_protects) > 0 && alltrue(
+    [for v in local.login_protects[*].user_id : v == local.user_id]
+  )
+}
+`, testAccDataLoginProtects_base(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

  1. Redundant code

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. remove the redundant code for the login protects datasource's test
2. update the check items and function naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataSourceLoginProtects_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceLoginProtects_basic
=== PAUSE TestAccDataSourceLoginProtects_basic
=== CONT  TestAccDataSourceLoginProtects_basic
--- PASS: TestAccDataSourceLoginProtects_basic (23.98s)
PASS
coverage: 3.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       24.121s coverage: 3.3% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.