### PR TITLE
fix(dms): fix rabbitmq queue consumerDetails.channelDetails type error

### DIFF
--- a/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_queue.go
+++ b/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_queue.go
@@ -306,33 +306,32 @@ func flattenConsumerDetails(paramsList []interface{}) interface{} {
 	rst := make([]interface{}, 0, len(paramsList))
 	for _, params := range paramsList {
 		rst = append(rst, map[string]interface{}{
-			"consumer_tag":    utils.PathSearch("consumer_tag", params, nil),
-			"channel_details": flattenChannelDetails(utils.PathSearch("channel_details", params, make([]interface{}, 0)).([]interface{})),
-			"ack_required":    utils.PathSearch("ack_required", params, nil),
-			"prefetch_count":  utils.PathSearch("prefetch_count", params, nil),
+			"consumer_tag": utils.PathSearch("consumer_tag", params, nil),
+			"channel_details": flattenChannelDetails(utils.PathSearch("channel_details", params,
+				make(map[string]interface{})).(map[string]interface{})),
+			"ack_required":   utils.PathSearch("ack_required", params, nil),
+			"prefetch_count": utils.PathSearch("prefetch_count", params, nil),
 		})
 	}
 
 	return rst
 }
 
-func flattenChannelDetails(paramsList []interface{}) interface{} {
-	if len(paramsList) == 0 {
+func flattenChannelDetails(channelDetails map[string]interface{}) []map[string]interface{} {
+	if len(channelDetails) == 0 {
 		return nil
 	}
-	rst := make([]interface{}, 0, len(paramsList))
-	for _, params := range paramsList {
-		rst = append(rst, map[string]interface{}{
-			"name":            utils.PathSearch("name", params, nil),
-			"number":          utils.PathSearch("number", params, nil),
-			"user":            utils.PathSearch("user", params, nil),
-			"connection_name": utils.PathSearch("connection_name", params, nil),
-			"peer_host":       utils.PathSearch("peer_host", params, nil),
-			"peer_port":       utils.PathSearch("peer_port", params, nil),
-		})
-	}
 
-	return rst
+	return []map[string]interface{}{
+		{
+			"name":            utils.PathSearch("name", channelDetails, nil),
+			"number":          utils.PathSearch("number", channelDetails, nil),
+			"user":            utils.PathSearch("user", channelDetails, nil),
+			"connection_name": utils.PathSearch("connection_name", channelDetails, nil),
+			"peer_host":       utils.PathSearch("peer_host", channelDetails, nil),
+			"peer_port":       utils.PathSearch("peer_port", channelDetails, nil),
+		},
+	}
 }
 
 func flattenQueueBingdings(paramsList []interface{}) interface{} {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixed type error in RabbitMQ Queue `consumer_details.channel_details` that caused deserialization 
failures during state synchronization when subscriptions were present.

**Root Cause:** The `consumer_details.channel_details` field was incorrectly typed, causing the 
provider to fail when parsing API responses for queues with active 
subscriptions.

**Impact:** Any Terraform operation requiring queue data retrieval 
(plan, apply, refresh) would fail with a parsing error.

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
nothing

**Release note**:

```release-note
1. change the schema of resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rabbitmq" -v -coverprofile="./huaweicloud/services/acceptance/rabbitmq/rabbitmq_coverage.cov" -coverpkg="./huaweicloud/services/rabbitmq" -run TestAccRabbitmqQueue_basic -timeout 360m -parallel 10
=== RUN   TestAccRabbitmqQueue_basic
=== PAUSE TestAccRabbitmqQueue_basic
=== CONT  TestAccRabbitmqQueue_basic
--- PASS: TestAccRabbitmqQueue_basic (592.62s)
PASS
coverage: 18.1% of statements in ./huaweicloud/services/rabbitmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rabbitmq  592.739s        coverage: 18.1% of statements in ./huaweicloud/services/rabbitmq
```

RabbitMQ queues now successfully synchronize server-side state. Parsing errors resolved.
<img width="971" height="443" alt="2d6e6b50fcf5d27fc09d5ff083dc7689" src="https://github.com/user-attachments/assets/bfd3371e-8355-4408-852b-29a957fd0e55" />

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
