### PR TITLE
refactor(iam/v5_resource_tag): optimize codes and docs for resource and data source

### DIFF
--- a/docs/data-sources/identityv5_resource_tags.md
+++ b/docs/data-sources/identityv5_resource_tags.md
@@ -3,12 +3,12 @@ subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identityv5_resource_tags"
 description: |-
-    Use this data source to query resource tag information.
+  Use this data source to query resource tag list within HuaweiCloud.
 ---
 
 # huaweicloud_identityv5_resource_tags
 
-Use this data source to query resource tag information.
+Use this data source to query resource tag list within HuaweiCloud.
 
 ## Example Usage
 
@@ -25,23 +25,17 @@ data "huaweicloud_identityv5_resource_tags" "test" {
 
 The following arguments are supported:
 
-* `resource_type` - (Required, String) Specifies the resource type, can be `trust agency` or `user`.
+* `resource_id` - (Required, String) Specifies the resource ID to be queried.
 
-* `resource_id` - (Required, String) Specifies the resource id, length is 1 to 64 characters,
-  only contains letters, numbers and `-` string.
+* `resource_type` - (Required, String) Specifies the resource type to be queried.  
+  The valid values are as follows:
+  + **agency**
+  + **user**
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `tags` - Indicates the custom tag list.
-  The [tags](#Identityv5_tags) structure is documented below.
+* `id` - The data source ID.
 
-<a name="Identityv5_tags"></a>
-The `tags` block supports:
-
-* `tag_key` - Indicates the tag key, can contain letters, numbers, spaces and any combination of symbols
-  `_`, `.`, `:`, `=`, `+`, `-`, `@`, but cannot start with space or begin with `_sys_`, length range [1,64].
-
-* `tag_value` - Indicates the tag value, can contain letters, numbers, spaces and any combination of symbols
-  `_`, `.`, `:`, `/`, `=`, `+`, `-`, `@`, can be empty string, length range [0,128].
+* `tags` - The key/value pairs associated with the resource.  

--- a/docs/resources/identityv5_resource_tag.md
+++ b/docs/resources/identityv5_resource_tag.md
@@ -3,27 +3,23 @@ subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identityv5_resource_tag"
 description: |-
-  Manages an IAM v5 resource tag within HuaweiCloud.
+  Manages an IAM resource tag within HuaweiCloud.
 ---
 
 # huaweicloud_identityv5_resource_tag
 
-Manages an IAM v5 resource tag within HuaweiCloud.
-
--> NOTE: You must have admin privileges to use this resource.
+Manages an IAM resource tag within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
 variable "resource_id" {}
+variable "tags" {}
 
 resource "huaweicloud_identityv5_resource_tag" "test" {
   resource_type = "user"
   resource_id   = var.resource_id
-  tags = {
-    foo = "bar"
-    key = "value"
-  }
+  tags          = var.tags
 }
 ```
 
@@ -31,17 +27,24 @@ resource "huaweicloud_identityv5_resource_tag" "test" {
 
 The following arguments are supported:
 
-* `resource_type` - (Required, String, NonUpdatable) Specifies the resource type, which can be `trust agency` or `user`.
+* `resource_type` - (Required, String, NonUpdatable) Specifies the resource type to be associated with the tags.  
+  The valid values are as follows:
+  + **agency**
+  + **user**
 
-* `resource_id` - (Required, String, NonUpdatable) Specifies the resource id, a string of 1 to 64 characters containing
-  only letters, numbers, and hyphens ("-").
+* `resource_id` - (Required, String, NonUpdatable) Specifies the resource ID to be associated with the tags.
 
-* `tags` - (Optional, Map) Specifies the tags of a VM node, key/value pair format.
+* `tags` - (Optional, Map) Specifies the key/value pairs to be associated with the resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
 
 ## Import
 
-Resource tag can be imported using the `<resource_type>/<resource_id>`. For example,
-if you have resource_type `user` and resource_id `xxxx`, you should use `user/xxxx` to import.
+The resource can be imported using `resource_type` and `resource_id`, separated by a slash, e.g.
 
 ```bash
 $ terraform import huaweicloud_identityv5_resource_tag.test <resource_type>/<resource_id>

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1632,7 +1632,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_identityv5_virtual_mfa_devices":      iam.DataSourceIdentityV5VirtualMfaDevices(),
 			"huaweicloud_identityv5_registered_services":      iam.DataSourceIdentityV5RegisteredServices(),
-			"huaweicloud_identityv5_resource_tags":            iam.DataSourceIdentityv5ResourceTags(),
+			"huaweicloud_identityv5_resource_tags":            iam.DataSourceV5ResourceTags(),
 			"huaweicloud_identityv5_users":                    iam.DataSourceIdentityV5Users(),
 			"huaweicloud_identityv5_service_principals":       iam.DataSourceIdentityV5ServicePrincipals(),
 			"huaweicloud_identityv5_groups":                   iam.DataSourceIdentityV5Groups(),
@@ -3395,7 +3395,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identityv5_group":                       iam.ResourceIdentityV5Group(),
 			"huaweicloud_identityv5_group_membership":            iam.ResourceIdentityV5GroupMembership(),
 			"huaweicloud_identityv5_access_key":                  iam.ResourceIdentityAccessKey(),
-			"huaweicloud_identityv5_resource_tag":                iam.ResourceIdentityV5ResourceTag(),
+			"huaweicloud_identityv5_resource_tag":                iam.ResourceV5ResourceTag(),
 			"huaweicloud_identityv5_service_linked_agency":       iam.ResourceIdentityv5ServiceLinkedAgency(),
 			"huaweicloud_identityv5_asymmetric_signature_switch": iam.ResourceIdentityV5AsymmetricSignatureSwitch(),
 

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_resource_tag_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_resource_tag_test.go
@@ -2,17 +2,14 @@ package iam
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 )
 
 func getV5ResourceTagResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -20,16 +17,8 @@ func getV5ResourceTagResourceFunc(cfg *config.Config, state *terraform.ResourceS
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
-	getResourceTagHttpUrl := "v5/{resource_type}/{resource_id}/tags"
-	getResourceTagPath := client.Endpoint + getResourceTagHttpUrl
-	getResourceTagPath = strings.ReplaceAll(getResourceTagPath, "{resource_type}", state.Primary.Attributes["resource_type"])
-	getResourceTagPath = strings.ReplaceAll(getResourceTagPath, "{resource_id}", state.Primary.Attributes["resource_id"])
-	getResourceTagOpt := golangsdk.RequestOpts{KeepResponseBody: true}
-	getResourceTagResp, err := client.Request("GET", getResourceTagPath, &getResourceTagOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving IAM resource tag: %s", err)
-	}
-	return utils.FlattenResponse(getResourceTagResp)
+
+	return iam.GetV5ResourceTagsById(client, state.Primary.Attributes["resource_type"], state.Primary.Attributes["resource_id"])
 }
 
 // Please ensure that the user executing the acceptance test has 'admin' permission.

--- a/huaweicloud/services/iam/common.go
+++ b/huaweicloud/services/iam/common.go
@@ -1,0 +1,77 @@
+package iam
+
+import (
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func buildV5ResourceTags(tagmap map[string]interface{}) []map[string]interface{} {
+	tags := make([]map[string]interface{}, 0, len(tagmap))
+	for k, v := range tagmap {
+		tags = append(tags, map[string]interface{}{
+			"tag_key":   k,
+			"tag_value": v,
+		})
+	}
+
+	return tags
+}
+
+func addV5TagsToResource(client *golangsdk.ServiceClient, tags map[string]interface{}, resourceType, resourceId string) error {
+	httpUrl := "v5/{resource_type}/{resource_id}/tags/create"
+	addPath := client.Endpoint + httpUrl
+	addPath = strings.ReplaceAll(addPath, "{resource_type}", resourceType)
+	addPath = strings.ReplaceAll(addPath, "{resource_id}", resourceId)
+	addOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"tags": buildV5ResourceTags(tags),
+		},
+	}
+	_, err := client.Request("POST", addPath, &addOpt)
+	return err
+}
+
+func expandV5TagsKeyToStringList(tagmap map[string]interface{}) []string {
+	tagKeys := make([]string, 0, len(tagmap))
+	for k := range tagmap {
+		tagKeys = append(tagKeys, k)
+	}
+
+	return tagKeys
+}
+
+func removeV5TagsFromResource(client *golangsdk.ServiceClient, tags map[string]interface{}, resourceType, resourceId string) error {
+	httpUrl := "v5/{resource_type}/{resource_id}/tags/delete"
+	removePath := client.Endpoint + httpUrl
+	removePath = strings.ReplaceAll(removePath, "{resource_type}", resourceType)
+	removePath = strings.ReplaceAll(removePath, "{resource_id}", resourceId)
+	removeOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         expandV5TagsKeyToStringList(tags),
+	}
+	_, err := client.Request("DELETE", removePath, &removeOpt)
+	return err
+}
+
+func getV5ResourceTags(client *golangsdk.ServiceClient, resourceType string, resourceId string) ([]interface{}, error) {
+	getHttpUrl := "v5/{resource_type}/{resource_id}/tags"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{resource_type}", resourceType)
+	getPath = strings.ReplaceAll(getPath, "{resource_id}", resourceId)
+	getOpt := golangsdk.RequestOpts{KeepResponseBody: true}
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("tags", getRespBody, make([]interface{}, 0)).([]interface{}), nil
+}

