### PR TITLE
fix(ram): the `ram_resource_share_permission` resource quality improvement

### DIFF
--- a/docs/resources/ram_resource_share_permission.md
+++ b/docs/resources/ram_resource_share_permission.md
@@ -26,21 +26,26 @@ resource "huaweicloud_ram_resource_share_permission" "test" {
 
 The following arguments are supported:
 
-* `resource_share_id` - (Required, String, NonUpdatable) Specifies the ID of the resource share.
+* `resource_share_id` - (Required, String, NonUpdatable) Specifies the ID of the resource sharing instance.
 
-* `permission_id` - (Required, String, NonUpdatable) Specifies the ID of the permission.
+* `permission_id` - (Required, String, NonUpdatable) Specifies the ID of the shared resource permission.
 
-* `replace` - (Optional, Bool, NonUpdatable) Specify a specific permission to replace or bind to the existing resource
-  type associated with the shared resource instance.
-  Setting it to **true** will replace the current permissions for the same resource type.
-  Setting it to **false** will bind the permission to the current resource type.
+* `replace` - (Optional, Bool, NonUpdatable) Specifies specific permissions to replace or bind to existing resource
+  types associated with resource sharing instance.
+  + Setting it to **true** will replace permission of the same resource type with the current permission.
+  + Setting it to **false** will bind the permission to the current resource type.
+
   The default value is **false**.
+
+  -> Each resource type in the resource sharing instance can only be bound with one permission. If the resource sharing
+  instance already has permission for the specified resource type and `replace` is set to **false**, the operation
+  returns an error. This helps prevent accidental override of permissions.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The resource ID.
+* `id` - The resource ID, format is `<resource_share_id>/<permission_id>`.
 
 * `permission_name` - Indicates the name of RAM permission.
 
@@ -54,7 +59,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The RAM resource share permission can be imported using the resource share ID and the permission ID
+The RAM resource share permission can be imported using the `resource_share_id` and the `permission_id`
 separated by a slash, e.g.
 
 ```bash
@@ -63,9 +68,9 @@ $ terraform import huaweicloud_ram_resource_share_permission.test <resource_shar
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attribute includes: `replace`.
-It is generally recommended running `terraform plan` after importing the permission. You can then decide
-if changes should be applied to the permission, or the resource definition should be updated to align with the permission.
-Also you can ignore changes as below.
+It is generally recommended running `terraform plan` after importing the permission. You can then decide if changes
+should be applied to the permission, or the resource definition should be updated to align with the permission.
+Also, you can ignore changes as below.
 
 ```hcl
 resource "huaweicloud_ram_resource_share_permission" "test" {

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3668,7 +3668,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ram_organization":              ram.ResourceRAMOrganization(),
 			"huaweicloud_ram_resource_share":            ram.ResourceRAMShare(),
 			"huaweicloud_ram_resource_share_accepter":   ram.ResourceShareAccepter(),
-			"huaweicloud_ram_resource_share_permission": ram.ResourceRAMResourceSharePermission(),
+			"huaweicloud_ram_resource_share_permission": ram.ResourceSharePermission(),
 
 			"huaweicloud_rds_mysql_account":                  rds.ResourceMysqlAccount(),
 			"huaweicloud_rds_mysql_binlog":                   rds.ResourceMysqlBinlog(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Fix errors in pagination queries.
2. Fix errors in the checkDeleted section.
3. Optimize code snippets and MD document descriptions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

the `ram_resource_share_permission` resource quality improvement

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ram" TESTARGS="-run TestAccResourceSharePermission_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccResourceSharePermission_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceSharePermission_basic
=== PAUSE TestAccResourceSharePermission_basic
=== CONT  TestAccResourceSharePermission_basic
--- PASS: TestAccResourceSharePermission_basic (22.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       23.005s

```
<img width="922" height="29" alt="image" src="https://github.com/user-attachments/assets/78a28cfa-492f-45bf-b931-4e8c887dc6f5" />



* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found

After modifying the value of the `permission_id` field in the state file, execute the `terraform plan`:
<img width="1357" height="879" alt="image" src="https://github.com/user-attachments/assets/b6acb98a-d777-46ae-8198-58b7c5febcc8" />

    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
