### PR TITLE
chore(iam): optimize the schema, docs and UT for creating user

### DIFF
--- a/docs/resources/identity_user.md
+++ b/docs/resources/identity_user.md
@@ -2,7 +2,8 @@
 subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identity_user"
-description: ""
+description: |-
+  Manages an IAM user resource within HuaweiCloud.
 ---
 
 # huaweicloud_identity_user
@@ -14,12 +15,13 @@ Manages an IAM user resource within HuaweiCloud.
 ## Example Usage
 
 ```hcl
-variable "user_1_password" {}
+variable "user_name" {}
+variable "password" {}
 
-resource "huaweicloud_identity_user" "user_1" {
-  name        = "user_1"
-  description = "A user"
-  password    = var.user_1_password
+resource "huaweicloud_identity_user" "test" {
+  name        = var.user_name
+  password    = var.password
+  description = "my user information"
 }
 ```
 
@@ -41,15 +43,16 @@ The following arguments are supported:
 * `country_code` - (Optional, String) Specifies the country code. The country code of the Chinese mainland is 0086. This
   parameter must be used together with `phone`.
 
-* `password` - (Optional, String) Specifies the password for the user with `6` to `32` characters. It must contain at least
-  two of the following character types: uppercase letters, lowercase letters, digits, and special characters.
+* `password` - (Optional, String) Specifies the password for the user with `6` to `32` characters. It must contain at
+  least two of the following character types: uppercase letters, lowercase letters, digits, and special characters.
 
-* `pwd_reset` - (Optional, Bool) Specifies whether or not the password should be reset. By default, the password is asked
-   to reset at the first login.
+* `pwd_reset` - (Optional, Bool) Specifies whether the password should be reset. By default, the password is asked
+  to reset at the first login.
 
-* `enabled` - (Optional, Bool) Specifies whether the user is enabled or disabled. Valid values are **true** and **false**.
+* `enabled` - (Optional, Bool) Specifies whether the user is enabled or disabled.
 
-* `access_type` - (Optional, String) Specifies the access type of the user. Available values are:
+* `access_type` - (Optional, String) Specifies the access type of the user.  
+  The valid values are as follows:
   + **default**: support both programmatic and management console access.
   + **programmatic**: only support programmatic access.
   + **console**: only support management console access.
@@ -62,9 +65,8 @@ The following arguments are supported:
   Only **TenantIdp** is supported now. This parameter must be used together with `external_identity_id`.
 
 * `login_protect_verification_method` - (Optional, String) Specifies the verification method of login protect. If it is
-  empty, the login protection will be disabled.
-  
-  Valid values are as follows:
+  empty, the login protection will be disabled.  
+  The valid values are as follows:
   + **sms**: Use phone number to verify.
   + **email**: Use email to verify.
   + **vmfa**: Use MFA to verify.
@@ -83,16 +85,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Users can be imported using the `id`, e.g.
+The users can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_identity_user.user_1 89c60255-9bd6-460c-822a-e2b959ede9d2
+$ terraform import huaweicloud_identity_user.test </id>
 ```
 
-But due to the security reason, `password` can not be imported, you can ignore it as below.
+Please add the followings if some attributes are missing when importing the resource.
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `password`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource. Also you can ignore changes as below.
 
 ```hcl
