### PR TITLE
refactor(iam): optimize codes and docs for user, group and agency attached policies

### DIFF
--- a/docs/data-sources/identityv5_agency_attached_policies.md
+++ b/docs/data-sources/identityv5_agency_attached_policies.md
@@ -3,17 +3,17 @@ subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identityv5_agency_attached_policies"
 description: |-
-  Use this data source to get attached policies for a specified IAM V5 agency.
+  Use this data source to get policy list attached to an agency within Huaweicloud.
 ---
 
 # huaweicloud_identityv5_agency_attached_policies
 
-Use this data source to get attached policies for a specified IAM V5 agency.
+Use this data source to get policy list attached to an agency within Huaweicloud.
 
 ## Example Usage
 
 ```hcl
-variable agency_id {}
+variable "agency_id" {}
 
 data "huaweicloud_identityv5_agency_attached_policies" "test" {
   agency_id = var.agency_id
@@ -30,16 +30,18 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `attached_policies` - Indicate the attached policies list.
+* `id` - The data source ID.
+
+* `attached_policies` - The list of policies attached to the agency.  
   The [attached_policies](#IdentityV5_agency_attached_policies) structure is documented below.
 
 <a name="IdentityV5_agency_attached_policies"></a>
-The `attached_policies` block contains:
+The `attached_policies` block supports:
 
-* `attached_at` - Indicate the time when the policy was attached.
+* `policy_id` - The ID of the policy.
 
-* `policy_id` - Indicate the ID of the policy.
+* `policy_name` - The name of the policy.
 
-* `policy_name` - Indicate the name of the policy.
+* `attached_at` - The creation time of the policy.
 
-* `urn` - Indicate the Uniform Resource Name (URN) of the policy.
+* `urn` - The Uniform Resource Name (URN) of the policy.

--- a/docs/data-sources/identityv5_group_attached_policies.md
+++ b/docs/data-sources/identityv5_group_attached_policies.md
@@ -3,17 +3,17 @@ subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identityv5_group_attached_policies"
 description: |-
-  Use this data source to get attached policies for a specified IAM V5 group.
+  Use this data source to get policy list attached to a group within Huaweicloud.
 ---
  
 # huaweicloud_identityv5_group_attached_policies
 
-Use this data source to get attached policies for a specified IAM V5 group.
+Use this data source to get policy list attached to a group within Huaweicloud.
 
 ## Example Usage
 
 ```hcl
