### PR TITLE
feat(ccm): ccm certificate resource support config tags

### DIFF
--- a/docs/resources/ccm_certificate.md
+++ b/docs/resources/ccm_certificate.md
@@ -119,6 +119,8 @@ is set to **MULTI_DOMAIN**.
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
   For enterprise users, if omitted, default enterprise project will be used.
 
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the resource.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -195,8 +197,8 @@ $ terraform import huaweicloud_ccm_certificate.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `effective_time`, `single_domain_number`.
-It is generally recommended running `terraform plan` after importing a resource.
+API response, security or some other reason. The missing attributes include: `effective_time`, `single_domain_number`,
+`tags`. It is generally recommended running `terraform plan` after importing a resource.
 You can then decide if changes should be applied to the resource, or the resource definition
 should be updated to align with the resource. Also, you can ignore changes as below.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

ccm certificate resource support config tags

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o ccm -f TestAccCCMCertificate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ccm" -v -coverprofile="./huaweicloud/services/acceptance/ccm/ccm_coverage.cov" -coverpkg="./huaweicloud/services/ccm" -run TestAccCCMCertificate_basic -timeout 360m -parallel 10
=== RUN   TestAccCCMCertificate_basic
=== PAUSE TestAccCCMCertificate_basic
=== CONT  TestAccCCMCertificate_basic
--- PASS: TestAccCCMCertificate_basic (78.78s)
PASS
coverage: 10.9% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       78.897s coverage: 10.9% of statements in ./huaweicloud/services/ccm
```
<img width="1312" height="39" alt="image" src="https://github.com/user-attachments/assets/1f6e521d-1cd2-4f68-8944-3881d2134e10" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
