### PR TITLE
fix(apig/api_batch_plugins_associate): fix incorrect argument inputs for client building

### DIFF
--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_batch_plugins_associate_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_batch_plugins_associate_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func getApiBatchPluginsAssociateFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.NewServiceClient(acceptance.HW_REGION_NAME, "apig")
+	client, err := cfg.NewServiceClient("apig", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating APIG client: %s", err)
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api_batch_plugins_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api_batch_plugins_associate.go
@@ -145,10 +145,9 @@ func bindPluginsToApi(client *golangsdk.ServiceClient, instanceId, apiId, envId 
 
 func resourceApiBatchPluginsAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
+		cfg = meta.(*config.Config)
 	)
-	client, err := cfg.NewServiceClient(region, "apig")
+	client, err := cfg.NewServiceClient("apig", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG client: %s", err)
 	}
@@ -263,7 +262,7 @@ func resourceApiBatchPluginsAssociateRead(_ context.Context, d *schema.ResourceD
 		cfg    = meta.(*config.Config)
 		region = cfg.GetRegion(d)
 	)
-	client, err := cfg.NewServiceClient(region, "apig")
+	client, err := cfg.NewServiceClient("apig", region)
 	if err != nil {
 		return diag.Errorf("error creating APIG client: %s", err)
 	}
@@ -360,8 +359,7 @@ func unbindPluginsFromApis(client *golangsdk.ServiceClient, instanceId, apiId, e
 
 func resourceApiBatchPluginsAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.NewServiceClient(region, "apig")
+	client, err := cfg.NewServiceClient("apig", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG client: %s", err)
 	}
@@ -433,8 +431,7 @@ func getConfiguredPluginIdsForApi(d *schema.ResourceData) []interface{} {
 
 func resourceApiBatchPluginsAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.NewServiceClient(region, "apig")
+	client, err := cfg.NewServiceClient("apig", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating APIG client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixed errors that occurred when obtaining the client.
<img width="725" height="141" alt="image" src="https://github.com/user-attachments/assets/76641050-6111-4fce-ad2e-0ddacaf7562a" />


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccApiBatchPluginsAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApiBatchPluginsAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccApiBatchPluginsAssociate_basic
=== PAUSE TestAccApiBatchPluginsAssociate_basic
=== CONT  TestAccApiBatchPluginsAssociate_basic
--- PASS: TestAccApiBatchPluginsAssociate_basic (279.33s)
PASS
coverage: 9.8% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      279.430s        coverage: 9.8% of statements in ./huaweicloud/services/apig
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
