### PR TITLE
fix(ram): the `ram_resource_instances_filter` dataSource quality improvement

### DIFF
--- a/docs/data-sources/ram_resource_instances_filter.md
+++ b/docs/data-sources/ram_resource_instances_filter.md
@@ -1,34 +1,20 @@
 ---
 subcategory: "Resource Access Manager (RAM)"
 layout: "huaweicloud"
-page_title: "HuaweiCloud: huaweicloud_ram_resource_instance_filter"
-description: |
-  Use this data source to filter the resource instance by tags.
+page_title: "HuaweiCloud: huaweicloud_ram_resource_instances_filter"
+description: |-
+  Use this data source to filter the resource instances by tags.
 ---
 
 # huaweicloud_ram_resource_instances_filter
 
-Use this data source to filter the resource instance by tags.
+Use this data source to filter the resource instances by tags.
 
 ## Example Usage
 
 ```hcl
-variable "without_any_tag" {}
-variable "key" {}
-variable "value" {}
-variable "match_key" {}
-variable "match_value" {}
-
 data "huaweicloud_ram_resource_instances_filter" "test" {
-  without_any_tag = var.without_any_tag
-  tags {
-    key   = var.key
-    values = [var.value] 
-  }
-  matches {
-    key   = var.match_key
-    value = [var.match_value]
-  }
+  without_any_tag = true
 }
 ```
 
@@ -37,57 +23,58 @@ data "huaweicloud_ram_resource_instances_filter" "test" {
 The following arguments are supported:
 
 * `without_any_tag` - (Optional, Bool) Specifies the flag to query instances without tags.
-  When this flag is set to true, it queries all resources without tags.
+  When this flag is set to **true**, it queries all resources without tags.
 
 * `tags` - (Optional, List) Specifies the list of tags.
 
-  The [tags](#tags) structure is documented below.
+  The [tags](#tags_struct) structure is documented below.
 
 * `matches` - (Optional, List) Specifies the name of RAM permission in which to query the data source.
 
-  The [matches](#matches) structure is documented below.
+  The [matches](#matches_struct) structure is documented below.
 
-<a name="tags"></a>
+<a name="tags_struct"></a>
 The `tags` block supports:
 
 * `key` - (Required, String) Specifies the key of tags.
 
 * `values` - (Optional, List) Specifies all values of the key in the tags.
 
-<a name="matches"></a>
+<a name="matches_struct"></a>
 The `matches` block supports:
 
 * `key` - (Required, String) Specifies the key of matched tags.
 
-* `value` - (Required, String) Specifies all values of the key in the matched tags.
+* `value` - (Required, String) Specifies the value of the key in the matched tags.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Indicates the resource ID.
+* `id` - The data source ID in UUID format.
 
-* `resources` - Indicates the list of the RAM permissions
-  The [resources](#RAM_Permissions) structure is documented below.
+* `resources` - The list of resource information.
 
-* `total_count` - The total number of the RAM permissions.
+  The [resources](#resources_struct) structure is documented below.
 
-<a name="RAM_Permissions"></a>
+* `total_count` - The total number.
+
+<a name="resources_struct"></a>
 The `resources` block supports:
 
 * `resource_id` - Indicates the ID of resource.
 
 * `resource_name` - Indicates the name of resource.
 
-* `resource_detail` - Indicates the details of resource.
-
 * `tags` - Indicates the list of tags.
 
-  The [tags](#tags) structure is documented below.
+  The [tags](#resources_tags_struct) structure is documented below.
 
-<a name="tags"></a>
+* `resource_detail` - Indicates the details of resource.
+
+<a name="resources_tags_struct"></a>
 The `tags` block supports:
 
 * `key` - Indicates the key of tags.
 
-* `value` - Indicates all values of the key in the tags.
+* `value` - Indicates the value of the key in the tags.

--- a/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_resource_instances_filter_test.go
+++ b/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_resource_instances_filter_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceRAMResourceInstanceFilter_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_ram_resource_instances_filter.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataSourceResourceInstancesFilter_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_ram_resource_instances_filter.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -19,22 +21,29 @@ func TestAccDataSourceRAMResourceInstanceFilter_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceRAMResourceInstanceFilter_without_any_tag_basic(),
+				Config: testDataSourceResourceInstancesFilter_without_any_tag_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.#"),
 					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_id"),
 					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.tags.#"),
 					resource.TestCheckResourceAttrSet(dataSource, "total_count"),
 				),
 			},
 			{
-				Config: testDataSourceRAMResourceInstanceFilter_with_tag_basic(),
+				Config: testDataSourceResourceInstancesFilter_with_tags_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_id"),
-					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_name"),
-					resource.TestCheckResourceAttrSet(dataSource, "resources.0.tags.0.key"),
-					resource.TestCheckResourceAttrSet(dataSource, "resources.0.tags.0.value"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "total_count"),
+				),
+			},
+			{
+				Config: testDataSourceResourceInstancesFilter_with_matches_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.#"),
 					resource.TestCheckResourceAttrSet(dataSource, "total_count"),
 				),
 			},
@@ -42,21 +51,32 @@ func TestAccDataSourceRAMResourceInstanceFilter_basic(t *testing.T) {
 	})
 }
 
-func testDataSourceRAMResourceInstanceFilter_without_any_tag_basic() string {
+func testDataSourceResourceInstancesFilter_without_any_tag_basic() string {
 	return `
 data "huaweicloud_ram_resource_instances_filter" "test" {
-	without_any_tag = true
+  without_any_tag = true
 }
 `
 }
 
-func testDataSourceRAMResourceInstanceFilter_with_tag_basic() string {
+func testDataSourceResourceInstancesFilter_with_tags_basic() string {
 	return `
 data "huaweicloud_ram_resource_instances_filter" "test" {
-	tags {
-		key   = "abc"
-		values = ["abc"]
-	}
+  tags {
+    key    = "test"
+    values = ["value"]
+  }
+}
+`
+}
+
+func testDataSourceResourceInstancesFilter_with_matches_basic() string {
+	return `
+data "huaweicloud_ram_resource_instances_filter" "test" {
+  matches {
+    key   = "test"
+    value = "value"
+  }
 }
 `
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Fix errors in the bulid method.
2. Supplement test cases to improve.
3. Optimize code snippets and MD document descriptions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

the `ram_resource_instances_filter` dataSource quality improvement

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ram" TESTARGS="-run TestAccDataSourceResourceInstancesFilter_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccDataSourceResourceInstancesFilter_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceResourceInstancesFilter_basic
=== PAUSE TestAccDataSourceResourceInstancesFilter_basic
=== CONT  TestAccDataSourceResourceInstancesFilter_basic
--- PASS: TestAccDataSourceResourceInstancesFilter_basic (29.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       29.826s
```
<img width="933" height="31" alt="image" src="https://github.com/user-attachments/assets/9e481f8d-ca58-4530-bee1-963451d73a22" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
