### PR TITLE
test(iam): optimize the acceptance case design for some identity resources

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_temporary_access_key_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_temporary_access_key_test.go
@@ -9,25 +9,33 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccIdentityTemporaryAccessKey_basic(t *testing.T) {
-	resourceName := "huaweicloud_identity_temporary_access_key.test"
-	agencyName := acceptance.RandomAccResourceName()
-	userName := acceptance.RandomAccResourceName()
-	initPassword := acceptance.RandomPassword()
-	dc := acceptance.InitDataSourceCheck(resourceName)
+func TestAccTemporaryAccessKey_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_identity_temporary_access_key.test"
+		rc           = acceptance.InitDataSourceCheck(resourceName)
+
+		name = acceptance.RandomAccResourceName()
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPrecheckDomainName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      nil,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source:            "hashicorp/random",
+				VersionConstraint: "3.3.0",
+			},
+		},
+		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: AccIdentityTemporaryAccessKeyByAgency(agencyName, userName, initPassword),
+				Config: testAccTemporaryAccessKey_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "access"),
 					resource.TestCheckResourceAttrSet(resourceName, "secret"),
@@ -35,9 +43,9 @@ func TestAccIdentityTemporaryAccessKey_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: AccIdentityTemporaryAccessKeyByToken(userName, initPassword),
+				Config: testAccTemporaryAccessKey_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "access"),
 					resource.TestCheckResourceAttrSet(resourceName, "secret"),
@@ -50,33 +58,74 @@ func TestAccIdentityTemporaryAccessKey_basic(t *testing.T) {
 
 func testAccTemporaryAccessKey_basic_base(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identity_agency" "test" {
-  name                  = "%[1]s_create_with_role_assignments"
-  description           = "Created by terraform acceptance test"
-  delegated_domain_name = "%[2]s"
+resource "random_string" "test" {
+  length           = 10
+  min_numeric      = 1
+  min_special      = 1
+  min_lower        = 1
+  override_special = "@!"
+}
+
+data "huaweicloud_identity_group" "test" {
+  name = "admin"
+}
+
+resource "huaweicloud_identity_user" "test" {
+  name        = "%[1]s"
+  password    = random_string.test.result
+  enabled     = true
+  description = "Created by terraform script"
+}
+
+resource "huaweicloud_identity_group_membership" "test" {
+  group = data.huaweicloud_identity_group.test.id
+  users = [huaweicloud_identity_user.test.id]
+}
+
+resource "huaweicloud_identity_user_token" "test" {
+  depends_on = [huaweicloud_identity_group_membership.test]
+
+  account_name = "%[2]s"
+  user_name    = huaweicloud_identity_user.test.name
+  password     = random_string.test.result
 }
 `, name, acceptance.HW_DOMAIN_NAME)
 }
 
-func AccIdentityTemporaryAccessKeyByAgency(agencyName, userName, initPassword string) string {
-	policy := "{\"Version\":\"1.1\",\"Statement\":[{\"Effect\":\"Allow\"," +
-		"\"Action\":[\"obs:object:GetObject\"],\"Resource\":[\"OBS:*:*:object:*\"]}]}"
+func testAccTemporaryAccessKey_basic_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-%[2]s
+resource "huaweicloud_identity_agency" "test" {
+  name                  = "%[2]s"
+  description           = "Created by terraform script"
+  delegated_domain_name = "%[3]s"
+}
 
 resource "huaweicloud_identity_temporary_access_key" "test" {
   token       = huaweicloud_identity_user_token.test.token
   methods     = "assume_role"
   agency_name = huaweicloud_identity_agency.test.name
   domain_name = huaweicloud_identity_agency.test.delegated_domain_name
-  policy      = "%[3]s"
+  policy      = jsonencode({
+	"Version": "1.1",
+	"Statement": [
+	  {
+	    "Effect": "Allow",
+	    "Action": [
+	      "obs:object:GetObject"
+	    ],
+	    "Resource": [
+	      "OBS:*:*:object:*"
+	    ]
+	  }
+	]
+  })
 }
-`, testAccTemporaryAccessKey_basic_base(agencyName), testAccIdentityUserToken_basic(userName, initPassword), policy)
+`, testAccTemporaryAccessKey_basic_base(name), name, acceptance.HW_DOMAIN_NAME)
 }
 
-func AccIdentityTemporaryAccessKeyByToken(userName, initPassword string) string {
+func testAccTemporaryAccessKey_basic_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -85,5 +134,5 @@ resource "huaweicloud_identity_temporary_access_key" "test" {
   methods          = "token"
   duration_seconds = 3600
 }
-`, testAccIdentityUserToken_basic(userName, initPassword))
+`, testAccTemporaryAccessKey_basic_base(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

- Hard-coding
- Redundant naming
- Insufficiently precise checks
- Test scenarios not very well

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the hard coding for the IAM service agency and temporary's test
2. update the check items and function naming
3. combine some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccServiceAgency_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccServiceAgency_basic -timeout 360m -parallel 10
=== RUN   TestAccServiceAgency_basic
=== PAUSE TestAccServiceAgency_basic
=== CONT  TestAccServiceAgency_basic
--- PASS: TestAccServiceAgency_basic (27.38s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       27.513s coverage: 5.1% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccTemporaryAccessKey_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccTemporaryAccessKey_basic -timeout 360m -parallel 10
=== RUN   TestAccTemporaryAccessKey_basic
=== PAUSE TestAccTemporaryAccessKey_basic
=== CONT  TestAccTemporaryAccessKey_basic
--- PASS: TestAccTemporaryAccessKey_basic (44.27s)
PASS
coverage: 6.9% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       44.360s coverage: 6.9% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
