### PR TITLE
fix(ram): the `ram_resource_permissions` dataSource quality improvement

### DIFF
--- a/docs/data-sources/ram_resource_permissions.md
+++ b/docs/data-sources/ram_resource_permissions.md
@@ -2,13 +2,13 @@
 subcategory: "Resource Access Manager (RAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ram_resource_permissions"
-description: |
-  Use this data source to get the list of RAM permissions.
+description: |-
+  Use this data source to get the list of RAM resource permissions within HuaweiCloud.
 ---
 
 # huaweicloud_ram_resource_permissions
 
-Use this data source to get the list of RAM permissions.
+Use this data source to get the list of RAM resource permissions within HuaweiCloud.
 
 ## Example Usage
 
@@ -45,12 +45,13 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The data source ID.
 
 * `permissions` - Indicates the list of the RAM permissions
-  The [permissions](#RAM_Permissions) structure is documented below.
 
-<a name="RAM_Permissions"></a>
+  The [permissions](#RAM_permissions) structure is documented below.
+
+<a name="RAM_permissions"></a>
 The `permissions` block supports:
 
-* `id` - Indicates the id of RAM permission.
+* `id` - Indicates the ID of RAM permission.
 
 * `name` - Indicates the name of RAM permission.
 
@@ -58,7 +59,7 @@ The `permissions` block supports:
 
 * `is_resource_type_default` - Whether the RAM permission resource type is default.
 
-* `created_at` - Indicates the RAM permission create time.
+* `created_at` - Indicates the RAM permission creation time.
 
 * `updated_at` - Indicates the RAM permission last update time.
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1842,7 +1842,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_obs_buckets":       obs.DataSourceObsBuckets(),
 			"huaweicloud_obs_bucket_object": obs.DataSourceObsBucketObject(),
 
-			"huaweicloud_ram_resource_permissions":                  ram.DataSourceRAMPermissions(),
+			"huaweicloud_ram_resource_permissions":                  ram.DataSourceResourcePermissions(),
 			"huaweicloud_ram_resource_share_invitations":            ram.DataSourceResourceShareInvitations(),
 			"huaweicloud_ram_shared_resources":                      ram.DataSourceRAMSharedResources(),
 			"huaweicloud_ram_shared_principals":                     ram.DataSourceRAMSharedPrincipals(),

--- a/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_resource_permissions_test.go
+++ b/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_resource_permissions_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourceRAMPermissions_basic(t *testing.T) {
+func TestAccDataSourceResourcePermissions_basic(t *testing.T) {
 	var (
-		rName = "data.huaweicloud_ram_resource_permissions.test"
-		dc    = acceptance.InitDataSourceCheck(rName)
+		dataSource = "data.huaweicloud_ram_resource_permissions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
 
 		byResourceType   = "data.huaweicloud_ram_resource_permissions.filter_by_resource_type"
 		dcByResourceType = acceptance.InitDataSourceCheck(byResourceType)
@@ -24,24 +24,26 @@ func TestAccDatasourceRAMPermissions_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceRAMPermissions_basic(),
+				Config: testDataSourceResourcePermissions_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(rName, "permissions.0.id"),
-					resource.TestCheckResourceAttrSet(rName, "permissions.0.name"),
-					resource.TestCheckResourceAttrSet(rName, "permissions.0.resource_type"),
-					resource.TestCheckResourceAttrSet(rName, "permissions.0.is_resource_type_default"),
-					resource.TestCheckResourceAttrSet(rName, "permissions.0.created_at"),
-					resource.TestCheckResourceAttrSet(rName, "permissions.0.updated_at"),
-					resource.TestCheckResourceAttrSet(rName, "permissions.0.permission_urn"),
-					resource.TestCheckResourceAttrSet(rName, "permissions.0.permission_type"),
-					resource.TestCheckResourceAttrSet(rName, "permissions.0.default_version"),
-					resource.TestCheckResourceAttrSet(rName, "permissions.0.version"),
-					resource.TestCheckResourceAttrSet(rName, "permissions.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.resource_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.is_resource_type_default"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.updated_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.permission_urn"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.permission_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.default_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.version"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.status"),
 
 					dcByResourceType.CheckResourceExists(),
 					resource.TestCheckOutput("is_resource_type_filter_useful", "true"),
@@ -57,12 +59,11 @@ func TestAccDatasourceRAMPermissions_basic(t *testing.T) {
 	})
 }
 
-func testAccDatasourceRAMPermissions_basic() string {
+func testDataSourceResourcePermissions_basic() string {
 	return `
-data "huaweicloud_ram_resource_permissions" "test" {
-}
+data "huaweicloud_ram_resource_permissions" "test" {}
 
-# Filter by resource_type
+# Filter by resource_type.
 locals {
   resource_type = data.huaweicloud_ram_resource_permissions.test.permissions[0].resource_type
 }
@@ -81,7 +82,7 @@ output "is_resource_type_filter_useful" {
   value = length(local.resource_type_filter_result) > 0 && alltrue(local.resource_type_filter_result)
 }
 
-# Filter by permission_type
+# Filter by permission_type.
 locals {
   permission_type = data.huaweicloud_ram_resource_permissions.test.permissions[0].permission_type
 }
@@ -100,7 +101,7 @@ output "is_permission_type_filter_useful" {
   value = length(local.permission_type_filter_result) > 0 && alltrue(local.permission_type_filter_result)
 }
 
-# Filter by name
+# Filter by name.
 locals {
   name = data.huaweicloud_ram_resource_permissions.test.permissions[0].name
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Optimize code snippets and MD document descriptions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

the `ram_resource_permissions` dataSource quality improvement

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ram" TESTARGS="-run TestAccDataSourceResourcePermissions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccDataSourceResourcePermissions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceResourcePermissions_basic
=== PAUSE TestAccDataSourceResourcePermissions_basic
=== CONT  TestAccDataSourceResourcePermissions_basic
--- PASS: TestAccDataSourceResourcePermissions_basic (12.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       13.052s
```
<img width="915" height="32" alt="image" src="https://github.com/user-attachments/assets/413f31a7-3837-445a-ac4c-9d4e83fd44a3" />


* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