-resource "huaweicloud_identity_user" "user_1" {
+resource "huaweicloud_identity_user" "test" {
   ...
 
   lifecycle {

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_user_token_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_user_token_test.go
@@ -10,9 +10,11 @@ import (
 )
 
 func TestAccIdentityUserToken_basic(t *testing.T) {
-	userName := acceptance.RandomAccResourceName()
-	initPassword := acceptance.RandomPassword()
-	resourceName := "huaweicloud_identity_user_token.test"
+	var (
+		resourceName = "huaweicloud_identity_user_token.test"
+
+		userName = acceptance.RandomAccResourceName()
+	)
 
 	// Avoid CheckDestroy because the token can not be destroyed.
 	// lintignore:AT001
@@ -22,9 +24,16 @@ func TestAccIdentityUserToken_basic(t *testing.T) {
 			acceptance.TestAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source: "hashicorp/random",
+				// The version of the random provider must be greater than 3.3.0 to support the 'numeric' parameter.
+				VersionConstraint: "3.3.0",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityUserToken_basic(userName, initPassword),
+				Config: testAccIdentityUserToken_basic(userName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "token"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
@@ -34,22 +43,24 @@ func TestAccIdentityUserToken_basic(t *testing.T) {
 	})
 }
 
-func testAccIdentityUserToken_basic(userName, initPassword string) string {
+func testAccIdentityUserToken_basic(userName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_identity_user_token" "test" {
   account_name = "%[2]s"
-  user_name    = huaweicloud_identity_user.user_1.name
-  password     = "%[3]s"
+  user_name    = huaweicloud_identity_user.test.name
+  password     = random_string.test.result
 }
-`, testAccIdentityUser_basic(userName, initPassword), acceptance.HW_DOMAIN_NAME, initPassword)
+`, testAccIdentityUser_basic(userName), acceptance.HW_DOMAIN_NAME)
 }
 
 func TestAccIdentityUserToken_project(t *testing.T) {
-	userName := acceptance.RandomAccResourceName()
-	initPassword := acceptance.RandomPassword()
-	resourceName := "huaweicloud_identity_user_token.test"
+	var (
+		resourceName = "huaweicloud_identity_user_token.test"
+
+		userName = acceptance.RandomAccResourceName()
+	)
 
 	// Avoid CheckDestroy because the token can not be destroyed.
 	// lintignore:AT001
@@ -59,9 +70,16 @@ func TestAccIdentityUserToken_project(t *testing.T) {
 			acceptance.TestAccPreCheckAdminOnly(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source: "hashicorp/random",
+				// The version of the random provider must be greater than 3.3.0 to support the 'numeric' parameter.
+				VersionConstraint: "3.3.0",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityUserToken_project(userName, initPassword),
+				Config: testAccIdentityUserToken_project(userName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "token"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
@@ -71,15 +89,15 @@ func TestAccIdentityUserToken_project(t *testing.T) {
 	})
 }
 
-func testAccIdentityUserToken_project(userName, initPassword string) string {
+func testAccIdentityUserToken_project(userName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_identity_user_token" "test" {
   account_name = "%[2]s"
-  user_name    = huaweicloud_identity_user.user_1.name
-  password     = "%[3]s"
-  project_name = "%[4]s"
+  user_name    = huaweicloud_identity_user.test.name
+  password     = random_string.test.result
+  project_name = "%[3]s"
 }
-`, testAccIdentityUser_basic(userName, initPassword), acceptance.HW_DOMAIN_NAME, initPassword, acceptance.HW_REGION_NAME)
+`, testAccIdentityUser_basic(userName), acceptance.HW_DOMAIN_NAME, acceptance.HW_REGION_NAME)
 }

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_user.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_user.go
@@ -28,10 +28,10 @@ import (
 // @API IAM GET /v3.0/OS-USER/users/{user_id}/login-protect
 func ResourceIdentityUser() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIdentityUserCreate,
-		ReadContext:   resourceIdentityUserRead,
-		UpdateContext: resourceIdentityUserUpdate,
-		DeleteContext: resourceIdentityUserDelete,
+		CreateContext: resourceUserCreate,
+		ReadContext:   resourceUserRead,
+		UpdateContext: resourceUserUpdate,
+		DeleteContext: resourceUserDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -39,51 +39,61 @@ func ResourceIdentityUser() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the user.`,
 			},
 			"password": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				Sensitive: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `The password for the user.`,
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the user.`,
 			},
 			"email": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The email address.`,
 			},
 			"phone": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				RequiredWith: []string{"country_code"},
+				Description:  `The mobile number.`,
 			},
 			"country_code": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				RequiredWith: []string{"phone"},
+				Description:  `The country code.`,
 			},
 			"external_identity_id": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the IAM user in the external system.`,
 			},
 			"external_identity_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				RequiredWith: []string{"external_identity_id"},
+				Description:  `The type of the IAM user in the external system.`,
 			},
 			"enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether the user is enabled or disabled.`,
 			},
 			"pwd_reset": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether the password should be reset.`,
 			},
 			"access_type": {
 				Type:     schema.TypeString,
@@ -92,22 +102,29 @@ func ResourceIdentityUser() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"default", "programmatic", "console",
 				}, false),
+				Description: `The access type of the user.`,
 			},
 			"login_protect_verification_method": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The verification method of login protect.`,
 			},
