### PR TITLE
feat(dds): the DDS instance supports node reduction

### DIFF
--- a/docs/resources/dds_instance.md
+++ b/docs/resources/dds_instance.md
@@ -270,6 +270,18 @@ The `flavor` block supports:
   + dds.mongodb.s6.large.4.mongos and dds.mongodb.s6.large.4.config have the same specifications.
   + dds.mongodb.s6.large.4.mongos and dds.mongodb.c3.large.4.config are not of the same specifications.
 
+* `node_list` - (Optional, List) Specifies the ID list of instance nodes to be deleted.  
+  
+  -> 1. This parameter is available only when you delete a replica set instance nodes or a cluster instance
+     mongos nodes.
+     <br/>2. When you delete a replica set instance nodes, this parameter can be empty, but it is required when
+     you delete a cluster instance mongos nodes.
+     <br/>3. For a 7-node replica set instance, `2` or `4` standby nodes can be deleted.
+     <br/>4. For a 5-node replica set instance, `2` standby nodes can be deleted.
+     <br/>5. The standby node of a 3-node replica set instance cannot be deleted.
+     <br/>6. At least keep `2` mongos nodes of a cluster instance.
+     <br/>7. Nodes cannot be deleted from instances that have abnormal nodes.
+
 The `backup_strategy` block supports:
 
 * `start_time` - (Required, String) Specifies the backup time window. Automated backups will be triggered during


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The DDS instance supports node reduction.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
1. delete mongos node
<img width="585" height="833" alt="image" src="https://github.com/user-attachments/assets/22289e4a-41d7-4357-a35d-ba7705245fa0" />
<img width="750" height="808" alt="image" src="https://github.com/user-attachments/assets/43d6dbfd-7e64-4020-92ab-742c7404d13b" />


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the DDS instance supports delete replica set nodes and cluster mongos nodes.
2. update corresponding acceptance test and documentation.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3Instance_prePaid"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_prePaid
=== PAUSE TestAccDDSV3Instance_prePaid
=== CONT  TestAccDDSV3Instance_prePaid
--- PASS: TestAccDDSV3Instance_prePaid (2237.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       2238.152s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3Instance_withAutoEnlargePolicy"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_withAutoEnlargePolicy -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_withAutoEnlargePolicy
=== PAUSE TestAccDDSV3Instance_withAutoEnlargePolicy
=== CONT  TestAccDDSV3Instance_withAutoEnlargePolicy
--- PASS: TestAccDDSV3Instance_withAutoEnlargePolicy (2249.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       2249.718s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
