### PR TITLE
refactor(iam/v5_virtual_mfa_device): optimize code and docs for datasource and resource

### DIFF
--- a/docs/data-sources/identityv5_virtual_mfa_devices.md
+++ b/docs/data-sources/identityv5_virtual_mfa_devices.md
@@ -1,19 +1,31 @@
 ---
 subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
-page_title: "HuaweiCloud: huaweicloud_identity_user_token_info"
+page_title: "HuaweiCloud: huaweicloud_identityV5_virtual_mfa_devices"
 description: |-
-  Use this data source to get the list of virtual MFA devices in the Identity and Access Management V5 service.
+  Use this data source to get the list of virtual MFA devices within HuaweiCloud.
 ---
 
 # huaweicloud_identityv5_virtual_mfa_devices
 
-Use this data source to get the list of virtual MFA devices in the Identity and Access Management V5 service.
+Use this data source to get the list of virtual MFA devices within HuaweiCloud.
 
 ## Example Usage
 
+### Query all virtual MFA devices
+
 ```hcl
-data "huaweicloud_identityV5_virtual_mfa_devices" "devices" {}
+data "huaweicloud_identityV5_virtual_mfa_devices" "test" {}
+```
+
+### Query virtual MFA devices by user ID
+
+```hcl
+variable "user_id" {}
+
+data "huaweicloud_identityV5_virtual_mfa_devices" "test" {
+  user_id = var.user_id
+}
 ```
 
 ## Argument Reference
@@ -26,14 +38,16 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `devices` - Indicates the list of virtual MFA devices. Structure is documented below.
-  The [devices](#IdentityMFA_Devices) structure is documented below.
+* `id` - The data source ID.
 
-<a name="IdentityMFA_Devices"></a>
+* `devices` - The list of virtual MFA devices that matched filter parameters.  
+  The [devices](#v5_virtual_mfa_devices) structure is documented below.
+
+<a name="v5_virtual_mfa_devices"></a>
 The `devices` block supports:
 
-* `enabled` - Indicates whether the MFA device is enabled.
+* `enabled` - Whether the MFA device is enabled.
 
-* `serial_number` - Indicates the serial number of the MFA device.
+* `serial_number` - The serial number of the MFA device.
 
-* `user_id` - Indicates the ID of the IAM user.
+* `user_id` - The ID of the IAM user.

--- a/docs/resources/identityv5_virtual_mfa_device.md
+++ b/docs/resources/identityv5_virtual_mfa_device.md
@@ -3,21 +3,21 @@ subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identityv5_virtual_mfa_device"
 description: |-
-  Manages an IAM v5 virtual mfa device resource within HuaweiCloud.
+  Manages an IAM virtual MFA device resource within HuaweiCloud.
 ---
 
 # huaweicloud_identityv5_virtual_mfa_device
 
-Manages an IAM v5 virtual mfa device resource within HuaweiCloud.
+Manages an IAM virtual MFA device resource within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
-variable "name" {}
+variable "device_name" {}
 variable "user_id" {}
 
 resource "huaweicloud_identityv5_virtual_mfa_device" "test" {
-  name    = var.name
+  name    = var.device_name
   user_id = var.user_id
 }
 ```
@@ -26,9 +26,9 @@ resource "huaweicloud_identityv5_virtual_mfa_device" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required, String, NonUpdatable) Specifies the name of the user. The username consists of 1 to 64 characters.
-  It can contain only uppercase letters, lowercase letters, digits, spaces, and special characters (-_) and cannot
-  start with a digit.
+* `name` - (Required, String, NonUpdatable) Specifies the name of the MFA device.
+   The name maximum length is `64` characters.  
+   Only letters, digits, underscores   (_) and hyphens (-) are allowed.
 
 * `user_id` - (Required, String, NonUpdatable) Specifies the ID of the user.
 
@@ -36,16 +36,33 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The resource ID of mfa device.
+* `id` - The resource ID, which is the serial number of the MFA device.
 
-* `base32_string_seed` - Indicates key information used for third-party generation of image verification codes.
+* `base32_string_seed` - The key information used for third-party generation of image verification codes.
 
-* `enabled` - Indicates whether the user is enabled or disabled. Valid values are **true** and **false**.
+* `enabled` - Whether the MFA device is enabled.
 
 ## Import
 
-The IAM v5 virtual mfa device can be imported using the id, e.g:
+The IAM virtual MFA device can be imported using the `user_id`, e.g:
 
 ```bash
-$ terraform import huaweicloud_identityv5_virtual_mfa_device.test <id>
+$ terraform import huaweicloud_identityv5_virtual_mfa_device.test <user_id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `name`. It is generally recommended
+running `terraform plan` after importing the resource. You can then decide if changes should be applied to the resource,
+or the resource definition should be updated to align with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_identityv5_virtual_mfa_device" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      name,
+    ]
+  }
+}
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1635,7 +1635,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_enterprise_project_groups":    iam.DataSourceIdentityEnterpriseProjectGroups(),
 			"huaweicloud_identity_enterprise_project_users":     iam.DataSourceIdentityEnterpriseProjectUsers(),
 
