### PR TITLE
fix(lakeformation): fix incorrect test case function name

### DIFF
--- a/huaweicloud/services/acceptance/lakeformation/resource_huaweicloud_lakeformation_instance_recover_test.go
+++ b/huaweicloud/services/acceptance/lakeformation/resource_huaweicloud_lakeformation_instance_recover_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccLakeFormationInstanceRecover_basic(t *testing.T) {
+func TestAccInstanceRecover_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
@@ -21,13 +21,13 @@ func TestAccLakeFormationInstanceRecover_basic(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLakeFormationInstanceRecover_basic(),
+				Config: testAccInstanceRecover_basic(),
 			},
 		},
 	})
 }
 
-func testAccLakeFormationInstanceRecover_basic() string {
+func testAccInstanceRecover_basic() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_lakeformation_instance_recover" "test" {
   instance_id = "%[1]s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix incorrect test case function name, remove module name in test function name.

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:

```release-note
1. Remove module name in the test function name of resource `huaweicloud_lakeformation_instance_recover`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lakeformation" -v -coverprofile="./huaweicloud/services/acceptance/lakeformation/lakeformation_coverage.cov" -coverpkg="./huaweicloud/services/lakeformation" -run TestAccInstanceRecover_basic -timeout 360m -parallel 10
=== RUN   TestAccInstanceRecover_basic
=== PAUSE TestAccInstanceRecover_basic
=== CONT  TestAccInstanceRecover_basic
--- PASS: TestAccInstanceRecover_basic (16.46s)
PASS
coverage: 8.6% of statements in ./huaweicloud/services/lakeformation
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lakeformation     16.578s coverage: 8.6% of statements in ./huaweicloud/services/lakeformation
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.