### PR TITLE
chore: test(rds): update attribute type and optimize acceptance tests

### DIFF
--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_database_privileges_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_database_privileges_test.go
@@ -2,6 +2,7 @@ package rds
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,24 +10,41 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccMysqlDatabasePrivileges_basic(t *testing.T) {
-	name := acceptance.RandomAccResourceName()
-	rName := "data.huaweicloud_rds_mysql_database_privileges.test"
+func TestAccDataMysqlDatabasePrivileges_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
 
-	dc := acceptance.InitDataSourceCheck(rName)
+		all = "data.huaweicloud_rds_mysql_database_privileges.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byUserName   = "data.huaweicloud_rds_mysql_database_privileges.filter_by_user_name"
+		dcByUserName = acceptance.InitDataSourceCheck(byUserName)
+
+		byReadonly   = "data.huaweicloud_rds_mysql_database_privileges.filter_by_readonly"
+		dcByReadonly = acceptance.InitDataSourceCheck(byReadonly)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source: "hashicorp/random",
+				// The version of the random provider must be greater than 3.3.0 to support the 'numeric' parameter.
+				VersionConstraint: "3.3.0",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMysqlDatabasePrivileges_basic(name),
+				Config: testAccDataMysqlDatabasePrivileges_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(rName, "users.#"),
-					resource.TestCheckResourceAttrSet(rName, "users.0.name"),
-					resource.TestCheckResourceAttrSet(rName, "users.0.readonly"),
+					resource.TestMatchResourceAttr(all, "users.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByUserName.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(byUserName, "users.0.name"),
+					resource.TestCheckResourceAttrSet(byUserName, "users.0.readonly"),
 					resource.TestCheckOutput("user_name_filter_is_useful", "true"),
+					dcByReadonly.CheckResourceExists(),
 					resource.TestCheckOutput("readonly_filter_is_useful", "true"),
 				),
 			},
@@ -34,30 +52,62 @@ func TestAccMysqlDatabasePrivileges_basic(t *testing.T) {
 	})
 }
 
