### PR TITLE
feat(lakeformation): supports new resource to manage instance

### DIFF
--- a/docs/resources/lakeformation_instance.md
+++ b/docs/resources/lakeformation_instance.md
@@ -1,0 +1,135 @@
+---
+subcategory: "LakeFormation"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lakeformation_instance"
+description: |-
+  Manages a LakeFormation instance resource within HuaweiCloud.
+---
+
+# huaweicloud_lakeformation_instance
+
+Manages a LakeFormation instance resource within HuaweiCloud.
+
+-> For more information on the specification configurations of the dedicated instance, please contact service OnCall via
+   O&M (Tickets) system.
+
+## Example Usage
+
+### Create a shared instance
+
+```hcl
+variable "instance_name" {}
+
+resource "huaweicloud_lakeformation_instance" "test" {
+  name        = var.instance_name
+  shared      = true
+  description = "Created by terraform script"
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+
+  # When deleting, move into the recycle bin instead of deleting it directly.
+  # You can manually manage it after 15 minutes.
+  to_recycle_bin = true
+}
+```
+
+### Create a dedicated instance
+
+```hcl
+variable "instance_name" {}
+
+resource "huaweicloud_lakeformation_instance" "test" {
+  name        = var.instance_name
+  shared      = false
+  description = "Created by terraform script"
+
+  specs {
+    spec_code  = "lakeformation.unit.basic.qps"
+    stride_num = 1 # 2000 QPS (1 * 2000)
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the instance is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `name` - (Required, String) Specifies the name of the instance.
+
+* `shared` - (Required, Bool, NonUpdatable) Specifies whether the instance is shared.
+
+* `specs` - (Optional, List) Specifies the list of custom specifications for dedicated instance.  
+  The [specs](#lakeformation_instance_specs) structure is documented below.
+
+* `description` - (Optional, String) Specifies the description of the instance.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the ID of the enterprise project.  
+  This parameter is only valid for enterprise users, if omitted, default enterprise project will be used.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the instance.
+
+* `to_recycle_bin` - (Optional, Bool) Specifies whether to put the instance into the recycle bin when deleting.  
+  Default value is `false`.
+
+  -> This parameter is only useful during the deletion phase. It cannot be deleted via the console or other ways within
+     fifteen minutes of being placed in the recycle bin.
+
+  ~> Instances in the recycle bin will continue to be billed.
+
+<a name="lakeformation_instance_specs"></a>
+The `specs` block supports:
+
+* `spec_code` - (Required, String) Specifies the specification code.  
+  The valid values ​​can be obtained by data source `huaweicloud_lakeformation_specifications`.
+
+* `stride_num` - (Optional, Int) Specifies the stride number of the specification.  
+
+  -> This parameter is only available when the value of parameter `shared` is **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `specs` - The list of custom specifications for dedicated instance.  
+  The [specs](#lakeformation_instance_specs_attr) structure is documented below.
+
+* `status` - The status of the instance.
+
+* `is_default` - Whether the instance is the default instance.
+
+* `create_time` - The creation time of the instance, in RFC3339 format.
+
+* `update_time` - The update time of the instance, in RFC3339 format.
+
+<a name="lakeformation_instance_specs_attr"></a>
+The `specs` block supports:
+
+* `product_id` - (Optional, String) Specifies the product ID of the specification.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 2 hours.
+* `update` - Default is 2 hours.
+* `delete` - Default is 20 minutes.
+
+## Import
+
+LakeFormation instances can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_lakeformation_instance.test <id>
+```
+
+After importing this resource, the value of the `to_recycle_bin` parameter stored in the `tfstate` file defaults to
+`false`. If this value differs from the current script, please apply the script value by executing the `terraform apply`
+command.

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -786,6 +786,11 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version: "v1.1",
 		Product: "CDM",
 	},
