### PR TITLE
feat(lakeformation): supports new data source to query specifications

### DIFF
--- a/docs/data-sources/lakeformation_specifications.md
+++ b/docs/data-sources/lakeformation_specifications.md
@@ -1,0 +1,70 @@
+---
+subcategory: "LakeFormation"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lakeformation_specifications"
+description: |-
+  Use this data source to get the list of LakeFormation instance specifications within HuaweiCloud.
+---
+
+# huaweicloud_lakeformation_specifications
+
+Use this data source to get the list of LakeFormation instance specifications within HuaweiCloud.
+
+## Example Usage
+
+### Query all instance specifications
+
+```hcl
+data "huaweicloud_lakeformation_specifications" "test" {}
+```
+
+### Query the instance specifications using spec_code filter parameter
+
+```hcl
+data "huaweicloud_lakeformation_specifications" "test" {
+  spec_code = "hws.resource.type.lakeformation.qps"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `spec_code` - (Optional, String) Specifies the code of the specification to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+`id` - The data source ID.
+
+* `specifications` - The list of specifications that matched filter parameters.
+  The [specifications](#lakeformation_specifications_attr) structure is documented below.
+
+<a name="lakeformation_specifications_attr"></a>
+The `specifications` block supports:
+
+* `spec_code` - The code of the specification.
+
+* `resource_type` - The resource type of the specification.
+
+* `stride` - The stride of the specification.
+
+* `unit` - The unit of the specification.
+
+* `min_stride_num` - The minimum stride number of the specification.
+
+* `max_stride_num` - The maximum stride number of the specification.
+
+* `usage_measure_id` - The usage measurement unit ID of the specification.
+
+* `usage_factor` - The usage factor of the specification.
+
+* `usage_value` - The usage value of the specification.
+
+* `free_usage_value` - The free usage value of the specification.
+
+* `stride_num_whitelist` - The stride number whitelist of the specification.

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -1010,6 +1010,13 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Product:          "KooGallery",
 	},
 
+	// catalog for LakeFormation
+	"lakeformation": {
+		Name:    "lakeformation",
+		Version: "v1",
+		Product: "LakeFormation",
+	},
+
 	// catalog for MetaStudio
 	"metastudio": {
 		Name:    "metastudio",

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -91,6 +91,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iotda"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/kafka"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/koogallery"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lakeformation"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/live"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lts"
@@ -1733,6 +1734,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_upgrade_packages":           iotda.DataSourceUpgradePackages(),
 
 			"huaweicloud_koogallery_assets": koogallery.DataSourceKooGalleryAssets(),
+
+			"huaweicloud_lakeformation_specifications": lakeformation.DataSourceSpecifications(),
 
 			"huaweicloud_lb_listeners":    lb.DataSourceListeners(),
 			"huaweicloud_lb_loadbalancer": lb.DataSourceELBV2Loadbalancer(),

--- a/huaweicloud/services/acceptance/lakeformation/data_source_huaweicloud_lakeformation_specifications_test.go
+++ b/huaweicloud/services/acceptance/lakeformation/data_source_huaweicloud_lakeformation_specifications_test.go
@@ -1,0 +1,87 @@
+package lakeformation
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSpecifications_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_lakeformation_specifications.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		bySpecCode   = "data.huaweicloud_lakeformation_specifications.filter_by_spec_code"
+		dcBySpecCode = acceptance.InitDataSourceCheck(bySpecCode)
+
+		byNotFoundSpecCode   = "data.huaweicloud_lakeformation_specifications.filter_by_not_found_spec_code"
+		dcByNotFoundSpecCode = acceptance.InitDataSourceCheck(byNotFoundSpecCode)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSpecifications_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "specifications.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcBySpecCode.CheckResourceExists(),
+					resource.TestCheckOutput("is_spec_code_filter_useful", "true"),
+					dcByNotFoundSpecCode.CheckResourceExists(),
+					resource.TestCheckOutput("is_spec_code_not_found_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceSpecifications_basic = `
+data "huaweicloud_lakeformation_specifications" "all" {}
+
+# Filter by spec_code
+locals {
+  first_spec_code = data.huaweicloud_lakeformation_specifications.all.specifications[0].spec_code
+}
+
+data "huaweicloud_lakeformation_specifications" "filter_by_spec_code" {
+  spec_code = local.first_spec_code
+}
+
+locals {
+  spec_code_filter_result = [
+    for v in data.huaweicloud_lakeformation_specifications.filter_by_spec_code.specifications[*].spec_code :
+	  v == local.first_spec_code
+  ]
+}
+
+output "is_spec_code_filter_useful" {
+  value = length(local.spec_code_filter_result) > 0 && alltrue(local.spec_code_filter_result)
+}
+
+# Filter by spec_code (not found)
+locals {
+  not_found_spec_code = "NOT_FOUND"
+}
+
+data "huaweicloud_lakeformation_specifications" "filter_by_not_found_spec_code" {
+  spec_code = local.not_found_spec_code
+}
+
+locals {
+  not_found_spec_code_filter_result = [
+    for v in data.huaweicloud_lakeformation_specifications.filter_by_not_found_spec_code.specifications[*].spec_code :
+	  strcontains(v, local.not_found_spec_code)
+  ]
+}
+
+output "is_spec_code_not_found_filter_useful" {
+  value = length(local.not_found_spec_code_filter_result) == 0
+}
+`

--- a/huaweicloud/services/lakeformation/data_source_huaweicloud_lakeformation_specifications.go
+++ b/huaweicloud/services/lakeformation/data_source_huaweicloud_lakeformation_specifications.go
@@ -1,0 +1,203 @@
+package lakeformation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LakeFormation GET /v1/{project_id}/specs
+func DataSourceSpecifications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSpecificationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the specifications are located.`,
+			},
+
+			// Optional parameters.
+			"spec_code": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The code of the specification to be queried.`,
+			},
+
+			// Attributes.
+			"specifications": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"spec_code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The code of the specification.`,
+						},
+						"resource_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the specification.`,
+						},
+						"stride": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The stride of the specification.`,
+						},
+						"unit": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The unit of the specification.`,
+						},
+						"min_stride_num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The minimum stride number of the specification.`,
+						},
+						"max_stride_num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The maximum value of the specification.`,
+						},
+						"usage_measure_id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The usage measurement unit ID of the specification.`,
+						},
+						"usage_factor": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the specification.`,
+						},
+						"usage_value": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The product ID of the specification.`,
+						},
+						"free_usage_value": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The free usage value of the specification.`,
+						},
+						"stride_num_whitelist": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The stride number whitelist of the specification.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeInt,
+							},
+						},
+					},
+				},
+				Description: `The list of specifications that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func listSpecifications(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/specs"
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	return utils.PathSearch("spec_codes", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenSpecifications(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"spec_code":            utils.PathSearch("spec_code", item, nil),
+			"resource_type":        utils.PathSearch("resource_type", item, nil),
+			"stride":               utils.PathSearch("stride", item, nil),
+			"unit":                 utils.PathSearch("unit", item, nil),
+			"min_stride_num":       utils.PathSearch("min_stride_num", item, nil),
+			"max_stride_num":       utils.PathSearch("max_stride_num", item, nil),
+			"usage_measure_id":     utils.PathSearch("usage_measure_id", item, nil),
+			"usage_factor":         utils.PathSearch("usage_factor", item, nil),
+			"usage_value":          utils.PathSearch("usage_value", item, nil),
+			"free_usage_value":     utils.PathSearch("free_usage_value", item, nil),
+			"stride_num_whitelist": utils.PathSearch("stride_num_whitelist", item, nil),
+		})
+	}
+
+	return result
+}
+
+func filterSpecifications(all []interface{}, d *schema.ResourceData) []interface{} {
+	result := make([]interface{}, 0, len(all))
+
+	for _, v := range all {
+		if param, ok := d.GetOk("spec_code"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("spec_code", v, nil)) {
+			continue
+		}
+
+		result = append(result, v)
+	}
+	return result
+}
+
+func dataSourceSpecificationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("lakeformation", region)
+	if err != nil {
+		return diag.Errorf("error creating LakeFormation client: %s", err)
+	}
+
+	specifications, err := listSpecifications(client)
+	if err != nil {
+		return diag.Errorf("error querying instance specifications: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("specifications", flattenSpecifications(filterSpecifications(specifications, d))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source that used to query instance specifications

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to query specifications
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lakeformation -f TestAccDataSpecifications_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lakeformation" -v -coverprofile="./huaweicloud/services/acceptance/lakeformation/lakeformation_coverage.cov" -coverpkg="./huaweicloud/services/lakeformation" -run TestAccDataSpecifications_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSpecifications_basic
=== PAUSE TestAccDataSpecifications_basic
=== CONT  TestAccDataSpecifications_basic
--- PASS: TestAccDataSpecifications_basic (11.01s)
PASS
coverage: 86.5% of statements in ./huaweicloud/services/lakeformation
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lakeformation     11.101s coverage: 86.5% of statements in ./huaweicloud/services/lakeformation
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
