### PR TITLE
feat(ccm): new datasource to query ca agency

### DIFF
--- a/docs/data-sources/ccm_private_ca_agency.md
+++ b/docs/data-sources/ccm_private_ca_agency.md
@@ -1,0 +1,32 @@
+---
+subcategory: "Cloud Certificate Manager (CCM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ccm_private_ca_agency"
+description: |-
+  Use this data source to get the list of CCM private CA agency.
+---
+
+# huaweicloud_ccm_private_ca_agency
+
+Use this data source to get the list of CCM private CA agency.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_ccm_private_ca_agency" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `agency_granted` - The agency granted.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -764,6 +764,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cciv2_resources":                cci.DataSourceV2Resources(),
 
 			"huaweicloud_ccm_certificates":                 ccm.DataSourceCertificates(),
+			"huaweicloud_ccm_private_ca_agency":            ccm.DataSourcePrivateCaAgency(),
 			"huaweicloud_ccm_certificate_export":           ccm.DataSourceCertificateExport(),
 			"huaweicloud_ccm_certificates_by_tags":         ccm.DataSourceCertificatesByTags(),
 			"huaweicloud_ccm_private_cas":                  ccm.DataSourcePrivateCas(),

--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_ca_agency_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_ca_agency_test.go
@@ -1,0 +1,36 @@
+package ccm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourcePrivateCaAgency_basic(t *testing.T) {
+	var (
+		datasource = "data.huaweicloud_ccm_private_ca_agency.test"
+		dc         = acceptance.InitDataSourceCheck(datasource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourcePrivateCaAgency_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(datasource, "agency_granted"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDatasourcePrivateCaAgency_basic = `
+data "huaweicloud_ccm_private_ca_agency" "test" {}
+`

--- a/huaweicloud/services/ccm/data_source_huaweicloud_ccm_private_ca_agency.go
+++ b/huaweicloud/services/ccm/data_source_huaweicloud_ccm_private_ca_agency.go
@@ -1,0 +1,76 @@
+package ccm
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CCM GET /v1/private-certificate-authorities/agency
+func DataSourcePrivateCaAgency() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourcePrivateCaAgencyRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// The API documentation identifies this field as a String, but it is actually a Boolean value.
+			"agency_granted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func datasourcePrivateCaAgencyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		httpUrl = "v1/private-certificate-authorities/agency"
+		product = "ccm"
+	)
+
+	client, err := conf.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CCM client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CCM private CA agency: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("agency_granted", utils.PathSearch("agency_granted", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query ca agency

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o ccm -f TestAccDatasourcePrivateCaAgency_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ccm" -v -coverprofile="./huaweicloud/services/acceptance/ccm/ccm_coverage.cov" -coverpkg="./huaweicloud/services/ccm" -run TestAccDatasourcePrivateCaAgency_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourcePrivateCaAgency_basic
=== PAUSE TestAccDatasourcePrivateCaAgency_basic
=== CONT  TestAccDatasourcePrivateCaAgency_basic
--- PASS: TestAccDatasourcePrivateCaAgency_basic (12.43s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       12.545s coverage: 4.2% of statements in ./huaweicloud/services/ccm
```
<img width="1283" height="78" alt="image" src="https://github.com/user-attachments/assets/34aea101-f385-4f48-aca6-db45dcd1b6a7" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