-variable group_id {}
+variable "group_id" {}
 
 data "huaweicloud_identityv5_group_attached_policies" "test" {
   group_id = var.group_id
@@ -24,22 +24,24 @@ data "huaweicloud_identityv5_group_attached_policies" "test" {
 
 The following arguments are supported:
 
-* `group_id` - (Required, String) Specifies the ID of the IAM group.
+* `group_id` - (Required, String) Specifies the ID of the IAM user group.
 
 ## Attribute Reference
 
-In addition to all arguments above, the following attributes are exported:
+In addition to all arguments above, the following attributes are exported:、
 
-* `attached_policies` - Indicate the attached policies list.
+* `id` - The data source ID.
+
+* `attached_policies` - Indicate the list of policies attached to the user group.  
   The [attached_policies](#IdentityV5Attached_policies) structure is documented below.
 
 <a name="IdentityV5Attached_policies"></a>
-The `attached_policies` block contains:
+The `attached_policies` block supports:
 
-* `attached_at` - Indicate the time when the policy was attached.
-  
-* `policy_id` - Indicate the ID of the policy.
-  
-* `policy_name` - Indicate the name of the policy.
-  
-* `urn` - Indicate the Uniform Resource Name (URN) of the policy.
+* `policy_id` - The ID of the policy.
+
+* `policy_name` - The name of the policy.
+
+* `attached_at` - The creation time of the policy.
+
+* `urn` - The Uniform Resource Name (URN) of the policy.

--- a/docs/data-sources/identityv5_user_attached_policies.md
+++ b/docs/data-sources/identityv5_user_attached_policies.md
@@ -3,17 +3,17 @@ subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identityv5_user_attached_policies"
 description: |-
-  Use this data source to get attached policies for a specified IAM V5 user.
+  Use this data source to get policy list attached to a user within Huaweicloud.
 ---
 
 # huaweicloud_identityv5_user_attached_policies
 
-Use this data source to get attached policies for a specified IAM V5 user.
+Use this data source to get policy list attached to a user within Huaweicloud.
 
 ## Example Usage
 
 ```hcl
-variable user_id {}
+variable "user_id" {}
 
 data "huaweicloud_identityv5_user_attached_policies" "test" {
   user_id = var.user_id
@@ -30,16 +30,18 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `attached_policies` - Indicate the attached policies of the IAM user.
-  The [attached_policies](#IdentityV5Attached_policies) structure is documented below.
+* `id` - The data source ID.
 
-<a name="IdentityV5Attached_policies"></a>
-The `attached_policies` block contains:
+* `attached_policies` - The list of policies attached to the user.  
+  The [attached_policies](#v5_user_attached_policies) structure is documented below.
 
-* `attached_at` - Indicate the time when the policy was attached.
+<a name="v5_user_attached_policies"></a>
+The `attached_policies` block supports:
 
-* `policy_id` - Indicate the ID of the policy.
+* `policy_id` - The ID of the policy.
 
-* `policy_name` - Indicate the name of the policy.
+* `policy_name` - The name of the policy.
 
-* `urn` - Indicate the Uniform Resource Name (URN) of the policy.
+* `attached_at` - The creation time of the policy.
+
+* `urn` - The Uniform Resource Name (URN) of the policy.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1643,10 +1643,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_identityv5_policies":                 iam.DataSourceIdentityV5Policies(),
 			"huaweicloud_identityv5_policy_versions":          iam.DataSourceIdentityV5PolicyVersions(),
 			"huaweicloud_identityv5_policy_attached_entities": iam.DataSourceIdentityV5PolicyAttachedEntities(),
-			"huaweicloud_identityv5_agency_attached_policies": iam.DataSourceIdentityV5AgencyAttachedPolicies(),
-			"huaweicloud_identityv5_group_attached_policies":  iam.DataSourceIdentityV5GroupAttachedPolicies(),
+			"huaweicloud_identityv5_agency_attached_policies": iam.DataSourceV5AgencyAttachedPolicies(),
+			"huaweicloud_identityv5_group_attached_policies":  iam.DataSourceV5GroupAttachedPolicies(),
 			"huaweicloud_identityv5_authorization_schema":     iam.DataSourceIdentityV5AuthorizationSchema(),
-			"huaweicloud_identityv5_user_attached_policies":   iam.DataSourceIdentityV5UserAttachedPolicies(),
+			"huaweicloud_identityv5_user_attached_policies":   iam.DataSourceV5UserAttachedPolicies(),
 			"huaweicloud_identityv5_access_key":               iam.DataSourceIdentityV5AccessKey(),
 
 			"huaweicloud_identitycenter_access_control_attribute_configurations": identitycenter.DataSourceAccessControlAttributeConfigurations(),

--- a/huaweicloud/services/iam/data_source_huaweicloud_identityv5_agency_attached_policies.go
+++ b/huaweicloud/services/iam/data_source_huaweicloud_identityv5_agency_attached_policies.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/go-uuid"
@@ -14,85 +15,136 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// DataSourceIdentityV5AgencyAttachedPolicies
 // @API IAM GET /v5/agencies/{agency_id}/attached-policies
-func DataSourceIdentityV5AgencyAttachedPolicies() *schema.Resource {
+func DataSourceV5AgencyAttachedPolicies() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceIdentityV5AgencyAttachedPoliciesRead,
+		ReadContext: dataSourceV5AgencyAttachedPoliciesRead,
 
 		Schema: map[string]*schema.Schema{
 			"agency_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the IAM agency.",
 			},
 			"attached_policies": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"attached_at": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"policy_id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the policy.",
 						},
 						"policy_name": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the policy.",
+						},
+						"attached_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The creation time of the policy.",
 						},
 						"urn": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The Uniform Resource Name (URN) of the policy.",
 						},
 					},
+					Description: "The list of policies attached to the agency.",
 				},
 			},
 		},
 	}
 }
 
-func dataSourceIdentityV5AgencyAttachedPoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.NewServiceClient("iam", region)
-	if err != nil {
-		return diag.Errorf("error creating IAM client: %s", err)
+func buildV5AgencyAttachedPoliciesQueryParams(marker string) string {
+	if marker != "" {
+		return fmt.Sprintf("&marker=%v", marker)
+	}
+	return ""
+}
+
+func listV5AgencyAttachedPolicies(client *golangsdk.ServiceClient, agencyId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v5/agencies/{agency_id}/attached-policies"
+		limit   = 100
+		marker  = ""
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{agency_id}", agencyId)
+	listPath = fmt.Sprintf("%s?limit=%v", listPath, limit)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
 
-	agencyId := d.Get("agency_id").(string)
-	var allPolicies []interface{}
-	var marker string
-	var path string
 	for {
-		path = client.Endpoint + "v5/agencies/{agency_id}/attached-policies" + buildListAttachedPoliciesV5Params(marker)
-		path = strings.ReplaceAll(path, "{agency_id}", agencyId)
-		reqOpt := &golangsdk.RequestOpts{KeepResponseBody: true}
-		r, err := client.Request("GET", path, reqOpt)
+		listPathWithMarker := listPath + buildV5AgencyAttachedPoliciesQueryParams(marker)
+		resp, err := client.Request("GET", listPathWithMarker, &opt)
 		if err != nil {
-			return diag.Errorf("error retrieving attached policies: %s", err)
+			return nil, err
 		}
-		resp, err := utils.FlattenResponse(r)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		policies := flattenListAttachedPoliciesV5Response(resp)
-		allPolicies = append(allPolicies, policies...)
 
-		marker = utils.PathSearch("page_info.next_marker", resp, "").(string)
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		policies := utils.PathSearch("attached_policies", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, policies...)
+
+		if len(policies) < limit {
+			break
+		}
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
 		if marker == "" {
 			break
 		}
 	}
 
-	id, err := uuid.GenerateUUID()
+	return result, nil
+}
+
+func dataSourceV5AgencyAttachedPoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	agencyId := d.Get("agency_id").(string)
+	policies, err := listV5AgencyAttachedPolicies(client, agencyId)
+	if err != nil {
+		return diag.Errorf("error retrieving agency (%s) attached policies: %s", agencyId, err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(id)
-	if err = d.Set("attached_policies", allPolicies); err != nil {
-		return diag.FromErr(err)
+	d.SetId(randomId)
+
+	return diag.FromErr(d.Set("attached_policies", flattenV5AgencyAttachedPolicies(policies)))
+}
+
+func flattenV5AgencyAttachedPolicies(policies []interface{}) []interface{} {
+	if policies == nil {
+		return nil
 	}
-	return nil
+
+	attachedPolicies := make([]interface{}, 0, len(policies))
+	for _, policy := range policies {
+		attachedPolicies = append(attachedPolicies, map[string]interface{}{
+			"policy_id":   utils.PathSearch("policy_id", policy, nil),
+			"policy_name": utils.PathSearch("policy_name", policy, nil),
+			"attached_at": utils.PathSearch("attached_at", policy, nil),
+			"urn":         utils.PathSearch("urn", policy, nil),
+		})
+	}
+
+	return attachedPolicies
 }

--- a/huaweicloud/services/iam/data_source_huaweicloud_identityv5_user_attached_policies.go
+++ b/huaweicloud/services/iam/data_source_huaweicloud_identityv5_user_attached_policies.go
@@ -3,8 +3,8 @@ package iam
 import (
 	"context"
 	"fmt"
+	"strings"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -16,35 +16,40 @@ import (
 )
 
 // @API IAM GET /v5/users/{user_id}/attached-policies
-func DataSourceIdentityV5UserAttachedPolicies() *schema.Resource {
+func DataSourceV5UserAttachedPolicies() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceIdentityV5UserAttachedPoliciesRead,
+		ReadContext: dataSourceV5UserAttachedPoliciesRead,
 
 		Schema: map[string]*schema.Schema{
 			"user_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the IAM user.",
 			},
 			"attached_policies": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"attached_at": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"policy_id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the policy.",
 						},
 						"policy_name": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the policy.",
+						},
+						"attached_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The creation time of the policy.",
 						},
 						"urn": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The Uniform Resource Name (URN) of the policy.",
 						},
 					},
 				},
@@ -53,75 +58,91 @@ func DataSourceIdentityV5UserAttachedPolicies() *schema.Resource {
 	}
 }
 
-func dataSourceIdentityV5UserAttachedPoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.NewServiceClient("iam", region)
-	if err != nil {
-		return diag.Errorf("error creating IAM client: %s", err)
+func buildV5UserAttachedPoliciesQueryParams(marker string) string {
+	if marker != "" {
+		return fmt.Sprintf("&marker=%v", marker)
+	}
+	return ""
+}
+
+func listV5UserAttachedPolicies(client *golangsdk.ServiceClient, userId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v5/users/{user_id}/attached-policies"
+		limit   = 100
+		marker  = ""
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{user_id}", userId)
+	listPath = fmt.Sprintf("%s?limit=%v", listPath, limit)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
 
-	var allPolicies []interface{}
-	var marker string
-	var path string
-
-	userID := d.Get("user_id").(string)
-
 	for {
-		path = client.Endpoint + "v5/users/" + userID + "/attached-policies" + buildListAttachedUserPoliciesV5Params(marker)
-		reqOpt := &golangsdk.RequestOpts{
-			KeepResponseBody: true,
-		}
-		r, err := client.Request("GET", path, reqOpt)
+		listPathWithMarker := listPath + buildV5UserAttachedPoliciesQueryParams(marker)
+		resp, err := client.Request("GET", listPathWithMarker, &opt)
 		if err != nil {
-			return diag.Errorf("error retrieving attached policies: %s", err)
-		}
-		resp, err := utils.FlattenResponse(r)
-		if err != nil {
-			return diag.FromErr(err)
+			return nil, err
 		}
 
-		policies := flattenListAttachedUserPoliciesV5Response(resp)
-		allPolicies = append(allPolicies, policies...)
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
 
-		marker = utils.PathSearch("page_info.next_marker", resp, "").(string)
+		policies := utils.PathSearch("attached_policies", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, policies...)
+		if len(policies) < limit {
+			break
+		}
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
 		if marker == "" {
 			break
 		}
 	}
 
-	id, _ := uuid.GenerateUUID()
-	d.SetId(id)
-
-	mErr := multierror.Append(nil,
-		d.Set("attached_policies", allPolicies),
-	)
-
-	return diag.FromErr(mErr.ErrorOrNil())
+	return result, nil
 }
 
-func buildListAttachedUserPoliciesV5Params(marker string) string {
-	res := "?limit=100"
-	if marker != "" {
-		res = fmt.Sprintf("%s&marker=%v", res, marker)
+func dataSourceV5UserAttachedPoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
 	}
-	return res
+
+	userId := d.Get("user_id").(string)
+	policies, err := listV5UserAttachedPolicies(client, userId)
+	if err != nil {
+		return diag.Errorf("error retrieving user (%s) attached policies: %s", userId, err)
+	}
+
+	randomId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(randomId)
+
+	return diag.FromErr(d.Set("attached_policies", flattenV5UserAttachedPolicies(policies)))
 }
 
-func flattenListAttachedUserPoliciesV5Response(resp interface{}) []interface{} {
-	if resp == nil {
+func flattenV5UserAttachedPolicies(policies []interface{}) []interface{} {
+	if len(policies) == 0 {
 		return nil
 	}
 
-	policies := utils.PathSearch("attached_policies", resp, make([]interface{}, 0)).([]interface{})
-	result := make([]interface{}, len(policies))
-	for i, policy := range policies {
-		result[i] = map[string]interface{}{
-			"attached_at": utils.PathSearch("attached_at", policy, nil),
+	result := make([]interface{}, 0, len(policies))
+	for _, policy := range policies {
+		result = append(result, map[string]interface{}{
 			"policy_id":   utils.PathSearch("policy_id", policy, nil),
 			"policy_name": utils.PathSearch("policy_name", policy, nil),
+			"attached_at": utils.PathSearch("attached_at", policy, nil),
 			"urn":         utils.PathSearch("urn", policy, nil),
-		}
+		})
 	}
+
 	return result
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The current code has the following issues and needs optimization:

- Redundant method naming
- Fields in the schema lack descriptions
- Some error messages are inaccurate
- Some content in the documentation is inaccurately described
- Some code is not standardized


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update functions naming
2. add a description to each field in the schema
3. correcting inaccurate error messages 
4. improve and optimize documentation and code
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccDataV5AgencyAttachedPolicies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5AgencyAttachedPolicies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5AgencyAttachedPolicies_basic
=== PAUSE TestAccDataV5AgencyAttachedPolicies_basic
=== CONT  TestAccDataV5AgencyAttachedPolicies_basic
--- PASS: TestAccDataV5AgencyAttachedPolicies_basic (21.92s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       22.058s coverage: 4.6% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccDataV5GroupAttachedPolicies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5GroupAttachedPolicies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5GroupAttachedPolicies_basic
=== PAUSE TestAccDataV5GroupAttachedPolicies_basic
=== CONT  TestAccDataV5GroupAttachedPolicies_basic
--- PASS: TestAccDataV5GroupAttachedPolicies_basic (19.97s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       20.142s coverage: 5.3% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccDataV5UserAttachedPolicies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV5UserAttachedPolicies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV5UserAttachedPolicies_basic
=== PAUSE TestAccDataV5UserAttachedPolicies_basic
=== CONT  TestAccDataV5UserAttachedPolicies_basic
--- PASS: TestAccDataV5UserAttachedPolicies_basic (23.30s)
PASS
coverage: 5.6% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       23.605s coverage: 5.6% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
