### PR TITLE
feat(iam): add new datasource for iam to query roles

### DIFF
--- a/docs/data-sources/identity_roles.md
+++ b/docs/data-sources/identity_roles.md
@@ -1,0 +1,140 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_identity_roles"
+description: |-
+  Use this data source to query the list of IAM roles within HuaweiCloud.
+---
+
+# huaweicloud_identity_roles
+
+Use this data source to query the list of IAM roles within HuaweiCloud.
+
+-> You *must* have IAM read privileges to use this data source.
+
+## Example Usage
+
+### Query All System Roles
+
+```hcl
+data "huaweicloud_identity_roles" "all" {
+}
+```
+
+### Query Roles by Display Name
+
+```hcl
+variable "display_name" {}
+
+data "huaweicloud_identity_roles" "by_display_name" {
+  display_name = var.display_name
+}
+```
+
+### Query Roles by Catalog
+
+```hcl
+data "huaweicloud_identity_roles" "by_catalog" {
+  catalog = "ELB"
+}
+```
+
+### Query Custom Policies
+
+```hcl
+variable "domain_id" {}
+
+data "huaweicloud_identity_roles" "custom" {
+  domain_id = var.domain_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Optional, String) Specifies the display name of the role to be queried.  
+  This parameter can be used to filter roles by permission name:
+  + **Permission name**: If you set this parameter to **ECS FullAccess**, the information about this permission
+    will be returned.
+  + **Filter condition**: If you set this parameter to **Administrator**, all administrator permissions that match
+    the condition will be returned.
+
+* `name` - (Optional, String) Specifies the name of the role to be queried.  
+  The system internal name of the permission.  
+  For example, the name of **CCS User** permission is **ccs_user**.  
+  It is recommended to use the `display_name` parameter.
+
+* `catalog` - (Optional, String) Specifies the catalog of the role to be queried.  
+  The service catalog of the permission.
+
+* `type` - (Optional, String) Specifies the display mode of the role to be queried.  
+  The valid values are as follows:
+  + **domain**: Returns roles with type **AA** and **AX**.
+  + **project**: Returns roles with type **AA** and **XA**.
+  + **all**: Returns roles with type **AA**, **AX** and **XA**.
+
+  -> The type values in the response have the following meanings:<br>
+     **AX** indicates displayed at the domain level;<br>
+     **XA** indicates displayed at the project level;<br>
+     **AA** indicates displayed at both domain and project levels;<br>
+     **XX** indicates not displayed at either domain or project level.
+
+* `permission_type` - (Optional, String) Specifies the permission type of the role to be queried.  
+  The valid values are as follows:
+  + **policy**: Returns system policies.
+  + **role**: Returns system roles.
+
+  -> This parameter takes effect when the `domain_id` parameter is empty.
+
+* `domain_id` - (Optional, String) Specifies the domain ID to be queried.  
+  If this parameter is specified, only custom policies of the account are returned.  
+  If this parameter is not specified, all system permissions (including system policies and system roles) are returned.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `roles` - The list of the roles.
+  The [roles](#identity_roles_attr) structure is documented below.
+
+<a name="identity_roles_attr"></a>
+The `roles` block supports:
+
+* `id` - The ID of the role.
+
+* `name` - The name of the role.
+
+* `display_name` - The display name of the role.
+
+* `description` - The description of the role.
+
+* `description_cn` - The description of the role in Chinese.
+
+* `catalog` - The catalog of the role.
+
+* `type` - The display mode of the role.
+
+* `flag` - The flag of the role.
+
+* `domain_id` - The domain ID of the role. This field is only returned for custom policies.
+
+* `policy` - The content of the role, in JSON format.
+
+* `created_at` - The creation time of the role, in RFC339 format.
+
+* `updated_at` - The last update time of the role, in RFC339 format.
+
+* `links` - The links of the role.
+  The [links](#identity_roles_links_attr) structure is documented below.
+
+<a name="identity_roles_links_attr"></a>
+The `links` block supports:
+
+* `self` - The self link of the role.
+
+* `previous` - The previous link of the role.
+
+* `next` - The next link of the role.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1615,6 +1615,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_identity_permissions":                  iam.DataSourceIdentityPermissions(),
 			"huaweicloud_identity_role":                         iam.DataSourceIdentityRole(),
+			"huaweicloud_identity_roles":                        iam.DataSourceV3Roles(),
 			"huaweicloud_identity_custom_role":                  iam.DataSourceIdentityCustomRole(),
 			"huaweicloud_identity_federation_domains":           iam.DataSourceIdentityFederationDomains(),
 			"huaweicloud_identity_federation_projects":          iam.DataSourceIdentityFederationProjects(),

--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_roles_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_roles_test.go
@@ -1,0 +1,193 @@
+package iam
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataV3Roles_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_identity_roles.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byDisplayName   = "data.huaweicloud_identity_roles.filter_by_display_name"
+		dcByDisplayName = acceptance.InitDataSourceCheck(byDisplayName)
+
+		byCatalog   = "data.huaweicloud_identity_roles.filter_by_catalog"
+		dcByCatalog = acceptance.InitDataSourceCheck(byCatalog)
+
+		byType   = "data.huaweicloud_identity_roles.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byPermissionType   = "data.huaweicloud_identity_roles.filter_by_permission_type"
+		dcByPermissionType = acceptance.InitDataSourceCheck(byPermissionType)
+
+		byDomainId   = "data.huaweicloud_identity_roles.filter_by_domain_id"
+		dcByDomainId = acceptance.InitDataSourceCheck(byDomainId)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPrecheckDomainId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataV3Roles_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "roles.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByDisplayName.CheckResourceExists(),
+					resource.TestCheckOutput("display_name_filter_is_useful", "true"),
+					dcByCatalog.CheckResourceExists(),
+					resource.TestCheckOutput("catalog_filter_is_useful", "true"),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					dcByPermissionType.CheckResourceExists(),
+					resource.TestCheckOutput("permission_type_filter_is_useful", "true"),
+					dcByDomainId.CheckResourceExists(),
+					resource.TestCheckOutput("domain_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataV3Roles_base(name string) string {
+	return fmt.Sprintf(`
+variable "role_configs" {
+  type = list(object({
+    suffix      = string
+    description = string
+    action      = string
+  }))
+  default = [
+    {
+      suffix      = "1"
+      description = "Created by terraform script for acc test 1"
+      action      = "obs:bucket:GetBucketAcl"
+    },
+    {
+      suffix      = "2"
+      description = "Created by terraform script for acc test 2"
+      action      = "ecs:servers:list"
+    },
+  ]
+}
+
+resource "huaweicloud_identity_role" "test" {
+  count = length(var.role_configs)
+
+  name        = "%[1]s_${var.role_configs[count.index].suffix}"
+  description = var.role_configs[count.index].description
+  type        = "AX"
+  policy      = jsonencode({
+    Version = "1.1"
+
+    Statement = [
+      {
+        Action = [var.role_configs[count.index].action]
+        Effect = "Allow"
+      }
+    ]
+  })
+}
+`, name)
+}
+
+func testAccDataV3Roles_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# All
+data "huaweicloud_identity_roles" "all" {
+  depends_on = [huaweicloud_identity_role.test]
+}
+
+# Filter by display_name
+locals {
+  display_name = try(data.huaweicloud_identity_roles.all.roles[0].display_name, "NOT_FOUND")
+}
+
+data "huaweicloud_identity_roles" "filter_by_display_name" {
+  display_name = local.display_name
+}
+
+locals {
+  display_name_filter_result = [
+    for v in data.huaweicloud_identity_roles.filter_by_display_name.roles[*].display_name : v == local.display_name
+  ]
+}
+
+output "display_name_filter_is_useful" {
+  value = length(local.display_name_filter_result) > 0 && alltrue(local.display_name_filter_result)
+}
+
+# Filter by catalog
+locals {
+  catalog = try(data.huaweicloud_identity_roles.all.roles[0].catalog, "NOT_FOUND")
+}
+
+data "huaweicloud_identity_roles" "filter_by_catalog" {
+  catalog = local.catalog
+}
+
+locals {
+  catalog_filter_result = [
+    for v in data.huaweicloud_identity_roles.filter_by_catalog.roles[*].catalog : v == local.catalog
+  ]
+}
+
+output "catalog_filter_is_useful" {
+  value = length(local.catalog_filter_result) > 0 && alltrue(local.catalog_filter_result)
+}
+
+# Filter by type
+locals {
+  type = "all"
+}
+
+data "huaweicloud_identity_roles" "filter_by_type" {
+  type    = local.type
+  catalog = "OBS"
+}
+
+output "type_filter_is_useful" {
+  value = length(data.huaweicloud_identity_roles.filter_by_type.roles) > 0
+}
+
+# Filter by permission_type
+locals {
+  permission_type = "policy"
+}
+
+data "huaweicloud_identity_roles" "filter_by_permission_type" {
+  permission_type = local.permission_type
+  catalog         = "VPC"
+}
+
+output "permission_type_filter_is_useful" {
+  value = length(data.huaweicloud_identity_roles.filter_by_permission_type.roles) > 0
+}
+
+# Filter by domain_id (custom policies)
+data "huaweicloud_identity_roles" "filter_by_domain_id" {
+  domain_id = "%[2]s"
+
+  depends_on = [huaweicloud_identity_role.test]
+}
+
+output "domain_id_filter_is_useful" {
+  value = length(data.huaweicloud_identity_roles.filter_by_domain_id.roles) >= 2
+}
+`, testAccDataV3Roles_base(name), acceptance.HW_DOMAIN_ID)
+}

