### PR TITLE
feat(ccm): new datasource to query cas by tags

### DIFF
--- a/docs/data-sources/ccm_private_cas_by_tags.md
+++ b/docs/data-sources/ccm_private_cas_by_tags.md
@@ -1,0 +1,83 @@
+---
+subcategory: "Cloud Certificate Manager (CCM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ccm_private_cas_by_tags"
+description: |-
+  Use this data source to get a list of CCM private CAs by tags.
+---
+
+# huaweicloud_ccm_private_cas_by_tags
+
+Use this data source to get a list of CCM private CAs by tags.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_ccm_private_cas_by_tags" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `tags` - (Optional, List) Specifies the containing tags.
+  It can contain a maximum of `20` keys, with a maximum of `20` values ​​under each key. The value array for each key can
+  be empty, but the structure must be complete. Keys cannot be duplicated, and values ​​for the same key cannot be
+  duplicated. The result returns a list of resources containing all tags. Keys are related by AND, and values ​​in the
+  key-value structure are related by OR. Without tag filtering, the full dataset is returned.
+
+  The [tags](#tags_Tag) structure is documented below.
+
+* `matches` - (Optional, List) Specifies the matches condition.
+  The key is the field to be matched, such as **resource_name**. The value is the match value.
+  The key is a fixed dictionary value and cannot contain duplicate keys or unsupported keys.
+
+  The [matches](#matches_Match) structure is documented below.
+
+<a name="tags_Tag"></a>
+The `tags` block supports:
+
+* `key` - (Optional, String) Specifies the key.
+
+* `values` - (Optional, List) Specifies the value array.
+
+<a name="matches_Match"></a>
+The `matches` block supports:
+
+* `key` - (Optional, String) Specifies the field to be matched.
+
+* `value` - (Optional, String) Specifies the match value.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_count` - The total number of resources.
+
+* `resources` - The CA details.
+
+  The [resources](#resources_response_struct) structure is documented below.
+
+<a name="resources_response_struct"></a>
+The `resources` block supports:
+
+* `resource_id` - The ID of the private CA.
+
+* `tags` - The tags of the private CA.
+  The [tags](#tags_response_struct) structure is documented below.
+
+* `resource_name` - The name of the private CA.
+
+* `resource_detail` - The details of the private CA in JSON string format.
+
+<a name="tags_response_struct"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `value` - The value of the tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -769,6 +769,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ccm_private_cas":                  ccm.DataSourcePrivateCas(),
 			"huaweicloud_ccm_private_ca_export":            ccm.DataSourcePrivateCaExport(),
 			"huaweicloud_ccm_private_ca_quota":             ccm.DataSourceCcmPrivateCaQuota(),
+			"huaweicloud_ccm_private_cas_by_tags":          ccm.DataSourcePrivateCasByTags(),
 			"huaweicloud_ccm_private_certificates":         ccm.DataSourcePrivateCertificates(),
 			"huaweicloud_ccm_private_certificate_export":   ccm.DataSourcePrivateCertificateExport(),
 			"huaweicloud_ccm_private_certificates_by_tags": ccm.DataSourcePrivateCertificatesByTags(),

--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_cas_by_tags_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_cas_by_tags_test.go
@@ -1,0 +1,58 @@
+package ccm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourcePrivateCAsByTags_basic(t *testing.T) {
+	var (
+		datasource = "data.huaweicloud_ccm_private_cas_by_tags.test"
+		dc         = acceptance.InitDataSourceCheck(datasource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Prepare private certificates in the runtime environment before running test cases.
+			acceptance.TestAccPreCheckCCMEnableFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourcePrivateCAsByTags_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_id"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_name"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_detail"),
+
+					resource.TestCheckOutput("non_exist_resources_is_zero", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDatasourcePrivateCAsByTags_basic = `
+data "huaweicloud_ccm_private_cas_by_tags" "test" {}
+
+data "huaweicloud_ccm_private_cas_by_tags" "non-exist" {
+  tags {
+    key    = "non-exist-key"
+    values = ["non-exist-value"]
+  }
+
+  matches {
+    key   = "resource_name"
+    value = "non-exist-value"
+  }
+}
+
+output "non_exist_resources_is_zero" {
+  value = length(data.huaweicloud_ccm_private_cas_by_tags.non-exist.resources) == 0
+}
+`

--- a/huaweicloud/services/ccm/data_source_huaweicloud_ccm_private_cas_by_tags.go
+++ b/huaweicloud/services/ccm/data_source_huaweicloud_ccm_private_cas_by_tags.go
@@ -1,0 +1,238 @@
+package ccm
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CCM POST /v1/private-certificate-authorities/resource-instances/filter
+func DataSourcePrivateCasByTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourcePrivateCasByTagsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     privateCasByTagsTagsSchema(),
+			},
+			"matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     privateCasByTagsMatchesSchema(),
+			},
+			"total_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     privateCasByTagsResourcesSchema(),
+			},
+		},
+	}
+}
+
+func privateCasByTagsMatchesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func privateCasByTagsTagsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"values": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func privateCasByTagsResourcesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     privateCasByTagsResourcesTagsSchema(),
+			},
+			"resource_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			// The API documentation does not provide the data structure for this field,
+			// so it is temporarily treated as a JSON string.
+			"resource_detail": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func privateCasByTagsResourcesTagsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildPrivateCasByTagsTagsBodyParams(rawArray []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, raw := range rawArray {
+		rawMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"key":    rawMap["key"],
+			"values": rawMap["values"],
+		})
+	}
+
+	return rst
+}
+
+func buildPrivateCasByTagsMatchesBodyParams(rawArray []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, raw := range rawArray {
+		rawMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"key":   rawMap["key"],
+			"value": rawMap["value"],
+		})
+	}
+
+	return rst
+}
+
+func buildPrivateCasByTagsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"tags":    buildPrivateCasByTagsTagsBodyParams(d.Get("tags").([]interface{})),
+		"matches": buildPrivateCasByTagsMatchesBodyParams(d.Get("matches").([]interface{})),
+		"limit":   50,
+	}
+}
+
+func datasourcePrivateCasByTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		httpUrl = "v1/private-certificate-authorities/resource-instances/filter"
+		product = "ccm"
+	)
+
+	client, err := conf.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CCM client: %s", err)
+	}
+
+	// The pagination parameter for this API is invalid. Specifying an offset value will retrieve duplicate data,
+	// so pagination is not currently supported.
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildPrivateCasByTagsBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CCM private CAs by tags: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	resources := utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{})
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("total_count", int(utils.PathSearch("total_count", respBody, float64(0)).(float64))),
+		d.Set("resources", flattenPrivateCasByTagsResources(resources)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPrivateCasByTagsResources(respArray []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		tagsResp := utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})
+		resourceDetailResp := utils.JsonToString(utils.PathSearch("resource_detail", v, nil))
+
+		rst = append(rst, map[string]interface{}{
+			"resource_id":     utils.PathSearch("resource_id", v, nil),
+			"tags":            flattenPrivateCasByTagsTagsResources(tagsResp),
+			"resource_name":   utils.PathSearch("resource_name", v, nil),
+			"resource_detail": resourceDetailResp,
+		})
+	}
+
+	return rst
+}
+
+func flattenPrivateCasByTagsTagsResources(respArray []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"key":   utils.PathSearch("key", v, nil),
+			"value": utils.PathSearch("value", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query cas by tags

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o ccm -f TestAccDatasourcePrivateCAsByTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ccm" -v -coverprofile="./huaweicloud/services/acceptance/ccm/ccm_coverage.cov" -coverpkg="./huaweicloud/services/ccm" -run TestAccDatasourcePrivateCAsByTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourcePrivateCAsByTags_basic
=== PAUSE TestAccDatasourcePrivateCAsByTags_basic
=== CONT  TestAccDatasourcePrivateCAsByTags_basic
--- PASS: TestAccDatasourcePrivateCAsByTags_basic (12.59s)
PASS
coverage: 6.2% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       12.678s coverage: 6.2% of statements in ./huaweicloud/services/ccm
```
<img width="1296" height="69" alt="image" src="https://github.com/user-attachments/assets/823ba587-e64b-458c-b964-abfa0b8c60fb" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
