### PR TITLE
fix(tms): the `tms_resource_tags` dataSource quality improvement

### DIFF
--- a/docs/data-sources/tms_resource_tags.md
+++ b/docs/data-sources/tms_resource_tags.md
@@ -13,9 +13,12 @@ Use this data source to get the list of tags by resource type.
 ## Example Usage
 
 ```hcl
+variable "resource_types" {}
+variable "project_id" {}
+
 data "huaweicloud_tms_resource_tags" "test" {
-  resource_types = "test_resource_type"
-  project_id     = "test_project_id"
+  resource_types = var.resource_types
+  project_id     = var.project_id
 }
 ```
 
@@ -32,10 +35,12 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `tags` - Indicates the list of tags.
-The [tags](#tags_struct) structure is documented below.
+
+  The [tags](#tags_struct) structure is documented below.
 
 * `errors` - Indicates the list of errors.
-The [errors](#errors_struct) structure is documented below.
+
+  The [errors](#errors_struct) structure is documented below.
 
 <a name="tags_struct"></a>
 The `tags` block supports:

--- a/huaweicloud/services/acceptance/tms/data_source_huaweicloud_tms_resource_tags_test.go
+++ b/huaweicloud/services/acceptance/tms/data_source_huaweicloud_tms_resource_tags_test.go
@@ -10,9 +10,11 @@ import (
 )
 
 func TestAccDataSourceTmsResourceTags_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_tms_resource_tags.test"
-	name := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(dataSource)
+	var (
+		dataSource = "data.huaweicloud_tms_resource_tags.test"
+		name       = acceptance.RandomAccResourceName()
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -37,7 +39,7 @@ func TestAccDataSourceTmsResourceTags_basic(t *testing.T) {
 func testDataSourceTmsResourceTags_base(name string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_identity_projects" "test" {
-  name = "ap-southeast-1"
+  name = "cn-north-4"
 }
 
 resource "huaweicloud_vpc" "vpc_1" {
@@ -57,7 +59,6 @@ resource "huaweicloud_vpc" "vpc_2" {
     k3 = "v3"
   }
 }
-
 `, name)
 }
 
@@ -69,6 +70,7 @@ data "huaweicloud_tms_resource_tags" "test" {
   resource_types = "vpc"
   project_id     = data.huaweicloud_identity_projects.test.projects[0].id
 }
+
 output "huaweicloud_tms_resource_tags_length" {
   value = length(data.huaweicloud_tms_resource_tags.test.tags) >= 3
 }

--- a/huaweicloud/services/tms/data_source_huaweicloud_tms_resource_tags.go
+++ b/huaweicloud/services/tms/data_source_huaweicloud_tms_resource_tags.go
@@ -39,7 +39,7 @@ func DataSourceTmsResourceTags() *schema.Resource {
 			"errors": {
 				Type:        schema.TypeList,
 				Computed:    true,
-				Elem:        tmsRessourceTagsErrorsSchema(),
+				Elem:        tmsResourceTagsErrorsSchema(),
 				Description: `Indicates the tag error.`,
 			},
 		},
@@ -63,7 +63,7 @@ func tmsResourceTagsSchema() *schema.Resource {
 	return &sc
 }
 
-func tmsRessourceTagsErrorsSchema() *schema.Resource {
+func tmsResourceTagsErrorsSchema() *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"error_code": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Optimize code snippets and MD document descriptions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

the `tms_resource_tags` dataSource quality improvement

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/tms" TESTARGS="-run TestAccDataSourceTmsResourceTags_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/tms -v -run TestAccDataSourceTmsResourceTags_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceTmsResourceTags_basic
=== PAUSE TestAccDataSourceTmsResourceTags_basic
=== CONT  TestAccDataSourceTmsResourceTags_basic
--- PASS: TestAccDataSourceTmsResourceTags_basic (32.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/tms       32.849s

```
<img width="855" height="32" alt="image" src="https://github.com/user-attachments/assets/b055b85c-1009-499b-bd45-b755ad19b584" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
