### PR TITLE
feat(hss): support `hss_webtamper_image_options` data source

### DIFF
--- a/docs/data-sources/hss_webtamper_image_options.md
+++ b/docs/data-sources/hss_webtamper_image_options.md
@@ -1,0 +1,84 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_webtamper_image_options"
+description: |-
+  Use this data source to get the list of HSS web tamper image options within HuaweiCloud.
+---
+
+# huaweicloud_hss_webtamper_image_options
+
+Use this data source to get the list of HSS web tamper image options within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "image_type" {}
+
+data "huaweicloud_hss_webtamper_image_options" "test" {
+  image_type = var.image_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `image_type` - (Required, String) Specifies the type of the image.  
+  The valid values are as follows:
+  + **registry**
+  + **local**
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `registry_type` - (Optional, String) Specifies the image warehouse type for the warehouse image.
+
+* `image_namespace` - (Optional, String) Specifies the organization name of the warehouse image.
+
+* `registry_name` - (Optional, String) Specifies the image warehouse name for the specified warehouse image.
+
+* `image_name` - (Optional, String) Specifies the image name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_num` - The total number.
+
+* `data_list` - The data list.
+
+The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `image_name` - The image name.
+
+* `image_full_name` - The image full name.
+
+* `image_id` - The image ID.
+
+* `image_version_list` - The image version list.
+
+* `image_namespace` - The organization name of the warehouse image.
+
+* `registry_name` - The image warehouse name for the specified warehouse image.
+
+* `registry_type` - The image warehouse type for the warehouse image.  
+  The valid values are as follows:
+  + **SwrPrivate**: SWR private repository.
+  + **SwrShared**: SWR shared repository.
+  + **SwrEnterprise**: SWR enterprise repository.
+  + **Harbor**: Harbor repository.
+  + **Jfrog**: JFrog repository.
+  + **Other**: Other repository.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1589,6 +1589,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_webtamper_rasp_protect_history":             hss.DataSourceWebtamperRaspProtectHistory(),
 			"huaweicloud_hss_webtamper_static_protect_history":           hss.DataSourceWebtamperStaticProtectHistory(),
 			"huaweicloud_hss_webtamper_policy":                           hss.DataSourceWebTamperPolicy(),
+			"huaweicloud_hss_webtamper_image_options":                    hss.DataSourceWebTamperImageOptions(),
 			"huaweicloud_hss_antivirus_custom_scan_policies":             hss.DataSourceAntivirusCustomScanPolicies(),
 			"huaweicloud_hss_antivirus_available_hosts":                  hss.DataSourceAntivirusAvailableHosts(),
 			"huaweicloud_hss_antivirus_statistic":                        hss.DataSourceAntivirusStatistic(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_image_options_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_image_options_test.go
@@ -1,0 +1,110 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceWebTamperImageOptions_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_hss_webtamper_image_options.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceWebTamperImageOptions_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "total_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.image_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.image_full_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.image_version_list.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.image_namespace"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.registry_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data_list.0.registry_type"),
+
+					resource.TestCheckOutput("is_image_namespace_filter_useful", "true"),
+					resource.TestCheckOutput("is_registry_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_image_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_enterprise_project_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceWebTamperImageOptions_basic() string {
+	return `
+data "huaweicloud_hss_webtamper_image_options" "test" {
+  image_type = "registry"
+}
+
+# Filter using image_namespace.
+locals {
+  image_namespace = data.huaweicloud_hss_webtamper_image_options.test.data_list[0].image_namespace
+}
+
+data "huaweicloud_hss_webtamper_image_options" "image_namespace_filter" {
+  image_type      = "registry"
+  image_namespace = local.image_namespace
+}
+
+output "is_image_namespace_filter_useful" {
+  value = length(data.huaweicloud_hss_webtamper_image_options.image_namespace_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_webtamper_image_options.image_namespace_filter.data_list[*].image_namespace : v == local.image_namespace]
+  )
+}
+
+# Filter using registry_name.
+locals {
+  registry_name = data.huaweicloud_hss_webtamper_image_options.test.data_list[0].registry_name
+}
+
+data "huaweicloud_hss_webtamper_image_options" "registry_name_filter" {
+  image_type    = "registry"
+  registry_name = local.registry_name
+}
+
+output "is_registry_name_filter_useful" {
+  value = length(data.huaweicloud_hss_webtamper_image_options.registry_name_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_webtamper_image_options.registry_name_filter.data_list[*].registry_name : v == local.registry_name]
+  )
+}
+
+# Filter using image_name.
+locals {
+  image_name = data.huaweicloud_hss_webtamper_image_options.test.data_list[0].image_name
+}
+
+data "huaweicloud_hss_webtamper_image_options" "image_name_filter" {
+  image_type = "registry"
+  image_name = local.image_name
+}
+
+output "is_image_name_filter_useful" {
+  value = length(data.huaweicloud_hss_webtamper_image_options.image_name_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_webtamper_image_options.image_name_filter.data_list[*].image_name : v == local.image_name]
+  )
+}
+
+# Filter using enterprise_project_id.
+data "huaweicloud_hss_webtamper_image_options" "enterprise_project_id_filter" {
+  image_type            = "registry"
+  enterprise_project_id = "all_granted_eps"
+}
+
+output "is_enterprise_project_id_filter_useful" {
+  value = length(data.huaweicloud_hss_webtamper_image_options.test.data_list) > 0
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_webtamper_image_options.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_webtamper_image_options.go
@@ -1,0 +1,208 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/webtamper/image-options
+func DataSourceWebTamperImageOptions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWebTamperImageOptionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"image_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"registry_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"image_namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"registry_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"image_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"total_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceWebTamperImageOptionsDataListSchema(),
+			},
+		},
+	}
+}
+
+func dataSourceWebTamperImageOptionsDataListSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"image_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_full_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_version_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"image_namespace": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"registry_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"registry_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildWebTamperImageOptionsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+	queryParams = fmt.Sprintf("%s&image_type=%v", queryParams, d.Get("image_type"))
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("registry_type"); ok {
+		queryParams = fmt.Sprintf("%s&registry_type=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("image_namespace"); ok {
+		queryParams = fmt.Sprintf("%s&image_namespace=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("registry_name"); ok {
+		queryParams = fmt.Sprintf("%s&registry_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("image_name"); ok {
+		queryParams = fmt.Sprintf("%s&image_name=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceWebTamperImageOptionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "hss"
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		result   = make([]interface{}, 0)
+		offset   = 0
+		totalNum float64
+		httpUrl  = "v5/{project_id}/webtamper/image-options"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildWebTamperImageOptionsQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS web tamper image options: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalNum = utils.PathSearch("total_num", respBody, float64(0)).(float64)
+		dataListResp := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataListResp) == 0 {
+			break
+		}
+
+		result = append(result, dataListResp...)
+		offset += len(dataListResp)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("total_num", totalNum),
+		d.Set("data_list", flattenWebTamperImageOptionsDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenWebTamperImageOptionsDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"image_name":      utils.PathSearch("image_name", v, nil),
+			"image_full_name": utils.PathSearch("image_full_name", v, nil),
+			"image_id":        utils.PathSearch("image_id", v, nil),
+			"image_version_list": utils.ExpandToStringList(
+				utils.PathSearch("image_version_list", v, make([]interface{}, 0)).([]interface{})),
+			"image_namespace": utils.PathSearch("image_namespace", v, nil),
+			"registry_name":   utils.PathSearch("registry_name", v, nil),
+			"registry_type":   utils.PathSearch("registry_type", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_webtamper_image_options` data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_webtamper_image_options` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceWebTamperImageOptions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceWebTamperImageOptions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWebTamperImageOptions_basic
=== PAUSE TestAccDataSourceWebTamperImageOptions_basic
=== CONT  TestAccDataSourceWebTamperImageOptions_basic
--- PASS: TestAccDataSourceWebTamperImageOptions_basic (13.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       13.820s
```
<img width="935" height="34" alt="image" src="https://github.com/user-attachments/assets/1cd7bd06-f856-472b-afa1-ff8b76d29c95" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