-			"huaweicloud_identityv5_virtual_mfa_devices":      iam.DataSourceIdentityV5VirtualMfaDevices(),
+			"huaweicloud_identityv5_virtual_mfa_devices":      iam.DataSourceV5VirtualMfaDevices(),
 			"huaweicloud_identityv5_registered_services":      iam.DataSourceIdentityV5RegisteredServices(),
 			"huaweicloud_identityv5_resource_tags":            iam.DataSourceV5ResourceTags(),
 			"huaweicloud_identityv5_users":                    iam.DataSourceIdentityV5Users(),
@@ -3398,7 +3398,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identityv5_policy_default_version":      iam.ResourceV5PolicyDefaultVersion(),
 			"huaweicloud_identityv5_policy_group_attach":         iam.ResourceV5PolicyGroupAttach(),
 			"huaweicloud_identityv5_policy_user_attach":          iam.ResourceV5PolicyUserAttach(),
-			"huaweicloud_identityv5_virtual_mfa_device":          iam.ResourceIdentityV5VirtualMFADevice(),
+			"huaweicloud_identityv5_virtual_mfa_device":          iam.ResourceV5VirtualMfaDevice(),
 			"huaweicloud_identityv5_group":                       iam.ResourceIdentityV5Group(),
 			"huaweicloud_identityv5_group_membership":            iam.ResourceIdentityV5GroupMembership(),
 			"huaweicloud_identityv5_access_key":                  iam.ResourceIdentityAccessKey(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_virtual_mfa_device_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_virtual_mfa_device_test.go
@@ -7,36 +7,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 )
 
 func getV5VirtualMFADeviceResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	getMFAClient, err := conf.NewServiceClient("iam", acceptance.HW_REGION_NAME)
+	client, err := conf.NewServiceClient("iam", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM Client: %s", err)
 	}
-	getMFAHttpUrl := "v5/mfa-devices?user_id=" + state.Primary.Attributes["user_id"]
-	getMFAPath := getMFAClient.Endpoint + getMFAHttpUrl
-	getMFAOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	getMFAResp, err := getMFAClient.Request("GET", getMFAPath, &getMFAOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving IAM virtual MFA device: %s", err)
-	}
-	respBody, err := utils.FlattenResponse(getMFAResp)
-	if err != nil {
-		return nil, fmt.Errorf("error flatten IAM virtual MFA device: %s", err)
-	}
-	check := utils.PathSearch("mfa_devices[0]", respBody, nil)
-	if check == nil {
-		return nil, fmt.Errorf("error retrieving IAM virtual MFA device: %s", err)
-	}
-	return check, nil
+
+	return iam.GetV5VirtualMfaDevice(client, state.Primary.Attributes["user_id"])
 }
 
 // Please ensure that the user executing the acceptance test has 'admin' permission.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The current code has the following issues and needs optimization:

- Redundant method naming
- Fields in the schema lack descriptions
- Some error messages are inaccurate
- Some content in the documentation is inaccurately described

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update functions naming
2. extract functional code blocks into functions
3. add a description to each field in the schema
4. correcting inaccurate error messages
5. improve and optimize the document
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV5VirtualMFADevice_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5VirtualMFADevice_basic -timeout 360m -parallel 10
=== RUN   TestAccV5VirtualMFADevice_basic
=== PAUSE TestAccV5VirtualMFADevice_basic
=== CONT  TestAccV5VirtualMFADevice_basic
--- PASS: TestAccV5VirtualMFADevice_basic (23.23s)
PASS
coverage: 3.6% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       23.345s coverage: 3.6% of statements in ./huaweicloud/services/iam
```

```
./scripts/coverage.sh -o iam -f TestAccDataV5VirtualMfaDevices_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5VirtualMfaDevices_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5VirtualMfaDevices_basic
=== PAUSE TestAccDataV5VirtualMfaDevices_basic
=== CONT  TestAccDataV5VirtualMfaDevices_basic
--- PASS: TestAccDataV5VirtualMfaDevices_basic (24.91s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       25.064s coverage: 4.2% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1132" height="822" alt="image" src="https://github.com/user-attachments/assets/868624be-57c9-4022-a94e-52555468254c" />

    ab. Related resources (parent resources) not found
    <img width="1173" height="770" alt="image" src="https://github.com/user-attachments/assets/194ac869-0159-489e-8fc1-9b91302d2a7a" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
