### PR TITLE
feat(lakeformation): add action resource for update default instance

### DIFF
--- a/docs/resources/lakeformation_instance_default_update.md
+++ b/docs/resources/lakeformation_instance_default_update.md
@@ -1,0 +1,42 @@
+---
+subcategory: "LakeFormation"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lakeformation_instance_default_update"
+description: |-
+  Use this resource to set a LakeFormation instance as default within HuaweiCloud.
+---
+
+# huaweicloud_lakeformation_instance_default_update
+
+Use this resource to set a LakeFormation instance as default within HuaweiCloud.
+
+-> This resource is only a one-time action resource for setting the LakeFormation instance as default. Deleting
+   this resource will not clear the corresponding request record, but will only remove the resource information from
+   the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_lakeformation_instance_default_update" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the instance needs to be set as default
+  is located.  
+  If omitted, the provider-level region will be used.  
+  Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the instance to be set as default.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3512,8 +3512,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_kps_export_private_key":       dew.ResourceKpsExportPrivateKey(),
 			"huaweicloud_kps_failed_task_delete":       dew.ResourceKpsFailedTaskDelete(),
 
-			"huaweicloud_lakeformation_instance":         lakeformation.ResourceInstance(),
-			"huaweicloud_lakeformation_instance_recover": lakeformation.ResourceInstanceRecover(),
+			"huaweicloud_lakeformation_instance":                lakeformation.ResourceInstance(),
+			"huaweicloud_lakeformation_instance_default_update": lakeformation.ResourceInstanceDefaultUpdate(),
+			"huaweicloud_lakeformation_instance_recover":        lakeformation.ResourceInstanceRecover(),
 
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),
 			"huaweicloud_lb_l7policy":     lb.ResourceL7PolicyV2(),

--- a/huaweicloud/services/acceptance/lakeformation/resource_huaweicloud_lakeformation_instance_default_update_test.go
+++ b/huaweicloud/services/acceptance/lakeformation/resource_huaweicloud_lakeformation_instance_default_update_test.go
@@ -1,0 +1,36 @@
+package lakeformation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccInstanceDefaultUpdate_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLakeFormationInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceDefaultUpdate_basic(),
+			},
+		},
+	})
+}
+
+func testAccInstanceDefaultUpdate_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lakeformation_instance_default_update" "test" {
+  instance_id = "%[1]s"
+}
+`, acceptance.HW_LAKE_FORMATION_INSTANCE_ID)
+}

--- a/huaweicloud/services/lakeformation/resource_huaweicloud_lakeformation_instance_default_update.go
+++ b/huaweicloud/services/lakeformation/resource_huaweicloud_lakeformation_instance_default_update.go
@@ -1,0 +1,115 @@
+package lakeformation
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var instanceDefaultUpdateNonUpdatableParams = []string{
+	"instance_id",
+}
+
+// @API LakeFormation POST /v1/{project_id}/instances/{instance_id}/default
+func ResourceInstanceDefaultUpdate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInstanceDefaultUpdateCreate,
+		ReadContext:   resourceInstanceDefaultUpdateRead,
+		UpdateContext: resourceInstanceDefaultUpdateUpdate,
+		DeleteContext: resourceInstanceDefaultUpdateDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(instanceDefaultUpdateNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the instance needs to be set as default is located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the instance needs to be set as default.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceInstanceDefaultUpdateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		httpUrl    = "v1/{project_id}/instances/{instance_id}/default"
+	)
+
+	client, err := cfg.NewServiceClient("lakeformation", region)
+	if err != nil {
+		return diag.Errorf("error creating LakeFormation client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error setting instance (%s) as default: %s", instanceId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceInstanceDefaultUpdateRead(ctx, d, meta)
+}
+
+func resourceInstanceDefaultUpdateRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInstanceDefaultUpdateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInstanceDefaultUpdateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for setting the LakeFormation instance as default.
+Deleting this resource will not clear the corresponding request record, but will only remove the resource information
+from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
According to the LakeForamtion service's API references, we can supports update default instance action of the service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
<img width="1443" height="1073" alt="image" src="https://github.com/user-attachments/assets/15639850-f35d-4cba-839f-bfd3380463c0" />

**Release note**:
```release-note
1. add new resource for LakeFormation service: huaweicloud_lakeformation_instance_default_update.
2. add corresponding acceptance test and documentation.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lakeformation" -v -coverprofile="./huaweicloud/services/acceptance/lakeformation/lakeformation_coverage.cov" -coverpkg="./huaweicloud/services/lakeformation" -run TestAccLakeFormationInstanceDefaultUpdate_basic -timeout 360m -parallel 10
=== RUN   TestAccLakeFormationInstanceDefaultUpdate_basic
=== PAUSE TestAccLakeFormationInstanceDefaultUpdate_basic
=== CONT  TestAccLakeFormationInstanceDefaultUpdate_basic
--- PASS: TestAccLakeFormationInstanceDefaultUpdate_basic (14.96s)
PASS
coverage: 8.3% of statements in ./huaweicloud/services/lakeformation
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lakeformation     15.066s coverage: 8.3% of statements in ./huaweicloud/services/lakeformation
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.