### PR TITLE
refactor(iam/password_poliy): optimize codes and docs for resource

### DIFF
--- a/docs/resources/identityv5_password_policy.md
+++ b/docs/resources/identityv5_password_policy.md
@@ -3,17 +3,16 @@ subcategory: "Identity and Access Management (IAM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_identityv5_password_policy"
 description: |-
-  Manages the account password policy v5 resource within HuaweiCloud.
+  Manages the account password policy resource within HuaweiCloud.
 ---
 
 # huaweicloud_identityv5_password_policy
 
-Manages the account password policy v5 resource within HuaweiCloud.
+Manages the account password policy resource within HuaweiCloud.
 
--> **NOTE:**
-  You *must* have admin privileges to use this resource.  
-  This resource overwrites an existing configuration, make sure one resource per account.  
-  During action `terraform destroy` it sets values the same as defaults for this resource.
+-> 1. You **must** have admin privileges to use this resource.
+  <br>2. This resource overwrites an existing configuration, make sure one resource per account.  
+  <br>3. During action `terraform destroy` it sets values the same as defaults for this resource.
 
 ## Example Usage
 
@@ -35,49 +34,55 @@ resource "huaweicloud_identityv5_password_policy" "test" {
 The following arguments are supported:
 
 * `maximum_consecutive_identical_chars` - (Optional, Int) Specifies the maximum number of times that a character is
-  allowed to consecutively present in a password. The value ranges from `0` to `32` and defaults to `0` which
-  indicates that consecutive identical characters are allowed in a password. For example, value `2` indicates that
-  two consecutive identical characters are not allowed in a password.
+  allowed to consecutively present in a password.  
+  The valid value ranges from `0` to `32`.  
+  Defaults to `0`, it means consecutive identical characters are allowed.
 
-* `minimum_password_age` - (Optional, Int) Specifies the minimum period (minutes) after which users are allowed to make
-  a password change. The value ranges from `0` to `1,440` and defaults to `0`.
+* `minimum_password_age` - (Optional, Int) Specifies the minimum password usage time, in minutes.  
+  The valid value ranges from `0` to `1,440`, defaults to `0`.
 
-* `minimum_password_length` - (Optional, Int) Specifies the minimum number of characters that a password must contain.
-  The value ranges from `8` to `32` and defaults to `8`.
+* `minimum_password_length` - (Optional, Int) Specifies the minimum number of characters that a password
+  must contain.  
+  The valid value ranges from `8` to `32`, defaults to `8`.
 
 * `password_reuse_prevention` - (Optional, Int) Specifies the password cannot be repeated with historical passwords
-  for a certain number of times. The value ranges from `0` to `24` and defaults to `1`. For example, value `3`
-  indicates that the user cannot set the last three passwords that the user has previously used when setting a new
-  password.
+  for a certain number of times.  
+  The valid value ranges from `0` to `24`.  
+  Defaults to `1`, it means the user cannot set the last one password that the user has previously used when setting
+  a new password.
 
 * `password_not_username_or_invert` - (Optional, Bool) Specifies whether the password can be the username or the
-  username spelled backwards. Defaults to `true`, which indicates that the username or the inversion of username
-  is not allowed to be used as a password.
+  username spelled backwards.  
+  Defaults to **true**, it means the username or the inversion of username is not allowed to be used as a password.
 
-* `password_validity_period` - (Optional, Int) Specifies the password validity period (days).
-  The value ranges from `0` to `180` and defaults to `0` which indicates that this requirement does not apply.
+* `password_validity_period` - (Optional, Int) Specifies the password validity period, in days.
+  The valid value ranges from `0` to `180`.  
+  Defaults to `0`, it means this requirement does not apply.
 
 * `password_char_combination` - (Optional, Int) Specifies the minimum number of character types that a password must
-  contain. The value ranges from `2` to `4` and defaults to `2` which indicates that a password must contain at least
-  two of the following: uppercase letters, lowercase letters, digits, and special characters.
+  contain.  
+  The valid value ranges from `2` to `4`.  
+  Defaults to `2`, it means a password must contain at least two of the following: uppercase letters, lowercase
+  letters, digits, and special characters.
 
 * `allow_user_to_change_password` - (Optional, Bool) Specifies whether IAM users are allowed to change their own
-  passwords, which does not apply to the root user. Defaults to `true`, which indicates IAM users are allowed to
-  change their own passwords.
+  passwords.  
+  Defaults to **true**.  
+  This parameter does not apply to the root user.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Indicates the ID of account password policy, which is the same as the account ID.
+* `id` - The resource ID, also the domain (account) ID.
 
-* `maximum_password_length` - Indicates the maximum number of characters that a password can contain.
+* `maximum_password_length` - The maximum number of characters that a password can contain.
 
-* `password_requirements` - Indicates the requirements of character that passwords must include.
+* `password_requirements` - The requirements of character that passwords must include.
 
 ## Import
 
-The IAM v5 password policy can be imported using the account ID or domain ID, e.g.
+The IAM v5 password policy can be imported using the `id`, e.g.
 
 ```bash
 $ terraform import huaweicloud_identityv5_password_policy.test <id>

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3413,7 +3413,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identityv5_user_password":               iam.ResourceIdentityV5UserPassword(),
 			"huaweicloud_identityv5_login_profile":               iam.ResourceV5LoginProfile(),
 			"huaweicloud_identityv5_login_policy":                iam.ResourceV5LoginPolicy(),
-			"huaweicloud_identityv5_password_policy":             iam.ResourceIdentityV5PasswordPolicy(),
+			"huaweicloud_identityv5_password_policy":             iam.ResourceV5PasswordPolicy(),
 			"huaweicloud_identityv5_policy_default_version":      iam.ResourceV5PolicyDefaultVersion(),
 			"huaweicloud_identityv5_policy_group_attach":         iam.ResourceV5PolicyGroupAttach(),
 			"huaweicloud_identityv5_policy_user_attach":          iam.ResourceV5PolicyUserAttach(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_password_policy_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_password_policy_test.go
@@ -7,42 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 )
-
-func getV5PasswordPolicy(client *golangsdk.ServiceClient) (interface{}, error) {
-	httpUrl := "v5/password-policy"
-	getPath := client.Endpoint + httpUrl
-	getOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	resp, err := client.Request("GET", getPath, &getOpt)
-	if err != nil {
-		return nil, err
-	}
-
-	respBody, err := utils.FlattenResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	if utils.PathSearch("password_policy.maximum_consecutive_identical_chars", respBody, float64(0)).(float64) != 0 ||
-		utils.PathSearch("password_policy.minimum_password_age", respBody, float64(0)).(float64) != 0 ||
-		utils.PathSearch("password_policy.minimum_password_length", respBody, float64(0)).(float64) != 8 ||
-		utils.PathSearch("password_policy.password_reuse_prevention", respBody, float64(0)).(float64) != 1 ||
-		!utils.PathSearch("password_policy.password_not_username_or_invert", respBody, false).(bool) ||
-		utils.PathSearch("password_policy.password_validity_period", respBody, float64(0)).(float64) != 0 ||
-		utils.PathSearch("password_policy.password_char_combination", respBody, float64(0)).(float64) != 2 ||
-		!utils.PathSearch("password_policy.allow_user_to_change_password", respBody, false).(bool) {
-		return respBody, nil
-	}
-
-	return nil, golangsdk.ErrDefault404{}
-}
 
 func getV5PasswordPolicyFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
 	client, err := cfg.NewServiceClient("iam", acceptance.HW_REGION_NAME)
@@ -50,7 +18,7 @@ func getV5PasswordPolicyFunc(cfg *config.Config, _ *terraform.ResourceState) (in
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
 
-	return getV5PasswordPolicy(client)
+	return iam.GetV5PasswordPolicy(client)
 }
 
 // Please ensure that the user executing the acceptance test has 'admin' permission.

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_password_policy.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_password_policy.go
@@ -14,15 +14,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// ResourceIdentityV5PasswordPolicy
 // @API IAM PUT /v5/password-policy
 // @API IAM GET /v5/password-policy
-func ResourceIdentityV5PasswordPolicy() *schema.Resource {
+func ResourceV5PasswordPolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIdentityV5PasswordPolicyUpdate,
-		ReadContext:   resourceIdentityV5PasswordPolicyRead,
-		UpdateContext: resourceIdentityV5PasswordPolicyUpdate,
-		DeleteContext: resourceIdentityV5PasswordPolicyDelete,
+		CreateContext: resourceV5PasswordPolicyUpdate,
+		ReadContext:   resourceV5PasswordPolicyRead,
+		UpdateContext: resourceV5PasswordPolicyUpdate,
+		DeleteContext: resourceV5PasswordPolicyDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -30,79 +29,95 @@ func ResourceIdentityV5PasswordPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"maximum_consecutive_identical_chars": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The maximum number of consecutive identical characters.`,
 			},
 			"minimum_password_age": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The minimum password usage time, in minutes.`,
 			},
 			"minimum_password_length": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     8,
+				Description: `The minimum number of characters that a password must contain.`,
 			},
 			"password_reuse_prevention": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     1,
+				Description: `The password cannot be repeated with historical for a certain number of times.`,
 			},
 			"password_not_username_or_invert": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether the password can be the username or the username spelled backwards.`,
 			},
 			"password_validity_period": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The password validity period, in days.`,
 			},
 			"password_char_combination": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     2,
+				Description: `The minimum number of character types that a password must contain.`,
 			},
 			"allow_user_to_change_password": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether IAM users are allowed to change their own passwords.`,
 			},