-func testAccMysqlDatabasePrivileges_basic(name string) string {
+func testAccDataMysqlDatabasePrivileges_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
+
+resource "huaweicloud_rds_mysql_database_privilege" "test" {
+  # The behavior of parameter 'name' of the database resource is 'Required', means this parameter does not
+  # have 'Know After Apply' behavior.
+  depends_on = [huaweicloud_rds_mysql_database.test]
+
+  instance_id = huaweicloud_rds_instance.test.id
+  db_name     = huaweicloud_rds_mysql_database.test.name
+  
+  dynamic "users" {
+    for_each = slice(huaweicloud_rds_mysql_account.test[*].name, 0, 1)
+
+    content {
+      name     = users.value
+      readonly = false
+    }
+  }
+  dynamic "users" {
+    for_each = slice(huaweicloud_rds_mysql_account.test[*].name, 1, 2)
+
+    content {
+      name     = users.value
+      readonly = true
+    }
+  }
+}
 
 data "huaweicloud_rds_mysql_database_privileges" "test" {
-  depends_on  = [huaweicloud_rds_mysql_database_privilege.test]
+  # The behavior of parameter 'instance_id' and 'db_name' of the privilege resource is 'Required', means this
+  # parameter does not have 'Know After Apply' behavior.
+  depends_on = [huaweicloud_rds_mysql_database_privilege.test]
+
   instance_id = huaweicloud_rds_mysql_database_privilege.test.instance_id
   db_name     = huaweicloud_rds_mysql_database_privilege.test.db_name
 }
 
 locals {
-  user_name = huaweicloud_rds_mysql_account.test_1.name
+  user_name = huaweicloud_rds_mysql_account.test[0].name # The first account is the one with the read-and-write permission.
 }
 
-data "huaweicloud_rds_mysql_database_privileges" "user_name_filter" {
-  depends_on  = [huaweicloud_rds_mysql_database_privilege.test]
+data "huaweicloud_rds_mysql_database_privileges" "filter_by_user_name" {
+  # The behavior of parameter 'instance_id' and 'db_name' of the privilege resource is 'Required', means this
+  # parameter does not have 'Know After Apply' behavior.
+  depends_on = [huaweicloud_rds_mysql_database_privilege.test]
+
   instance_id = huaweicloud_rds_mysql_database_privilege.test.instance_id
   db_name     = huaweicloud_rds_mysql_database_privilege.test.db_name
   user_name   = local.user_name
 }
 
 output "user_name_filter_is_useful" {
-  value = length(data.huaweicloud_rds_mysql_database_privileges.user_name_filter.users) > 0 && alltrue(
-  [for v in data.huaweicloud_rds_mysql_database_privileges.user_name_filter.users[*].name : v == local.user_name]
+  value = length(data.huaweicloud_rds_mysql_database_privileges.filter_by_user_name.users) > 0 && alltrue(
+    [for v in data.huaweicloud_rds_mysql_database_privileges.filter_by_user_name.users[*].name : v == local.user_name]
   )
 }
 
@@ -65,18 +115,20 @@ locals {
   readonly = tolist(huaweicloud_rds_mysql_database_privilege.test.users)[0].readonly
 }
 
-data "huaweicloud_rds_mysql_database_privileges" "readonly_filter" {
-  depends_on  = [huaweicloud_rds_mysql_database_privilege.test]
+data "huaweicloud_rds_mysql_database_privileges" "filter_by_readonly" {
+  # The behavior of parameter 'instance_id' and 'db_name' of the privilege resource is 'Required', means this
+  # parameter does not have 'Know After Apply' behavior.
+  depends_on = [huaweicloud_rds_mysql_database_privilege.test]
+
   instance_id = huaweicloud_rds_mysql_database_privilege.test.instance_id
   db_name     = huaweicloud_rds_mysql_database_privilege.test.db_name
   readonly    = local.readonly
 }
 
 output "readonly_filter_is_useful" {
-  value = length(data.huaweicloud_rds_mysql_database_privileges.readonly_filter.users) > 0 && alltrue(
-  [for v in data.huaweicloud_rds_mysql_database_privileges.readonly_filter.users[*].readonly : v == local.readonly]
-)
+  value = length(data.huaweicloud_rds_mysql_database_privileges.filter_by_readonly.users) > 0 && alltrue(
+    [for v in data.huaweicloud_rds_mysql_database_privileges.filter_by_readonly.users[*].readonly : v == local.readonly]
+  )
 }
-
-`, testAccRdsDatabasePrivilege_basic(name))
+`, testAccMysqlDatabasePrivilege_basic_base(name))
 }

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_mysql_database_privileges.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_mysql_database_privileges.go
@@ -44,7 +44,7 @@ func DataSourceRdsMysqlDatabasePrivileges() *schema.Resource {
 				Optional: true,
 			},
 			"users": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     usersSchema(),
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Incorrect attribute behavior of data source `huaweicloud_rds_mysql_database_privileges`: the schema type of attribute 'users' should be `TypeList`, but got `TypeSet`. we cannot tracing the element via simple indexes (hash numbers are used for TypeSet).

And the acceptance tests of resource and data source for MySQL database privilege is not standard.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. change the behavior of attribute 'users' from TypeSet to TypeList
2. optimize the acceptance tests of MySQL database privilege
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o rds -f TestAccMysqlDatabasePrivilege_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rds" -v -coverprofile="./huaweicloud/services/acceptance/rds/rds_coverage.cov" -coverpkg="./huaweicloud/services/rds" -run TestAccMysqlDatabasePrivilege_basic -timeout 360m -parallel 10
=== RUN   TestAccMysqlDatabasePrivilege_basic
=== PAUSE TestAccMysqlDatabasePrivilege_basic
=== CONT  TestAccMysqlDatabasePrivilege_basic
--- PASS: TestAccMysqlDatabasePrivilege_basic (704.51s)
PASS
coverage: 10.4% of statements in ./huaweicloud/services/rds
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       704.600s        coverage: 10.4% of statements in ./huaweicloud/services/rds
```
```
./scripts/coverage.sh -o rds -f TestAccDataMysqlDatabasePrivileges_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rds" -v -coverprofile="./huaweicloud/services/acceptance/rds/rds_coverage.cov" -coverpkg="./huaweicloud/services/rds" -run TestAccDataMysqlDatabasePrivileges_basic -timeout 360m -parallel 10
=== RUN   TestAccDataMysqlDatabasePrivileges_basic
=== PAUSE TestAccDataMysqlDatabasePrivileges_basic
=== CONT  TestAccDataMysqlDatabasePrivileges_basic
--- PASS: TestAccDataMysqlDatabasePrivileges_basic (722.95s)
PASS
coverage: 10.8% of statements in ./huaweicloud/services/rds
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       723.121s        coverage: 10.8% of statements in ./huaweicloud/services/rds
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
