### PR TITLE
feat(oms): add new data source to query OMS supported cloud vendors

### DIFF
--- a/docs/data-sources/oms_cloud_type_venders.md
+++ b/docs/data-sources/oms_cloud_type_venders.md
@@ -1,0 +1,39 @@
+---
+subcategory: "Object Storage Migration Service (OMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_oms_cloud_type_venders"
+description: |-
+  Use this data source to query OMS supported cloud venders.
+---
+
+# huaweicloud_oms_cloud_type_venders
+
+Use this data source to query OMS supported cloud venders.
+
+## Example Usage
+
+```hcl
+variable "type" {}
+
+data "huaweicloud_oms_cloud_type_venders" "test" {
+  type = var.type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Required, String) Specifies the connection end type.
+  The value can be **src** (source) or **dst** (destination).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` -  The data source ID.
+
+* `venders` - The list of supported cloud venders.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1864,6 +1864,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_obs_buckets":       obs.DataSourceObsBuckets(),
 			"huaweicloud_obs_bucket_object": obs.DataSourceObsBucketObject(),
 
+			"huaweicloud_oms_cloud_type_venders":   oms.DataSourceCloudTypeVenders(),
 			"huaweicloud_oms_migration_sync_tasks": oms.DataSourceMigrationSyncTasks(),
 
 			"huaweicloud_ram_resource_permissions":                  ram.DataSourceResourcePermissions(),

--- a/huaweicloud/services/acceptance/oms/data_source_huaweicloud_oms_cloud_type_venders_test.go
+++ b/huaweicloud/services/acceptance/oms/data_source_huaweicloud_oms_cloud_type_venders_test.go
@@ -1,0 +1,38 @@
+package oms
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCloudTypeVenders_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_oms_cloud_type_venders.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCloudTypeVenders_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "venders.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceCloudTypeVenders_basic = `
+data "huaweicloud_oms_cloud_type_venders" "test" {
+  type = "src"
+}
+`

--- a/huaweicloud/services/oms/data_source_huaweicloud_oms_cloud_type_venders.go
+++ b/huaweicloud/services/oms/data_source_huaweicloud_oms_cloud_type_venders.go
@@ -1,0 +1,85 @@
+package oms
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API OMS GET /v2/{project_id}/objectstorage/cloud-type
+func DataSourceCloudTypeVenders() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCloudTypeVendersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"venders": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceCloudTypeVendersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/{project_id}/objectstorage/cloud-type?type={type}"
+		sourceType = d.Get("type").(string)
+	)
+
+	client, err := cfg.NewServiceClient("oms", region)
+	if err != nil {
+		return diag.Errorf("error creating OMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{type}", sourceType)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the OMS supported cloud venders: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("venders", utils.PathSearch("[*]", respBody, make([]interface{}, 0)).([]interface{})),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query OMS supported cloud venders.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source to query OMS supported cloud venders.
2. add corresponding acceptance test and documentation.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/oms" TESTARGS="-run TestAccDataSourceObjectstorageCloudType_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/oms -v -run TestAccDataSourceObjectstorageCloudType_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceObjectstorageCloudType_basic
--- PASS: TestAccDataSourceObjectstorageCloudType_basic (18.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/oms       18.794s
```
<img width="1208" height="19" alt="image" src="https://github.com/user-attachments/assets/6cd134af-4561-4a3c-b205-1a0c351c270a" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