-
 			"maximum_password_length": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The maximum number of characters that a password can contain.`,
 			},
 			"password_requirements": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The requirements of character that passwords must include.`,
 			},
 		},
 	}
 }
 
-func resourceIdentityV5PasswordPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV5PasswordPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating IAM Client: %s", err)
+		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
-	createPasswordPolicyHttpUrl := "v5/password-policy"
-	createPasswordPolicyPath := iamClient.Endpoint + createPasswordPolicyHttpUrl
-	createPasswordPolicyOpt := golangsdk.RequestOpts{
+	httpUrl := "v5/password-policy"
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         buildCreatePasswordPolicyOptBodyParams(d),
+		JSONBody:         buildCreateV5PasswordPolicyBodyParams(d),
 	}
 
-	_, err = iamClient.Request("PUT", createPasswordPolicyPath, &createPasswordPolicyOpt)
+	_, err = client.Request("PUT", createPath, &createOpt)
 	if err != nil {
 		return diag.Errorf("error creating IAM password policy: %s", err)
 	}
+
 	if d.IsNewResource() {
 		d.SetId(cfg.DomainID)
 	}
-	return resourceIdentityV5PasswordPolicyRead(ctx, d, meta)
+
+	return resourceV5PasswordPolicyRead(ctx, d, meta)
 }
 
