### PR TITLE
feat(ccm): new resource to manage ca ocsp switch status

### DIFF
--- a/docs/resources/ccm_private_ca_switch_ocsp.md
+++ b/docs/resources/ccm_private_ca_switch_ocsp.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Cloud Certificate Manager (CCM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ccm_private_ca_switch_ocsp"
+description: |-
+  Manages a CCM private CA switch OCSP resource within HuaweiCloud.
+---
+
+# huaweicloud_ccm_private_ca_switch_ocsp
+
+Manages a CCM private CA switch OCSP resource within HuaweiCloud.
+
+-> Deleting this resource will not recover the private CA OCSP switch status, but will only remove the
+  resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "ca_id" {}
+
+resource "huaweicloud_ccm_private_ca_switch_ocsp" "test" {
+  ca_id       = var.ca_id
+  ocsp_switch = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `ca_id` - (Required, String, NonUpdatable) Specifies the ID of the private CA you want to switch OCSP.
+
+* `ocsp_switch` - (Required, Bool) Specifies whether to enable or disable OCSP.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also the private CA ID).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2801,6 +2801,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ccm_certificate_push":           ccm.ResourceCertificatePush(),
 			"huaweicloud_ccm_private_ca":                 ccm.ResourcePrivateCertificateAuthority(),
 			"huaweicloud_ccm_private_ca_revoke":          ccm.ResourcePrivateCaRevoke(),
+			"huaweicloud_ccm_private_ca_switch_ocsp":     ccm.ResourcePrivateCaSwitchOcsp(),
 			"huaweicloud_ccm_private_certificate":        ccm.ResourcePrivateCertificate(),
 			"huaweicloud_ccm_private_certificate_revoke": ccm.ResourcePrivateCertificateRevoke(),
 			"huaweicloud_ccm_private_ca_restore":         ccm.ResourcePrivateCaRestore(),

--- a/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_switch_ocsp_test.go
+++ b/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_switch_ocsp_test.go
@@ -1,0 +1,56 @@
+package ccm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourcePrivateCaSwitchOcsp_basic(t *testing.T) {
+	// This resource does not support Read and Destroy, so CheckExist and CheckDestroy are ignored.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Prepare private CA in the runtime environment before running test cases.
+			acceptance.TestAccPreCheckCCMPrivateCaID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourcePrivateCaSwitchOcsp_basic(),
+			},
+			{
+				Config: testAccResourcePrivateCaSwitchOcsp_update(),
+			},
+		},
+	})
+}
+
+func testAccResourcePrivateCaSwitchOcsp_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ccm_private_ca_switch_ocsp" "test" {
+  ca_id       = "%s"
+  ocsp_switch = true
+}
+`, acceptance.HW_CCM_PRIVATE_CA_ID)
+}
+
+func testAccResourcePrivateCaSwitchOcsp_update() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ccm_private_ca_switch_ocsp" "test" {
+  ca_id       = "%[1]s"
+  ocsp_switch = false
+}
+
+resource "huaweicloud_ccm_private_ca_switch_ocsp" "test_duplicate_situation" {
+  depends_on = [huaweicloud_ccm_private_ca_switch_ocsp.test]
+
+  ca_id       = "%[1]s"
+  ocsp_switch = false
+}
+`, acceptance.HW_CCM_PRIVATE_CA_ID)
+}

--- a/huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca_switch_ocsp.go
+++ b/huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca_switch_ocsp.go
@@ -1,0 +1,150 @@
+package ccm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CCM POST /v1/private-certificate-authorities/{ca_id}/ocsp/switch
+func ResourcePrivateCaSwitchOcsp() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePrivateCaSwitchOcspCreate,
+		UpdateContext: resourcePrivateCaSwitchOcspUpdate,
+		ReadContext:   resourcePrivateCaSwitchOcspRead,
+		DeleteContext: resourcePrivateCaSwitchOcspDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"ca_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"ca_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ocsp_switch": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func switchPrivateCaOcsp(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v1/private-certificate-authorities/{ca_id}/ocsp/switch"
+	requestPath = strings.ReplaceAll(requestPath, "{ca_id}", d.Get("ca_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+			202,
+			204,
+		},
+		JSONBody: map[string]interface{}{
+			"ocsp_switch": d.Get("ocsp_switch"),
+		},
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	if err == nil {
+		return nil
+	}
+
+	var errCode403 golangsdk.ErrDefault403
+	if errors.As(err, &errCode403) {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode403.Body, &apiError); jsonErr != nil {
+			log.Printf("[ERROR] unable to unmarshal switch private CA OCSP error response: %s", jsonErr)
+			return err
+		}
+
+		// Error code "PCA.10010071" and "PCA.10010072" mean a duplicate operation status, which can be considered as
+		// a successful operation status.
+		errCode := utils.PathSearch("error_code", apiError, "").(string)
+		if errCode == "PCA.10010072" || errCode == "PCA.10010071" {
+			return nil
+		}
+	}
+
+	return err
+}
+
+func resourcePrivateCaSwitchOcspCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ccm"
+		caId    = d.Get("ca_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CCM client: %s", err)
+	}
+
+	if err := switchPrivateCaOcsp(client, d); err != nil {
+		return diag.Errorf("error switching CCM private CA OCSP in create operation: %s", err)
+	}
+
+	d.SetId(caId)
+
+	return resourcePrivateCaSwitchOcspRead(ctx, d, meta)
+}
+
+func resourcePrivateCaSwitchOcspRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourcePrivateCaSwitchOcspUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ccm"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CCM client: %s", err)
+	}
+
+	if err := switchPrivateCaOcsp(client, d); err != nil {
+		return diag.Errorf("error switching CCM private CA OCSP in update operation: %s", err)
+	}
+
+	return resourcePrivateCaSwitchOcspRead(ctx, d, meta)
+}
+
+func resourcePrivateCaSwitchOcspDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `Deleting this resource will not recover the private CA OCSP switch status, but will only remove the
+	resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage ca ocsp switch status

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o ccm -f TestAccResourcePrivateCaSwitchOcsp_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ccm" -v -coverprofile="./huaweicloud/services/acceptance/ccm/ccm_coverage.cov" -coverpkg="./huaweicloud/services/ccm" -run TestAccResourcePrivateCaSwitchOcsp_basic -timeout 360m -parallel 10
=== RUN   TestAccResourcePrivateCaSwitchOcsp_basic
=== PAUSE TestAccResourcePrivateCaSwitchOcsp_basic
=== CONT  TestAccResourcePrivateCaSwitchOcsp_basic
--- PASS: TestAccResourcePrivateCaSwitchOcsp_basic (24.99s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       25.085s coverage: 5.3% of statements in ./huaweicloud/services/ccm
```
<img width="1300" height="80" alt="image" src="https://github.com/user-attachments/assets/c8bfc630-ec3a-4fbf-99db-1e13f232c39f" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
