### PR TITLE
refactor(iam/v5_group_membership): resource only support local script management

### DIFF
--- a/docs/resources/identityv5_group_membership.md
+++ b/docs/resources/identityv5_group_membership.md
@@ -10,6 +10,10 @@ description: |-
 
 Manages an IAM group membership resource within HuaweiCloud.
 
+-> If this resource was imported and no changes were deployed before deletion (a change must be triggered to apply the
+   `users` configured in the script), terraform will delete all bound users in specified group.
+   Otherwise, terraform will only delete the bound users managed by the last change.
+
 ## Example Usage
 
 ```hcl
@@ -20,7 +24,14 @@ variable "user_ids" {
 
 resource "huaweicloud_identityv5_group_membership" "test" {
   group_id     = var.user_group_id
-  user_id_list = var.user_ids
+
+  dynamic "users" {
+    for_each = var.user_ids
+
+    content {
+      user_id = users.value
+    }
+  }
 }
 ```
 
@@ -30,7 +41,13 @@ The following arguments are supported:
 
 * `group_id` - (Required, String, NonUpdatable) Specifies the ID of the user group.
 
-* `user_id_list` - (Required, List) Specifies the list of user IDs to associate with the group.
+* `users` - (Required, List) Specifies the list of users to associate with the group.  
+  The [users](#v5_group_membership_users) structure is documented below.
+
+<a name="v5_group_membership_users"></a>
+The `users` block supports:
+
+* `user_id` - (Required, String) Specifies the ID of the user.
 
 ## Attribute Reference
 
@@ -39,12 +56,10 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The resource ID.
 
 * `users` - The list of users associated with the group.  
-  The [users](#v5_group_membership_users) structure is documented below.
+  The [users](#v5_group_membership_users_attr) structure is documented below.
 
-<a name="v5_group_membership_users"></a>
+<a name="v5_group_membership_users_attr"></a>
 The `users` block supports:
-
-* `user_id` - The ID of the user.
 
 * `user_name` - The name of the user.
 

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_group_membership_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identityv5_group_membership_test.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,11 +19,194 @@ func getV5GroupMembershipFunc(cfg *config.Config, state *terraform.ResourceState
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
 
-	return iam.GetV5GroupassociateUsers(client, state.Primary.ID)
+	return iam.GetV5GroupassociateUsers(client, state.Primary.ID, nil)
 }
 
 // Please ensure that the user executing the acceptance test has 'admin' permission.
 func TestAccV5GroupMembership_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		obj    interface{}
+		rName  = "huaweicloud_identityv5_group_membership.test"
+		rName2 = "huaweicloud_identityv5_group_membership.test2"
+		rc     = acceptance.InitResourceCheck(rName, &obj, getV5GroupMembershipFunc)
+		rc2    = acceptance.InitResourceCheck(rName2, &obj, getV5GroupMembershipFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rc.CheckResourceDestroy(),
+			rc2.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV5GroupMembership_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "group_id", "huaweicloud_identityv5_group.test", "id"),
+					resource.TestMatchResourceAttr(rName, "user_id_list.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(rName, "users.#", "2"),
+					resource.TestCheckResourceAttr(rName, "users_origin.#", "2"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.user_id"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.user_name"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.is_root_user"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.urn"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.enabled"),
+					rc2.CheckResourceExists(),
+					// Users number is the sum of itself and the number of huaweicloud_identityv5_user.test, so it is 3.
+					resource.TestCheckResourceAttr(rName2, "users.#", "3"),
+					resource.TestCheckResourceAttr(rName2, "users_origin.#", "1"),
+				),
+			},
+			{
+				Config: testAccV5GroupMembership_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					// After resources refreshed, the users will be overridden as all users under the same group.
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "users.#", "3"),
+					resource.TestCheckResourceAttr(rName, "users_origin.#", "2"),
+					rc2.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName2, "users.#", "3"),
+					resource.TestCheckResourceAttr(rName2, "users_origin.#", "1"),
+				),
+			},
+			{
+				Config: testAccV5GroupMembership_basic_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					// When multiple resources are used to manage the same group, users will store the results
+					// modified by other resources, resulting in users displaying all binding results except for the
+					// first change.
+					resource.TestMatchResourceAttr(rName, "users.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(rName, "users_origin.#", "1"),
+					rc2.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName2, "users.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(rName2, "users_origin.#", "1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"users_origin", // Only different in the acceptance test.
+					"users",        // The order in the script differs from the order returned by the API.
+				},
+			},
+			// After importing the resources, users will contain all the users under the same group.
+			{
+				Config: testAccV5GroupMembership_basic_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "users.#", "2"),
+					resource.TestCheckResourceAttr(rName, "users_origin.#", "1"),
+					rc2.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName2, "users.#", "2"),
+					resource.TestCheckResourceAttr(rName2, "users_origin.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccV5GroupMembership_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identityv5_group" "test" {
+  group_name = "%[1]s"
+}
+
+resource "huaweicloud_identityv5_user" "test" {
+  count = 4
+
+  name        = "%[1]s${count.index}"
+  description = "Created %[1]s${count.index} by terraform"
+  enabled     = true
+}
+
+locals {
+  user_ids = huaweicloud_identityv5_user.test[*].id
+}
+`, name)
+}
+
+func testAccV5GroupMembership_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_identityv5_group_membership" "test" {
+  group_id     = huaweicloud_identityv5_group.test.id
+
+  dynamic "users" {
+    for_each = slice(local.user_ids, 0, 2)
+
+    content {
+      user_id = users.value
+    }
+  }
+}
+
+resource "huaweicloud_identityv5_group_membership" "test2" {
+  group_id     = huaweicloud_identityv5_group.test.id
+
+  dynamic "users" {
+    for_each = slice(local.user_ids, 3, 4)
+
+    content {
+      user_id = users.value
+    }
+  }
+
+  # Wait for the first resource to bind users successfully, then bind new users.
+  depends_on = [huaweicloud_identityv5_group_membership.test]
+}
+`, testAccV5GroupMembership_base(name))
+}
+
+func testAccV5GroupMembership_basic_step2(name string) string {
+	// Refresh users for all resources.
+	return testAccV5GroupMembership_basic_step1(name)
+}
+
+func testAccV5GroupMembership_basic_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_identityv5_group_membership" "test" {
+  group_id     = huaweicloud_identityv5_group.test.id
+
+  dynamic "users" {
+    for_each = slice(local.user_ids, 0, 1)
+
+    content {
+      user_id = users.value
+    }
+  }
+}
+
+resource "huaweicloud_identityv5_group_membership" "test2" {
+  group_id     = huaweicloud_identityv5_group.test.id
+
+  dynamic "users" {
+    for_each = slice(local.user_ids, 2, 3)
+
+    content {
+      user_id = users.value
+    }
+  }
+}
+`, testAccV5GroupMembership_base(name))
+}
+
+// Please ensure that the user executing the acceptance test has 'admin' permission.
+func TestAccV5GroupMembership_deprecated(t *testing.T) {
 	var (
 		name = acceptance.RandomAccResourceName()
 
@@ -40,7 +224,7 @@ func TestAccV5GroupMembership_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccV5GroupMembership_basic_step1(name),
+				Config: testAccV5GroupMembership_deprecated_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "group_id", "huaweicloud_identityv5_group.test", "id"),
@@ -48,27 +232,18 @@ func TestAccV5GroupMembership_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccV5GroupMembership_basic_step2(name),
+				Config: testAccV5GroupMembership_deprecated_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "user_id_list.#", "2"),
 					resource.TestCheckResourceAttr(rName, "users.#", "2"),
-				),
-			},
-			{
-				Config: testAccV5GroupMembership_basic_step3(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "user_id_list.#", "1"),
-					resource.TestCheckResourceAttrPair(rName, "user_id_list.0", "huaweicloud_identityv5_user.test.1", "id"),
-					resource.TestCheckResourceAttr(rName, "users.#", "1"),
-					resource.TestCheckResourceAttrPair(rName, "users.0.user_id", "huaweicloud_identityv5_user.test.1", "id"),
-					resource.TestCheckResourceAttrPair(rName, "users.0.user_name", "huaweicloud_identityv5_user.test.1", "name"),
-					resource.TestCheckResourceAttrPair(rName, "users.0.is_root_user", "huaweicloud_identityv5_user.test.1", "is_root_user"),
-					resource.TestCheckResourceAttrPair(rName, "users.0.created_at", "huaweicloud_identityv5_user.test.1", "created_at"),
-					resource.TestCheckResourceAttrPair(rName, "users.0.urn", "huaweicloud_identityv5_user.test.1", "urn"),
-					resource.TestCheckResourceAttrPair(rName, "users.0.description", "huaweicloud_identityv5_user.test.1", "description"),
-					resource.TestCheckResourceAttrPair(rName, "users.0.enabled", "huaweicloud_identityv5_user.test.1", "enabled"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.user_id"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.user_name"),
+					resource.TestCheckResourceAttr(rName, "users.0.is_root_user", "false"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.urn"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.description"),
+					resource.TestCheckResourceAttr(rName, "users.0.enabled", "true"),
 				),
 			},
 			{
@@ -80,7 +255,7 @@ func TestAccV5GroupMembership_basic(t *testing.T) {
 	})
 }
 
-func testAccV5GroupMembership_base(name string) string {
+func testAccV5GroupMembership_deprecated_base(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identityv5_group" "test" {
   group_name = "%[1]s"
@@ -96,7 +271,7 @@ resource "huaweicloud_identityv5_user" "test" {
 `, name)
 }
 