-func buildCreatePasswordPolicyOptBodyParams(d *schema.ResourceData) map[string]interface{} {
-	bodyParams := map[string]interface{}{
+func buildCreateV5PasswordPolicyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
 		"maximum_consecutive_identical_chars": d.Get("maximum_consecutive_identical_chars"),
 		"minimum_password_age":                d.Get("minimum_password_age"),
 		"minimum_password_length":             d.Get("minimum_password_length"),
@@ -112,53 +127,82 @@ func buildCreatePasswordPolicyOptBodyParams(d *schema.ResourceData) map[string]i
 		"password_char_combination":           d.Get("password_char_combination"),
 		"allow_user_to_change_password":       d.Get("allow_user_to_change_password"),
 	}
-	return bodyParams
 }
 
-func resourceIdentityV5PasswordPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+func GetV5PasswordPolicy(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v5/password-policy"
+	getPath := client.Endpoint + httpUrl
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return diag.Errorf("error creating IAM Client: %s", err)
+		return nil, err
 	}
 
-	getPasswordPolicyHttpUrl := "v5/password-policy"
-	getPasswordPolicyPath := iamClient.Endpoint + getPasswordPolicyHttpUrl
-	getPasswordPolicyOpt := golangsdk.RequestOpts{KeepResponseBody: true}
-	getPasswordPolicyResp, err := iamClient.Request("GET", getPasswordPolicyPath, &getPasswordPolicyOpt)
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	passwordPolicy := utils.PathSearch("password_policy", respBody, nil)
+	if utils.PathSearch("maximum_consecutive_identical_chars", passwordPolicy, float64(0)).(float64) != 0 ||
+		utils.PathSearch("minimum_password_age", passwordPolicy, float64(0)).(float64) != 0 ||
+		utils.PathSearch("minimum_password_length", passwordPolicy, float64(0)).(float64) != 8 ||
+		utils.PathSearch("password_reuse_prevention", passwordPolicy, float64(0)).(float64) != 1 ||
+		!utils.PathSearch("password_not_username_or_invert", passwordPolicy, false).(bool) ||
+		utils.PathSearch("password_validity_period", passwordPolicy, float64(0)).(float64) != 0 ||
+		utils.PathSearch("password_char_combination", passwordPolicy, float64(0)).(float64) != 2 ||
+		!utils.PathSearch("allow_user_to_change_password", passwordPolicy, false).(bool) {
+		return passwordPolicy, nil
+	}
+
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/v5/password-policy",
+			RequestId: "NONE",
+			Body:      []byte("All configurations of password policy have been restored to the default value"),
+		},
+	}
+}
+
+func resourceV5PasswordPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	passwordPolicy, err := GetV5PasswordPolicy(client)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error fetching the IAM account password policy")
 	}
