### PR TITLE
feat(lakeformation): supports new data source to qeury instances

### DIFF
--- a/docs/data-sources/lakeformation_instances.md
+++ b/docs/data-sources/lakeformation_instances.md
@@ -1,0 +1,97 @@
+---
+subcategory: "LakeFormation"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lakeformation_instances"
+description: |-
+  Use this data source to get the list of LakeFormation instances within HuaweiCloud.
+---
+
+# huaweicloud_lakeformation_instances
+
+Use this data source to get the list of LakeFormation instances within HuaweiCloud.
+
+## Example Usage
+
+### Query all instances
+
+```hcl
+data "huaweicloud_lakeformation_instances" "test" {}
+```
+
+### Query instances using name filter parameter
+
+```hcl
+variable "instance_name" {}
+
+data "huaweicloud_lakeformation_instances" "test" {
+  name = var.instance_name
+}
+```
+
+### Query instances in the recycle bin
+
+```hcl
+data "huaweicloud_lakeformation_instances" "test" {
+  in_recycle_bin = true
+}
+```
+
+### Query instances using enterprise project ID filter parameter
+
+```hcl
+variable "enterprise_project_id" {}
+
+data "huaweicloud_lakeformation_instances" "test" {
+  enterprise_project_id = var.enterprise_project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `in_recycle_bin` - (Optional, Bool) Specifies whether to query instances in the recycle bin.
+  Defaults to `false`.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the instances
+  belong.  
+  Defaults to query instances under all enterprise projects.
+
+* `name` - (Optional, String) Specifies the name of the instance to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+`id` - The data source ID.
+
+* `instances` - The list of instances that matched filter parameters.
+  The [instances](#lakeformation_instances_attr) structure is documented below.
+
+<a name="lakeformation_instances_attr"></a>
+The `instances` block supports:
+
+* `instance_id` - The ID of the instance.
+
+* `name` - The name of the instance.
+
+* `description` - The description of the instance.
+
+* `enterprise_project_id` - The ID of the enterprise project to which the instance belongs.
+
+* `shared` - Whether the instance is shared.
+
+* `default_instance` - Whether the instance is the default instance.
+
+* `create_time` - The creation timestamp of the instance.
+
+* `update_time` - The update timestamp of the instance.
+
+* `status` - The status of the instance.
+
+* `in_recycle_bin` - Whether the instance is in the recycle bin.
+
+* `tags` - The key/value pairs to associate with the instance.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1736,6 +1736,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_koogallery_assets": koogallery.DataSourceKooGalleryAssets(),
 
 			"huaweicloud_lakeformation_specifications": lakeformation.DataSourceSpecifications(),
+			"huaweicloud_lakeformation_instances":      lakeformation.DataSourceInstances(),
 
 			"huaweicloud_lb_listeners":    lb.DataSourceListeners(),
 			"huaweicloud_lb_loadbalancer": lb.DataSourceELBV2Loadbalancer(),

--- a/huaweicloud/services/acceptance/lakeformation/data_source_huaweicloud_lakeformation_instances_test.go
+++ b/huaweicloud/services/acceptance/lakeformation/data_source_huaweicloud_lakeformation_instances_test.go
@@ -1,0 +1,149 @@
+package lakeformation
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataInstances_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_lakeformation_instances.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byInRecycleBin   = "data.huaweicloud_lakeformation_instances.filter_by_in_recycle_bin"
+		dcByInRecycleBin = acceptance.InitDataSourceCheck(byInRecycleBin)
+
+		byAllGrantedEps   = "data.huaweicloud_lakeformation_instances.filter_by_all_granted_eps"
+		dcByAllGrantedEps = acceptance.InitDataSourceCheck(byAllGrantedEps)
+
+		byEpsId   = "data.huaweicloud_lakeformation_instances.filter_by_enterprise_project_id"
+		dcByEpsId = acceptance.InitDataSourceCheck(byEpsId)
+
+		byName   = "data.huaweicloud_lakeformation_instances.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceInstances_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "instances.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByInRecycleBin.CheckResourceExists(),
+					resource.TestCheckOutput("is_in_recycle_bin_filter_useful", "true"),
+					dcByAllGrantedEps.CheckResourceExists(),
+					resource.TestCheckOutput("is_all_granted_eps_filter_useful", "true"),
+					dcByEpsId.CheckResourceExists(),
+					resource.TestCheckOutput("is_enterprise_project_id_filter_useful", "true"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckResourceAttrPair(byName, "instances.0.instance_id",
+						"data.huaweicloud_lakeformation_instances.all", "instances.0.instance_id"),
+					resource.TestCheckResourceAttrPair(byName, "instances.0.name",
+						"data.huaweicloud_lakeformation_instances.all", "instances.0.name"),
+					resource.TestCheckResourceAttrPair(byName, "instances.0.description",
+						"data.huaweicloud_lakeformation_instances.all", "instances.0.description"),
+					resource.TestCheckResourceAttrPair(byName, "instances.0.enterprise_project_id",
+						"data.huaweicloud_lakeformation_instances.all", "instances.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrPair(byName, "instances.0.shared",
+						"data.huaweicloud_lakeformation_instances.all", "instances.0.shared"),
+					resource.TestCheckResourceAttrPair(byName, "instances.0.default_instance",
+						"data.huaweicloud_lakeformation_instances.all", "instances.0.default_instance"),
+					resource.TestCheckResourceAttrPair(byName, "instances.0.create_time",
+						"data.huaweicloud_lakeformation_instances.all", "instances.0.create_time"),
+					resource.TestCheckResourceAttrPair(byName, "instances.0.update_time",
+						"data.huaweicloud_lakeformation_instances.all", "instances.0.update_time"),
+					resource.TestCheckResourceAttrPair(byName, "instances.0.status",
+						"data.huaweicloud_lakeformation_instances.all", "instances.0.status"),
+					resource.TestCheckResourceAttrPair(byName, "instances.0.in_recycle_bin",
+						"data.huaweicloud_lakeformation_instances.all", "instances.0.in_recycle_bin"),
+					resource.TestCheckResourceAttrPair(byName, "instances.0.tags.%",
+						"data.huaweicloud_lakeformation_instances.all", "instances.0.tags.%"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceInstances_basic = `
+data "huaweicloud_lakeformation_instances" "all" {}
+
+# Filter by in_recycle_bin
+locals {
+  in_recycle_bin = data.huaweicloud_lakeformation_instances.all.instances[0].in_recycle_bin
+}
+
+data "huaweicloud_lakeformation_instances" "filter_by_in_recycle_bin" {
+  in_recycle_bin = local.in_recycle_bin
+}
+
+locals {
+  in_recycle_bin_filter_result = [
+    for v in data.huaweicloud_lakeformation_instances.filter_by_in_recycle_bin.instances[*].in_recycle_bin :
+      v == local.in_recycle_bin
+  ]
+}
+
+output "is_in_recycle_bin_filter_useful" {
+  value = length(local.in_recycle_bin_filter_result) > 0 && alltrue(local.in_recycle_bin_filter_result)
+}
+
+# Query all instances with all_granted_eps enterprise project ID
+data "huaweicloud_lakeformation_instances" "filter_by_all_granted_eps" {
+  enterprise_project_id = "all_granted_eps"
+}
+
+output "is_all_granted_eps_filter_useful" {
+  value = length(data.huaweicloud_lakeformation_instances.filter_by_all_granted_eps.instances) > 0
+}
+
+# Filter by a specified enterprise project ID
+locals {
+  enterprise_project_id = data.huaweicloud_lakeformation_instances.all.instances[0].enterprise_project_id
+}
+
+data "huaweicloud_lakeformation_instances" "filter_by_enterprise_project_id" {
+  enterprise_project_id = local.enterprise_project_id
+}
+
+locals {
+  enterprise_project_id_filter_result = [
+    for v in data.huaweicloud_lakeformation_instances.filter_by_enterprise_project_id.instances[*].enterprise_project_id :
+      v == local.enterprise_project_id
+  ]
+}
+
+output "is_enterprise_project_id_filter_useful" {
+  value = length(local.enterprise_project_id_filter_result) > 0 && alltrue(local.enterprise_project_id_filter_result)
+}
+
+# Filter by name
+locals {
+  instance_name = try(data.huaweicloud_lakeformation_instances.all.instances[0].name, "NOT_FOUND")
+}
+
+data "huaweicloud_lakeformation_instances" "filter_by_name" {
+  name = local.instance_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_lakeformation_instances.filter_by_name.instances[*].name :
+      v == local.instance_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+`

--- a/huaweicloud/services/lakeformation/data_source_huaweicloud_lakeformation_instances.go
+++ b/huaweicloud/services/lakeformation/data_source_huaweicloud_lakeformation_instances.go
@@ -1,0 +1,228 @@
+package lakeformation
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LakeFormation GET /v1/{project_id}/instances
+func DataSourceInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the instances are located.`,
+			},
+
+			// Optional parameters.
+			"in_recycle_bin": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to query instances in the recycle bin.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the enterprise project to which the instances belong.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the instance to be queried.`,
+			},
+
+			// Attributes.
+			"instances": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of instances that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the instance.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the instance.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the instance.`,
+						},
+						"enterprise_project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the enterprise project to which the instance belongs.`,
+						},
+						"shared": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the instance is shared.`,
+						},
+						"default_instance": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the instance is the default instance.`,
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation timestamp of the instance.`,
+						},
+						"update_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The update timestamp of the instance.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the instance.`,
+						},
+						"in_recycle_bin": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the instance is in the recycle bin.`,
+						},
+						"tags": common.TagsComputedSchema(`The key/value pairs to associate with the instance.`),
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildInstancesQueryParams(d *schema.ResourceData) string {
+	var (
+		enterpriseProjectId = "all_granted_eps"
+		// in_recycle_bin is required by API, defaults to false.
+		res = fmt.Sprintf("&in_recycle_bin=%v", d.Get("in_recycle_bin").(bool))
+	)
+
+	// enterprise_project_id is required by API, default is "all_granted_eps"
+	if epsId, ok := d.GetOk("enterprise_project_id"); ok {
+		enterpriseProjectId = epsId.(string)
+	}
+	res = fmt.Sprintf("%s&enterprise_project_id=%v", res, enterpriseProjectId)
+
+	if name, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, name.(string))
+	}
+
+	return res
+}
+
+func listInstances(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/instances?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildInstancesQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		instances := utils.PathSearch("instances", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, instances...)
+		if len(instances) < limit {
+			break
+		}
+		offset += len(instances)
+	}
+
+	return result, nil
+}
+
+func flattenInstances(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"instance_id":           utils.PathSearch("instance_id", item, nil),
+			"name":                  utils.PathSearch("name", item, nil),
+			"description":           utils.PathSearch("description", item, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", item, nil),
+			"shared":                utils.PathSearch("shared", item, nil),
+			"default_instance":      utils.PathSearch("default_instance", item, nil),
+			"create_time": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
+				item, "").(string))/1000, false),
+			"update_time": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("update_time",
+				item, "").(string))/1000, false),
+			"status":         utils.PathSearch("status", item, nil),
+			"in_recycle_bin": utils.PathSearch("in_recycle_bin", item, nil),
+			"tags":           utils.FlattenTagsToMap(utils.PathSearch("tags", item, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func dataSourceInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("lakeformation", region)
+	if err != nil {
+		return diag.Errorf("error creating LakeFormation client: %s", err)
+	}
+
+	resp, err := listInstances(client, d)
+	if err != nil {
+		return diag.Errorf("error querying instances: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instances", flattenInstances(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source for LakeFormation service: huaweicloud_lakeformation_instances

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Seems like the filter parameter `tags` is unavailable.
<img width="1966" height="1020" alt="image" src="https://github.com/user-attachments/assets/88eced98-ca12-4fa8-bcc6-6e2668822769" />

Coverage:
<img width="988" height="153" alt="image" src="https://github.com/user-attachments/assets/6c775cdb-2da9-4427-99fb-f123f8b5e19c" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to qeury instances
2. supports corresponding acceptance test and documentation
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lakeformation -f TestAccDataInstances_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lakeformation" -v -coverprofile="./huaweicloud/services/acceptance/lakeformation/lakeformation_coverage.cov" -coverpkg="./huaweicloud/services/lakeformation" -run TestAccDataInstances_basic -timeout 360m -parallel 10
=== RUN   TestAccDataInstances_basic
=== PAUSE TestAccDataInstances_basic
=== CONT  TestAccDataInstances_basic
--- PASS: TestAccDataInstances_basic (12.36s)
PASS
coverage: 17.4% of statements in ./huaweicloud/services/lakeformation
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lakeformation     12.469s coverage: 17.4% of statements in ./huaweicloud/services/lakeformation
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
