### PR TITLE
fix(vpcep): optimize the code and test case of VPCEP data source

### DIFF
--- a/docs/data-sources/vpcep_resources_by_tags.md
+++ b/docs/data-sources/vpcep_resources_by_tags.md
@@ -1,27 +1,24 @@
 ---
 subcategory: "VPC Endpoint (VPCEP)"
 layout: "huaweicloud"
-page_title: "HuaweiCloud: huaweicloud_vpcep_resources"
+page_title: "HuaweiCloud: huaweicloud_vpcep_resources_by_tags"
 description: |-
-  Use this data source to get vpcep endpoints filtered by tags within HuaweiCloud.
+  Use this data source to get the lis of VPCEP resources filtered by tags within HuaweiCloud.
 ---
 
 # huaweicloud_vpcep_resources_by_tags
 
-Use this data source to get vpcep resources filtered by tags within HuaweiCloud.
+Use this data source to get the lis of VPCEP resources filtered by tags within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
+variable "resource_type" {}
+variable "action" {}
+
 data "huaweicloud_vpcep_resources_by_tags" "test" {
-  action = "filter"
-  resource_type = "endpoint_service"
-  tags = [
-    {
-      key    = "key_string"
-      values = ["value_string"]
-    }
-  ]
+  resource_type = var.resource_type
+  action        = var.action
 }
 ```
 
@@ -32,77 +29,62 @@ The following arguments are supported:
 * `region` - (Optional, String) Specifies the region in which to query the resource.
   If omitted, the provider-level region will be used.
 
-* `resource_type` - (Required, String) Specifies the resource type to which the tags belong that to be queried.  
+* `resource_type` - (Required, String) Specifies the resource type.
   The value can be **endpoint_service** or **endpoint**.
 
-* `action` - (Required, String) Specifies the action name. Possible values are **count** and **filter**.
-  + **count**: querying count of data filtered by tags.
-  + **filter**: querying details of data filtered by tags.
+* `action` - (Required, String) Specifies the action name.
+  The valid values are **filter** and **count**.
+  If `action` set to **filter**, indicates query the VPCEP resources based on tags filtering conditions.
+  If `action` set to **count**, indicates only query the total number of VPCEP resources.
 
-* `tags` - (Optional, List) Specifies the list of included tags. Backups with these tags will be filtered.
+* `tags` - (Optional, List) Specifies the tags are included.
   The [tags](#tags_struct) structure is documented below.
 
-* `tags_any` - (Optional, List) Specifies the list of tags. Backups with any tags in this list will be filtered.
+* `tags_any` - (Optional, List) Specifies the any tags are included.
   The [tags_any](#tags_struct) structure is documented below.
 
-* `not_tags` - (Optional, List) Specifies the list of excluded tags. Backups without these tags will be filtered.
+* `not_tags` - (Optional, List) Specifies the tags are excluded.
   The [not_tags](#tags_struct) structure is documented below.
 
-* `not_tags_any` - (Optional, List) Specifies the list of tags. Backups without any tags in this list will be filtered.
+* `not_tags_any` - (Optional, List) Specifies the any tags are excluded.
   The [not_tags_any](#tags_struct) structure is documented below.
 
 -> For arguments above, include `tags`, `tags_any`, `not_tags`, `not_tags_any` have limits as follows:
-  <br/>1. This list cannot be an empty list.
-  <br/>2. The list can contain up to `10` keys.
-  <br/>3. Keys in this list must be unique.
-  <br/>4. If no tag filtering condition is specified, full data is returned.
+  <br/>1. A maximum of `10` tag keys are included, and each tag value can have a maximum of `10` values.
+  <br/>2. Each tag value can be an empty array, but the tag structure cannot be missing.
+  Tag keys must be unique. Values of the same tag key must be unique.
+  <br/>3. Keys are in the AND relationship (`tags`,`not_tags`).
+  <br/>4. Keys are in the OR relationship (`tags_any`,`not_tags_any`).
+  <br/>5. Values in the key-value structure are in the OR relationship.
 
-* `without_any_tag` - (Optional, Bool) Specifies whether ignore tags params.
-  If this parameter is set to **true**, all resources without tags are queried.
-  In this case, the `tag`, `not_tags`, `tags_any`, and `not_tags_any` fields are ignored.
-
-* `sys_tags` - (Optional, List) Specifies the system tags.
-  The [sys_tags](#tags_struct) structure is documented below.
-
-  -> The sys_tags has limits as follows:
-  <br/>1. Only users with the op_service permission can obtain this field.
-  <br/>2. Field `sys_tags` and tag filter conditions (`tags`, `tags_any`, `not_tags`, `not_tags_any`)
-  cannot  be used at the same time.
-  <br/>3. If no `sys_tags` exists, use other tag APIs for filtering. If no tag filter is specified, full data is returned.
-  <br/>4. This list cannot be an empty list.
-
-* `matches` - (Optional, List) Specifies the matches supported by resources. Keys in this list must be unique.
-  Only one key is supported currently. Multiple-key support will be available later.
+* `matches` - (Optional, List) Specifies the search field.
   The [matches](#matches_struct) structure is documented below.
+
+* `without_any_tag` - (Optional, Bool) Specifies whether ignore tags parameters.
+  The value can be **true** or **false** (Default value).
+  When `without_any_tag` is set to **true**, ignore parameter verification on the `tags`, `not_tags`,
+  `tags_any`, and `not_tags_any`.
 
 <a name="tags_struct"></a>
 The `tags` block supports:
 
-* `key` - (Required, String) Specifies the key of the resource tag. It contains a maximum of `127` unicode characters.
-  A tag key cannot be an empty string. Spaces before and after a key will be deprecated.
+* `key` - (Required, String) Specifies the tag key.
+  Each tag key can contain a maximum of `128` characters but cannot be left blank.
+  key cannot be an empty string or spaces.
 
-* `values` - (Required, List) Specifies the list of values corresponding to the key.
-
-  -> The field has the following restrictions:
-    <br/>1. The list can contain up to `10` values.
-    <br/>2. A tag value contains up to `255` unicode characters. Spaces before and after a key will be deprecated.
-    <br/>3. Values in this list must be unique.
-    <br/>4. Values in this list are in an OR relationship.
-    <br/>5. This list can be empty and each value can be an empty character string.
-    <br/>6. If this list is left blank, it indicates that all values are included.
-    <br/>7. The asterisk (*) is a reserved character in the system.
-    If the value starts with (*), it indicates that fuzzy match is performed based on the value following (*).
-    The value cannot contain only asterisks.
+* `values` - (Required, List) Specifies the tag values.
+  Each tag value contains a maximum of `255` characters.
+  The tag value can be an empty array but cannot be left blank. If values are left blank,
+  it indicates querying any value.
+  Values are in the OR relationship.
 
 <a name="matches_struct"></a>
 The `matches` block supports:
 
-* `key` - (Required, String) Specifies the key of the resource tag.
-  A key can only be set to **resource_name**, indicating the resource name.
+* `key` - (Required, String) Specifies the matches key.
+  Only **resource_name** for key is supported.
 
-* `value` - (Required, String) Specifies the value of the resource tag.
-  A value consists of up to `255` characters.
-  If key is **resource_name**, an empty string indicates exact match and any non-empty string indicates fuzzy match.
+* `value` - (Required, String) Specifies the matches value.
 
 ## Attribute Reference
 
@@ -112,7 +94,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `total_count` - The total number of matched resources.
 
-* `resources` - List of matched resources.
+* `resources` - The resource details.
   The [resources](#vpcep_resources) structure is documented below.
 
 <a name="vpcep_resources"></a>
@@ -120,12 +102,9 @@ The `resources` block supports:
 
 * `resource_id` - The resource ID.
 
-* `resource_name` - The resource name.
+* `resource_name` - The resource name. If the resource does not have a name, the ID is returned.
 
-* `resource_detail` - The detail of the matched resources.
-  The value is a resource object used for extension. This parameter is left blank by default.
-
-* `tags` - The tag list.
+* `tags` - The tags list.
   The [tags](#vpcep_resources_tags) structure is documented below.
 
 <a name="vpcep_resources_tags"></a>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Optimize the code and test case of VPCEP data source.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  1.data_source_huaweicloud_vpcep_resources_by_tags
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST="./huaweicloud/services/acceptance/vpcep" TESTARGS="-run TestAccDataSourceVpcepResourcesByTags_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccDataSourceVpcepResourcesByTags_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceVpcepResourcesByTags_basic
=== PAUSE TestAccDataSourceVpcepResourcesByTags_basic
=== CONT  TestAccDataSourceVpcepResourcesByTags_basic
--- PASS: TestAccDataSourceVpcepResourcesByTags_basic (75.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     75.835s
```
<img width="1203" height="16" alt="image" src="https://github.com/user-attachments/assets/7fa128c5-d85b-4555-a71c-c89cda348534" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
