### PR TITLE
feat(oms): add data source to query OMS cloud vendor supported regions

### DIFF
--- a/docs/data-sources/oms_cloud_vender_regions.md
+++ b/docs/data-sources/oms_cloud_vender_regions.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Object Storage Migration Service (OMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_oms_cloud_vender_regions"
+description: |-
+  Use this data source to query regions supported for a cloud vender.
+---
+
+# huaweicloud_oms_cloud_vender_regions
+
+Use this data source to query regions supported for a cloud vender.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_oms_cloud_vender_regions" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` -  The data source ID.
+
+* `region_info` - The list of supported regions.
+
+  The [region_info](#oms_cloud_vender_regions_region_info_struct) structure is documented below.
+
+<a name="oms_cloud_vender_regions_region_info_struct"></a>
+The `region_info` block supports:
+
+* `service_name` - The cloud vender name.
+
+* `region_list` - The region details.
+
+  The [region_list](#oms_cloud_vender_regions_region_list_struct) structure is documented below.
+
+<a name="oms_cloud_vender_regions_region_list_struct"></a>
+The `region_list` block supports:
+
+* `cloud_type` - The cloud service name.
+
+* `value` - The region name.
+
+* `description` - The region description.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1877,6 +1877,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_oms_bucket_region":         oms.DataSourceObjectstorageBucketRegion(),
 			"huaweicloud_oms_buckets":               oms.DataSourceObjectstorageBuckets(),
 			"huaweicloud_oms_cloud_type_venders":    oms.DataSourceCloudTypeVenders(),
+			"huaweicloud_oms_cloud_vender_regions":  oms.DataSourceCloudVenderRegions(),
 			"huaweicloud_oms_migration_sync_tasks":  oms.DataSourceMigrationSyncTasks(),
 			"huaweicloud_oms_migration_tasks":       oms.DataSourceMigrationTasks(),
 			"huaweicloud_oms_migration_task_groups": oms.DataSourceMigrationTaskGroups(),

--- a/huaweicloud/services/acceptance/oms/data_source_huaweicloud_oms_cloud_vender_regions_test.go
+++ b/huaweicloud/services/acceptance/oms/data_source_huaweicloud_oms_cloud_vender_regions_test.go
@@ -1,0 +1,39 @@
+package oms
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCloudVenderRegions_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_oms_cloud_vender_regions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCloudVenderRegions_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "region_info.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "region_info.0.service_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "region_info.0.region_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "region_info.0.region_list.0.cloud_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "region_info.0.region_list.0.value"),
+					resource.TestCheckResourceAttrSet(dataSource, "region_info.0.region_list.0.description"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceCloudVenderRegions_basic = `data "huaweicloud_oms_cloud_vender_regions" "test" {}`

--- a/huaweicloud/services/oms/data_source_huaweicloud_oms_cloud_vender_regions.go
+++ b/huaweicloud/services/oms/data_source_huaweicloud_oms_cloud_vender_regions.go
@@ -1,0 +1,141 @@
+package oms
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API OMS GET /v2/{project_id}/objectstorage/data-center
+func DataSourceCloudVenderRegions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCloudVenderRegionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"region_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"service_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cloud_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"description": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCloudVenderRegionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/objectstorage/data-center"
+	)
+
+	client, err := cfg.NewServiceClient("oms", region)
+	if err != nil {
+		return diag.Errorf("error creating OMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the cloud vendor supported regions: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("region_info", flattenCloudVenderRegions(
+			utils.PathSearch("[*]", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCloudVenderRegions(dataList []interface{}) []interface{} {
+	if len(dataList) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(dataList))
+	for _, v := range dataList {
+		rst = append(rst, map[string]interface{}{
+			"service_name": utils.PathSearch("service_name", v, nil),
+			"region_list": flattenObjectstorageRegionList(
+				utils.PathSearch("region_list", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenObjectstorageRegionList(dataList []interface{}) []interface{} {
+	if len(dataList) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(dataList))
+	for _, v := range dataList {
+		rst = append(rst, map[string]interface{}{
+			"cloud_type":  utils.PathSearch("cloud_type", v, nil),
+			"value":       utils.PathSearch("value", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to query OMS cloud vendor supported regions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add  a new data source to query OMS cloud vendor supported regions.
2. add corresponding acceptance test and documentation.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/oms" TESTARGS="-run TestAccDataSourceCloudVenderRegions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/oms -v -run TestAccDataSourceCloudVenderRegions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCloudVenderRegions_basic
--- PASS: TestAccDataSourceCloudVenderRegions_basic (15.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/oms       15.805s
```
<img width="1205" height="22" alt="image" src="https://github.com/user-attachments/assets/805c9e51-cd81-4113-b3a6-e50edbdcbc9d" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
