### PR TITLE
feat(ccm): new datasource to query certificates by tags

### DIFF
--- a/docs/data-sources/ccm_certificates_by_tags.md
+++ b/docs/data-sources/ccm_certificates_by_tags.md
@@ -1,0 +1,184 @@
+---
+subcategory: "Cloud Certificate Manager (CCM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ccm_certificates_by_tags"
+description: |-
+  Use this data source to get the list of CCM SSL certificates by tags.
+---
+
+# huaweicloud_ccm_certificates_by_tags
+
+Use this data source to get the list of CCM SSL certificates by tags.
+
+## Example Usage
+
+### Filter the certificate list
+
+```hcl
+data "huaweicloud_ccm_certificates_by_tags" "test" {
+  resource_instances = "resource_instances"
+  action             = "filter"
+}
+```
+
+### Query the certificate total count
+
+```hcl
+data "huaweicloud_ccm_certificates_by_tags" "test" {
+  resource_instances = "resource_instances"
+  action             = "count"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `resource_instances` - (Required, String) Specifies the resource instances. Only support **resource_instances**.
+
+* `action` - (Required, String) Specifies the action value. Valid values are **filter** and **count**.
+
+* `without_any_tag` - (Optional, Bool) Specifies whether to query the certificates without tags.
+  When the value of this field is **true**, all resources without tags are queried, and the fields `tags`, `tags_any`,
+  `not_tags`, and `not_tags_any` are ignored.
+
+* `tags` - (Optional, List) Specifies the containing tags.
+  It can contain a maximum of `20` keys, with a maximum of `20` values ​​under each key. The value array for each key can
+  be empty, but the structure must be complete. Keys cannot be duplicated, and values ​​for the same key cannot be
+  duplicated. The result returns a list of resources containing all tags. Keys are related by AND, and values ​​in the
+  key-value structure are related by OR. Without tag filtering, the full dataset is returned.
+
+  The [tags](#tags_Tag) structure is documented below.
+
+* `tags_any` - (Optional, List) Specifies any included tags.
+  It can contain a maximum of `20` keys, with a maximum of `20` values ​​under each key. The value array for each key can
+  be empty, but the structure must be complete. Keys cannot be duplicated, and values ​​for the same key cannot be
+  duplicated. The result returns a list of resources containing tags. Keys are related by OR, and values ​​in the
+  key-value structure are also related by OR. Without filtering, the full dataset is returned.
+
+  The [tags_any](#tags_Tag) structure is documented below.
+
+* `not_tags` - (Optional, List) Specifies not included tags.
+  It can contain a maximum of `20` keys, with a maximum of `20` values ​​under each key. The value array for each key can
+  be empty, but the structure must be complete. Keys cannot be duplicated, and values ​​for the same key cannot be
+  duplicated. The result returns a list of resources excluding tags. Keys are related by AND, and values ​​in the
+  key-value structure are related by OR. Without filtering, the full dataset is returned.
+
+  The [not_tags](#tags_Tag) structure is documented below.
+
+* `not_tags_any` - (Optional, List) Specifies any tags that are not included.
+  It can contain a maximum of `20` keys, with a maximum of `20` values ​​under each key. The value array for each key can
+  be empty, but the structure must be complete. Keys cannot be duplicated, and values ​​for the same key cannot be
+  duplicated. The result returns a list of resources excluding tags. Keys are related by OR, and values ​​in the
+  key-value structure are also related by OR. Without filtering, the full dataset is returned.
+
+  The [not_tags_any](#tags_Tag) structure is documented below.
+
+* `matches` - (Optional, List) Specifies the matches condition.
+  The key is the field to be matched, such as **resource_name**. The value is the match value.
+  The key is a fixed dictionary value and cannot contain duplicate keys or unsupported keys.
+
+  The [matches](#matches_Match) structure is documented below.
+
+<a name="tags_Tag"></a>
+The `tags`, `tags_any`, `not_tags`, `not_tags_any` block supports:
+
+* `key` - (Optional, String) Specifies the key.
+
+* `values` - (Optional, List) Specifies the value array.
+
+<a name="matches_Match"></a>
+The `matches` block supports:
+
+* `key` - (Optional, String) Specifies the field to be matched.
+
+* `value` - (Optional, String) Specifies the match value.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_count` - The total number of resources.
+
+* `resources` - The resource list.
+  The [resources](#resources_response_struct) structure is documented below.
+
+<a name="resources_response_struct"></a>
+The `resources` block supports:
+
+* `resource_id` - The resource ID of the certificate.
+
+* `tags` - The tags of the certificate.
+  The [tags](#tags_response_struct) structure is documented below.
+
+* `resource_name` - The resource name of the certificate.
+
+* `resource_detail` - The resource detail of the certificate.
+  The [resource_detail](#resource_detail_struct) structure is documented below.
+
+<a name="tags_response_struct"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `value` - The value of the tag.
+
+<a name="resource_detail_struct"></a>
+The `resource_detail` block supports:
+
+* `cert_id` - The ID of the certificate.
+
+* `cert_name` - The name of the certificate.
+
+* `domain` - The domain of the certificate.
+
+* `cert_type` - The type of the certificate. Valid values are **OV_SSL_CERT** and **EV_SSL_CERT**.
+
+* `cert_brand` - The brand of the certificate.
+
+* `domain_type` - The type of the domain. Valid values are **SINGLE_DOMAIN**, **MULTI_DOMAIN**, and **WILDCARD**.
+
+* `purchase_period` - The purchase period of the certificate, the unit is year.
+
+* `expired_time` - The expiration time of the certificate, the unit is milliseconds.
+
+* `order_status` - The order status of the certificate.
+
+* `domain_num` - The number of domains.
+
+* `wildcard_number` - The number of wildcard domains.
+
+* `sans` - The SANs of the certificate.
+
+* `cert_des` - The description of the certificate.
+
+* `signature_algorithm` - The signature algorithm.
+
+* `fail_reason` - The fail reason.
+
+* `partner_order_id` - The order serial number.
+
+* `push_support` - Whether the certificate is supported to push.
+
+* `cert_issued_time` - The certificate issue time, unit is milliseconds.
+
+* `resource_id` - The resource ID of the certificate.
+
+* `unsubscribe_support` - Whether the certificate is supported to unsubscribe.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `origin_cert_id` - The origin certificate ID.
+
+* `renewal_cert_id` - The renewal certificate ID.
+
+* `auto_renew_status` - The auto-renewal status.
+
+* `remain_cert_number` - The remaining number of certificates.
+
+* `auto_deploy_support` - Whether the certificate is supported to auto-deploy.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -764,6 +764,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_ccm_certificates":               ccm.DataSourceCertificates(),
 			"huaweicloud_ccm_certificate_export":         ccm.DataSourceCertificateExport(),
+			"huaweicloud_ccm_certificates_by_tags":       ccm.DataSourceCertificatesByTags(),
 			"huaweicloud_ccm_private_cas":                ccm.DataSourcePrivateCas(),
 			"huaweicloud_ccm_private_ca_export":          ccm.DataSourcePrivateCaExport(),
 			"huaweicloud_ccm_private_certificates":       ccm.DataSourcePrivateCertificates(),

--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_certificates_by_tags_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_certificates_by_tags_test.go
@@ -1,0 +1,83 @@
+package ccm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceCertificatesByTags_basic(t *testing.T) {
+	var (
+		datasource = "data.huaweicloud_ccm_certificates_by_tags.test"
+		dc         = acceptance.InitDataSourceCheck(datasource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Prepare certificates in the runtime environment before running test cases.
+			acceptance.TestAccPreCheckCCMEnableFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceCertificatesByTags_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_id"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_name"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail.0.cert_id"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail.0.cert_name"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail.0.domain"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail.0.cert_type"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail.0.cert_brand"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail.0.domain_type"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail.0.purchase_period"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail.0.expired_time"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail.0.order_status"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail.0.domain_num"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail.0.wildcard_number"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail.0.sans"),
+
+					resource.TestCheckOutput("non_exist_resources_is_zero", "true"),
+					resource.TestCheckOutput("total_count_greater_than_zero", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDatasourceCertificatesByTags_basic = `
+data "huaweicloud_ccm_certificates_by_tags" "test" {
+  resource_instances = "resource_instances"
+  action             = "filter"
+}
+
+data "huaweicloud_ccm_certificates_by_tags" "non-exist" {
+  resource_instances = "resource_instances"
+  action             = "filter"
+  tags {
+    key    = "non-exist-key"
+    values = ["non-exist-value"]
+  }
+  matches {
+    key   = "resource_name"
+    value = "non-exist-value"
+  }
+}
+
+output "non_exist_resources_is_zero" {
+  value = length(data.huaweicloud_ccm_certificates_by_tags.non-exist.resources) == 0
+}
+
+data "huaweicloud_ccm_certificates_by_tags" "total-count" {
+  resource_instances = "resource_instances"
+  action             = "count"
+}
+
+output "total_count_greater_than_zero" {
+  value = data.huaweicloud_ccm_certificates_by_tags.total-count.total_count > 0
+}
+`

--- a/huaweicloud/services/ccm/data_source_huaweicloud_ccm_certificates_by_tags.go
+++ b/huaweicloud/services/ccm/data_source_huaweicloud_ccm_certificates_by_tags.go
@@ -1,0 +1,442 @@
+package ccm
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CCM POST /v3/scm/{resource_instances}/action
+func DataSourceCertificatesByTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceCertificatesByTagsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"resource_instances": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"without_any_tag": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     buildCertificatesByTagsTagsSchema(),
+			},
+			"tags_any": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     buildCertificatesByTagsTagsSchema(),
+			},
+			"not_tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     buildCertificatesByTagsTagsSchema(),
+			},
+			"not_tags_any": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     buildCertificatesByTagsTagsSchema(),
+			},
+			"matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     buildCertificatesByTagsMatchesSchema(),
+			},
+			"total_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     buildCertificatesByTagsResourcesSchema(),
+			},
+		},
+	}
+}
+
+func buildCertificatesByTagsResourcesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     buildCertificatesByTagsResourcesTagsSchema(),
+			},
+			"resource_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_detail": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     buildCertificatesByTagsResourcesResourceDetailSchema(),
+			},
+		},
+	}
+}
+
+func buildCertificatesByTagsResourcesResourceDetailSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cert_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cert_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cert_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cert_brand": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"purchase_period": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"expired_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"order_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"wildcard_number": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"sans": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cert_des": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"signature_algorithm": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"fail_reason": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"partner_order_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"push_support": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"cert_issued_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"unsubscribe_support": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"origin_cert_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"renewal_cert_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auto_renew_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"remain_cert_number": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"auto_deploy_support": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCertificatesByTagsResourcesTagsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCertificatesByTagsMatchesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func buildCertificatesByTagsTagsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"values": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func buildCertificatesByTagsTagsBodyParams(rawArray []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, raw := range rawArray {
+		rawMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"key":    rawMap["key"],
+			"values": rawMap["values"],
+		})
+	}
+
+	return rst
+}
+
+func buildCertificatesByTagsMatchesBodyParams(rawArray []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, raw := range rawArray {
+		rawMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"key":   rawMap["key"],
+			"value": rawMap["value"],
+		})
+	}
+
+	return rst
+}
+
+func buildCertificatesByTagsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"action":          d.Get("action"),
+		"without_any_tag": d.Get("without_any_tag"),
+		"tags":            buildCertificatesByTagsTagsBodyParams(d.Get("tags").([]interface{})),
+		"tags_any":        buildCertificatesByTagsTagsBodyParams(d.Get("tags_any").([]interface{})),
+		"not_tags":        buildCertificatesByTagsTagsBodyParams(d.Get("not_tags").([]interface{})),
+		"not_tags_any":    buildCertificatesByTagsTagsBodyParams(d.Get("not_tags_any").([]interface{})),
+		"matches":         buildCertificatesByTagsMatchesBodyParams(d.Get("matches").([]interface{})),
+	}
+}
+
+func datasourceCertificatesByTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		conf              = meta.(*config.Config)
+		region            = conf.GetRegion(d)
+		httpUrl           = "v3/scm/{resource_instances}/action"
+		product           = "scm"
+		resourceInstances = d.Get("resource_instances").(string)
+		action            = d.Get("action").(string)
+		offset            = 0
+		limit             = 50
+		allResults        []interface{}
+		totalCount        = 0
+	)
+
+	client, err := conf.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CCM client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{resource_instances}", resourceInstances)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	bodyParams := buildCertificatesByTagsBodyParams(d)
+
+	for {
+		if action == "filter" {
+			bodyParams["limit"] = limit
+			bodyParams["offset"] = offset
+		}
+
+		requestOpt.JSONBody = utils.RemoveNil(bodyParams)
+		resp, err := client.Request("POST", requestPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving CCM certificates by tags: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if action == "count" {
+			totalCount = int(utils.PathSearch("total_count", respBody, float64(0)).(float64))
+			break
+		}
+
+		resources := utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{})
+		if len(resources) == 0 {
+			break
+		}
+
+		allResults = append(allResults, resources...)
+		offset += len(resources)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("total_count", totalCount),
+		d.Set("resources", flattenCertificatesByTagsResources(allResults)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCertificatesByTagsResources(respArray []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		tagsResp := utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})
+		resourceDetailResp := utils.PathSearch("resource_detail", v, nil)
+
+		rst = append(rst, map[string]interface{}{
+			"resource_id":     utils.PathSearch("resource_id", v, nil),
+			"tags":            flattenCertificatesByTagsTagsResources(tagsResp),
+			"resource_name":   utils.PathSearch("resource_name", v, nil),
+			"resource_detail": flattenCertificatesByTagsResourceDetailResources(resourceDetailResp),
+		})
+	}
+
+	return rst
+}
+
+func flattenCertificatesByTagsTagsResources(respArray []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"key":   utils.PathSearch("key", v, nil),
+			"value": utils.PathSearch("value", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenCertificatesByTagsResourceDetailResources(respBody interface{}) []interface{} {
+	if respBody == nil {
+		return nil
+	}
+
+	resourceDetail := map[string]interface{}{
+		"cert_id":               utils.PathSearch("cert_id", respBody, nil),
+		"cert_name":             utils.PathSearch("cert_name", respBody, nil),
+		"domain":                utils.PathSearch("domain", respBody, nil),
+		"cert_type":             utils.PathSearch("cert_type", respBody, nil),
+		"cert_brand":            utils.PathSearch("cert_brand", respBody, nil),
+		"domain_type":           utils.PathSearch("domain_type", respBody, nil),
+		"purchase_period":       utils.PathSearch("purchase_period", respBody, nil),
+		"expired_time":          utils.PathSearch("expired_time", respBody, nil),
+		"order_status":          utils.PathSearch("order_status", respBody, nil),
+		"domain_num":            utils.PathSearch("domain_num", respBody, nil),
+		"wildcard_number":       utils.PathSearch("wildcard_number", respBody, nil),
+		"sans":                  utils.PathSearch("sans", respBody, nil),
+		"cert_des":              utils.PathSearch("cert_des", respBody, nil),
+		"signature_algorithm":   utils.PathSearch("signature_algorithm", respBody, nil),
+		"fail_reason":           utils.PathSearch("fail_reason", respBody, nil),
+		"partner_order_id":      utils.PathSearch("partner_order_id", respBody, nil),
+		"push_support":          utils.PathSearch("push_support", respBody, nil),
+		"cert_issued_time":      utils.PathSearch("cert_issued_time", respBody, nil),
+		"resource_id":           utils.PathSearch("resource_id", respBody, nil),
+		"unsubscribe_support":   utils.PathSearch("unsubscribe_support", respBody, nil),
+		"enterprise_project_id": utils.PathSearch("enterprise_project_id", respBody, nil),
+		"origin_cert_id":        utils.PathSearch("origin_cert_id", respBody, nil),
+		"renewal_cert_id":       utils.PathSearch("renewal_cert_id", respBody, nil),
+		"auto_renew_status":     utils.PathSearch("auto_renew_status", respBody, nil),
+		"remain_cert_number":    utils.PathSearch("remain_cert_number", respBody, nil),
+		"auto_deploy_support":   utils.PathSearch("auto_deploy_support", respBody, nil),
+	}
+
+	return []interface{}{resourceDetail}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query certificates by tags

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o ccm -f TestAccDatasourceCertificatesByTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ccm" -v -coverprofile="./huaweicloud/services/acceptance/ccm/ccm_coverage.cov" -coverpkg="./huaweicloud/services/ccm" -run TestAccDatasourceCertificatesByTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceCertificatesByTags_basic
=== PAUSE TestAccDatasourceCertificatesByTags_basic
=== CONT  TestAccDatasourceCertificatesByTags_basic
--- PASS: TestAccDatasourceCertificatesByTags_basic (13.46s)
PASS
coverage: 7.4% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       13.547s coverage: 7.4% of statements in ./huaweicloud/services/ccm
```
<img width="1300" height="63" alt="image" src="https://github.com/user-attachments/assets/b91b85c2-2405-429d-822a-1f3347b9da9f" />




* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