-	getPasswordPolicyRespBody, err := utils.FlattenResponse(getPasswordPolicyResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
 
 	mErr := multierror.Append(
-		d.Set("maximum_consecutive_identical_chars", utils.PathSearch("password_policy.maximum_consecutive_identical_chars",
-			getPasswordPolicyRespBody, nil)),
-		d.Set("maximum_password_length", utils.PathSearch("password_policy.maximum_password_length", getPasswordPolicyRespBody, nil)),
-		d.Set("minimum_password_age", utils.PathSearch("password_policy.minimum_password_age", getPasswordPolicyRespBody, nil)),
-		d.Set("minimum_password_length", utils.PathSearch("password_policy.minimum_password_length", getPasswordPolicyRespBody, nil)),
-		d.Set("password_reuse_prevention", utils.PathSearch("password_policy.password_reuse_prevention", getPasswordPolicyRespBody, nil)),
-		d.Set("password_not_username_or_invert", utils.PathSearch("password_policy.password_not_username_or_invert", getPasswordPolicyRespBody, nil)),
-		d.Set("password_requirements", utils.PathSearch("password_policy.password_requirements", getPasswordPolicyRespBody, nil)),
-		d.Set("password_validity_period", utils.PathSearch("password_policy.password_validity_period", getPasswordPolicyRespBody, nil)),
-		d.Set("password_char_combination", utils.PathSearch("password_policy.password_char_combination", getPasswordPolicyRespBody, nil)),
-		d.Set("allow_user_to_change_password", utils.PathSearch("password_policy.allow_user_to_change_password", getPasswordPolicyRespBody, nil)),
+		d.Set("maximum_consecutive_identical_chars", utils.PathSearch("maximum_consecutive_identical_chars", passwordPolicy, nil)),
+		d.Set("maximum_password_length", utils.PathSearch("maximum_password_length", passwordPolicy, nil)),
+		d.Set("minimum_password_age", utils.PathSearch("minimum_password_age", passwordPolicy, nil)),
+		d.Set("minimum_password_length", utils.PathSearch("minimum_password_length", passwordPolicy, nil)),
+		d.Set("password_reuse_prevention", utils.PathSearch("password_reuse_prevention", passwordPolicy, nil)),
+		d.Set("password_not_username_or_invert", utils.PathSearch("password_not_username_or_invert", passwordPolicy, nil)),
+		d.Set("password_requirements", utils.PathSearch("password_requirements", passwordPolicy, nil)),
+		d.Set("password_validity_period", utils.PathSearch("password_validity_period", passwordPolicy, nil)),
+		d.Set("password_char_combination", utils.PathSearch("password_char_combination", passwordPolicy, nil)),
+		d.Set("allow_user_to_change_password", utils.PathSearch("allow_user_to_change_password", passwordPolicy, nil)),
 	)
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceIdentityV5PasswordPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV5PasswordPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	iamClient, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
+	client, err := cfg.NewServiceClient("iam", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating IAM Client: %s", err)
+		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
 	deletePasswordPolicyHttpUrl := "v5/password-policy"
-	deletePasswordPolicyPath := iamClient.Endpoint + deletePasswordPolicyHttpUrl
+	deletePasswordPolicyPath := client.Endpoint + deletePasswordPolicyHttpUrl
 	deletePasswordPolicyOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		JSONBody: map[string]interface{}{
@@ -173,7 +217,7 @@ func resourceIdentityV5PasswordPolicyDelete(_ context.Context, d *schema.Resourc
 		},
 	}
 
-	_, err = iamClient.Request("PUT", deletePasswordPolicyPath, &deletePasswordPolicyOpt)
+	_, err = client.Request("PUT", deletePasswordPolicyPath, &deletePasswordPolicyOpt)
 	if err != nil {
 		return diag.Errorf("error resetting the IAM account password policy: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The current code has the following issues and needs optimization:

- Redundant method naming
- Fields in the schema lack descriptions
- Some error messages are inaccurate
- Some content in the documentation is inaccurately described
- Some code is not standardized

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update functions naming
2. add a description to each field in the schema
3. correcting inaccurate error messages 
4. improve and optimize documentation and code
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV5PasswordPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5PasswordPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccV5PasswordPolicy_basic
=== PAUSE TestAccV5PasswordPolicy_basic
=== CONT  TestAccV5PasswordPolicy_basic
--- PASS: TestAccV5PasswordPolicy_basic (38.52s)
PASS
coverage: 2.4% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       38.628s coverage: 2.4% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
     <img width="1263" height="857" alt="image" src="https://github.com/user-attachments/assets/c0234966-7686-4013-95df-8a41fe034692" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
