### PR TITLE
test(iam): optimize the acceptance case design for permissions datasource

### DIFF
--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_permissions_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_permissions_test.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,9 +9,26 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccIdentityPermissionsDataSource_basic(t *testing.T) {
-	resourceName := "data.huaweicloud_identity_permissions.test"
-	dc := acceptance.InitDataSourceCheck(resourceName)
+func TestAccDataPermissions_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_identity_permissions.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_identity_permissions.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byCatalog   = "data.huaweicloud_identity_permissions.filter_by_catalog"
+		dcByCatalog = acceptance.InitDataSourceCheck(byCatalog)
+
+		byType   = "data.huaweicloud_identity_permissions.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byCustom   = "data.huaweicloud_identity_permissions.filter_by_custom"
+		dcByCustom = acceptance.InitDataSourceCheck(byCustom)
+
+		byScopeType   = "data.huaweicloud_identity_permissions.filter_by_scope_type"
+		dcByScopeType = acceptance.InitDataSourceCheck(byScopeType)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -20,14 +38,19 @@ func TestAccIdentityPermissionsDataSource_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityPermissionsDataSource_basic(),
+				Config: testAccDataPermissions_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(resourceName, "permissions.#"),
+					resource.TestMatchResourceAttr(all, "permissions.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByName.CheckResourceExists(),
 					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					dcByCatalog.CheckResourceExists(),
 					resource.TestCheckOutput("catalog_filter_is_useful", "true"),
+					dcByType.CheckResourceExists(),
 					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					dcByCustom.CheckResourceExists(),
 					resource.TestCheckOutput("custom_filter_is_useful", "true"),
+					dcByScopeType.CheckResourceExists(),
 					resource.TestCheckOutput("scope_type_filter_is_useful", "true"),
 				),
 			},
@@ -35,51 +58,102 @@ func TestAccIdentityPermissionsDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccIdentityPermissionsDataSource_basic() string {
-	return `
-data "huaweicloud_identity_permissions" "test" {
+const testAccDataPermissions_basic = `
+# All
+data "huaweicloud_identity_permissions" "all" {
 }
 
-data "huaweicloud_identity_permissions" "by_name" {
+# Filter by name
+locals {
   name = "KMS Administrator"
 }
 
-data "huaweicloud_identity_permissions" "by_catalog" {
-  catalog = "ELB"
+data "huaweicloud_identity_permissions" "filter_by_name" {
+  name = local.name
 }
 
-data "huaweicloud_identity_permissions" "obs_policy" {
-  type    = "system-policy"
-  catalog = "OBS"
-}
-
-data "huaweicloud_identity_permissions" "custom" {
-  type = "custom"
-}
-
-data "huaweicloud_identity_permissions" "by_scope_type" {
-  scope_type = "project"
-  name = "CCE FullAccess"
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_identity_permissions.filter_by_name.permissions[*].name : v == local.name
+  ]
 }
 
 output "name_filter_is_useful" {
-  value = alltrue([for v in data.huaweicloud_identity_permissions.by_name.permissions[*].name : v == "KMS Administrator"])
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by catalog
+locals {
+  catalog = "ELB"
+}
+
+data "huaweicloud_identity_permissions" "filter_by_catalog" {
+  catalog = local.catalog
+}
+
+locals {
+  catalog_filter_result = [
+    for v in data.huaweicloud_identity_permissions.filter_by_catalog.permissions[*].catalog : v == local.catalog
+  ]
 }
 
 output "catalog_filter_is_useful" {
-  value = alltrue([for v in data.huaweicloud_identity_permissions.by_catalog.permissions[*].catalog : v == "ELB"])
+  value = length(local.catalog_filter_result) > 0 && alltrue(local.catalog_filter_result)
+}
+
+# Filter by type
+locals {
+  type         = "system-policy"
+  type_catalog = "OBS"
+}
+
+data "huaweicloud_identity_permissions" "filter_by_type" {
+  type    = local.type
+  catalog = local.type_catalog
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_identity_permissions.filter_by_type.permissions[*].catalog : v == local.type_catalog
+  ]
 }
 
 output "type_filter_is_useful" {
-  value = alltrue([for v in data.huaweicloud_identity_permissions.obs_policy.permissions[*].catalog : v == "OBS"])
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+
+# Filter by custom
+locals {
+  custom         = "custom"
+  custom_catalog = "CUSTOMED"
+}
+
+data "huaweicloud_identity_permissions" "filter_by_custom" {
+  type = local.custom
+}
+
+locals {
+  custom_filter_result = [
+    for v in data.huaweicloud_identity_permissions.filter_by_custom.permissions[*].catalog : v == local.custom_catalog
+  ]
 }
 
 output "custom_filter_is_useful" {
-  value = alltrue([for v in data.huaweicloud_identity_permissions.custom.permissions[*].catalog : v == "CUSTOMED"])
+  value = alltrue(local.custom_filter_result)
+}
+
+# Filter by scope type
+locals {
+  scope_type      = "project"
+  scope_type_name = "CCE FullAccess"
+}
+
+data "huaweicloud_identity_permissions" "filter_by_scope_type" {
+  scope_type = local.scope_type
+  name       = local.scope_type_name
 }
 
 output "scope_type_filter_is_useful" {
-  value = alltrue([length(data.huaweicloud_identity_permissions.by_scope_type.permissions) == 1])
+  value = alltrue([length(data.huaweicloud_identity_permissions.filter_by_scope_type.permissions) == 1])
 }
 `
-}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The old test cases suffer from several design problems:

  1. Redundant code
  2. Insufficiently precise checks

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. remove the redundant code for the permission datasource‘s test
2. update the check items and function naming
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataSourcePermissions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourcePermissions_basic
=== PAUSE TestAccDataSourcePermissions_basic
=== CONT  TestAccDataSourcePermissions_basic
--- PASS: TestAccDataSourcePermissions_basic (315.23s)
PASS
coverage: 2.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       315.354s        coverage: 2.3% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.