### PR TITLE
refactor(iam): optimize codes and docs for v5 login policy and login profile

### DIFF
--- a/docs/resources/identityv5_login_policy.md
+++ b/docs/resources/identityv5_login_policy.md
@@ -3,40 +3,57 @@ subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identityv5_login_policy"
 description: |-
-  Manages the account login policy v5 resource within HuaweiCloud.
+  Manages the account login policy resource within HuaweiCloud.
 ---
 
 # huaweicloud_identityv5_login_policy
 
-Manages the account login policy v5 resource within HuaweiCloud.
+Manages the account login policy resource within HuaweiCloud.
 
--> **NOTE:**
-  You *must* have admin privileges to use this resource.  
+-> You *must* have admin privileges to use this resource.  
   This resource overwrites an existing configuration, make sure one resource per account.  
   During action `terraform destroy` it sets values the same as defaults for this resource.
 
 ## Example Usage
 
 ```hcl
+variable "allow_address_netmasks" {
+  type = list(object({
+    address_netmask = string
+    description     = optional(string)
+  }))
+}
+variable "allow_ip_ranges" {
+  type = list(object({
+    ip_range    = string
+    description = optional(string)
+  }))
+}
+
 resource "huaweicloud_identityv5_login_policy" "test" {
   user_validity_period       = 20
-  custom_info_for_login      = "hello Terraform"
   lockout_duration           = 30
   login_failed_times         = 10
   period_with_login_failures = 30
   session_timeout            = 120
   show_recent_login_info     = true
-  allow_address_netmasks {
-    address_netmask = "255.0.0.0/1"
-    description     = "terraform test"
+
+  dynamic "allow_address_netmasks" {
+    for_each = var.allow_address_netmasks
+
+    content {
+      address_netmask = allow_address_netmasks.value.address_netmask
+      description     = allow_address_netmasks.value.description
+    }
   }
-  allow_ip_ranges {
-    ip_range    = "0.0.0.0-255.255.255.254"
-    description = "terraform test1"
-  }
-  allow_ip_ranges {
-    ip_range    = "0.0.0.0-255.255.255.100"
-    description = "terraform test2"
+
+  dynamic "allow_ip_ranges" {
+    for_each = var.allow_ip_ranges
+
+    content {
+      ip_range    = allow_ip_ranges.value.ip_range
+      description = allow_ip_ranges.value.description
+    }
   }
 }
 ```
