### PR TITLE
feat(hss): support `hss_event_severity` data source

### DIFF
--- a/docs/data-sources/hss_event_severity.md
+++ b/docs/data-sources/hss_event_severity.md
@@ -1,0 +1,166 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_event_severity"
+description: |-
+  Use this data source to get the list of HSS event severity levels within HuaweiCloud.
+---
+
+# huaweicloud_hss_event_severity
+
+Use this data source to get the list of HSS event severity levels within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable category {}
+
+data "huaweicloud_hss_event_severity" "test" {
+  category = var.category
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `category` - (Required, String) Specifies the event category.  
+  Valid values are:
+  + **host**: Host security event.
+  + **container**: Container security event.
+  + **serverless**: Serverless scenario security event.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `begin_time` - (Optional, Int) Specifies the start time, 13-digit timestamp. Must be less than or equal to `end_time`.
+  If `end_time` is not passed, the current time will be queried by default.
+
+* `end_time` - (Optional, Int) Specifies the end time, 13-digit timestamp. Must be greater than or equal to
+  `begin_time`. If `begin_time` is not passed, the query will start from timestamp 0 by default.
+
+* `last_days` - (Optional, Int) Specifies the number of days for query time range.
+  Mutually exclusive with custom query time `begin_time` and `end_time`.
+
+* `host_name` - (Optional, String) Specifies the server name.
+
+* `host_id` - (Optional, String) Specifies the server ID.
+
+* `private_ip` - (Optional, String) Specifies the server private IP.
+
+* `public_ip` - (Optional, String) Specifies the server public IP.
+
+* `container_name` - (Optional, String) Specifies the container instance name.
+
+* `event_type` - (Optional, Int) Specifies the event type.  
+  The valid values are as follows:
+  + **1001**: Common malware.
+  + **1002**: Virus.
+  + **1003**: Worm.
+  + **1004**: Trojan.
+  + **1005**: Botnet.
+  + **1006**: Backdoor.
+  + **1010**: Rootkit.
+  + **1011**: Ransomware.
+  + **1012**: Hacker tool.
+  + **1015**: Web shell.
+  + **1016**: Mining.
+  + **1017**: Reverse shell.
+  + **2001**: Common vulnerability exploit.
+  + **2012**: Remote code execution.
+  + **2047**: Redis vulnerability exploit.
+  + **2048**: Hadoop vulnerability exploit.
+  + **2049**: MySQL vulnerability exploit.
+  + **3002**: File privilege escalation.
+  + **3003**: Process privilege escalation.
+  + **3004**: Critical file change.
+  + **3005**: File/directory change.
+  + **3007**: Abnormal process behavior.
+  + **3015**: High-risk command execution.
+  + **3018**: Abnormal shell.
+  + **3026**: Crontab privilege escalation.
+  + **3027**: Suspicious crontab task.
+  + **3029**: System protection disabled.
+  + **3030**: Backup deletion.
+  + **3031**: Suspicious registry operations.
+  + **3036**: Container image blocking.
+  + **4002**: Brute-force attack.
+  + **4004**: Abnormal login.
+  + **4006**: Invalid accounts.
+  + **4014**: Account added.
+  + **4020**: Password theft.
+  + **6002**: Port scan.
+  + **6003**: Server scan.
+  + **13001**: Kubernetes event deletion.
+  + **13002**: Abnormal pod behavior.
+  + **13003**: Enumerating user information.
+  + **13004**: Cluster role binding.
+
+* `handle_status` - (Optional, String) Specifies the handle status.  
+  Valid values are:
+  + **unhandled**: Not handled.
+  + **handled**: Handled.
+
+* `severity` - (Optional, String) Specifies the threat level.  
+  Valid values are:
+  + **Security**: Security.
+  + **Low**: Low risk.
+  + **Medium**: Medium risk.
+  + **High**: High risk.
+  + **Critical**: Critical.
+
+* `severity_list` - (Optional, List) Specifies the threat level list. Valid values are the same as `severity`.
+
+* `attack_tag` - (Optional, String) Specifies the attack identifier.  
+  Valid values are:
+  + **attack_success**: Attack succeeded.
+  + **attack_attempt**: Attack attempted.
+  + **attack_blocked**: Attack blocked.
+  + **abnormal_behavior**: Abnormal behavior.
+  + **collapsible_host**: Host compromised.
+  + **system_vulnerability**: System vulnerability.
+
+* `asset_value` - (Optional, String) Specifies the asset importance.  
+  Valid values are:
+  + **important**: Important asset.
+  + **common**: Common asset.
+  + **test**: Test asset.
+
+* `tag_list` - (Optional, List) Specifies the event tag list, for example: `["热点事件"]`.
+
+* `att_ck` - (Optional, String) Specifies the ATT&CK attack level.  
+  Valid values are:
+  + **Reconnaissance**
+  + **Initial Access**
+  + **Execution**
+  + **Persistence**
+  + **Privilege Escalation**
+  + **Defense Evasion**
+  + **Credential Access**
+  + **Command and Control**
+  + **Impact**
+
+* `event_name` - (Optional, String) Specifies the alarm name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_num` - The total number.
+
+* `low_num` - The number of low risk.
+
+* `medium_num` - The number of medium  risk.
+
+* `high_num` - The number of high risk.
+
+* `critical_num` - The number of critical risk.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1495,6 +1495,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_event_login_white_lists":                    hss.DataSourceEventLoginWhiteLists(),
 			"huaweicloud_hss_event_alarm_white_lists":                    hss.DataSourceEventAlarmWhiteLists(),
 			"huaweicloud_hss_event_types":                                hss.DataSourceEventTypes(),
+			"huaweicloud_hss_event_severity":                             hss.DataSourceEventSeverity(),
 			"huaweicloud_hss_event_unblock_ips":                          hss.DataSourceEventUnblockIps(),
 			"huaweicloud_hss_files_change_hosts":                         hss.DataSourceFilesChangeHosts(),
 			"huaweicloud_hss_files_statistic":                            hss.DataSourceFilesStatistic(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_event_severity_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_event_severity_test.go
@@ -1,0 +1,55 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEventSeverity_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_event_severity.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceEventSeverity_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "low_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "medium_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "high_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "critical_num"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceEventSeverity_basic() string {
+	return `
+data "huaweicloud_hss_event_severity" "test" {
+  category              = "host"
+  enterprise_project_id = "all_granted_eps"
+  begin_time            = "1768287600000"
+  end_time              = "1768298400000"
+  event_type            = 1001
+  handle_status         = "unhandled"
+  severity              = "Security"
+  severity_list         = ["Security", "Low"]
+  attack_tag            = "attack_success"
+  asset_value           = "common"
+  tag_list              = ["热点事件"]
+  att_ck                = "Reconnaissance"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_event_severity.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_event_severity.go
@@ -1,0 +1,227 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/event/severity
+func DataSourceEventSeverity() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEventSeverityRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"begin_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"last_days": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"container_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"event_type": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"handle_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"severity": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"severity_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"attack_tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"asset_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tag_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"att_ck": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"event_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"low_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"medium_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"high_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"critical_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildEventSeverityQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := fmt.Sprintf("?category=%s", d.Get("category"))
+	severityList := d.Get("severity_list").([]interface{})
+	tagList := d.Get("tag_list").([]interface{})
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+
+	for _, key := range []string{
+		"begin_time",
+		"end_time",
+		"last_days",
+		"host_name",
+		"host_id",
+		"private_ip",
+		"public_ip",
+		"container_name",
+		"event_type",
+		"handle_status",
+		"severity",
+		"attack_tag",
+		"asset_value",
+		"att_ck",
+		"event_name",
+	} {
+		if v, ok := d.GetOk(key); ok {
+			queryParams = fmt.Sprintf("%s&%s=%v", queryParams, key, v)
+		}
+	}
+
+	if len(severityList) > 0 {
+		for _, v := range severityList {
+			queryParams = fmt.Sprintf("%s&severity_list=%v", queryParams, v)
+		}
+	}
+
+	if len(tagList) > 0 {
+		for _, v := range tagList {
+			queryParams = fmt.Sprintf("%s&tag_list=%v", queryParams, v)
+		}
+	}
+
+	return queryParams
+}
+
+func dataSourceEventSeverityRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/event/severity"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildEventSeverityQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS event severity: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", utils.PathSearch("total_num", respBody, nil)),
+		d.Set("low_num", utils.PathSearch("low_num", respBody, nil)),
+		d.Set("medium_num", utils.PathSearch("medium_num", respBody, nil)),
+		d.Set("high_num", utils.PathSearch("high_num", respBody, nil)),
+		d.Set("critical_num", utils.PathSearch("critical_num", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_event_severity` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_event_severity` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceEventSeverity_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceEventSeverity_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceEventSeverity_basic
=== PAUSE TestAccDataSourceEventSeverity_basic
=== CONT  TestAccDataSourceEventSeverity_basic
--- PASS: TestAccDataSourceEventSeverity_basic (13.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       13.410s
```
<img width="879" height="38" alt="image" src="https://github.com/user-attachments/assets/3d5b8c10-180d-40b6-8552-e48c1e54b7a1" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
