### PR TITLE
test(VPC): fix vpc network interface tags and subnet tags test

### DIFF
--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_network_interface_tags_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_network_interface_tags_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceVpcNetworkInterfaceTags_basic(t *testing.T) {
+func TestAccDataSourceNetworkInterfaceTags_basic(t *testing.T) {
 	dataSource := "data.huaweicloud_vpc_network_interface_tags.test"
 	rName := acceptance.RandomAccResourceName()
 	dc := acceptance.InitDataSourceCheck(dataSource)
@@ -21,17 +21,19 @@ func TestAccDataSourceVpcNetworkInterfaceTags_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceVpcNetworkInterfaceTags_basic(rName),
+				Config: testDataSourceDataSourceNetworkInterfaceTags_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_results_not_empty", "true"),
+					resource.TestCheckResourceAttrSet(dataSource, "tags.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "tags.0.key"),
+					resource.TestCheckResourceAttrSet(dataSource, "tags.0.values.#"),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceDataSourceVpcNetworkInterfaceTags_basic(name string) string {
+func testDataSourceDataSourceNetworkInterfaceTags_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -39,8 +41,5 @@ data "huaweicloud_vpc_network_interface_tags" "test" {
   depends_on = [ huaweicloud_vpc_network_interface.test ]
 }
 
-output "is_results_not_empty" {
-  value = length(data.huaweicloud_vpc_network_interface_tags.test.tags) > 0
-}
 `, testAccNetworkInterface_basic(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. fix vpc_subnet_tags test
2. fix vpc_network_interface_tags test

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix vpc network interface tags and subnet tags test
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/vpc/ TESTARGS='-run TestAccDataSourceVpcSubnetTags_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc/ -v -run TestAccDataSourceVpcSubnetTags_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceVpcSubnetTags_basic
=== PAUSE TestAccDataSourceVpcSubnetTags_basic
=== CONT  TestAccDataSourceVpcSubnetTags_basic
--- PASS: TestAccDataSourceVpcSubnetTags_basic (85.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       85.523s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