@@ -45,73 +62,78 @@ resource "huaweicloud_identityv5_login_policy" "test" {
 
 The following arguments are supported:
 
-* `user_validity_period` - (Optional, Int) Specifies the validity period (days) to disable users
-  if they have not logged in within the period. The valid value is range from `0` to `240`.
+* `user_validity_period` - (Optional, Int) Specifies the validity period to disable users, in days.  
+  If users do not log in within the validity period, their account will be disabled, and this value does not apply
+  to the root user.  
+  The valid value ranges from `0` to `240`.
 
 * `custom_info_for_login` - (Optional, String) Specifies the custom information that will be displayed
-  upon successful login. It cannot contain the following special
-  characters: `@`, `#`, `%`, `&`, `<`, `>`, `\`, `$`, `^` and `*`.
-  Its maximum length: 64.
+  upon successful login.  
+  It cannot contain the following special characters: `@#%&<>\$^*`.  
+  The maximum length is `64` characters.
 
-* `lockout_duration` - (Optional, Int) Specifies the duration (minutes) to lock users out.
-  The valid value is range from `15` to `1440`, defaults to `15`.
+* `lockout_duration` - (Optional, Int) Specifies the lockout duration after multiple failed login
+  attempts, in minutes.  
+  The valid value ranges from `15` to `1,440`, defaults to `15`.
 
-* `login_failed_times` - (Optional, Int) Specifies the number of unsuccessful login attempts to lock users out.
-  The valid value is range from `3` to `10`, defaults to `5`.
+* `login_failed_times` - (Optional, Int) Specifies number of consecutive failed login attempts before
+  the account is locked.  
+  The valid value ranges from `3` to `10`, defaults to `5`.
 
-* `period_with_login_failures` - (Optional, Int) Specifies the period (minutes) to count the number of unsuccessful
-  login attempts. The valid value is range from `15` to `60`, defaults to `15`.
+* `period_with_login_failures` - (Optional, Int) Specifies The period to reset the account lockout
+  counter, in minutes.  
+  The valid value ranges from `15` to `60`, defaults to `15`.
   
-* `session_timeout` - (Optional, Int) Specifies the session timeout (minutes) that will apply if you or users created
-  using your account do not perform any operations within a specific period.
-  The valid value is range from `15` to `1,440`, defaults to `60`.
+* `session_timeout` - (Optional, Int) Specifies the session timeout duration after user login, in minutes.  
+  The valid value ranges from `15` to `1,440`, defaults to `60`.
 
-* `show_recent_login_info` - (Optional, Bool) Specifies whether to display last login information upon successful login.
-  The value can be **true** or **false**.
+* `show_recent_login_info` - (Optional, Bool) Specifies whether to display the last login information.  
+  Defaults to **false**.
 
-* `allow_address_netmasks` - (Optional, List) Specifies the IP addresses or network segments that are allowed to access.
+* `allow_address_netmasks` - (Optional, List) Specifies the IP address list or network segment list that are
+  allowed to access.  
   The [allow_address_netmasks](#IdentityV5LoginPolicy_AllowAddressNetmasks) structure is documented below.
 
-* `allow_ip_ranges` - (Optional, List) Specifies the IP address range that can be accessed.
+* `allow_ip_ranges` - (Optional, List) Specifies the IP address range list that are allowed to access.  
   The [allow_ip_ranges](#IdentityV5LoginPolicy_AllowIpRanges) structure is documented below.
 
-* `allow_ip_ranges_ipv6` - (Optional, List) Specifies the IPv6 address range that can be accessed.
+* `allow_ip_ranges_ipv6` - (Optional, List) Specifies the IPv6 address range list that are allowed to access.  
   The [allow_ip_ranges_ipv6](#IdentityV5LoginPolicy_AllowIpRangesIpv6) structure is documented below.
 
 <a name="IdentityV5LoginPolicy_AllowAddressNetmasks"></a>
-The `allow_address_netmasks` block contains:
+The `allow_address_netmasks` block supports:
 
 * `address_netmask` - (Required, String) Specifies the IP address or network segment, for example, `192.168.0.1/24`.
 
-* `description` - (Optional, String) Specifies the description information, which cannot contain the following special
-  characters: `@`, `#`, `%`, `&`, `<`, `>`, `\`, `$`, `^` and `*`.
+* `description` - (Optional, String) Specifies the description information.  
+  It cannot contain the following special characters: `@#%&<>\$^*`.
 
 <a name="IdentityV5LoginPolicy_AllowIpRanges"></a>
-The `allow_ip_ranges` block contains:
+The `allow_ip_ranges` block supports:
 
 * `ip_range` - (Required, String) Specifies the IP address range, for example, `0.0.0.0-255.255.255.255`.
 
-* `description` - (Optional, String) Specifies the description information, which cannot contain the following special
-  characters: `@`, `#`, `%`, `&`, `<`, `>`, `\`, `$`, `^` and `*`.
+* `description` - (Optional, String) Specifies the description information.  
+  It cannot contain the following special characters: `@#%&<>\$^*`.
 
 <a name="IdentityV5LoginPolicy_AllowIpRangesIpv6"></a>
-The `allow_ip_ranges_ipv6` block contains:
+The `allow_ip_ranges_ipv6` block supports:
 
 * `ip_range` - (Required, String) Specifies the IPv6 address range.
 
-* `description` - (Optional, String) Specifies the description information, which cannot contain the following special
-  characters: `@`, `#`, `%`, `&`, `<`, `>`, `\`, `$`, `^` and `*`.
+* `description` - (Optional, String) Specifies the description information.  
+  It cannot contain the following special characters: `@#%&<>\$^*`.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Indicates the ID of account login policy, which is the same as the account ID.
+* `id` - The resource ID, also the domain ID.
 
 ## Import
 
-Identity login policy can be imported using the account ID or domain ID, e.g.
+The login policy can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_identityv5_login_policy.example <your account ID>
+$ terraform import huaweicloud_identityv5_login_policy.test <id>
 ```

--- a/docs/resources/identityv5_login_profile.md
+++ b/docs/resources/identityv5_login_profile.md
@@ -3,29 +3,22 @@ subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identityv5_login_profile"
 description: |-
-  Manages an IAM v5 login profile resource within HuaweiCloud.
+  Manages an IAM login profile resource within HuaweiCloud.
 ---
 
 # huaweicloud_identityv5_login_profile
 
-Manages an IAM v5 login profile resource within HuaweiCloud.
+Manages an IAM login profile resource within HuaweiCloud.
 
--> NOTE: You must have admin privileges to use this resource.
+-> You must have admin privileges to use this resource.
 
 ## Example Usage
 
 ```hcl
-variable "name" {}
+variable "user_id" {}
 
-resource "huaweicloud_identityv5_user" "user" {
-  name        = var.name
-  enabled     = true
-  description = "tested by terraform"
-}
-
-resource "huaweicloud_identityv5_login_profile" "login_profile" {
-  user_id                 = huaweicloud_identityv5_user.user.id
-  password                = "default888"
+resource "huaweicloud_identityv5_login_profile" "test" {
+  user_id                 = var.user_id
   password_reset_required = true
 }
 ```
@@ -36,25 +29,26 @@ The following arguments are supported:
 
 * `user_id` - (Required, String, NonUpdatable) Specifies the ID of the user.
 
+* `password_reset_required` - (Optional, Bool) Specifies whether the user needs to reset the password at the
+  next login.  
+  Default: **false**.
+  
 * `password` - (Optional, String) Specifies the password of the user login.
-
-* `password_reset_required` - (Optional, Bool) Specifies whether the IAM user need to change their password when next
-  time they log in. The value can be: **true**, **false**. Default: **true**.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Indicates the ID of the user.
+* `id` - The resource ID, also the user ID.
 
-* `password_expires_at` - Indicates IAM user password expiration time.
+* `password_expires_at` - The password expiration time of the user.
 
-* `created_at` - Indicates the creation time of the IAM user login information.
+* `created_at` - The creation time of the login profile.
 
 ## Import
 
-The IAM v5 login profile can be imported using the id, e.g:
+The login profile can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_identityv5_login_profile.login_profile <user_id>
+$ terraform import huaweicloud_identityv5_login_profile.test <id>
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3385,8 +3385,8 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_identityv5_user":                        iam.ResourceIdentityV5User(),
 			"huaweicloud_identityv5_user_password":               iam.ResourceIdentityV5UserPassword(),
-			"huaweicloud_identityv5_login_profile":               iam.ResourceIdentityV5LoginProfile(),
-			"huaweicloud_identityv5_login_policy":                iam.ResourceIdentityV5LoginPolicy(),
+			"huaweicloud_identityv5_login_profile":               iam.ResourceV5LoginProfile(),
+			"huaweicloud_identityv5_login_policy":                iam.ResourceV5LoginPolicy(),
 			"huaweicloud_identityv5_password_policy":             iam.ResourceIdentityV5PasswordPolicy(),
 			"huaweicloud_identityv5_policy_default_version":      iam.ResourceIamV5PolicyDefaultVersion(),
 			"huaweicloud_identityv5_policy_group_attach":         iam.ResourceIdentityV5PolicyGroupAttach(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_login_policy_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_login_policy_test.go
@@ -7,51 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 )
-
-func getV5LoginPolicy(client *golangsdk.ServiceClient) (interface{}, error) {
-	httpUrl := "v5/login-policy"
-	getPath := client.Endpoint + httpUrl
-	getOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-
-	resp, err := client.Request("GET", getPath, &getOpt)
-	if err != nil {
-		return nil, err
-	}
-
-	respBody, err := utils.FlattenResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	// If the login policy values are not the default values, means the login policy is not destroyed.
-	if utils.PathSearch("login_policy.user_validity_period", respBody, float64(0)).(float64) != 0 ||
-		utils.PathSearch("login_policy.custom_info_for_login", respBody, "").(string) != "" ||
-		utils.PathSearch("login_policy.lockout_duration", respBody, float64(0)).(float64) != 15 ||
-		utils.PathSearch("login_policy.login_failed_times", respBody, float64(0)).(float64) != 5 ||
-		utils.PathSearch("login_policy.period_with_login_failures", respBody, float64(0)).(float64) != 15 ||
-		utils.PathSearch("login_policy.session_timeout", respBody, float64(0)).(float64) != 60 ||
-		utils.PathSearch("login_policy.show_recent_login_info", respBody, false).(bool) ||
-		utils.PathSearch("length(login_policy.allow_address_netmasks)", respBody, float64(0)).(float64) != 0 ||
-		utils.PathSearch("length(login_policy.allow_ip_ranges)", respBody, float64(0)).(float64) != 1 ||
-		utils.PathSearch("login_policy.allow_ip_ranges[0].ip_range", respBody, "").(string) != "0.0.0.0-255.255.255.255" ||
-		utils.PathSearch("login_policy.allow_ip_ranges[0].description", respBody, "").(string) != "" ||
-		utils.PathSearch("length(login_policy.allow_ip_ranges_ipv6)", respBody, float64(0)).(float64) != 1 ||
-		utils.PathSearch("login_policy.allow_ip_ranges_ipv6[0].ip_range", respBody, "").(string) !=
-			"0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF" ||
-		utils.PathSearch("login_policy.allow_ip_ranges_ipv6[0].description", respBody, "").(string) != "" {
-		return respBody, nil
-	}
-
-	return nil, golangsdk.ErrDefault404{}
-}
 
 func getV5LoginPolicyFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
 	client, err := cfg.NewServiceClient("iam", acceptance.HW_REGION_NAME)
@@ -59,7 +18,7 @@ func getV5LoginPolicyFunc(cfg *config.Config, _ *terraform.ResourceState) (inter
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
 
-	return getV5LoginPolicy(client)
+	return iam.GetV5LoginPolicy(client)
 }
 
 // Please ensure that the user executing the acceptance test has 'admin' permission.

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_login_profile_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_login_profile_test.go
@@ -2,17 +2,14 @@ package iam
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 )
 
 func getV5LoginProfileFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -20,17 +17,8 @@ func getV5LoginProfileFunc(cfg *config.Config, state *terraform.ResourceState) (
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
-	getLoginProfileHttpUrl := "v5/users/{user_id}/login-profile"
-	getLoginProfilePath := client.Endpoint + getLoginProfileHttpUrl
-	getLoginProfilePath = strings.ReplaceAll(getLoginProfilePath, "{user_id}", state.Primary.ID)
-	getLoginProfileOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	getLoginProfileResp, err := client.Request("GET", getLoginProfilePath, &getLoginProfileOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving IAM login profile: %s", err)
-	}
-	return utils.FlattenResponse(getLoginProfileResp)
+
+	return iam.GetV5LoginProfile(client, state.Primary.Attributes["user_id"])
 }
 
 // Please ensure that the user executing the acceptance test has 'admin' permission.

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_login_policy.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_login_policy.go
@@ -14,15 +14,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// ResourceIdentityV5LoginPolicy
 // @API IAM PUT /v5/login-policy
 // @API IAM GET /v5/login-policy
-func ResourceIdentityV5LoginPolicy() *schema.Resource {
+func ResourceV5LoginPolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIdentityV5LoginPolicyUpdate,
-		ReadContext:   resourceIdentityV5LoginPolicyRead,
-		UpdateContext: resourceIdentityV5LoginPolicyUpdate,
-		DeleteContext: resourceIdentityV5LoginPolicyDelete,
+		CreateContext: resourceV5LoginPolicyUpdate,
+		ReadContext:   resourceV5LoginPolicyRead,
+		UpdateContext: resourceV5LoginPolicyUpdate,
+		DeleteContext: resourceV5LoginPolicyDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -30,33 +29,40 @@ func ResourceIdentityV5LoginPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"user_validity_period": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The validity period to disable users, in days.`,
 			},
 			"custom_info_for_login": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The custom information that will be displayed upon successful login.`,
 			},
 			"lockout_duration": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The lockout duration after multiple failed login attempts, in minutes.`,
 			},
 			"login_failed_times": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The number of consecutive failed login attempts before the account is locked.`,
 			},
 			"period_with_login_failures": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The period to reset the account lockout counter, in minutes.`,
 			},
 			"session_timeout": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The session timeout duration after user login, in minutes.`,
 			},
 			"show_recent_login_info": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to display the last login information.`,
 			},
 			"allow_address_netmasks": {
 				Type:     schema.TypeList,
@@ -64,15 +70,18 @@ func ResourceIdentityV5LoginPolicy() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"address_netmask": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The IP address or network segment.`,
 						},
 						"description": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The description information`,
 						},
 					},
 				},
