### PR TITLE
feat(lakeformation): add action resource for recover the instance of recycle bin

### DIFF
--- a/docs/resources/lakeformation_instance_recover.md
+++ b/docs/resources/lakeformation_instance_recover.md
@@ -1,0 +1,42 @@
+---
+subcategory: "LakeFormation"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lakeformation_instance_recover"
+description: |-
+  Use this resource to recover a LakeFormation instance from the recycle bin within HuaweiCloud.
+---
+
+# huaweicloud_lakeformation_instance_recover
+
+Use this resource to recover a LakeFormation instance from the recycle bin within HuaweiCloud.
+
+-> This resource is only a one-time action resource for recovering the LakeFormation instance from the recycle bin.
+   Deleting this resource will not clear the corresponding request record, but will only remove the resource
+   information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_lakeformation_instance_recover" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the instance needs to be recovered is located.  
+  If omitted, the provider-level region will be used.  
+  Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the instance to be recovered
+  from the recycle bin.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3512,7 +3512,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_kps_export_private_key":       dew.ResourceKpsExportPrivateKey(),
 			"huaweicloud_kps_failed_task_delete":       dew.ResourceKpsFailedTaskDelete(),
 
-			"huaweicloud_lakeformation_instance": lakeformation.ResourceInstance(),
+			"huaweicloud_lakeformation_instance":         lakeformation.ResourceInstance(),
+			"huaweicloud_lakeformation_instance_recover": lakeformation.ResourceInstanceRecover(),
 
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),
 			"huaweicloud_lb_l7policy":     lb.ResourceL7PolicyV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -279,6 +279,8 @@ var (
 	HW_VOD_WATERMARK_FILE   = os.Getenv("HW_VOD_WATERMARK_FILE")
 	HW_VOD_MEDIA_ASSET_FILE = os.Getenv("HW_VOD_MEDIA_ASSET_FILE")
 
+	HW_LAKE_FORMATION_INSTANCE_ID = os.Getenv("HW_LAKE_FORMATION_INSTANCE_ID")
+
 	HW_LTS_ENABLE_FLAG                 = os.Getenv("HW_LTS_ENABLE_FLAG")
 	HW_LTS_STRUCT_CONFIG_TEMPLATE_ID   = os.Getenv("HW_LTS_STRUCT_CONFIG_TEMPLATE_ID")
 	HW_LTS_STRUCT_CONFIG_TEMPLATE_NAME = os.Getenv("HW_LTS_STRUCT_CONFIG_TEMPLATE_NAME")
@@ -3202,6 +3204,13 @@ func TestAccPreCheckEgEventSubscriptionIds(t *testing.T, min int) {
 	if HW_EG_EVENT_SUBSCRIPTION_IDS == "" || len(strings.Split(HW_EG_EVENT_SUBSCRIPTION_IDS, ",")) < min {
 		t.Skipf(`At least %d subscription ID(s) must be supported during the HW_EG_EVENT_SUBSCRIPTION_IDS, separated by 
 		commas (,).`, min)
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLakeFormationInstanceId(t *testing.T) {
+	if HW_LAKE_FORMATION_INSTANCE_ID == "" {
+		t.Skip("HW_LAKE_FORMATION_INSTANCE_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/lakeformation/resource_huaweicloud_lakeformation_instance_recover_test.go
+++ b/huaweicloud/services/acceptance/lakeformation/resource_huaweicloud_lakeformation_instance_recover_test.go
@@ -1,0 +1,36 @@
+package lakeformation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccLakeFormationInstanceRecover_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLakeFormationInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLakeFormationInstanceRecover_basic(),
+			},
+		},
+	})
+}
+
+func testAccLakeFormationInstanceRecover_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lakeformation_instance_recover" "test" {
+  instance_id = "%[1]s"
+}
+`, acceptance.HW_LAKE_FORMATION_INSTANCE_ID)
+}

--- a/huaweicloud/services/lakeformation/resource_huaweicloud_lakeformation_instance_recover.go
+++ b/huaweicloud/services/lakeformation/resource_huaweicloud_lakeformation_instance_recover.go
@@ -1,0 +1,115 @@
+package lakeformation
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var instanceRecoverNonUpdatableParams = []string{
+	"instance_id",
+}
+
+// @API LakeFormation POST /v1/{project_id}/instances/{instance_id}/recover
+func ResourceInstanceRecover() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInstanceRecoverCreate,
+		ReadContext:   resourceInstanceRecoverRead,
+		UpdateContext: resourceInstanceRecoverUpdate,
+		DeleteContext: resourceInstanceRecoverDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(instanceRecoverNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the instance needs to be recovered is located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the instance to be recovered from the recycle bin.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceInstanceRecoverCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		httpUrl    = "v1/{project_id}/instances/{instance_id}/recover"
+	)
+
+	client, err := cfg.NewServiceClient("lakeformation", region)
+	if err != nil {
+		return diag.Errorf("error creating LakeFormation client: %s", err)
+	}
+
+	recoverPath := client.Endpoint + httpUrl
+	recoverPath = strings.ReplaceAll(recoverPath, "{project_id}", client.ProjectID)
+	recoverPath = strings.ReplaceAll(recoverPath, "{instance_id}", instanceId)
+
+	recoverOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err = client.Request("POST", recoverPath, &recoverOpt)
+	if err != nil {
+		return diag.Errorf("error recovering instance (%s): %s", instanceId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceInstanceRecoverRead(ctx, d, meta)
+}
+
+func resourceInstanceRecoverRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInstanceRecoverUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInstanceRecoverDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for recovering the LakeFormation instance from the
+recycle bin. Deleting this resource will not clear the corresponding request record, but will only remove the resource
+information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
According to the LakeForamtion service's API references, we can supports recover action of instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
<img width="1452" height="1112" alt="image" src="https://github.com/user-attachments/assets/d53a1daf-bb40-4b9a-bd10-3aa4030eb1a9" />

**Release note**:
```release-note
1. add new resource for LakeFormation service: huaweicloud_lakeformation_instance_recover.
2. add corresponding acceptance test and documentation.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lakeformation" -v -coverprofile="./huaweicloud/services/acceptance/lakeformation/lakeformation_coverage.cov" -coverpkg="./huaweicloud/services/lakeformation" -run TestAccLakeFormationInstanceRecover_basic -timeout 360m -parallel 10
=== RUN   TestAccLakeFormationInstanceRecover_basic
=== PAUSE TestAccLakeFormationInstanceRecover_basic
=== CONT  TestAccLakeFormationInstanceRecover_basic
--- PASS: TestAccLakeFormationInstanceRecover_basic (15.73s)
PASS
coverage: 8.6% of statements in ./huaweicloud/services/lakeformation
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lakeformation     15.843s coverage: 8.6% of statements in ./huaweicloud/services/lakeformation
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.