-func testAccV5GroupMembership_basic_step1(name string) string {
+func testAccV5GroupMembership_deprecated_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -104,10 +279,10 @@ resource "huaweicloud_identityv5_group_membership" "test" {
   group_id     = huaweicloud_identityv5_group.test.id
   user_id_list = slice(huaweicloud_identityv5_user.test[*].id, 0, 2)
 }
-`, testAccV5GroupMembership_base(name))
+`, testAccV5GroupMembership_deprecated_base(name))
 }
 
-func testAccV5GroupMembership_basic_step2(name string) string {
+func testAccV5GroupMembership_deprecated_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -115,16 +290,5 @@ resource "huaweicloud_identityv5_group_membership" "test" {
   group_id     = huaweicloud_identityv5_group.test.id
   user_id_list = slice(huaweicloud_identityv5_user.test[*].id, 1, 3)
 }
-`, testAccV5GroupMembership_base(name))
-}
-
-func testAccV5GroupMembership_basic_step3(name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_identityv5_group_membership" "test" {
-  group_id     = huaweicloud_identityv5_group.test.id
-  user_id_list = slice(huaweicloud_identityv5_user.test[*].id, 1, 2)
-}
-`, testAccV5GroupMembership_base(name))
+`, testAccV5GroupMembership_deprecated_base(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The current resources do not support managing memberships for local script configurations only.

After importing, origin is set to null. Deleting the resource at this point will delete all users bound to this group.
<img width="1812" height="888" alt="image" src="https://github.com/user-attachments/assets/510907b0-f6b1-4427-9c6f-bc8bcd0014c8" />

However, if a meaningful change is made, origin is reset to the last script configuration value, allowing for targeted deletion of some bindings during the deletion phase.
<img width="1774" height="828" alt="image" src="https://github.com/user-attachments/assets/daa03f78-5bcf-4a6e-9c47-af90e208b0d0" />



**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. deprecated 'user_id_list' parameter, and change 'users' and 'users.user_id' to optional behavior.
2. provide an internal field 'users_origin' to record the configuration in the script.
3. because 'users' type is TypeList, it need to be sorted according to the order of origin.
5. resource can only manage custom membership settings in local and ignore remote settings
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```