+	"lakeformation": {
+		Name:    "lakeformation",
+		Version: "v1",
+		Product: "LakeFormation",
+	},
 
 	// catalog for Application
 	"apig": {
@@ -1008,13 +1013,6 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Scope:            "global",
 		WithOutProjectID: true,
 		Product:          "KooGallery",
-	},
-
-	// catalog for LakeFormation
-	"lakeformation": {
-		Name:    "lakeformation",
-		Version: "v1",
-		Product: "LakeFormation",
 	},
 
 	// catalog for MetaStudio

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3512,6 +3512,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_kps_export_private_key":       dew.ResourceKpsExportPrivateKey(),
 			"huaweicloud_kps_failed_task_delete":       dew.ResourceKpsFailedTaskDelete(),
 
+			"huaweicloud_lakeformation_instance": lakeformation.ResourceInstance(),
+
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),
 			"huaweicloud_lb_l7policy":     lb.ResourceL7PolicyV2(),
 			"huaweicloud_lb_l7rule":       lb.ResourceL7RuleV2(),

--- a/huaweicloud/services/acceptance/lakeformation/resource_huaweicloud_lakeformation_instance_test.go
+++ b/huaweicloud/services/acceptance/lakeformation/resource_huaweicloud_lakeformation_instance_test.go
@@ -1,0 +1,252 @@
+package lakeformation
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lakeformation"
+)
+
+func getInstanceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("lakeformation", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LakeFormation client: %s", err)
+	}
+
+	return lakeformation.GetInstanceById(client, state.Primary.ID)
+}
+
+func TestAccInstance_basic(t *testing.T) {
+	var (
+		instance interface{}
+
+		resourceName = "huaweicloud_lakeformation_instance.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &instance, getInstanceFunc)
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstance_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "shared", "true"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					// After the shared instance is created, some additional specifications will be returned, and the
+					// value of `stride_num` will most likely not be 0.
+					resource.TestMatchResourceAttr(resourceName, "specs.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "to_recycle_bin", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestMatchResourceAttr(resourceName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccInstance_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "shared", "true"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestMatchResourceAttr(resourceName, "specs.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "baar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "to_recycle_bin", "true"),
+					resource.TestMatchResourceAttr(resourceName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(resourceName, "update_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// Used to compare the differences between the script configuration and the remote configuration,
+					// only prompts changes in the acceptance test, and changes will be hidden by DiffSuppress in actual use.
+					"specs_origin",
+					"to_recycle_bin",
+				},
+			},
+		},
+	})
+}
+
+func testAccInstance_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lakeformation_instance" "test" {
+  name                  = "%[1]s"
+  shared                = true
+  description           = "Created by terraform script"
+  enterprise_project_id = "%[2]s"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccInstance_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lakeformation_instance" "test" {
+  name                  = "%[1]s"
+  shared                = true
+  description           = ""
+  enterprise_project_id = "%[2]s"
+
+  tags = {
+    foo   = "baar"
+    owner = "terraform"
+  }
+
+  to_recycle_bin = true
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+// Please delete the dedicated instance 15 minutes after the test is completed, otherwise additional charges will apply.
+// - After deletion, the instance will be placed in the recycle bin and billed until it is removed from the recycle bin.
+// - Instances will be automatically deleted after being stored in the recycle bin for more than one day and cannot be recovered.
+// - To prevent your business from being affected, please wait 15 minutes after placing the instance in the recycle bin before forcibly deleting it.
+// - Once an instance is deleted, the task cannot be recovered.
+func TestAccInstance_dedicated(t *testing.T) {
+	var (
+		instance interface{}
+
+		resourceName = "huaweicloud_lakeformation_instance.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &instance, getInstanceFunc)
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstance_dedicatedPrePaid_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "shared", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					// After the dedicated instance is created, some additional specifications will be returned (not
+					// just the QPS specification), and the value of `stride_num` will most likely not be 0.
+					resource.TestMatchResourceAttr(resourceName, "specs.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(resourceName, "specs.0.spec_code", "lakeformation.unit.basic.qps"),
+					resource.TestCheckResourceAttr(resourceName, "specs.0.stride_num", "1"),
+					resource.TestCheckResourceAttr(resourceName, "to_recycle_bin", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestMatchResourceAttr(resourceName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccInstance_dedicatedPrePaid_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "shared", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by terraform script"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					// Although the number of specification list objects returned after update is likely to remain unchanged,
+					// the value of `metadata.stride_num` may change.
+					resource.TestMatchResourceAttr(resourceName, "specs.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(resourceName, "specs.0.spec_code", "lakeformation.unit.basic.qps"),
+					resource.TestCheckResourceAttr(resourceName, "specs.0.stride_num", "2"),
+					resource.TestCheckResourceAttr(resourceName, "to_recycle_bin", "true"),
+					resource.TestMatchResourceAttr(resourceName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(resourceName, "update_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// Used to compare the differences between the script configuration and the remote configuration,
+					// only prompts changes in the acceptance test, and changes will be hidden by DiffSuppress in actual use.
+					"specs_origin",
+					"to_recycle_bin",
+				},
+			},
+		},
+	})
+}
+
+func testAccInstance_dedicatedPrePaid_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lakeformation_instance" "test" {
+  name                  = "%[1]s"
+  shared                = false
+  description           = "Created by terraform script"
+  enterprise_project_id = "%[2]s"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+
+  specs {
+    spec_code  = "lakeformation.unit.basic.qps"
+    stride_num = 1 # 2000 QPS (1 * 2000)
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccInstance_dedicatedPrePaid_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lakeformation_instance" "test" {
+  name                  = "%[1]s"
+  shared                = false
+  description           = "Updated by terraform script"
+  enterprise_project_id = "%[2]s"
+
+  tags = {
+    foo   = "baar"
+    owner = "terraform"
+  }
+
+  specs {
+    spec_code  = "lakeformation.unit.basic.qps"
+    stride_num = 2 # 4000 QPS (2 * 2000)
+  }
+
+  to_recycle_bin = true
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/lakeformation/resource_huaweicloud_lakeformation_instance.go
+++ b/huaweicloud/services/lakeformation/resource_huaweicloud_lakeformation_instance.go
@@ -1,0 +1,621 @@
+package lakeformation
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	instanceParamKeys          = []string{"specs"}
+	instanceNonUpdatableParams = []string{"shared", "enterprise_project_id"}
+)
+
+// @API LakeFormation POST /v1/{project_id}/instances
+// @API LakeFormation GET /v1/{project_id}/instances/{instance_id}
+// @API LakeFormation PUT /v1/{project_id}/instances/{instance_id}
+// @API LakeFormation POST /v1/{project_id}/instances/{instance_id}/scale
+// @API LakeFormation PUT /v1/{project_id}/instances/{instance_id}/tags
+// @API LakeFormation DELETE /v1/{project_id}/instances/{instance_id}
+func ResourceInstance() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInstanceCreate,
+		ReadContext:   resourceInstanceRead,
+		UpdateContext: resourceInstanceUpdate,
+		DeleteContext: resourceInstanceDelete,
+
+		CustomizeDiff: customdiff.All(
+			config.FlexibleForceNew(instanceNonUpdatableParams),
+			config.MergeDefaultTags(),
+		),
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(2 * time.Hour),
+			Update: schema.DefaultTimeout(2 * time.Hour),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the instance is located.`,
+			},
+
+			// Required parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the instance.`,
+			},
+			"shared": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: `Whether the instance is shared.`,
+			},
+
+			// Optional parameters.
+			"specs": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"spec_code": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							Description: utils.SchemaDesc(`The specification code.`,
+								utils.SchemaDescInput{
+									Required: true,
+								},
+							),
+						},
+						// The `Required` property of numeric types may cause unexpected changes when additional
+						// objects are returned from the remote source, thus deviating from the Diff logic.
+						"stride_num": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `The stride number of the specification.`,
+						},
+						"product_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							Description: utils.SchemaDesc(`The product ID of the specification.`,
+								utils.SchemaDescInput{
+									Computed: true,
+								},
+							),
+						},
+					},
+				},
+				DiffSuppressFunc: utils.SuppressObjectSliceDiffs(),
+				Description:      `The list of specifications.`,
+			},
+
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the instance.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the enterprise project.`,
+			},
+			"tags": common.TagsSchema(`The key/value pairs to associate with the instance.`),
+			"to_recycle_bin": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: `Whether to put the instance into the recycle bin when delete postpaid instance.`,
+			},
+
+			// Attributes.
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the instance.`,
+			},
+			"is_default": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the instance is the default instance.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the instance, in RFC3339 format.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the instance, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+
+			// Internal attributes.
+			"specs_origin": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"spec_code": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The specification code.`,
+						},
+						"stride_num": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `The stride number.`,
+						},
+						"product_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The product ID.`,
+						},
+					},
+				},
+				DiffSuppressFunc: utils.SuppressDiffAll,
+				Description: utils.SchemaDesc(
+					`The script configuration value of this change is also the original value used for comparison with
+the new value next time the change is made. The corresponding parameter name is 'specs'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func buildInstanceSpecs(specs []interface{}) []interface{} {
+	if len(specs) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(specs))
+	for _, spec := range specs {
+		result = append(result, map[string]interface{}{
+			// Required parameters.
+			"spec_code":  utils.PathSearch("spec_code", spec, nil),
+			"stride_num": utils.PathSearch("stride_num", spec, nil),
+			// Optional parameters.
+			"product_id": utils.PathSearch("product_id", spec, nil),
+		})
+	}
+
+	return result
+}
+
+func buildCreateInstanceBodyParams(cfg *config.Config, d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		// Required parameters.
+		"name": d.Get("name"),
+		// The current POST API does not return any information (instance ID or order ID) when creating a prePaid
+		// type instance, so, the instance status cannot be tracked, that's why it is forced to be set to postPaid.
+		"charge_mode": "postPaid",
+		"shared":      d.Get("shared"),
+		// Optional parameters.
+		"specs":                 buildInstanceSpecs(d.Get("specs").([]interface{})),
+		"description":           utils.ValueIgnoreEmpty(d.Get("description")),
+		"enterprise_project_id": utils.ValueIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
+		"tags":                  utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
+	}
+
+	return bodyParams
+}
+
+func GetInstanceById(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/instances/{instance_id}"
+	)
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	// Instances in the recycle bin will return a 'DELETING' status and the value of attribute 'in_recycle_bin' will be true.
+	if utils.PathSearch("status", respBody, "").(string) == "DELETING" && utils.PathSearch("in_recycle_bin", respBody, false).(bool) {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/instances/{instance_id}",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the instance (%s) has been moved to the recycle bin", instanceId)),
+			},
+		}
+	}
+	return respBody, nil
+}
+
+func instanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceId string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetInstanceById(client, instanceId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
+				return "not_found", "COMPLETED", nil
+			}
+			return respBody, "ERROR", err
+		}
+
+		statusResp := utils.PathSearch("status", respBody, "").(string)
+		if utils.StrSliceContains([]string{"RESOURCE_PREPARATION_FAIL", "SCALE_FAIL"},
+			statusResp) {
+			return respBody, "ERROR", fmt.Errorf("unexpected status (%s)", statusResp)
+		}
+
+		if utils.StrSliceContains(targets, statusResp) {
+			return respBody, "COMPLETED", nil
+		}
+		return "continue", "PENDING", nil
+	}
+}
+
+func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("lakeformation", region)
+	if err != nil {
+		return diag.Errorf("error creating LakeFormation client: %s", err)
+	}
+
+	httpUrl := "v1/{project_id}/instances"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateInstanceBodyParams(cfg, d)),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating instance: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	instanceId := utils.PathSearch("instance_id", respBody, "").(string)
+	if instanceId == "" {
+		return diag.Errorf("unable to find the instance ID from the API response")
+	}
+	d.SetId(instanceId)
+
+	err = utils.RefreshSliceParamOriginValues(d, instanceParamKeys)
+	if err != nil {
+		// Don't report errors if origin values are failed to be refreshed.
+		log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      instanceStateRefreshFunc(client, instanceId, []string{"RUNNING"}),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        45 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the status of instance (%s) to become running: %s", instanceId, err)
+	}
+
+	return resourceInstanceRead(ctx, d, meta)
+}
+
+func orderSpecsBySpecsOrderOrigin(specs, specsOrigin []interface{}) []interface{} {
+	if len(specsOrigin) == 0 {
+		return specs
+	}
+
+	sortedSpecs := make([]interface{}, 0, len(specs))
+	specsCopy := specs
+	for copyIndex, spec := range specsCopy {
+		specCode := utils.PathSearch("spec_code", spec, "").(string)
+		for originIndex, specOrigin := range specsOrigin {
+			if utils.PathSearch("spec_code", specOrigin, "").(string) != specCode {
+				continue
+			}
+			sortedSpecs = append(sortedSpecs, specsCopy[copyIndex])
+			// Retain additional specification configurations from the remote service and these will not be sorted.
+			specsCopy = append(specsCopy[:copyIndex], specsCopy[copyIndex+1:]...)
+			specsOrigin = append(specsOrigin[:originIndex], specsOrigin[originIndex+1:]...)
+		}
+	}
+	sortedSpecs = append(sortedSpecs, specsCopy...)
+	sortedSpecs = append(sortedSpecs, specsOrigin...)
+	return sortedSpecs
+}
+
+func flattenInstanceSpecs(specs, specsOrderOrigin []interface{}) []map[string]interface{} {
+	if len(specs) < 1 {
+		return nil
+	}
+
+	sortedSpecs := orderSpecsBySpecsOrderOrigin(specs, specsOrderOrigin)
+	result := make([]map[string]interface{}, 0, len(sortedSpecs))
+	for _, spec := range sortedSpecs {
+		result = append(result, map[string]interface{}{
+			"spec_code":  utils.PathSearch("spec_code", spec, nil),
+			"stride_num": utils.PathSearch("stride_num", spec, nil),
+			"product_id": utils.PathSearch("product_id", spec, nil),
+		})
+	}
+
+	return result
+}
+
+func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("lakeformation", region)
+	if err != nil {
+		return diag.Errorf("error creating LakeFormation client: %s", err)
+	}
+
+	respBody, err := GetInstanceById(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving LakeFormation instance")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		// Required parameters.
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("shared", utils.PathSearch("shared", respBody, nil)),
+		// Optional parameters.
+		d.Set("specs", flattenInstanceSpecs(utils.PathSearch("specs", respBody, make([]interface{}, 0)).([]interface{}),
+			d.Get("specs_origin").([]interface{}))),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", respBody, nil)),
+		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("tags", respBody,
+			make([]interface{}, 0)).([]interface{}))),
+		// Attributes.
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("is_default", utils.PathSearch("default_instance", respBody, nil)),
+		d.Set("create_time", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
+			respBody, "").(string))/1000, false)),
+		d.Set("update_time", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("update_time",
+			respBody, "").(string))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateInstanceBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": d.Get("description"),
+	}
+}
+
+func updateInstance(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/instances/{instance_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildUpdateInstanceBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func updateInstanceSpecs(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl    = "v1/{project_id}/instances/{instance_id}/scale"
+		instanceId = d.Id()
+		rawConfig  = d.GetRawConfig()
+	)
+
+	scalePath := client.Endpoint + httpUrl
+	scalePath = strings.ReplaceAll(scalePath, "{project_id}", client.ProjectID)
+	scalePath = strings.ReplaceAll(scalePath, "{instance_id}", d.Id())
+
+	scaleOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"specs": buildInstanceSpecs(utils.GetNestedObjectFromRawConfig(rawConfig, "specs").([]interface{})),
+		},
+	}
+
+	_, err := client.Request("POST", scalePath, &scaleOpt)
+	if err != nil {
+		return fmt.Errorf("error updating instance (%s) specs: %s", instanceId, err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      instanceStateRefreshFunc(client, d.Id(), []string{"RUNNING"}),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        45 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for the status of instance (%s) scale to complete: %s", d.Id(), err)
+	}
+	return nil
+}
+
+func updateInstanceTags(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/instances/{instance_id}/tags"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"tags": utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
+		},
+	}
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("lakeformation", region)
+	if err != nil {
+		return diag.Errorf("error creating client: %s", err)
+	}
+
+	if d.HasChanges("name", "description") {
+		err = updateInstance(client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("specs") {
+		err = updateInstanceSpecs(ctx, client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		err = utils.RefreshSliceParamOriginValues(d, instanceParamKeys)
+		if err != nil {
+			// Don't report errors if origin values are failed to be refreshed.
+			log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		err = updateInstanceTags(client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceInstanceRead(ctx, d, meta)
+}
+
+func deleteInstance(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/instances/{instance_id}?to_recycle_bin={to_recycle_bin}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", d.Id())
+	deletePath = strings.ReplaceAll(deletePath, "{to_recycle_bin}", strconv.FormatBool(d.Get("to_recycle_bin").(bool)))
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("lakeformation", region)
+	if err != nil {
+		return diag.Errorf("error creating client: %s", err)
+	}
+
+	err = deleteInstance(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting instance")
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: instanceStateRefreshFunc(client, instanceId, nil),
+		Timeout: d.Timeout(schema.TimeoutDelete),
+		// Some instances will not enter the recycle bin immediately after deletion, and there will be a period of time
+		// during which data is lost, which may be a design issue on the service side.
+		Delay:        10 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the deletion of instance (%s) to complete: %s", instanceId, err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

According to the LakeForamtion service's API references, we can supports these following features in the instance resource and supports instance management for shared type and dedicated type:
- Create instance (shared type and dedicated type)
- Show instance detail
- Update the basic information of instance
- Update the instance specifications
- Batch update the instance tags (override behavior)
- Delete instance (immediately delete or put into the recycle bin)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The validation about the `default_tags`, and `enable_force_new`:

1. default_tags
<img width="1562" height="1045" alt="image" src="https://github.com/user-attachments/assets/b63580ea-8be8-4ed5-9139-30c02f48b882" />
<img width="1597" height="932" alt="image" src="https://github.com/user-attachments/assets/0696d574-e85e-4078-aad5-56c10391dd20" />

2. enable_force_new

- value: **false** or **null**
<img width="748" height="529" alt="image" src="https://github.com/user-attachments/assets/05480026-0bc2-4e6c-b478-650f52284afc" />

- value: **true**
<img width="929" height="938" alt="image" src="https://github.com/user-attachments/assets/558d341a-bba6-4fc0-925c-59e75b0c0401" />

3. code coverages

- Coverage after executing basic test
<img width="966" height="173" alt="image" src="https://github.com/user-attachments/assets/67a7cf2e-bac4-4289-8cb4-db71cf8d61fe" />

- Coverage after executing dedicated test
<img width="1013" height="463" alt="image" src="https://github.com/user-attachments/assets/5bf390da-f8df-4e72-9241-21c9a3ce8721" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
5. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource for LakeFormation service: huaweicloud_lakeformation_instance.
2. add corresponding acceptance test and documentation.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lakeformation -f TestAccInstance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lakeformation" -v -coverprofile="./huaweicloud/services/acceptance/lakeformation/lakeformation_coverage.cov" -coverpkg="./huaweicloud/services/lakeformation" -run TestAccInstance_basic -timeout 360m -parallel 10
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (93.65s)
PASS
coverage: 65.3% of statements in ./huaweicloud/services/lakeformation
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lakeformation     93.774s coverage: 65.3% of statements in ./huaweicloud/services/lakeformation
```
```
./scripts/coverage.sh -o lakeformation -f TestAccInstance_dedicated
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lakeformation" -v -coverprofile="./huaweicloud/services/acceptance/lakeformation/lakeformation_coverage.cov" -coverpkg="./huaweicloud/services/lakeformation" -run TestAccInstance_dedicated -timeout 360m -parallel 10
=== RUN   TestAccInstance_dedicated
=== PAUSE TestAccInstance_dedicated
=== CONT  TestAccInstance_dedicated
--- PASS: TestAccInstance_dedicated (4082.18s)
PASS
coverage: 67.0% of statements in ./huaweicloud/services/lakeformation
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lakeformation     4082.253s       coverage: 67.0% of statements in ./huaweicloud/services/lakeformation
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="921" height="650" alt="image" src="https://github.com/user-attachments/assets/6ac92873-7ae6-4d18-844f-8cebd7b9b866" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="943" height="859" alt="image" src="https://github.com/user-attachments/assets/77a96246-dac8-40c1-8451-3494bff68c0d" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
