### PR TITLE
feat(hss): support `hss_container_kubernetes_clusters_daemonsets` data source

### DIFF
--- a/docs/data-sources/hss_container_kubernetes_clusters_daemonsets.md
+++ b/docs/data-sources/hss_container_kubernetes_clusters_daemonsets.md
@@ -1,0 +1,163 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_container_kubernetes_clusters_daemonsets"
+description: |-
+  Use this data source to get the list of HSS container Kubernetes cluster daemonsets within HuaweiCloud.
+---
+
+# huaweicloud_hss_container_kubernetes_clusters_daemonsets
+
+Use this data source to get the list of HSS container Kubernetes cluster daemonsets within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_container_kubernetes_clusters_daemonsets" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `type` - (Optional, String) Specifies the cluster type.  
+  The valid values are as follows:
+  + **cce**: CCE cluster.
+  + **ali**: Alibaba Cloud cluster.
+  + **tencent**: Tencent Cloud cluster.
+  + **azure**: Microsoft Azure cluster.
+  + **aws**: Amazon cluster.
+  + **self_built_hw**: Huawei Cloud self-built cluster.
+  + **self_built_idc**: IDC self-built cluster.
+
+* `show_cluster_log_status` - (Optional, Bool) Specifies whether the query results display the access status of
+  cluster logs. The valid values are **true** and **false**, defaults to **false**.
+
+* `access_status` - (Optional, Bool) Specifies to query based on the access status of the cluster,
+  with **true** indicating access and **false** indicating no access.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_num` - The total number of connected clusters.
+
+* `upgradeful_num` - The total number of clusters to be upgraded.
+
+* `err_running_num` - The total number of abnormal clusters running.
+
+* `err_access_num` - The total number of abnormal cluster connections.
+
+* `data_list` - The data list.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `latest_version` - Is it the latest version.
+
+* `agent_version` - The cluster agent version.
+
+* `cluster_name` - The cluster name.
+
+* `cluster_id` - The cluster ID.
+
+* `namespace` - The namespace.
+
+* `cluster_type` - The cluster type.
+
+* `node_num` - The total number of nodes.
+
+* `ds_info` - The daemonset status.
+
+  The [ds_info](#ds_info_struct) structure is documented below.
+
+* `cluster_status` - The cluster status.  
+  The valid values are as follows:
+  + **Available**: Indicating that the cluster is in a normal state.
+  + **Unavailable**: Indicating cluster anomaly, manual deletion is required or contact the administrator for deletion.
+  + **ScalingUp**: Indicating that the cluster is currently undergoing expansion.
+  + **ScalingDown**: Indicating that the cluster is currently undergoing capacity reduction.
+  + **Creating**: Indicating that the cluster is currently in the process of being created.
+  + **Deleting**: Indicating that the cluster is in the process of being deleted.
+  + **Upgrading**: Indicating that the cluster is currently undergoing an upgrade process.
+  + **Resizing**: The cluster is currently undergoing specification changes.
+  + **RollingBack**: Indicating that the cluster is currently in the process of rolling back.
+  + **RollbackFailed**: Indicating a cluster rollback exception, please contact the administrator for a rollback retry.
+  + **Empty**: The cluster has no resources.
+
+* `installed_status` - The Cluster DS installation status.  
+  The valid values are as follows:
+  + **installing**
+  + **install_success**
+  + **install_failed**
+  + **partically_success**
+  + **upgrade_success**
+  + **upgrade_failed**
+  + **upgrading**
+  + **none**
+
+* `access_status` - The cluster ANP access status.  
+  The valid values are as follows:
+  + **not_connect**
+  + **connect_success**
+  + **connect_fail**
+  + **connect_disruption**
+
+* `combined_status` - The combination state of cluster ANP and DS.  
+  The valid values are as follows:
+  + **accessing**
+  + **access_error**
+  + **running**
+  + **run_error**
+  + **upgrading**
+  + **upgrade_error**
+
+* `failed_message` - The reasons for cluster plugin access failure.
+
+* `cluster_log_status` - The access status of cluster logs.  
+  The valid values are as follows:
+  + **success**
+  + **partial_success**
+
+* `invoked_service` - Call the service to identify the CCE free medical examination report.  
+  The valid values are as follows:
+  + **hss**
+  + **cce**
+
+* `registry_info` - The image warehouse information.
+
+  The [registry_info](#registry_info_struct) structure is documented below.
+
+<a name="ds_info_struct"></a>
+The `ds_info` block supports:
+
+* `desired_num` - The target quantity.
+
+* `current_num` - The current quantity.
+
+* `ready_num` - The ready quantity.
+
+<a name="registry_info_struct"></a>
+The `registry_info` block supports:
+
+* `registry_type` - The image repository type.
+
+* `registry_addr` - The image warehouse address.
+
+* `registry_username` - The image repository username.
+
+* `namespace` - The namespace.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1476,6 +1476,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_kubernetes_endpoint_detail":       hss.DataSourceContainerKubernetesEndpointDetail(),
 			"huaweicloud_hss_container_kubernetes_mcc":                   hss.DataSourceContainerKubernetesMCC(),
 			"huaweicloud_hss_container_kubernetes_template":              hss.DataSourceHssContainerKubernetesTemplate(),
+			"huaweicloud_hss_container_kubernetes_clusters_daemonsets":   hss.DataSourceContainerKubernetesClustersDaemonsets(),
 			"huaweicloud_hss_container_nodes":                            hss.DataSourceContainerNodes(),
 			"huaweicloud_hss_container_node_statistics":                  hss.DataSourceContainerNodeStatistics(),
 			"huaweicloud_hss_container_cluster_risks":                    hss.DataSourceContainerClusterRisks(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_kubernetes_clusters_daemonsets_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_container_kubernetes_clusters_daemonsets_test.go
@@ -1,0 +1,102 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceContainerKubernetesClustersDaemonsets_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_container_kubernetes_clusters_daemonsets.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSCCEProtection(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceContainerKubernetesClustersDaemonsets_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "upgradeful_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "err_running_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "err_access_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.latest_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.agent_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.cluster_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.cluster_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.namespace"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.cluster_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.node_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.ds_info.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.cluster_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.installed_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.access_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.combined_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.registry_info.#"),
+
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceContainerKubernetesClustersDaemonsets_base() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_container_kubernetes_cluster_daemonset" "test" {
+  cluster_id   = "%[1]s"
+  cluster_name = "%[2]s"
+  auto_upgrade = true
+
+  runtime_info {
+    runtime_name = "crio_endpoint"
+    runtime_path = "user/test"
+  }
+
+  schedule_info {
+    node_selector = ["test=test"]
+  }
+}
+`, acceptance.HW_CCE_CLUSTER_ID, acceptance.HW_CCE_CLUSTER_NAME)
+}
+
+func testDataSourceContainerKubernetesClustersDaemonsets_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_hss_container_kubernetes_clusters_daemonsets" "test" {
+  depends_on = [huaweicloud_hss_container_kubernetes_cluster_daemonset.test]
+
+  enterprise_project_id   = "all_granted_eps"
+  show_cluster_log_status = true
+  access_status           = true
+}
+
+# Filter using type.
+locals {
+  type = data.huaweicloud_hss_container_kubernetes_clusters_daemonsets.test.data_list[0].cluster_type
+}
+
+data "huaweicloud_hss_container_kubernetes_clusters_daemonsets" "type_filter" {
+  enterprise_project_id = "all_granted_eps"
+  type                  = local.type
+}
+
+output "type_filter_is_useful" {
+  value = length(data.huaweicloud_hss_container_kubernetes_clusters_daemonsets.type_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_container_kubernetes_clusters_daemonsets.type_filter.data_list[*].cluster_type : v == local.type]
+  )
+}
+`, testDataSourceContainerKubernetesClustersDaemonsets_base())
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_container_kubernetes_clusters_daemonsets.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_container_kubernetes_clusters_daemonsets.go
@@ -1,0 +1,323 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/container/kubernetes/clusters/daemonsets
+func DataSourceContainerKubernetesClustersDaemonsets() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceContainerKubernetesClustersDaemonsetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"show_cluster_log_status": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"access_status": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"upgradeful_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"err_running_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"err_access_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"latest_version": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"agent_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"namespace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"node_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ds_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"desired_num": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"current_num": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"ready_num": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"cluster_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"installed_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"access_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"combined_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"failed_message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_log_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"invoked_service": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"registry_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"registry_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"registry_addr": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"registry_username": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"namespace": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildContainerKubernetesClustersDaemonsetsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("type"); ok {
+		queryParams = fmt.Sprintf("%s&type=%v", queryParams, v)
+	}
+	if d.Get("show_cluster_log_status").(bool) {
+		queryParams = fmt.Sprintf("%s&show_cluster_log_status=%v", queryParams, true)
+	}
+	if d.Get("access_status").(bool) {
+		queryParams = fmt.Sprintf("%s&access_status=%v", queryParams, true)
+	}
+
+	return queryParams
+}
+
+func dataSourceContainerKubernetesClustersDaemonsetsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		product       = "hss"
+		epsId         = cfg.GetEnterpriseProjectID(d)
+		httpUrl       = "v5/{project_id}/container/kubernetes/clusters/daemonsets"
+		result        = make([]interface{}, 0)
+		offset        = 0
+		totalNum      float64
+		upgradefulNum float64
+		errRunningNum float64
+		errAccessNum  float64
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildContainerKubernetesClustersDaemonsetsQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS container kubernetes clusters daemonsets: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalNum = utils.PathSearch("total_num", respBody, float64(0)).(float64)
+		upgradefulNum = utils.PathSearch("upgradeful_num", respBody, float64(0)).(float64)
+		errRunningNum = utils.PathSearch("err_running_num", respBody, float64(0)).(float64)
+		errAccessNum = utils.PathSearch("err_access_num", respBody, float64(0)).(float64)
+		dataListResp := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataListResp) == 0 {
+			break
+		}
+
+		result = append(result, dataListResp...)
+		offset += len(dataListResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", totalNum),
+		d.Set("upgradeful_num", upgradefulNum),
+		d.Set("err_running_num", errRunningNum),
+		d.Set("err_access_num", errAccessNum),
+		d.Set("data_list", flattenDaemonsetsDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDaemonsetsDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"latest_version":     utils.PathSearch("latest_version", v, nil),
+			"agent_version":      utils.PathSearch("agent_version", v, nil),
+			"cluster_name":       utils.PathSearch("cluster_name", v, nil),
+			"cluster_id":         utils.PathSearch("cluster_id", v, nil),
+			"namespace":          utils.PathSearch("namespace", v, nil),
+			"cluster_type":       utils.PathSearch("cluster_type", v, nil),
+			"node_num":           utils.PathSearch("node_num", v, nil),
+			"ds_info":            flattenDataListDsInfo(utils.PathSearch("ds_info", v, nil)),
+			"cluster_status":     utils.PathSearch("cluster_status", v, nil),
+			"installed_status":   utils.PathSearch("installed_status", v, nil),
+			"access_status":      utils.PathSearch("access_status", v, nil),
+			"combined_status":    utils.PathSearch("combined_status", v, nil),
+			"failed_message":     utils.PathSearch("failed_message", v, nil),
+			"cluster_log_status": utils.PathSearch("cluster_log_status", v, nil),
+			"invoked_service":    utils.PathSearch("invoked_service", v, nil),
+			"registry_info": flattenDataListRegistryInfo(
+				utils.PathSearch("registry_info", v, nil)),
+		})
+	}
+
+	return result
+}
+
+func flattenDataListDsInfo(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"desired_num": utils.PathSearch("desired_num", resp, nil),
+			"current_num": utils.PathSearch("current_num", resp, nil),
+			"ready_num":   utils.PathSearch("ready_num", resp, nil),
+		},
+	}
+}
+
+func flattenDataListRegistryInfo(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"registry_type":     utils.PathSearch("registry_type", resp, nil),
+			"registry_addr":     utils.PathSearch("registry_addr", resp, nil),
+			"registry_username": utils.PathSearch("registry_username", resp, nil),
+			"namespace":         utils.PathSearch("namespace", resp, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_container_kubernetes_clusters_daemonsets` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_container_kubernetes_clusters_daemonsets` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceContainerKubernetesClustersDaemonsets_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceContainerKubernetesClustersDaemonsets_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceContainerKubernetesClustersDaemonsets_basic
=== PAUSE TestAccDataSourceContainerKubernetesClustersDaemonsets_basic
=== CONT  TestAccDataSourceContainerKubernetesClustersDaemonsets_basic
--- PASS: TestAccDataSourceContainerKubernetesClustersDaemonsets_basic (19.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       19.609s
```
<img width="1040" height="33" alt="image" src="https://github.com/user-attachments/assets/e1c7817a-4717-4ff8-83a9-ab0ddcf43d2d" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