--- a/huaweicloud/services/iam/data_source_huaweicloud_identity_roles.go
+++ b/huaweicloud/services/iam/data_source_huaweicloud_identity_roles.go
@@ -1,0 +1,297 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IAM GET /v3/roles
+func DataSourceV3Roles() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV3RolesRead,
+
+		Schema: map[string]*schema.Schema{
+			// Optional parameters.
+			"display_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The display name of the role to be queried.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the role to be queried.`,
+			},
+			"catalog": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The catalog of the role to be queried.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The display mode of the role to be queried.`,
+			},
+			"permission_type": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   `The permission type of the role to be queried.`,
+				ConflictsWith: []string{"domain_id"},
+			},
+			"domain_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The domain ID to be queried.`,
+			},
+
+			// Attributes.
+			"roles": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the roles.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the role.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the role.`,
+						},
+						"display_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The display name of the role.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the role.`,
+						},
+						"description_cn": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the role in Chinese.`,
+						},
+						"catalog": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The catalog of the role.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The display mode of the role.`,
+						},
+						"flag": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The flag of the role.`,
+						},
+						"domain_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The domain ID of the role.`,
+						},
+						"policy": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The content of the role, in JSON format.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the role, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The last update time of the role, in RFC3339 format.`,
+						},
+						"links": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The links of the role.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"self": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The self link of the role.`,
+									},
+									"previous": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The previous link of the role.`,
+									},
+									"next": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The next link of the role.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildV3RolesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("display_name"); ok {
+		res = fmt.Sprintf("%s&display_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("catalog"); ok {
+		res = fmt.Sprintf("%s&catalog=%v", res, v)
+	}
+	if v, ok := d.GetOk("type"); ok {
+		res = fmt.Sprintf("%s&type=%v", res, v)
+	}
+	if v, ok := d.GetOk("permission_type"); ok {
+		res = fmt.Sprintf("%s&permission_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("domain_id"); ok {
+		res = fmt.Sprintf("%s&domain_id=%v", res, v)
+	}
+
+	return res
+}
+
+func flattenV3RoleLinks(links map[string]interface{}) []map[string]interface{} {
+	if len(links) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"self":     utils.PathSearch("self", links, nil),
+			"previous": utils.PathSearch("previous", links, nil),
+			"next":     utils.PathSearch("next", links, nil),
+		},
+	}
+}
+
+func flattenV3Roles(roles []interface{}) []map[string]interface{} {
+	if len(roles) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(roles))
+	for _, role := range roles {
+		createdAt, _ := strconv.ParseInt(utils.PathSearch("created_time", role, "").(string), 10, 64)
+		updatedAt, _ := strconv.ParseInt(utils.PathSearch("updated_time", role, "").(string), 10, 64)
+
+		result = append(result, map[string]interface{}{
+			"id":             utils.PathSearch("id", role, nil),
+			"name":           utils.PathSearch("name", role, nil),
+			"display_name":   utils.PathSearch("display_name", role, nil),
+			"description":    utils.PathSearch("description", role, nil),
+			"description_cn": utils.PathSearch("description_cn", role, nil),
+			"catalog":        utils.PathSearch("catalog", role, nil),
+			"type":           utils.PathSearch("type", role, nil),
+			"flag":           utils.PathSearch("flag", role, nil),
+			"domain_id":      utils.PathSearch("domain_id", role, nil),
+			"policy":         utils.JsonToString(utils.PathSearch("policy", role, nil)),
+			"created_at":     utils.FormatTimeStampRFC3339(createdAt/1000, false),
+			"updated_at":     utils.FormatTimeStampRFC3339(updatedAt/1000, false),
+			"links": flattenV3RoleLinks(
+				utils.PathSearch("links", role, make(map[string]interface{})).(map[string]interface{})),
+		})
+	}
+
+	return result
+}
+
+func listV3Roles(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v3/roles?per_page={per_page}"
+		result  = make([]interface{}, 0)
+		page    = 1
+		perPage = 300
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{per_page}", strconv.Itoa(perPage))
+	listPath += buildV3RolesQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithPage := fmt.Sprintf("%s&page=%s", listPath, strconv.Itoa(page))
+
+		resp, err := client.Request("GET", listPathWithPage, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		roles := utils.PathSearch("roles", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, roles...)
+		if len(roles) < perPage {
+			break
+		}
+		page++
+	}
+
+	return result, nil
+}
+
+func dataSourceV3RolesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("iam", region)
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	roles, err := listV3Roles(client, d)
+	if err != nil {
+		return diag.Errorf("error querying roles: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("roles", flattenV3Roles(roles)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Add new datasource for IAM to query roles.

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:

**Release note**:
<img width="1411" height="978" alt="image" src="https://github.com/user-attachments/assets/af594b54-dc0d-4dc9-9c90-d4b3d57a6890" />

```release-note
1. Implement provider functionality
2. Add comprehensive test suite
3. Create resource documentation
```

## PR Checklist
* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccDataV3Roles_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV3Roles_basic
=== PAUSE TestAccDataV3Roles_basic
=== CONT  TestAccDataV3Roles_basic
--- PASS: TestAccDataV3Roles_basic (18.11s)
PASS
coverage: 3.1% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       18.244s coverage: 3.1% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.