+				Description: `IP address list or network segment list that are allowed to access.`,
 			},
 			"allow_ip_ranges": {
 				Type:     schema.TypeList,
@@ -80,15 +89,18 @@ func ResourceIdentityV5LoginPolicy() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ip_range": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The IP address range.`,
 						},
 						"description": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The description information.`,
 						},
 					},
 				},
+				Description: `The IP address range list that are allowed to access.`,
 			},
 			"allow_ip_ranges_ipv6": {
 				Type:     schema.TypeList,
@@ -96,45 +108,49 @@ func ResourceIdentityV5LoginPolicy() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ip_range": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The IPv6 address range.`,
 						},
 						"description": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The description information.`,
 						},
 					},
 				},
+				Description: `The IPv6 address range list that are allowed to access.`,
 			},
 		},
 	}
 }
 
-func resourceIdentityV5LoginPolicyUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV5LoginPolicyUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating IAM Client: %s", err)
+		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
 	createLoginPolicyHttpUrl := "v5/login-policy"
-	createLoginPolicyPath := iamClient.Endpoint + createLoginPolicyHttpUrl
+	createLoginPolicyPath := client.Endpoint + createLoginPolicyHttpUrl
 	createLoginPolicyOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         buildCreateLoginPolicyBodyParams(d),
+		JSONBody:         buildCreateV5LoginPolicyBodyParams(d),
 	}
 
-	_, err = iamClient.Request("PUT", createLoginPolicyPath, &createLoginPolicyOpt)
+	_, err = client.Request("PUT", createLoginPolicyPath, &createLoginPolicyOpt)
 	if err != nil {
-		return diag.Errorf("error creating IAM login policy: %s", err)
+		return diag.Errorf("error creating login policy: %s", err)
 	}
+
 	if d.IsNewResource() {
 		d.SetId(cfg.DomainID)
 	}
 	return nil
 }
 
-func buildCreateLoginPolicyBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildCreateV5LoginPolicyBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"user_validity_period":       d.Get("user_validity_period"),
 		"custom_info_for_login":      d.Get("custom_info_for_login"),
@@ -150,52 +166,93 @@ func buildCreateLoginPolicyBodyParams(d *schema.ResourceData) map[string]interfa
 	return bodyParams
 }
 
-func resourceIdentityV5LoginPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
-	if err != nil {
-		return diag.Errorf("error creating IAM Client: %s", err)
+func GetV5LoginPolicy(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v5/login-policy"
+	getPath := client.Endpoint + httpUrl
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
 
-	getLoginPolicyHttpUrl := "v5/login-policy"
-	getLoginPolicyPath := iamClient.Endpoint + getLoginPolicyHttpUrl
-	getLoginPolicyOpt := golangsdk.RequestOpts{KeepResponseBody: true}
-	getLoginPolicyResp, err := iamClient.Request("GET", getLoginPolicyPath, &getLoginPolicyOpt)
+	resp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving IAM login policy")
+		return nil, err
 	}
-	getLoginPolicyRespBody, err := utils.FlattenResponse(getLoginPolicyResp)
+
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
-		return diag.FromErr(err)
+		return nil, err
+	}
+
+	loginPolicy := utils.PathSearch("login_policy", respBody, nil)
+	// If the login policy values are not the default values, means the login policy is not destroyed.
+	if utils.PathSearch("user_validity_period", loginPolicy, float64(0)).(float64) != 0 ||
+		utils.PathSearch("custom_info_for_login", loginPolicy, "").(string) != "" ||
+		utils.PathSearch("lockout_duration", loginPolicy, float64(0)).(float64) != 15 ||
+		utils.PathSearch("login_failed_times", loginPolicy, float64(0)).(float64) != 5 ||
+		utils.PathSearch("period_with_login_failures", loginPolicy, float64(0)).(float64) != 15 ||
+		utils.PathSearch("session_timeout", loginPolicy, float64(0)).(float64) != 60 ||
+		utils.PathSearch("show_recent_login_info", loginPolicy, false).(bool) ||
+		utils.PathSearch("length(allow_address_netmasks)", loginPolicy, float64(0)).(float64) != 0 ||
+		utils.PathSearch("length(allow_ip_ranges)", loginPolicy, float64(0)).(float64) != 1 ||
+		utils.PathSearch("allow_ip_ranges[0].ip_range", loginPolicy, "").(string) != "0.0.0.0-255.255.255.255" ||
+		utils.PathSearch("allow_ip_ranges[0].description", loginPolicy, "").(string) != "" ||
+		utils.PathSearch("length(allow_ip_ranges_ipv6)", loginPolicy, float64(0)).(float64) != 1 ||
+		utils.PathSearch("allow_ip_ranges_ipv6[0].ip_range", loginPolicy, "").(string) !=
+			"0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF" ||
+		utils.PathSearch("allow_ip_ranges_ipv6[0].description", loginPolicy, "").(string) != "" {
+		return loginPolicy, nil
+	}
+
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/v5/login-policy",
+			RequestId: "NONE",
+			Body:      []byte("All configurations of login policy have been restored to the default value"),
+		},
+	}
+}
+
+func resourceV5LoginPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	respBody, err := GetV5LoginPolicy(client)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving login policy")
 	}
 
 	mErr := multierror.Append(
-		d.Set("user_validity_period", utils.PathSearch("login_policy.user_validity_period", getLoginPolicyRespBody, nil)),
-		d.Set("custom_info_for_login", utils.PathSearch("login_policy.custom_info_for_login", getLoginPolicyRespBody, nil)),
-		d.Set("lockout_duration", utils.PathSearch("login_policy.lockout_duration", getLoginPolicyRespBody, nil)),
-		d.Set("login_failed_times", utils.PathSearch("login_policy.login_failed_times", getLoginPolicyRespBody, nil)),
-		d.Set("period_with_login_failures", utils.PathSearch("login_policy.period_with_login_failures", getLoginPolicyRespBody, nil)),
-		d.Set("session_timeout", utils.PathSearch("login_policy.session_timeout", getLoginPolicyRespBody, nil)),
-		d.Set("show_recent_login_info", utils.PathSearch("login_policy.show_recent_login_info", getLoginPolicyRespBody, nil)),
-		d.Set("allow_address_netmasks", utils.PathSearch("login_policy.allow_address_netmasks", getLoginPolicyRespBody, nil)),
-		d.Set("allow_ip_ranges", utils.PathSearch("login_policy.allow_ip_ranges", getLoginPolicyRespBody, nil)),
-		d.Set("allow_ip_ranges_ipv6", utils.PathSearch("login_policy.allow_ip_ranges_ipv6", getLoginPolicyRespBody, nil)),
+		d.Set("user_validity_period", utils.PathSearch("user_validity_period", respBody, nil)),
+		d.Set("custom_info_for_login", utils.PathSearch("custom_info_for_login", respBody, nil)),
+		d.Set("lockout_duration", utils.PathSearch("lockout_duration", respBody, nil)),
+		d.Set("login_failed_times", utils.PathSearch("login_failed_times", respBody, nil)),
+		d.Set("period_with_login_failures", utils.PathSearch("period_with_login_failures", respBody, nil)),
+		d.Set("session_timeout", utils.PathSearch("session_timeout", respBody, nil)),
+		d.Set("show_recent_login_info", utils.PathSearch("show_recent_login_info", respBody, nil)),
+		d.Set("allow_address_netmasks", utils.PathSearch("allow_address_netmasks", respBody, nil)),
+		d.Set("allow_ip_ranges", utils.PathSearch("allow_ip_ranges", respBody, nil)),
+		d.Set("allow_ip_ranges_ipv6", utils.PathSearch("allow_ip_ranges_ipv6", respBody, nil)),
 	)
 	if mErr.ErrorOrNil() != nil {
-		return diag.Errorf("error saving IAM login policy resource (%s) fields: %s", d.Id(), mErr)
+		return diag.Errorf("error saving login policy resource (%s) fields: %s", d.Id(), mErr)
 	}
+
 	return nil
 }
 
-func resourceIdentityV5LoginPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV5LoginPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating IAM Client: %s", err)
+		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
 	deleteLoginPolicyHttpUrl := "v5/login-policy"
-	deleteLoginPolicyPath := iamClient.Endpoint + deleteLoginPolicyHttpUrl
+	deleteLoginPolicyPath := client.Endpoint + deleteLoginPolicyHttpUrl
 	allowIpRanges := make([]map[string]interface{}, 1)
 	allowIpRanges[0] = map[string]interface{}{
 		"ip_range":    "0.0.0.0-255.255.255.255",
@@ -222,9 +279,9 @@ func resourceIdentityV5LoginPolicyDelete(_ context.Context, d *schema.ResourceDa
 		},
 	}
 
-	_, err = iamClient.Request("PUT", deleteLoginPolicyPath, &deleteLoginPolicyOpt)
+	_, err = client.Request("PUT", deleteLoginPolicyPath, &deleteLoginPolicyOpt)
 	if err != nil {
-		return diag.Errorf("error deleting IAM login policy: %s", err)
+		return diag.Errorf("error deleting login policy: %s", err)
 	}
 	return nil
 }

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_login_profile.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_login_profile.go
@@ -2,11 +2,13 @@ package iam
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -15,20 +17,20 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var v5LoginProfileNonUpdatableParams = []string{"user_id"}
+
 // @API IAM POST /v5/users/{user_id}/login-profile
 // @API IAM GET /v5/users/{user_id}/login-profile
 // @API IAM PUT /v5/users/{user_id}/login-profile
 // @API IAM DELETE /v5/users/{user_id}/login-profile
-var loginProfileNonUpdatableParams = []string{"user_id"}
-
-func ResourceIdentityV5LoginProfile() *schema.Resource {
+func ResourceV5LoginProfile() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIdentityV5LoginProfileCreate,
-		ReadContext:   resourceIdentityV5LoginProfileRead,
-		UpdateContext: resourceIdentityV5LoginProfileUpdate,
-		DeleteContext: resourceIdentityV5LoginProfileDelete,
+		CreateContext: resourceV5LoginProfileCreate,
+		ReadContext:   resourceV5LoginProfileRead,
+		UpdateContext: resourceV5LoginProfileUpdate,
+		DeleteContext: resourceV5LoginProfileDelete,
 
-		CustomizeDiff: config.FlexibleForceNew(loginProfileNonUpdatableParams),
+		CustomizeDiff: config.FlexibleForceNew(v5LoginProfileNonUpdatableParams),
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -36,156 +38,213 @@ func ResourceIdentityV5LoginProfile() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"user_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the user.`,
 			},
 			"password_reset_required": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether the user needs to reset the password at the next login.`,
 			},
 			"password": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				Computed:  true,
-				Sensitive: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Sensitive:   true,
+				Description: `The password of the user login.`,
 			},
+			// Attributes.
 			"password_expires_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The password expiration time of the user.`,
 			},
 			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the login profile.`,
+			},
+			// Internal parameter(s).
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
 			},
 		},
 	}
 }
 
-func resourceIdentityV5LoginProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV5LoginProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
+
 	userId := d.Get("user_id").(string)
 	createLoginProfileHttpUrl := "v5/users/{user_id}/login-profile"
-	createLoginProfilePath := iamClient.Endpoint + createLoginProfileHttpUrl
+	createLoginProfilePath := client.Endpoint + createLoginProfileHttpUrl
 	createLoginProfilePath = strings.ReplaceAll(createLoginProfilePath, "{user_id}", userId)
 	createLoginProfileOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         buildCreateLoginProfileBodyParams(d),
+		JSONBody:         buildCreateV5LoginProfileBodyParams(d),
 	}
-	createLoginProfileResp, err := iamClient.Request("POST", createLoginProfilePath, &createLoginProfileOpt)
+	createLoginProfileResp, err := client.Request("POST", createLoginProfilePath, &createLoginProfileOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error get IAM login profile")
+		return diag.Errorf("error creating login profile for user (%s): %s", userId, err)
 	}
+
 	createLoginProfileBody, err := utils.FlattenResponse(createLoginProfileResp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	id := utils.PathSearch("login_profile.user_id", createLoginProfileBody, "").(string)
-	if id == "" {
-		return diag.Errorf("error creating IAM login profile: user_id is not found in API response: %s", err)
+	loginProfileUserId := utils.PathSearch("login_profile.user_id", createLoginProfileBody, "").(string)
+	if loginProfileUserId == "" {
+		return diag.Errorf("unable to find user ID from API response: %s", err)
 	}
-	d.SetId(id)
-	return resourceIdentityV5LoginProfileRead(ctx, d, meta)
+
+	d.SetId(loginProfileUserId)
+	return resourceV5LoginProfileRead(ctx, d, meta)
 }
 
-func buildCreateLoginProfileBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildCreateV5LoginProfileBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"password":                d.Get("password").(string),
+		"password": d.Get("password").(string),
+		// For the API, this parameter is required.
 		"password_reset_required": d.Get("password_reset_required"),
 	}
 	return bodyParams
 }
 
-func resourceIdentityV5LoginProfileRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func getV5LoginProfileConfig(client *golangsdk.ServiceClient, userId string) (interface{}, error) {
+	getHttpUrl := "v5/users/{user_id}/login-profile"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{user_id}", userId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("login_profile", respBody, nil), nil
+}
+
+func GetV5LoginProfile(client *golangsdk.ServiceClient, userId string) (interface{}, error) {
+	loginProfile, err := getV5LoginProfileConfig(client, userId)
+	if err != nil {
+		return nil, err
+	}
+
+	if loginProfile == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v5/users/{user_id}/login-profile",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the login profile of the user (%s) does not exist", userId)),
+			},
+		}
+	}
+
+	return loginProfile, nil
+}
+
+func resourceV5LoginProfileRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
-	getLoginProfileHttpUrl := "v5/users/{user_id}/login-profile"
-	getLoginProfilePath := iamClient.Endpoint + getLoginProfileHttpUrl
-	getLoginProfilePath = strings.ReplaceAll(getLoginProfilePath, "{user_id}", d.Id())
-	getLoginProfileOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	getLoginProfileResp, err := iamClient.Request("GET", getLoginProfilePath, &getLoginProfileOpt)
+	loginProfile, err := GetV5LoginProfile(client, d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error getting IAM login profile")
+		return common.CheckDeletedDiag(d, err, "error getting login profile")
 	}
-	getLoginProfileRespBody, err := utils.FlattenResponse(getLoginProfileResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	loginProfile := utils.PathSearch("login_profile", getLoginProfileRespBody, nil)
+
 	if loginProfile == nil {
-		return common.CheckDeletedDiag(d, err, "error getting IAM login profile : profile is not found in API response")
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("unable to find login profile of the user (%s) in API response", d.Id()))
 	}
-	mErr := multierror.Append(nil,
+
+	mErr := multierror.Append(
 		d.Set("user_id", utils.PathSearch("user_id", loginProfile, nil)),
 		d.Set("password_reset_required", utils.PathSearch("password_reset_required", loginProfile, nil)),
 		d.Set("created_at", utils.PathSearch("created_at", loginProfile, nil)),
 		d.Set("password_expires_at", utils.PathSearch("password_expires_at", loginProfile, nil)),
 	)
-	if err = mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error setting login profile fields: %s", err)
-	}
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceIdentityV5LoginProfileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+func resourceV5LoginProfileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		userId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
+
 	updateChanges := []string{
 		"password",
 		"password_reset_required",
 	}
 	if d.HasChanges(updateChanges...) {
 		updateLoginProfileHttpUrl := "v5/users/{user_id}/login-profile"
-		updateLoginProfilePath := iamClient.Endpoint + updateLoginProfileHttpUrl
-		updateLoginProfilePath = strings.ReplaceAll(updateLoginProfilePath, "{user_id}", d.Id())
+		updateLoginProfilePath := client.Endpoint + updateLoginProfileHttpUrl
+		updateLoginProfilePath = strings.ReplaceAll(updateLoginProfilePath, "{user_id}", userId)
 		baseBody := map[string]interface{}{}
 		if d.HasChange("password") {
 			baseBody["password"] = d.Get("password").(string)
 		}
+
 		if d.HasChange("password_reset_required") {
 			baseBody["password_reset_required"] = d.Get("password_reset_required")
 		}
+
 		updateLoginProfileOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
 			JSONBody:         baseBody,
 		}
-		_, err := iamClient.Request("PUT", updateLoginProfilePath, &updateLoginProfileOpt)
+		_, err := client.Request("PUT", updateLoginProfilePath, &updateLoginProfileOpt)
 		if err != nil {
-			return diag.Errorf("error updating IAM login profile: %s", err)
+			return diag.Errorf("error updating login profile of the user (%s): %s", userId, err)
 		}
 	}
-	return resourceIdentityV5LoginProfileRead(ctx, d, meta)
+
+	return resourceV5LoginProfileRead(ctx, d, meta)
 }
 
-func resourceIdentityV5LoginProfileDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+func resourceV5LoginProfileDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		userId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
+
 	deleteLoginProfileHttpUrl := "v5/users/{user_id}/login-profile"
-	deleteLoginProfilePath := iamClient.Endpoint + deleteLoginProfileHttpUrl
-	deleteLoginProfilePath = strings.ReplaceAll(deleteLoginProfilePath, "{user_id}", d.Id())
+	deleteLoginProfilePath := client.Endpoint + deleteLoginProfileHttpUrl
+	deleteLoginProfilePath = strings.ReplaceAll(deleteLoginProfilePath, "{user_id}", userId)
 	deleteLoginProfileOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
-	_, err = iamClient.Request("DELETE", deleteLoginProfilePath, &deleteLoginProfileOpt)
+	_, err = client.Request("DELETE", deleteLoginProfilePath, &deleteLoginProfileOpt)
 	if err != nil {
-		return diag.Errorf("error deleting IAM login profile: %s", err)
+		return diag.Errorf("error deleting login profile of the user (%s): %s", userId, err)
 	}
+
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The current code has the following issues and needs optimization:

- Redundant method naming
- Fields in the schema lack descriptions
- Missing `enable_force_new` in resource
- Some error messages are inaccurate
- Some content in the documentation is inaccurately described

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Nonupdatable feature:
<img width="749" height="217" alt="image" src="https://github.com/user-attachments/assets/913c2d85-14fb-4aae-b233-011d7e7d1911" />

ForceNew enabled:
<img width="1051" height="524" alt="image" src="https://github.com/user-attachments/assets/0283c9cc-9148-41c1-92a3-12e00cd6e6de" />


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update functions naming
2. add missing 'enable_force_new' internal parameter
3. add a description to each field in the schema
4. correcting inaccurate error messages
5. improve and optimize the document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o iam -f TestAccV5LoginPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5LoginPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccV5LoginPolicy_basic
=== PAUSE TestAccV5LoginPolicy_basic
=== CONT  TestAccV5LoginPolicy_basic
--- PASS: TestAccV5LoginPolicy_basic (35.29s)
PASS
coverage: 2.4% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       35.401s coverage: 2.4% of statements in ./huaweicloud/services/iam
```

```
./scripts/coverage.sh -o iam -f TestAccV5LoginProfile_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5LoginProfile_basic -timeout 360m -parallel 10
=== RUN   TestAccV5LoginProfile_basic
=== PAUSE TestAccV5LoginProfile_basic
=== CONT  TestAccV5LoginProfile_basic
--- PASS: TestAccV5LoginProfile_basic (76.00s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       76.175s coverage: 3.8% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    For `huaweicloud_identityv5_login_profile`
     <img width="1157" height="844" alt="image" src="https://github.com/user-attachments/assets/88b4a811-91c7-411e-a1cf-fc9b62d54a28" />
   
    For `huaweicloud_identityv5_login_policy`
     <img width="1886" height="914" alt="image" src="https://github.com/user-attachments/assets/4964fb35-1ee7-44f2-98a6-9fdaa1892b0e" />

     ab. Related resources (parent resources) not found
     The user does not exist for `huaweicloud_identityv5_login_profile`
    <img width="1189" height="750" alt="image" src="https://github.com/user-attachments/assets/6c974e1a-ea83-46d4-ae77-fc2399a53653" />


  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