huawei@wuzhuanhong-dev:~/go/src/terraform-provider-huaweicloud$ ./scripts/coverage.sh -o iam -f TestAccV5GroupMembership_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV5GroupMembership_ -timeout 360m -parallel 10
=== RUN   TestAccV5GroupMembership_basic
=== PAUSE TestAccV5GroupMembership_basic
=== RUN   TestAccV5GroupMembership_deprecated
=== PAUSE TestAccV5GroupMembership_deprecated
=== CONT  TestAccV5GroupMembership_basic
=== CONT  TestAccV5GroupMembership_deprecated
--- PASS: TestAccV5GroupMembership_deprecated (47.50s)
--- PASS: TestAccV5GroupMembership_basic (84.17s)
PASS
coverage: 5.4% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       84.326s coverage: 5.4% of statements in ./huaweicloud/services/iam
```
<img width="974" height="42" alt="image" src="https://github.com/user-attachments/assets/0b7065e7-08aa-4bde-8d77-fc21c36df70c" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found

    When the user managing local scripts has been unbound.
    <img width="1856" height="863" alt="image" src="https://github.com/user-attachments/assets/e97e33c1-25b7-4fd7-adaa-92351e4956de" />
    When there are no users in the user group.
    <img width="1508" height="904" alt="image" src="https://github.com/user-attachments/assets/f1de7510-e7d8-4cfe-9a6c-5ea3319ff270" />



    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