--- a/huaweicloud/services/iam/data_source_huaweicloud_identityv5_resource_tags.go
+++ b/huaweicloud/services/iam/data_source_huaweicloud_identityv5_resource_tags.go
@@ -2,41 +2,38 @@ package iam
 
 import (
 	"context"
-	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API IAM GET /v5/{resource_type}/{resource_id}/tags
-func DataSourceIdentityv5ResourceTags() *schema.Resource {
+func DataSourceV5ResourceTags() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceIAMIdentityv5TagsRead,
+		ReadContext: dataSourceV5TagsRead,
 
 		Schema: map[string]*schema.Schema{
 			"resource_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource ID to be queried.`,
 			},
 			"resource_type": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource type to be queried.`,
 			},
-
-			"tags": common.TagsComputedSchema(),
+			"tags": common.TagsComputedSchema(`The key/value pairs associated with the resource.`),
 		},
 	}
 }
 
-func dataSourceIAMIdentityv5TagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceV5TagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
 	if err != nil {
@@ -45,30 +42,23 @@ func dataSourceIAMIdentityv5TagsRead(_ context.Context, d *schema.ResourceData, 
 
 	resourceType := d.Get("resource_type").(string)
 	resourceId := d.Get("resource_id").(string)
-	getResourceTagHttpUrl := "v5/{resource_type}/{resource_id}/tags"
-	getResourceTagPath := iamClient.Endpoint + getResourceTagHttpUrl
-	getResourceTagPath = strings.ReplaceAll(getResourceTagPath, "{resource_type}", resourceType)
-	getResourceTagPath = strings.ReplaceAll(getResourceTagPath, "{resource_id}", resourceId)
-	getResourceTagOpt := golangsdk.RequestOpts{KeepResponseBody: true}
-	getResourceTagResp, err := iamClient.Request("GET", getResourceTagPath, &getResourceTagOpt)
+	tags, err := getV5ResourceTags(iamClient, resourceType, resourceId)
 	if err != nil {
-		return diag.Errorf("error retrieving IAM resource tag: %s", err)
+		return diag.Errorf("error retrieving tags of %s (%s): %s", resourceType, resourceId, err)
 	}
 
-	getResourceTagRespBody, err := utils.FlattenResponse(getResourceTagResp)
+	randomId, err := uuid.GenerateUUID()
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("unable to generate ID: %s", err)
 	}
-	id, err := uuid.GenerateUUID()
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	d.SetId(id)
-	mErr := multierror.Append(nil,
-		d.Set("tags", flattenTagsToMap(utils.PathSearch("tags", getResourceTagRespBody, nil))),
+	d.SetId(randomId)
+
+	mErr := multierror.Append(
+		d.Set("tags", flattenTagsToMap(tags)),
 	)
 	if err = mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error setting tags fields: %s", err)
 	}
+
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The CRUD logic for tags is implemented as public methods in the common.go file.

The current code has the following issues and needs optimization:

- Redundant method naming
- Fields in the schema lack descriptions
- Some error messages are inaccurate
- Some content in the documentation is inaccurately described

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update functions naming
2. Extract functional code blocks into functions
3. add a description to each field in the schema
4. correcting inaccurate error messages
5. improve and optimize the document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccDataV5ResourceTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5ResourceTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5ResourceTags_basic
=== PAUSE TestAccDataV5ResourceTags_basic
=== CONT  TestAccDataV5ResourceTags_basic
--- PASS: TestAccDataV5ResourceTags_basic (20.49s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       20.608s coverage: 4.3% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccV5ResourceTag_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5ResourceTag_basic -timeout 360m -parallel 10
=== RUN   TestAccV5ResourceTag_basic
=== PAUSE TestAccV5ResourceTag_basic
=== CONT  TestAccV5ResourceTag_basic
--- PASS: TestAccV5ResourceTag_basic (35.60s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       35.709s coverage: 4.3% of statements in ./huaweicloud/services/iam
```

* [x ] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
The resource have not any tags.
     <img width="1144" height="793" alt="image" src="https://github.com/user-attachments/assets/029d2ad9-6336-42c6-b405-a57b5b9b6bcf" />

    The resource does nor exist to which tags belong.
    <img width="1176" height="857" alt="image" src="https://github.com/user-attachments/assets/7fe157fe-64dd-43fe-be2b-611e068eca46" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
