### PR TITLE
feat(hss): support `hss_vulnerability_scan_estimated_time` data source

### DIFF
--- a/docs/data-sources/hss_vulnerability_scan_estimated_time.md
+++ b/docs/data-sources/hss_vulnerability_scan_estimated_time.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_vulnerability_scan_estimated_time"
+description: |-
+  Use this data source to get the estimated time of HSS vulnerability scan within HuaweiCloud.
+---
+
+# huaweicloud_hss_vulnerability_scan_estimated_time
+
+Use this data source to get the estimated time of HSS vulnerability scan within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_vulnerability_scan_estimated_time" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `manual_scan_type` - (Optional, List) Specifies the manual vulnerability detection type.  
+  The valid values are as follows:
+  + **linux_vul**
+  + **windows_vul**
+  + **web_cms**
+  + **app_vul**
+  + **urgent_vul**
+
+* `range_type` - (Optional, String) Specifies the range of detected hosts.  
+  The valid values are as follows:
+  + **all_host**
+  + **specific_host**
+
+* `agent_ids` - (Optional, List) Specifies the list of agents to be tested.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `queue_time` - The waiting time required to queue for vulnerability scanning, measured in minutes.
+
+* `run_time` - The time required for the execution of this task, in minutes.
+
+* `total_time` - The total time required from now until the end of the task, in minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1570,6 +1570,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_vulnerability_task_statistics":              hss.DataSourceHssVulnerabilityTaskStatistics(),
 			"huaweicloud_hss_vulnerability_urgent_vulnerabilities":       hss.DataSourceVulnerabilityUrgentVulnerabilities(),
 			"huaweicloud_hss_vulnerability_whitelist_options":            hss.DataSourceVulnerabilityWhiteListOptions(),
+			"huaweicloud_hss_vulnerability_scan_estimated_time":          hss.DataSourceVulnerabilityScanEstimatedTime(),
 			"huaweicloud_hss_webtamper_hosts":                            hss.DataSourceWebTamperHosts(),
 			"huaweicloud_hss_webtamper_host_management_hosts":            hss.DataSourceWebTamperHostManagementHosts(),
 			"huaweicloud_hss_webtamper_protection_statistics":            hss.DataSourceWebtamperProtectionStatistics(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_vulnerability_scan_estimated_time_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_vulnerability_scan_estimated_time_test.go
@@ -1,0 +1,43 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceVulnerabilityScanEstimatedTime_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_vulnerability_scan_estimated_time.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceVulnerabilityScanEstimatedTime_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "queue_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "run_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceVulnerabilityScanEstimatedTime_basic() string {
+	return `
+data "huaweicloud_hss_vulnerability_scan_estimated_time" "test" {
+  manual_scan_type = ["linux_vul"]
+  range_type       = "all_host"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_vulnerability_scan_estimated_time.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_vulnerability_scan_estimated_time.go
@@ -1,0 +1,127 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS POST /v5/{project_id}/vulnerability/scan/task/estimated-time
+func DataSourceVulnerabilityScanEstimatedTime() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVulnerabilityScanEstimatedTimeRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"manual_scan_type": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"range_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"agent_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"queue_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"run_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"total_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildVulnerabilityScanEstimatedTimeQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func buildVulnerabilityScanEstimatedTimeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"manual_scan_type": utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("manual_scan_type").([]interface{}))),
+		"range_type":       utils.ValueIgnoreEmpty(d.Get("range_type")),
+		"agent_ids":        utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("agent_ids").([]interface{}))),
+	}
+}
+
+func dataSourceVulnerabilityScanEstimatedTimeRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/vulnerability/scan/task/estimated-time"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildVulnerabilityScanEstimatedTimeQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildVulnerabilityScanEstimatedTimeBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS vulnerability scan estimated time: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("queue_time", utils.PathSearch("total_time", respBody, nil)),
+		d.Set("run_time", utils.PathSearch("queue_time", respBody, nil)),
+		d.Set("total_time", utils.PathSearch("run_time", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_vulnerability_scan_estimated_time` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_vulnerability_scan_estimated_time` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceVulnerabilityScanEstimatedTime_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceVulnerabilityScanEstimatedTime_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceVulnerabilityScanEstimatedTime_basic
=== PAUSE TestAccDataSourceVulnerabilityScanEstimatedTime_basic
=== CONT  TestAccDataSourceVulnerabilityScanEstimatedTime_basic
--- PASS: TestAccDataSourceVulnerabilityScanEstimatedTime_basic (10.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       10.591s
```
<img width="985" height="34" alt="image" src="https://github.com/user-attachments/assets/2c252aa7-cb25-4a9a-9077-977d969c4bf4" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