+
+			// Attributes
 			"password_strength": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The password strength.`,
 			},
 			"create_time": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the IAM user was created.`,
 			},
 			"last_login": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the IAM user last login.`,
 			},
 		},
 	}
@@ -127,7 +144,7 @@ func buildExternalIdentityType(d *schema.ResourceData) string {
 	return "TenantIdp"
 }
 
-func resourceIdentityUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	iamClient, err := cfg.IAMV3Client(cfg.GetRegion(d))
 	if err != nil {
@@ -173,7 +190,7 @@ func resourceIdentityUserCreate(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
-	return resourceIdentityUserRead(ctx, d, meta)
+	return resourceUserRead(ctx, d, meta)
 }
 
 func updateLoginProtect(client *golangsdk.ServiceClient, userID, method string) error {
@@ -195,7 +212,7 @@ func updateLoginProtect(client *golangsdk.ServiceClient, userID, method string) 
 	return nil
 }
 
-func resourceIdentityUserRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	iamClient, err := cfg.IAMV3Client(cfg.GetRegion(d))
 	if err != nil {
@@ -250,7 +267,7 @@ func normalizePhoneNumber(raw string) string {
 	return phone
 }
 
-func resourceIdentityUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	iamClient, err := cfg.IAMV3Client(cfg.GetRegion(d))
 	if err != nil {
@@ -329,10 +346,10 @@ func resourceIdentityUserUpdate(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
-	return resourceIdentityUserRead(ctx, d, meta)
+	return resourceUserRead(ctx, d, meta)
 }
 
-func resourceIdentityUserDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	identityClient, err := cfg.IdentityV3Client(cfg.GetRegion(d))
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
optimize the schema, docs and UT for creating user
- `huaweicloud_identity_user`
- `huaweicloud_identity_user_token`
- `data.huaweicloud_identity_user_token_info`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. optimize the resource codes of IAM user
2. optimize the docs and acceptance of  IAM user，as well as other acceptance related to IAM user
```

## PR Checklist
### resource_huaweicloud_identity_user
```go
=== RUN   TestAccIdentityUser_basic
=== PAUSE TestAccIdentityUser_basic
=== CONT  TestAccIdentityUser_basic
--- PASS: TestAccIdentityUser_basic (55.96s)
PASS

=== RUN   TestAccIdentityUser_external
=== PAUSE TestAccIdentityUser_external
=== CONT  TestAccIdentityUser_external
--- PASS: TestAccIdentityUser_external (46.00s)
PASS
```

### resource_huaweicloud_identity_user_token
```go
=== RUN   TestAccIdentityUserToken_basic
=== PAUSE TestAccIdentityUserToken_basic
=== CONT  TestAccIdentityUserToken_basic
--- PASS: TestAccIdentityUserToken_basic (20.87s)
PASS
```

### data.huaweicloud_identity_user_token_info
```go
=== RUN   TestAccIdentityUserTokenInfo_basic
=== PAUSE TestAccIdentityUserTokenInfo_basic
=== CONT  TestAccIdentityUserTokenInfo_basic
--- PASS: TestAccIdentityUserTokenInfo_basic (25.09s)
PASS
```