### PR TITLE
chore(rds): optimize the privilege management resource codes of MySQL database

### DIFF
--- a/docs/resources/rds_mysql_database_privilege.md
+++ b/docs/resources/rds_mysql_database_privilege.md
@@ -37,22 +37,25 @@ resource "huaweicloud_rds_mysql_database_privilege" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the RDS database privilege resource. If omitted,
-  the provider-level region will be used. Changing this creates a new resource.
+* `region` - (Optional, String, ForceNew) The region where the database and users (accounts) are located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
 
-* `instance_id` - (Required, String, NonUpdatable) Specifies the RDS instance ID.
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the MySQL instance.
 
-* `db_name` - (Required, String, NonUpdatable) Specifies the database name.
+* `db_name` - (Required, String, NonUpdatable) Specifies the database name to which the users (accounts) are privileged.
 
-* `users` - (Required, List) Specifies the account that associated with the database. Structure is documented below.
+* `users` - (Required, List) Specifies the user (account) permissions with the database.  
+  The [users](#rds_mysql_database_privilege_users) structure is documented below.
 
+<a name="rds_mysql_database_privilege_users"></a>
 The `users` block supports:
 
 * `name` - (Required, String) Specifies the username of the database account.
 
-* `readonly` - (Optional, Bool) Specifies the read-only permission. The value can be:
-  + **true**: indicates the read-only permission.
-  + **false**: indicates the read and write permission.
+* `readonly` - (Optional, Bool) Specifies whether the user has read-only permission.  
+  The valid values are as follows:
+  + **true**: The database grants the current user **read-only** permission.
+  + **false**: The database grants the current user **read-and-write** permission.
 
   The default value is **false**.
 
@@ -77,3 +80,6 @@ RDS database privilege can be imported using the `instance id` and `db_name`, e.
 ```bash
 $ terraform import huaweicloud_rds_mysql_database_privilege.test <instance_id>/<db_name>
 ```
+
+~> During the import process, all privileges under the database and managed remotely will be synchronized to the
+   `terraform.tfstate` file.

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_database_privilege.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_database_privilege.go
@@ -1,16 +1,11 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product RDS
-// ---------------------------------------------------------------
-
 package rds
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,14 +15,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/pagination"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var mysqlDatabasePrivilegeNonUpdatableParams = []string{"instance_id", "db_name"}
+var (
+	mysqlDatabasePrivilegeNonUpdatableParams = []string{
+		"instance_id",
+		"db_name",
+	}
+	objSliceParamKeysForMysqlDatabasePrivilege = []string{
+		"users",
+	}
+)
 
 // @API RDS DELETE /v3/{project_id}/instances/{instance_id}/db_privilege
 // @API RDS POST /v3/{project_id}/instances/{instance_id}/db_privilege
@@ -35,13 +37,13 @@ var mysqlDatabasePrivilegeNonUpdatableParams = []string{"instance_id", "db_name"
 // @API RDS GET /v3/{project_id}/instances/{instance_id}/database/db_user
 func ResourceMysqlDatabasePrivilege() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceMysqlDatabasePrivilegeCreate,
-		UpdateContext: resourceMysqlDatabasePrivilegeUpdate,
+		CreateContext: resourceMysqlDatabasePrivilegeCreateAndUpdate,
 		ReadContext:   resourceMysqlDatabasePrivilegeRead,
+		UpdateContext: resourceMysqlDatabasePrivilegeCreateAndUpdate,
 		DeleteContext: resourceMysqlDatabasePrivilegeDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: mysqlDatabasePrivilegeImportState,
 		},
 
 		CustomizeDiff: config.FlexibleForceNew(mysqlDatabasePrivilegeNonUpdatableParams),
@@ -54,361 +56,456 @@ func ResourceMysqlDatabasePrivilege() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The region where the database and users (accounts) are located.`,
 			},
+
+			// Required parameters.
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `Specifies the ID of the RDS Mysql instance.`,
+				Description: `The ID of the MySQL instance.`,
 			},
 			"db_name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `Specifies the database name.`,
+				Description: `The database name to which the users (accounts) are privileged.`,
 			},
 			"users": {
-				Type:        schema.TypeSet,
-				Required:    true,
-				Description: `Specifies the account that associated with the database.`,
-				Elem:        mysqlDatabasePrivilegeUserSchema(),
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The username of the database account.`,
+						},
+						"readonly": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							Description: `Whether the user has read-only permission.`,
+						},
+					},
+				},
+				DiffSuppressFunc: utils.SuppressObjectSliceDiffs(),
+				Description:      `The user (account) permissions with the database.`,
 			},
+
+			// Internal parameters.
 			"enable_force_new": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
-				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+
+			// Internal attributes.
+			"users_origin": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: utils.SuppressDiffAll,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Specifies the username of the database account.`,
+						},
+						"readonly": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Specifies the read-only permission.`,
+						},
+					},
+				},
+				Description: utils.SchemaDesc(
+					`The script configuration value of this change is also the original value used for comparison with
+the new value next time the change is made. The corresponding parameter name is 'users'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
 			},
 		},
 	}
 }
 
-func mysqlDatabasePrivilegeUserSchema() *schema.Resource {
-	sc := schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: `Specifies the username of the database account.`,
-			},
-			"readonly": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Computed:    true,
-				Description: `Specifies the read-only permission.`,
-			},
-		},
+func findDeleteUserPrivilegesFromDatabase(oirginUsers, rawConfigUsers []interface{}) []interface{} {
+	if len(oirginUsers) < 1 {
+		return nil
 	}
-	return &sc
+
+	result := make([]interface{}, 0, len(oirginUsers))
+	for _, user := range oirginUsers {
+		if utils.PathSearch(fmt.Sprintf("length([?name == '%v'])", utils.PathSearch("name", user, "")), rawConfigUsers, float64(0)).(float64) < 1 {
+			// If the new user list does not contain this user, it is considered that this user is no longer privileged.
+			result = append(result, user)
+		} else if !utils.PathSearch(fmt.Sprintf("[?name=='%v']|[0].readonly == `%v`",
+			utils.PathSearch("name", user, ""), utils.PathSearch("readonly", user, "")), rawConfigUsers, false).(bool) {
+			// If the read-only permission of this user is different from the new user list, it is considered that this user needs to be updated.
+			result = append(result, user)
+		}
+	}
+	return result
 }
 
-func resourceMysqlDatabasePrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+func buildDeleteUserPrivilegesFromDatabaseRequestBodyUsers(users []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(users))
+	for _, user := range users {
+		result = append(result, map[string]interface{}{
+			"name": utils.ValueIgnoreEmpty(utils.PathSearch("name", user, nil)),
+		})
+	}
+	return result
+}
 
-	// createMysqlDatabasePrivilege: create RDS Mysql database privilege.
-	createMysqlDatabasePrivilegeProduct := "rds"
-	createMysqlDatabasePrivilegeClient, err := cfg.NewServiceClient(createMysqlDatabasePrivilegeProduct, region)
+func buildDeleteUserPrivilegesFromDatabaseBodyParams(dbName string, users []interface{}) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"db_name": dbName,
+		"users":   buildDeleteUserPrivilegesFromDatabaseRequestBodyUsers(users),
+	}
+	return bodyParams
+}
+
+func deleteMysqlDatabasePrivilege(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	users []interface{}, timeout time.Duration) error {
+	var (
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/db_privilege"
+		instanceId = d.Get("instance_id").(string)
+		dbName     = d.Get("db_name").(string)
+
+		start = 0
+		// A single request supports a maximum of 50 users.
+		end = int(math.Min(50, float64(len(users))))
+	)
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+
+	for start < end {
+		opt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         utils.RemoveNil(buildDeleteUserPrivilegesFromDatabaseBodyParams(dbName, users[start:end])),
+		}
+
+		retryFunc := func() (interface{}, bool, error) {
+			_, err := client.Request("DELETE", deletePath, &opt)
+			retry, err := handleMultiOperationsError(err)
+			return nil, retry, err
+		}
+		_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+			Ctx:          ctx,
+			RetryFunc:    retryFunc,
+			WaitFunc:     rdsInstanceStateRefreshFunc(client, instanceId),
+			WaitTarget:   []string{"ACTIVE"},
+			Timeout:      timeout,
+			DelayTimeout: 1 * time.Second,
+			PollInterval: 10 * time.Second,
+		})
+		if err != nil {
+			return fmt.Errorf("error deleting user privileges from MySQL database: %s", err)
+		}
+		start += 50
+		end = int(math.Min(float64(end+50), float64(len(users))))
+	}
+	return nil
+}
+
+func findAddUserPrivilegesToDatabase(rawConfigUsers, remoteStateUsers []interface{}) []interface{} {
+	if len(rawConfigUsers) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(rawConfigUsers))
+	for _, user := range rawConfigUsers {
+		if utils.PathSearch(fmt.Sprintf("length([?name == '%v'])", utils.PathSearch("name", user, "")), remoteStateUsers, float64(0)).(float64) < 1 {
+			// If the old user list does not contain this user, it is considered that this user is a newly privileged user.
+			result = append(result, user)
+		} else if !utils.PathSearch(fmt.Sprintf("[?name=='%v']|[0].readonly == `%v`",
+			utils.PathSearch("name", user, ""), utils.PathSearch("readonly", user, "")), remoteStateUsers, false).(bool) {
+			// If the read-only permission of this user is different from the old user list, it is considered that this user needs to be updated.
+			result = append(result, user)
+		}
+	}
+	return result
+}
+
+func buildAddUserPrivilegesToDatabaseRequestBodyUsers(users []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(users))
+	for _, user := range users {
+		result = append(result, map[string]interface{}{
+			"name":     utils.ValueIgnoreEmpty(utils.PathSearch("name", user, nil)),
+			"readonly": utils.ValueIgnoreEmpty(utils.PathSearch("readonly", user, nil)),
+		})
+	}
+	return result
+}
+
+func buildAddUserPrivilegesToDatabaseBodyParams(dbName string, users []interface{}) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"db_name": dbName,
+		"users":   buildAddUserPrivilegesToDatabaseRequestBodyUsers(users),
+	}
+	return bodyParams
+}
+
+func addPrivilegesToDatabase(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	users []interface{}, timeout time.Duration) error {
+	var (
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/db_privilege"
+		instanceId = d.Get("instance_id").(string)
+		dbName     = d.Get("db_name").(string)
+
+		start = 0
+		// A single request supports a maximum of 50 users.
+		end = int(math.Min(50, float64(len(users))))
+	)
+
+	addPath := client.Endpoint + httpUrl
+	addPath = strings.ReplaceAll(addPath, "{project_id}", client.ProjectID)
+	addPath = strings.ReplaceAll(addPath, "{instance_id}", instanceId)
+
+	for start < end {
+		opt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         utils.RemoveNil(buildAddUserPrivilegesToDatabaseBodyParams(dbName, users[start:end])),
+		}
+
+		retryFunc := func() (interface{}, bool, error) {
+			_, err := client.Request("POST", addPath, &opt)
+			retry, err := handleMultiOperationsError(err)
+			return nil, retry, err
+		}
+		_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+			Ctx:          ctx,
+			RetryFunc:    retryFunc,
+			WaitFunc:     rdsInstanceStateRefreshFunc(client, instanceId),
+			WaitTarget:   []string{"ACTIVE"},
+			Timeout:      timeout,
+			DelayTimeout: 1 * time.Second,
+			PollInterval: 10 * time.Second,
+		})
+		if err != nil {
+			return fmt.Errorf("error creating user privileges for MySQL database: %s", err)
+		}
+		start += 50
+		end = int(math.Min(float64(end+50), float64(len(users))))
+	}
+	return nil
+}
+
+func resourceMysqlDatabasePrivilegeCreateAndUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		rawConfigUsers = utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "users").([]interface{})
+		originUsers    = d.Get("users_origin").([]interface{})
+		instanceId     = d.Get("instance_id").(string)
+		dbName         = d.Get("db_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("rds", region)
 	if err != nil {
 		return diag.Errorf("error creating RDS client: %s", err)
 	}
 
-	err = createMysqlDatabasePrivilege(ctx, d, createMysqlDatabasePrivilegeClient, d.Get("users").(*schema.Set).List())
-	if err != nil {
-		return diag.FromErr(err)
+	if d.IsNewResource() {
+		d.SetId(fmt.Sprintf("%s/%s", instanceId, dbName))
 	}
 
-	instanceId := d.Get("instance_id").(string)
-	dbName := d.Get("db_name").(string)
-	d.SetId(instanceId + "/" + dbName)
+	remoteStateUsers, err := ListMysqlDatabasePrivileges(client, instanceId, dbName, originUsers, true)
+	if err != nil {
+		return diag.Errorf("error getting remoteMySQL database privileges before update: %s", err)
+	}
 
+	deleteUsers := findDeleteUserPrivilegesFromDatabase(originUsers, rawConfigUsers)
+	addUsers := findAddUserPrivilegesToDatabase(rawConfigUsers, remoteStateUsers)
+
+	if len(deleteUsers) > 0 {
+		err = deleteMysqlDatabasePrivilege(ctx, client, d, deleteUsers, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if len(addUsers) > 0 {
+		err = addPrivilegesToDatabase(ctx, client, d, addUsers, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// If the request is successful, obtain the values of all slice parameters first and save them to the corresponding
+	// '_origin' attributes for subsequent determination and construction of the request body during next updates.
+	// And whether corresponding parameters are changed, the origin values must be refreshed.
+	err = utils.RefreshObjectParamOriginValues(d, objSliceParamKeysForMysqlDatabasePrivilege)
+	if err != nil {
+		// Don't report an error if origin refresh fails
+		log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+	}
 	return resourceMysqlDatabasePrivilegeRead(ctx, d, meta)
 }
 
-func resourceMysqlDatabasePrivilegeRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+func orderMysqlDatabasePrivilegesByUsersOrigin(databasePrivileges, usersOrigin []interface{}) []interface{} {
+	if len(usersOrigin) < 1 {
+		return databasePrivileges
+	}
 
-	var mErr *multierror.Error
+	sortedDatabasePrivileges := make([]interface{}, 0, len(databasePrivileges))
+	databasePrivilegesCopy := databasePrivileges
+	for _, userOrigin := range usersOrigin {
+		userNameOrigin := utils.PathSearch("name", userOrigin, "").(string)
+		for index, databasePrivilege := range databasePrivilegesCopy {
+			if utils.PathSearch("name", databasePrivilege, "").(string) == userNameOrigin {
+				// Add the found database privilege to the sorted database privileges list.
+				sortedDatabasePrivileges = append(sortedDatabasePrivileges, databasePrivilegesCopy[index])
+				// Remove the processed database privilege from the original array.
+				databasePrivilegesCopy = append(databasePrivilegesCopy[:index], databasePrivilegesCopy[index+1:]...)
+				break
+			}
+		}
+	}
 
-	// getMysqlDatabasePrivilege: query RDS Mysql database privilege
+	return sortedDatabasePrivileges
+}
+
+func ListMysqlDatabasePrivileges(client *golangsdk.ServiceClient, instanceId, dbName string, usersOrigin []interface{},
+	ignoreNotFound ...bool) ([]interface{}, error) {
 	var (
-		getMysqlDatabasePrivilegeHttpUrl = "v3/{project_id}/instances/{instance_id}/database/db_user"
-		getMysqlDatabasePrivilegeProduct = "rds"
+		httpUrl = "v3/{project_id}/instances/{instance_id}/database/db_user?db-name={db_name}&limit={limit}"
+		limit   = 100
+		page    = 1
 	)
-	getMysqlDatabasePrivilegeClient, err := cfg.NewServiceClient(getMysqlDatabasePrivilegeProduct, region)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{db_name}", dbName)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	result := make([]interface{}, 0)
+	for {
+		listPathWithPage := fmt.Sprintf("%s&page=%d", listPath, page)
+		requestResp, err := client.Request("GET", listPathWithPage, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		users := utils.PathSearch("users", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, users...)
+		if len(users) < limit {
+			break
+		}
+		page++
+	}
+
+	parsedUsers := orderMysqlDatabasePrivilegesByUsersOrigin(result, usersOrigin)
+	if len(parsedUsers) < 1 && (len(ignoreNotFound) < 1 || !ignoreNotFound[0]) {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v3/{project_id}/instances/{instance_id}/database/db_user",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the database privileges (%#v) for database (%s) do not exist", usersOrigin, dbName)),
+			},
+		}
+	}
+	return parsedUsers, nil
+}
+
+func flattenMysqlDatabasePrivilegeUsers(users []interface{}) []interface{} {
+	if len(users) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(users))
+	for _, user := range users {
+		result = append(result, map[string]interface{}{
+			"name":     utils.PathSearch("name", user, nil),
+			"readonly": utils.PathSearch("readonly", user, nil),
+		})
+	}
+	return result
+}
+
+func resourceMysqlDatabasePrivilegeRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		instanceId  = d.Get("instance_id").(string)
+		dbName      = d.Get("db_name").(string)
+		usersOrigin = d.Get("users_origin").([]interface{})
+	)
+
+	client, err := cfg.NewServiceClient("rds", region)
 	if err != nil {
 		return diag.Errorf("error creating RDS client: %s", err)
 	}
 
-	// Split instance_id and database from resource id
-	parts := strings.Split(d.Id(), "/")
-	if len(parts) != 2 {
-		return diag.Errorf("invalid id format, must be <instance_id>/<db_name>")
-	}
-	instanceId := parts[0]
-	dbName := parts[1]
-
-	getMysqlDatabasePrivilegePath := getMysqlDatabasePrivilegeClient.Endpoint + getMysqlDatabasePrivilegeHttpUrl
-	getMysqlDatabasePrivilegePath = strings.ReplaceAll(getMysqlDatabasePrivilegePath, "{project_id}",
-		getMysqlDatabasePrivilegeClient.ProjectID)
-	getMysqlDatabasePrivilegePath = strings.ReplaceAll(getMysqlDatabasePrivilegePath, "{instance_id}", instanceId)
-
-	getMysqlDatabasePrivilegeQueryParams := buildGetMysqlDatabasePrivilegeQueryParams(dbName)
-	getMysqlDatabasePrivilegePath += getMysqlDatabasePrivilegeQueryParams
-
-	getMysqlDatabasePrivilegeResp, err := pagination.ListAllItems(
-		getMysqlDatabasePrivilegeClient,
-		"page",
-		getMysqlDatabasePrivilegePath,
-		&pagination.QueryOpts{MarkerField: ""})
-
+	users, err := ListMysqlDatabasePrivileges(client, instanceId, dbName, usersOrigin)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving RDS Mysql database privilege")
+		return common.CheckDeletedDiag(d, err, "")
 	}
 
-	getMysqlDatabasePrivilegeRespJson, err := json.Marshal(getMysqlDatabasePrivilegeResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	var getMysqlDatabasePrivilegeRespBody interface{}
-	err = json.Unmarshal(getMysqlDatabasePrivilegeRespJson, &getMysqlDatabasePrivilegeRespBody)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	users := flattenGetMysqlDatabasePrivilegeResponseBodyGetUser(getMysqlDatabasePrivilegeRespBody)
-	if len(users) == 0 {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
-	}
-
-	mErr = multierror.Append(
-		mErr,
+	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("instance_id", instanceId),
-		d.Set("db_name", dbName),
-		d.Set("users", users),
+		d.Set("users", flattenMysqlDatabasePrivilegeUsers(users)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func flattenGetMysqlDatabasePrivilegeResponseBodyGetUser(resp interface{}) []interface{} {
-	if resp == nil {
-		return nil
-	}
-	curJson := utils.PathSearch("users", resp, make([]interface{}, 0))
-	curArray := curJson.([]interface{})
-	rst := make([]interface{}, 0, len(curArray))
-	for _, v := range curArray {
-		rst = append(rst, map[string]interface{}{
-			"name":     utils.PathSearch("name", v, nil),
-			"readonly": utils.PathSearch("readonly", v, nil),
-		})
-	}
-	return rst
-}
-
-func buildGetMysqlDatabasePrivilegeQueryParams(dbName string) string {
-	return fmt.Sprintf("?db-name=%s&page=1&limit=100", dbName)
-}
-
-func resourceMysqlDatabasePrivilegeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// updateMysqlDatabasePrivilege: update RDS Mysql database privilege.
-	var (
-		updateMysqlDatabasePrivilegeProduct = "rds"
-	)
-	updateMysqlDatabasePrivilegeClient, err := cfg.NewServiceClient(updateMysqlDatabasePrivilegeProduct, region)
-	if err != nil {
-		return diag.Errorf("error creating RDS client: %s", err)
-	}
-
-	oldRaws, newRaws := d.GetChange("users")
-	createUsers := newRaws.(*schema.Set).List()
-	deleteUsers := oldRaws.(*schema.Set).Difference(newRaws.(*schema.Set)).List()
-
-	if len(deleteUsers) > 0 {
-		err = deleteMysqlDatabasePrivilege(ctx, d, updateMysqlDatabasePrivilegeClient, deleteUsers)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if len(createUsers) > 0 {
-		err = createMysqlDatabasePrivilege(ctx, d, updateMysqlDatabasePrivilegeClient, createUsers)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	return resourceMysqlDatabasePrivilegeRead(ctx, d, meta)
-}
-
 func resourceMysqlDatabasePrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		users  = d.Get("users").([]interface{})
+	)
 
-	// deleteMysqlDatabasePrivilege: delete RDS Mysql database privilege
-	deleteMysqlDatabasePrivilegeProduct := "rds"
-	deleteMysqlDatabasePrivilegeClient, err := cfg.NewServiceClient(deleteMysqlDatabasePrivilegeProduct, region)
+	// The value of users_origin is empty only when the resource is imported and the terraform apply command is not executed.
+	// In this case, all information obtained from the remote service is used to remove user relationships from the database.
+	if originUsers, ok := d.GetOk("users_origin"); ok && len(originUsers.([]interface{})) > 0 {
+		log.Printf("[DEBUG] Find the custom users configuration, according to it to remove users from the database (%v)", d.Id())
+		users = originUsers.([]interface{})
+	}
+
+	client, err := cfg.NewServiceClient("rds", region)
 	if err != nil {
 		return diag.Errorf("error creating RDS client: %s", err)
 	}
 
-	err = deleteMysqlDatabasePrivilege(ctx, d, deleteMysqlDatabasePrivilegeClient, d.Get("users").(*schema.Set).List())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	return nil
+	err = deleteMysqlDatabasePrivilege(ctx, client, d, users, d.Timeout(schema.TimeoutDelete))
+	return diag.FromErr(err)
 }
 
-func createMysqlDatabasePrivilege(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
-	rawUsers interface{}) error {
-	// createMysqlDatabasePrivilege: create RDS Mysql database privilege.
-	createMysqlDatabasePrivilegeHttpUrl := "v3/{project_id}/instances/{instance_id}/db_privilege"
-
-	instanceId := d.Get("instance_id").(string)
-	dbName := d.Get("db_name").(string)
-
-	createMysqlDatabasePrivilegePath := client.Endpoint + createMysqlDatabasePrivilegeHttpUrl
-	createMysqlDatabasePrivilegePath = strings.ReplaceAll(createMysqlDatabasePrivilegePath, "{project_id}",
-		client.ProjectID)
-	createMysqlDatabasePrivilegePath = strings.ReplaceAll(createMysqlDatabasePrivilegePath, "{instance_id}",
-		instanceId)
-
-	createMysqlDatabasePrivilegeOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
+func mysqlDatabasePrivilegeImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid resource ID format for privilege management, want '<instance_id>/<db_name>', but got '%s'", d.Id())
 	}
 
-	users := buildCreateMysqlDatabasePrivilegeRequestBodyUser(rawUsers)
-	start := 0
-	end := int(math.Min(50, float64(len(users))))
-	for start < end {
-		// A single request supports a maximum of 50 elements.
-		subUsers := users[start:end]
-		createMysqlDatabasePrivilegeOpt.JSONBody = utils.RemoveNil(buildMysqlDatabasePrivilegeBodyParams(dbName, subUsers))
-		log.Printf("[DEBUG] Create RDS Mysql database privilege options: %#v", createMysqlDatabasePrivilegeOpt)
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+		d.Set("db_name", parts[1]),
+	)
 
-		retryFunc := func() (interface{}, bool, error) {
-			_, err := client.Request("POST", createMysqlDatabasePrivilegePath, &createMysqlDatabasePrivilegeOpt)
-			retry, err := handleMultiOperationsError(err)
-			return nil, retry, err
-		}
-		_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
-			Ctx:          ctx,
-			RetryFunc:    retryFunc,
-			WaitFunc:     rdsInstanceStateRefreshFunc(client, instanceId),
-			WaitTarget:   []string{"ACTIVE"},
-			Timeout:      d.Timeout(schema.TimeoutCreate),
-			DelayTimeout: 1 * time.Second,
-			PollInterval: 10 * time.Second,
-		})
-		if err != nil {
-			return fmt.Errorf("error creating RDS Mysql database privilege: %s", err)
-		}
-		start += 50
-		end = int(math.Min(float64(end+50), float64(len(users))))
-	}
-	return nil
-}
-
-func deleteMysqlDatabasePrivilege(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
-	rawUsers interface{}) error {
-	// deleteMysqlDatabasePrivilege: delete RDS Mysql database privilege
-	deleteMysqlDatabasePrivilegeHttpUrl := "v3/{project_id}/instances/{instance_id}/db_privilege"
-
-	instanceId := d.Get("instance_id").(string)
-	dbName := d.Get("db_name").(string)
-
-	deleteMysqlDatabasePrivilegePath := client.Endpoint + deleteMysqlDatabasePrivilegeHttpUrl
-	deleteMysqlDatabasePrivilegePath = strings.ReplaceAll(deleteMysqlDatabasePrivilegePath, "{project_id}",
-		client.ProjectID)
-	deleteMysqlDatabasePrivilegePath = strings.ReplaceAll(deleteMysqlDatabasePrivilegePath, "{instance_id}",
-		instanceId)
-
-	deleteMysqlDatabasePrivilegeOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-
-	users := buildDeleteMysqlDatabasePrivilegeRequestBodyDeleteUser(rawUsers)
-	start := 0
-	end := int(math.Min(50, float64(len(users))))
-	for start < end {
-		// A single request supports a maximum of 50 elements.
-		subUsers := users[start:end]
-		deleteMysqlDatabasePrivilegeOpt.JSONBody = utils.RemoveNil(buildMysqlDatabasePrivilegeBodyParams(dbName, subUsers))
-		log.Printf("[DEBUG] Delete RDS Mysql database privilege options: %#v", deleteMysqlDatabasePrivilegeOpt)
-
-		retryFunc := func() (interface{}, bool, error) {
-			_, err := client.Request("DELETE", deleteMysqlDatabasePrivilegePath, &deleteMysqlDatabasePrivilegeOpt)
-			retry, err := handleMultiOperationsError(err)
-			return nil, retry, err
-		}
-		_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
-			Ctx:          ctx,
-			RetryFunc:    retryFunc,
-			WaitFunc:     rdsInstanceStateRefreshFunc(client, instanceId),
-			WaitTarget:   []string{"ACTIVE"},
-			Timeout:      d.Timeout(schema.TimeoutDelete),
-			DelayTimeout: 1 * time.Second,
-			PollInterval: 10 * time.Second,
-		})
-		if err != nil {
-			return fmt.Errorf("error deleting RDS Mysql database privilege: %s", err)
-		}
-		start += 50
-		end = int(math.Min(float64(end+50), float64(len(users))))
-	}
-	return nil
-}
-
-func buildMysqlDatabasePrivilegeBodyParams(dbName string, users interface{}) map[string]interface{} {
-	bodyParams := map[string]interface{}{
-		"db_name": dbName,
-		"users":   users,
-	}
-	return bodyParams
-}
-
-func buildCreateMysqlDatabasePrivilegeRequestBodyUser(rawParams interface{}) []map[string]interface{} {
-	if rawArray, ok := rawParams.([]interface{}); ok {
-		if len(rawArray) == 0 {
-			return nil
-		}
-
-		rst := make([]map[string]interface{}, len(rawArray))
-		for i, v := range rawArray {
-			raw := v.(map[string]interface{})
-			rst[i] = map[string]interface{}{
-				"name":     utils.ValueIgnoreEmpty(raw["name"]),
-				"readonly": utils.ValueIgnoreEmpty(raw["readonly"]),
-			}
-		}
-		return rst
-	}
-	return nil
-}
-
-func buildDeleteMysqlDatabasePrivilegeRequestBodyDeleteUser(rawParams interface{}) []map[string]interface{} {
-	if rawArray, ok := rawParams.([]interface{}); ok {
-		if len(rawArray) == 0 {
-			return nil
-		}
-
-		rst := make([]map[string]interface{}, len(rawArray))
-		for i, v := range rawArray {
-			raw := v.(map[string]interface{})
-			rst[i] = map[string]interface{}{
-				"name": utils.ValueIgnoreEmpty(raw["name"]),
-			}
-		}
-		return rst
-	}
-	return nil
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }

--- a/huaweicloud/utils/resource_diff.go
+++ b/huaweicloud/utils/resource_diff.go
@@ -912,97 +912,207 @@ func diffObjectSliceLength(paramKey, oldVal, newVal string, d *schema.ResourceDa
 	oldCount, _ := strconv.Atoi(oldVal)
 	newCount, _ := strconv.Atoi(newVal)
 
-	// If origin is empty or nil, this is the first time setting the value
-	if originVal == nil {
+	// If counts are the same, suppress diff
+	if oldCount == newCount {
+		log.Printf("[DEBUG][diffObjectSliceLength] Old count (%d) equals new count (%d), suppressing diff", oldCount, newCount)
+		return true
+	}
+
+	// Get old and new values from GetChange
+	oldParamVal, newParamVal := d.GetChange(baseField)
+	tfstateSlice := convertToObjectSlice(oldParamVal)   // tfstate (remote state)
+	rawConfigSlice := convertToObjectSlice(newParamVal) // RawConfig (script config)
+	originSlice := convertToObjectSlice(originVal)      // origin
+
+	log.Printf("[DEBUG][diffObjectSliceLength] paramKey='%s', oldCount=%d, newCount=%d, originSlice length=%d, tfstateSlice length=%d, "+
+		"rawConfigSlice length=%d",
+		paramKey, oldCount, newCount, len(originSlice), len(tfstateSlice), len(rawConfigSlice))
+
+	// Detailed logging for debugging
+	log.Printf("[DEBUG][diffObjectSliceLength] 1. RawConfig: %v", formatObjectSliceForLog(rawConfigSlice))
+	log.Printf("[DEBUG][diffObjectSliceLength] 2. tfstate: %v", formatObjectSliceForLog(tfstateSlice))
+	log.Printf("[DEBUG][diffObjectSliceLength] 3. origin: %v", formatObjectSliceForLog(originSlice))
+
+	// Check 1: (RawConfig - tfstate) ∩ (RawConfig - origin)
+	// If not empty, it means there are local additions
+	localAdditions := calculateLocalAdditions(originVal, oldParamVal, newParamVal)
+	rawConfigMinusTfstate := FindObjectSliceElementsNotInAnother(rawConfigSlice, tfstateSlice)
+	rawConfigMinusOrigin := FindObjectSliceElementsNotInAnother(rawConfigSlice, originSlice)
+
+	log.Printf("[DEBUG][diffObjectSliceLength] 4. (RawConfig - tfstate): %v", formatObjectSliceForLog(rawConfigMinusTfstate))
+	log.Printf("[DEBUG][diffObjectSliceLength] 5. (RawConfig - origin): %v", formatObjectSliceForLog(rawConfigMinusOrigin))
+	log.Printf("[DEBUG][diffObjectSliceLength] 6. (RawConfig - tfstate) ∩ (RawConfig - origin): %v", formatObjectSliceForLog(localAdditions))
+
+	if len(localAdditions) > 0 {
+		log.Printf("[DEBUG][diffObjectSliceLength] Found local additions (RawConfig - tfstate) ∩ (RawConfig - origin): %d, NOT suppressing diff",
+			len(localAdditions))
 		return false
 	}
 
-	// Check if origin is effectively empty
-	var originCount int
-	var isEmpty bool
-	switch v := originVal.(type) {
-	case []interface{}:
-		originCount = len(v)
-		isEmpty = len(v) == 0
-	case *schema.Set:
-		originCount = v.Len()
-		isEmpty = v.Len() == 0
-	default:
-		originCount = 0
-		isEmpty = true
+	// Check 2: (tfstate - RawConfig) ∩ (origin - RawConfig)
+	// If not empty, it means there are local removals
+	localRemovals := calculateLocalRemovals(originVal, oldParamVal, newParamVal)
+	tfstateMinusRawConfig := FindObjectSliceElementsNotInAnother(tfstateSlice, rawConfigSlice)
+	originMinusRawConfig := FindObjectSliceElementsNotInAnother(originSlice, rawConfigSlice)
+
+	log.Printf("[DEBUG][diffObjectSliceLength] 7. (tfstate - RawConfig): %v", formatObjectSliceForLog(tfstateMinusRawConfig))
+	log.Printf("[DEBUG][diffObjectSliceLength] 8. (origin - RawConfig): %v", formatObjectSliceForLog(originMinusRawConfig))
+	log.Printf("[DEBUG][diffObjectSliceLength] 9. (tfstate - RawConfig) ∩ (origin - RawConfig): %v", formatObjectSliceForLog(localRemovals))
+
+	// Check if all removed elements are local removals
+	// If there are remote additions (elements in tfstate - RawConfig but not in localRemovals),
+	// we should suppress the length diff to allow element-level suppression
+	remoteAdditions := make([]map[string]interface{}, 0)
+	for _, elem := range tfstateMinusRawConfig {
+		if !ObjectSliceContains(localRemovals, elem) {
+			remoteAdditions = append(remoteAdditions, elem)
+		}
 	}
 
-	// If origin is empty, check if this is a remote-only change that should be suppressed
-	if isEmpty {
-		// Get current remote state to check if this is a remote-only change
-		currentVal := d.Get(baseField)
-		if currentVal != nil {
-			var currentCount int
-			switch v := currentVal.(type) {
-			case []interface{}:
-				currentCount = len(v)
-			case *schema.Set:
-				currentCount = v.Len()
-			default:
-				currentCount = 0
-			}
+	log.Printf("[DEBUG][diffObjectSliceLength] Remote additions (elements in tfstate - RawConfig but not in localRemovals): %v",
+		formatObjectSliceForLog(remoteAdditions))
 
-			// If new count is less than current count, this might be a remote removal
-			// that should be suppressed (unless it's a local removal)
-			if newCount < currentCount {
-				return true
+	if len(localRemovals) > 0 {
+		if len(remoteAdditions) > 0 {
+			// There are both local removals and remote additions
+			// We need to NOT suppress the length diff to show the deletion operation
+			// The adjusted old count (excluding remote additions) should be used conceptually:
+			// adjustedOldCount = oldCount - len(remoteAdditions) = 4 - 1 = 3
+			// This means we want to show "3 -> 2" conceptually, but Terraform will show "4 -> 2"
+			// However, we can suppress remote additions at element level, so only local removals are shown
+			// Note: We cannot modify oldVal/newVal in diff suppression functions, but we can control
+			// which elements are shown/hidden at element level
+			adjustedOldCount := oldCount - len(remoteAdditions)
+			log.Printf("[DEBUG][diffObjectSliceLength] Found local removals (%d) and remote additions (%d), "+
+				"adjusted old count: %d -> %d (conceptually %d -> %d)",
+				len(localRemovals), len(remoteAdditions), oldCount, newCount, adjustedOldCount, newCount)
+			log.Printf("[DEBUG][diffObjectSliceLength] NOT suppressing length diff to show deletion operation, " +
+				"remote additions will be suppressed at element level")
+			return false
+		}
+		// All removed elements are local removals, don't suppress
+		log.Printf("[DEBUG][diffObjectSliceLength] Found local removals (tfstate - RawConfig) ∩ (origin - RawConfig): %d, NOT suppressing diff",
+			len(localRemovals))
+		return false
+	}
+
+	// Both checks are empty, suppress diff
+	log.Printf("[DEBUG][diffObjectSliceLength] No local additions or removals, suppressing diff")
+	return true
+}
+
+// findTargetObjectFromState finds the target object from state attributes by objectHash
+func findTargetObjectFromState(d *schema.ResourceData, baseField, objectHash string, tfstateSlice []map[string]interface{}) map[string]interface{} {
+	if d.State() == nil || d.State().Attributes == nil {
+		return nil
+	}
+
+	tempObject := make(map[string]interface{})
+	for key, val := range d.State().Attributes {
+		if strings.HasPrefix(key, fmt.Sprintf("%s.%s.", baseField, objectHash)) {
+			fieldName := strings.TrimPrefix(key, fmt.Sprintf("%s.%s.", baseField, objectHash))
+			tempObject[fieldName] = val
+		}
+	}
+
+	if len(tempObject) == 0 {
+		return nil
+	}
+
+	// Found object in state attributes, try to find the full object in tfstateSlice
+	for _, tfstateObjMap := range tfstateSlice {
+		matches := true
+		for key, val := range tempObject {
+			if tfstateVal, ok := tfstateObjMap[key]; !ok || !reflect.DeepEqual(val, tfstateVal) {
+				matches = false
+				break
 			}
 		}
+		if matches {
+			log.Printf("[DEBUG][findTargetObjectFromState] Found full object from state attributes matching objectHash '%s': %v",
+				objectHash, tfstateObjMap)
+			return tfstateObjMap
+		}
+	}
+	return nil
+}
 
-		return false
+// findTargetObjectByOldVal finds the target object by matching oldVal in tfstateSlice
+func findTargetObjectByOldVal(oldVal string, tfstateSlice, rawConfigSlice []map[string]interface{}) map[string]interface{} {
+	if oldVal == "" {
+		return nil
 	}
 
-	// Check if there are actual changes that require length difference to be shown
-	hasLocalAdditions := newCount > oldCount
-	hasLocalRemovals := newCount < originCount
-
-	// If oldCount > newCount and newCount == originCount, this is a remote addition
-	// (objects were added remotely but not in script, and script value equals origin)
-	if oldCount > newCount && newCount == originCount {
-		// Check if there are objects in old value that are not in origin (remote additions)
-		oldParamVal, _ := d.GetChange(baseField)
-		if oldParamVal != nil {
-			var oldObjectList []interface{}
-			switch v := oldParamVal.(type) {
-			case []interface{}:
-				oldObjectList = v
-			case *schema.Set:
-				oldObjectList = v.List()
-			}
-			// Count how many objects in old value are not in origin
-			remoteAdditionsCount := 0
-			for _, oldItem := range oldObjectList {
-				if itemMap, ok := oldItem.(map[string]interface{}); ok {
-					if !isObjectInOrigin(itemMap, originVal) {
-						remoteAdditionsCount++
-					}
+	for _, tfstateObjMap := range tfstateSlice {
+		if !ObjectSliceContains(rawConfigSlice, tfstateObjMap) {
+			for _, fieldVal := range tfstateObjMap {
+				if fmt.Sprintf("%v", fieldVal) == oldVal {
+					log.Printf("[DEBUG][findTargetObjectByOldVal] Found object matching oldVal='%s' in tfstateSlice: %v",
+						oldVal, tfstateObjMap)
+					return tfstateObjMap
 				}
 			}
-			// If the number of remote additions matches the difference, suppress the diff
-			if remoteAdditionsCount >= (oldCount - newCount) {
-				log.Printf("[DEBUG][diffObjectSliceLength] Old count (%d) > new count (%d) and new count equals origin count (%d), with %d remote "+
-					"additions, suppressing diff (remote addition)",
-					oldCount, newCount, originCount, remoteAdditionsCount)
-				return true
-			}
+		}
+	}
+	return nil
+}
+
+// findTargetObjectFromLocalRemovals finds the target object by matching objectHash fields with localRemovals
+func findTargetObjectFromLocalRemovals(d *schema.ResourceData, baseField, objectHash string,
+	localRemovals []map[string]interface{}) map[string]interface{} {
+	if len(localRemovals) == 0 || d.State() == nil || d.State().Attributes == nil {
+		return nil
+	}
+
+	// Get all fields for this objectHash from state attributes
+	objectFields := make(map[string]interface{})
+	for key, val := range d.State().Attributes {
+		if strings.HasPrefix(key, fmt.Sprintf("%s.%s.", baseField, objectHash)) {
+			fieldName := strings.TrimPrefix(key, fmt.Sprintf("%s.%s.", baseField, objectHash))
+			objectFields[fieldName] = val
 		}
 	}
 
-	// If there are actual local changes, don't suppress length difference
-	if hasLocalAdditions || hasLocalRemovals {
-		log.Printf("[DEBUG][diffObjectSliceLength] Is local additions happened? %v", hasLocalAdditions)
-		log.Printf("[DEBUG][diffObjectSliceLength] Is local removals happened? %v", hasLocalRemovals)
-		return false
+	if len(objectFields) == 0 {
+		return nil
 	}
 
-	// If no actual changes, suppress length difference (e.g., remote-only additions/removals)
-	log.Printf("[DEBUG][diffObjectSliceLength] No local changes, suppressing length difference")
-	return true
+	// Try to match them with objects in localRemovals
+	for _, localRemovalObj := range localRemovals {
+		matches := true
+		for fieldName, fieldVal := range objectFields {
+			if localRemovalVal, ok := localRemovalObj[fieldName]; !ok || !reflect.DeepEqual(fieldVal, localRemovalVal) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			log.Printf("[DEBUG][findTargetObjectFromLocalRemovals] Found object by matching objectHash '%s' "+
+				"fields with localRemovals: %v", objectHash, localRemovalObj)
+			return localRemovalObj
+		}
+	}
+	return nil
+}
+
+// findTargetObjectBySingleMatch finds the target object when there's exactly one removed object and one local removal
+func findTargetObjectBySingleMatch(tfstateSlice, rawConfigSlice, localRemovals []map[string]interface{}) map[string]interface{} {
+	removedObjects := make([]map[string]interface{}, 0)
+	for _, tfstateObjMap := range tfstateSlice {
+		if !ObjectSliceContains(rawConfigSlice, tfstateObjMap) {
+			removedObjects = append(removedObjects, tfstateObjMap)
+		}
+	}
+
+	// If there's exactly one removed object and one local removal, they should match
+	if len(removedObjects) == 1 && len(localRemovals) == 1 {
+		if ObjectSliceContains(localRemovals, removedObjects[0]) {
+			log.Printf("[DEBUG][findTargetObjectBySingleMatch] Found object by matching single removed object with localRemovals: %v",
+				removedObjects[0])
+			return removedObjects[0]
+		}
+	}
+	return nil
 }
 
 // diffObjectSliceElement handles individual object slice elements
@@ -1014,160 +1124,585 @@ func diffObjectSliceElement(paramKey, oldVal, newVal string, d *schema.ResourceD
 	}
 	baseField := parts[0]
 
+	// If this is a CREATE scenario (oldVal is empty and newVal has value), don't suppress diff
+	if oldVal == "" && newVal != "" {
+		log.Printf("[DEBUG][diffObjectSliceElement] CREATE scenario detected (oldVal='', newVal='%s'), "+
+			"NOT suppressing diff to show field", newVal)
+		return false
+	}
+
 	originParamKey := fmt.Sprintf("%s_origin", baseField)
 	originVal := d.Get(originParamKey)
+	objectHash := parts[1]
 
 	log.Printf("[DEBUG][diffObjectSliceElement] baseField='%s', oldVal='%s', newVal='%s', originVal=%v",
 		baseField, oldVal, newVal, originVal)
 
-	// For object slices, we need to check the entire object, not just individual fields
-	// Get the object hash from paramKey (e.g., "objects.1234567890.type" -> "1234567890")
-	objectHash := parts[1]
+	// Check if this object is being removed (in localRemovals)
+	oldParamVal, newParamVal := d.GetChange(baseField)
+	localRemovals := calculateLocalRemovals(originVal, oldParamVal, newParamVal)
+	tfstateSlice := convertToObjectSlice(oldParamVal)
+	rawConfigSlice := convertToObjectSlice(newParamVal)
 
-	// Handle element removal case: newVal is empty (object is being removed from script)
-	// This includes both local removal and remote addition (object exists in console but not in script)
-	if newVal == "" {
-		return handleObjectElementRemoval(baseField, objectHash, originVal, d)
+	log.Printf("[DEBUG][diffObjectSliceElement] Checking if object '%s' (paramKey='%s') is in localRemovals, localRemovals=%v",
+		objectHash, paramKey, formatObjectSliceForLog(localRemovals))
+
+	// Try to find the target object using multiple strategies
+	targetObject := findTargetObjectFromState(d, baseField, objectHash, tfstateSlice)
+	if targetObject == nil {
+		targetObject = findTargetObjectByOldVal(oldVal, tfstateSlice, rawConfigSlice)
+	}
+	if targetObject == nil {
+		targetObject = findTargetObjectFromLocalRemovals(d, baseField, objectHash, localRemovals)
+	}
+	if targetObject == nil {
+		targetObject = findTargetObjectBySingleMatch(tfstateSlice, rawConfigSlice, localRemovals)
 	}
 
-	// Handle element addition/modification case: newVal has value
-	// This includes both local addition and remote addition (object exists in both console and script)
+	// Check if the target object is in localRemovals
+	if targetObject != nil {
+		if ObjectSliceContains(localRemovals, targetObject) {
+			log.Printf("[DEBUG][diffObjectSliceElement] Object '%s' (paramKey='%s') is in (tfstate - RawConfig) ∩ (origin - RawConfig), "+
+				"NOT suppressing diff (local removal)", objectHash, paramKey)
+			return false
+		}
+		log.Printf("[DEBUG][diffObjectSliceElement] Object '%s' (paramKey='%s') is NOT in localRemovals", objectHash, paramKey)
+	} else {
+		log.Printf("[DEBUG][diffObjectSliceElement] Could not find target object for objectHash '%s' (oldVal='%s'), continuing with normal logic",
+			objectHash, oldVal)
+	}
+
+	// Handle element removal case
+	if newVal == "" {
+		log.Printf("[DEBUG][diffObjectSliceElement] Calling handleObjectElementRemoval for paramKey='%s', objectHash='%s'",
+			paramKey, objectHash)
+		return handleObjectElementRemoval(baseField, objectHash, oldVal, originVal, d)
+	}
+
+	// Handle element addition/modification case
+	log.Printf("[DEBUG][diffObjectSliceElement] Calling handleObjectElementAddition for paramKey='%s', objectHash='%s'",
+		paramKey, objectHash)
 	return handleObjectElementAddition(baseField, objectHash, originVal, d)
 }
 
+// calculateLocalRemovals calculates local removals: (tfstate - RawConfig) ∩ (origin - RawConfig)
+func calculateLocalRemovals(originVal interface{}, oldParamVal, newParamVal interface{}) []map[string]interface{} {
+	originSlice := convertToObjectSlice(originVal)
+	tfstateSlice := convertToObjectSlice(oldParamVal)
+	rawConfigSlice := convertToObjectSlice(newParamVal)
+
+	tfstateMinusRawConfig := FindObjectSliceElementsNotInAnother(tfstateSlice, rawConfigSlice)
+	originMinusRawConfig := FindObjectSliceElementsNotInAnother(originSlice, rawConfigSlice)
+
+	localRemovals := make([]map[string]interface{}, 0)
+	for _, elem := range tfstateMinusRawConfig {
+		if ObjectSliceContains(originMinusRawConfig, elem) {
+			localRemovals = append(localRemovals, elem)
+		}
+	}
+	return localRemovals
+}
+
+// calculateLocalAdditions calculates local additions: (RawConfig - tfstate) ∩ (RawConfig - origin)
+func calculateLocalAdditions(originVal interface{}, oldParamVal, newParamVal interface{}) []map[string]interface{} {
+	originSlice := convertToObjectSlice(originVal)
+	tfstateSlice := convertToObjectSlice(oldParamVal)
+	rawConfigSlice := convertToObjectSlice(newParamVal)
+
+	rawConfigMinusTfstate := FindObjectSliceElementsNotInAnother(rawConfigSlice, tfstateSlice)
+	rawConfigMinusOrigin := FindObjectSliceElementsNotInAnother(rawConfigSlice, originSlice)
+
+	localAdditions := make([]map[string]interface{}, 0)
+	for _, elem := range rawConfigMinusTfstate {
+		if ObjectSliceContains(rawConfigMinusOrigin, elem) {
+			localAdditions = append(localAdditions, elem)
+		}
+	}
+	return localAdditions
+}
+
+// findObjectByOldVal finds an object in oldObjectList by matching oldVal
+func findObjectByOldVal(oldObjectList []interface{}, rawConfigSlice []map[string]interface{}, oldVal string) map[string]interface{} {
+	for _, oldItem := range oldObjectList {
+		if itemMap, ok := oldItem.(map[string]interface{}); ok {
+			if !ObjectSliceContains(rawConfigSlice, itemMap) {
+				for _, fieldVal := range itemMap {
+					if fmt.Sprintf("%v", fieldVal) == oldVal {
+						return itemMap
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// handleObjectElementRemovalWhenOldObjectNil handles the case when oldObject is nil
+func handleObjectElementRemovalWhenOldObjectNil(baseField, objectHash, oldVal string, originVal interface{}, d *schema.ResourceData) bool {
+	oldParamVal, newParamVal := d.GetChange(baseField)
+	if oldParamVal == nil || newParamVal == nil {
+		log.Printf("[DEBUG][handleObjectElementRemovalWhenOldObjectNil] Cannot find object '%s' in old state, suppressing diff", objectHash)
+		return true
+	}
+
+	var oldCount, newCount int
+	var oldObjectList []interface{}
+	switch v := oldParamVal.(type) {
+	case []interface{}:
+		oldCount = len(v)
+		oldObjectList = v
+	case *schema.Set:
+		oldCount = v.Len()
+		oldObjectList = v.List()
+	}
+	switch v := newParamVal.(type) {
+	case []interface{}:
+		newCount = len(v)
+	case *schema.Set:
+		newCount = v.Len()
+	}
+
+	if oldCount <= newCount {
+		log.Printf("[DEBUG][handleObjectElementRemovalWhenOldObjectNil] Cannot find object '%s' in old state, suppressing diff", objectHash)
+		return true
+	}
+
+	var newObjectList []interface{}
+	switch v := newParamVal.(type) {
+	case []interface{}:
+		newObjectList = v
+	case *schema.Set:
+		newObjectList = v.List()
+	}
+
+	localRemovals := calculateLocalRemovals(originVal, oldObjectList, newObjectList)
+	log.Printf("[DEBUG][handleObjectElementRemovalWhenOldObjectNil] localRemovals: %v", formatObjectSliceForLog(localRemovals))
+
+	// Try to get the current object by objectHash from state attributes
+	currentObject := getObjectFromOldState(d, baseField, objectHash)
+	if currentObject == nil {
+		currentObject = make(map[string]interface{})
+		if d.State() != nil && d.State().Attributes != nil {
+			for key, val := range d.State().Attributes {
+				if strings.HasPrefix(key, fmt.Sprintf("%s.%s.", baseField, objectHash)) {
+					fieldName := strings.TrimPrefix(key, fmt.Sprintf("%s.%s.", baseField, objectHash))
+					currentObject[fieldName] = val
+				}
+			}
+		}
+	}
+
+	// If we still can't get the object, try to find it from oldObjectList using oldVal
+	if len(currentObject) == 0 && oldVal != "" {
+		rawConfigSlice := convertToObjectSlice(newObjectList)
+		currentObject = findObjectByOldVal(oldObjectList, rawConfigSlice, oldVal)
+		if currentObject != nil {
+			log.Printf("[DEBUG][handleObjectElementRemovalWhenOldObjectNil] Found object '%s' in oldObjectList by matching oldVal='%s': %v",
+				objectHash, oldVal, currentObject)
+		}
+	}
+
+	// Check if the current object is in localRemovals
+	if len(currentObject) > 0 {
+		if ObjectSliceContains(localRemovals, currentObject) {
+			log.Printf("[DEBUG][handleObjectElementRemovalWhenOldObjectNil] Object '%s' (oldVal='%s') is in "+
+				"(tfstate - RawConfig) ∩ (origin - RawConfig), NOT suppressing diff (local removal)", objectHash, oldVal)
+			return false
+		}
+		log.Printf("[DEBUG][handleObjectElementRemovalWhenOldObjectNil] Object '%s' (oldVal='%s') is NOT in "+
+			"(tfstate - RawConfig) ∩ (origin - RawConfig), suppressing diff (remote addition)", objectHash, oldVal)
+		return true
+	}
+
+	log.Printf("[DEBUG][handleObjectElementRemovalWhenOldObjectNil] Cannot identify object '%s' (oldVal='%s') by objectHash or oldVal, "+
+		"suppressing diff (remote addition)", objectHash, oldVal)
+	return true
+}
+
+// getFullObjectFromStateAttributes gets the full object from state attributes by objectHash
+func getFullObjectFromStateAttributes(d *schema.ResourceData, baseField, objectHash string) map[string]interface{} {
+	if d.State() == nil || d.State().Attributes == nil {
+		return nil
+	}
+
+	fullObject := make(map[string]interface{})
+	for key, val := range d.State().Attributes {
+		if strings.HasPrefix(key, fmt.Sprintf("%s.%s.", baseField, objectHash)) {
+			fieldName := strings.TrimPrefix(key, fmt.Sprintf("%s.%s.", baseField, objectHash))
+			fullObject[fieldName] = val
+		}
+	}
+
+	if len(fullObject) == 0 {
+		return nil
+	}
+
+	log.Printf("[DEBUG][getFullObjectFromStateAttributes] Got full object from state attributes by objectHash '%s': %v",
+		objectHash, fullObject)
+	return fullObject
+}
+
+// findFullObjectByOldVal finds the full object in tfstateSlice by matching oldVal
+func findFullObjectByOldVal(oldVal string, tfstateSlice, rawConfigSlice []map[string]interface{}) map[string]interface{} {
+	if oldVal == "" {
+		return nil
+	}
+
+	for _, tfstateObjMap := range tfstateSlice {
+		if ObjectSliceContains(rawConfigSlice, tfstateObjMap) {
+			continue
+		}
+
+		for _, fieldVal := range tfstateObjMap {
+			if fmt.Sprintf("%v", fieldVal) == oldVal {
+				log.Printf("[DEBUG][findFullObjectByOldVal] Found full object matching oldVal='%s' in tfstateSlice (being removed): %v",
+					oldVal, tfstateObjMap)
+				return tfstateObjMap
+			}
+		}
+	}
+
+	return nil
+}
+
+// findFullObjectByOldObject finds the full object in tfstateSlice by matching oldObject
+func findFullObjectByOldObject(oldObject map[string]interface{}, tfstateSlice, rawConfigSlice []map[string]interface{}) map[string]interface{} {
+	if len(oldObject) == 0 {
+		return nil
+	}
+
+	for _, tfstateObjMap := range tfstateSlice {
+		if ObjectSliceContains(rawConfigSlice, tfstateObjMap) {
+			continue
+		}
+
+		matches := true
+		for key, val := range oldObject {
+			if tfstateVal, ok := tfstateObjMap[key]; !ok || !reflect.DeepEqual(val, tfstateVal) {
+				matches = false
+				break
+			}
+		}
+
+		if matches {
+			log.Printf("[DEBUG][findFullObjectByOldObject] Found full object matching oldObject in tfstateSlice (being removed): %v",
+				tfstateObjMap)
+			return tfstateObjMap
+		}
+	}
+
+	return nil
+}
+
+// removalObjectSearchParams contains parameters for searching an object during removal checking
+type removalObjectSearchParams struct {
+	d              *schema.ResourceData
+	baseField      string
+	objectHash     string
+	oldVal         string
+	oldObject      map[string]interface{}
+	tfstateSlice   []map[string]interface{}
+	rawConfigSlice []map[string]interface{}
+}
+
+// findFullObjectForRemoval finds the full object for removal checking
+func findFullObjectForRemoval(params removalObjectSearchParams) map[string]interface{} {
+	// Strategy 1: Try to get the full object from state attributes by objectHash
+	fullObject := getFullObjectFromStateAttributes(params.d, params.baseField, params.objectHash)
+	if len(fullObject) > 0 {
+		return fullObject
+	}
+
+	// Strategy 2: Try to find the full object in tfstateSlice by matching oldVal
+	fullObject = findFullObjectByOldVal(params.oldVal, params.tfstateSlice, params.rawConfigSlice)
+	if len(fullObject) > 0 {
+		return fullObject
+	}
+
+	// Strategy 3: Try to find the full object by matching oldObject
+	fullObject = findFullObjectByOldObject(params.oldObject, params.tfstateSlice, params.rawConfigSlice)
+	return fullObject
+}
+
+// checkObjectInLocalRemovals checks if the object is in localRemovals, prioritizing fullObject over oldObject
+func checkObjectInLocalRemovals(fullObject, oldObject map[string]interface{},
+	localRemovals []map[string]interface{}) bool {
+	// Priority 1: Check fullObject if available
+	if len(fullObject) > 0 {
+		if ObjectSliceContains(localRemovals, fullObject) {
+			log.Printf("[DEBUG][checkObjectInLocalRemovals] Full object is in localRemovals")
+			return true
+		}
+		log.Printf("[DEBUG][checkObjectInLocalRemovals] Full object is NOT in localRemovals")
+		return false
+	}
+
+	// Priority 2: Check oldObject (partial) if fullObject is not available
+	if ObjectSliceContains(localRemovals, oldObject) {
+		log.Printf("[DEBUG][checkObjectInLocalRemovals] oldObject (partial) is in localRemovals")
+		return true
+	}
+
+	log.Printf("[DEBUG][checkObjectInLocalRemovals] Could not find full object and oldObject (partial) is NOT in localRemovals")
+	return false
+}
+
 // handleObjectElementRemoval handles the case when an object element is being removed
-func handleObjectElementRemoval(baseField, objectHash string, originVal interface{}, d *schema.ResourceData) bool {
-	log.Printf("[DEBUG][handleObjectElementRemoval] Object element '%s' is being removed, checking if should suppress diff", objectHash)
+func handleObjectElementRemoval(baseField, objectHash, oldVal string, originVal interface{}, d *schema.ResourceData) bool {
+	log.Printf("[DEBUG][handleObjectElementRemoval] Object element '%s' is being removed (oldVal='%s'), checking if should suppress diff",
+		objectHash, oldVal)
 
 	// Get the object from old state (console value)
 	oldObject := getObjectFromOldState(d, baseField, objectHash)
 
 	// If we can't get the object from old state, try to check if it's a remote addition
 	if oldObject == nil {
-		// Check if the object exists in console value by checking if old value has more objects than new value
-		oldParamVal, newParamVal := d.GetChange(baseField)
-		if oldParamVal != nil && newParamVal != nil {
-			var oldCount, newCount int
-			var oldObjectList []interface{}
-			switch v := oldParamVal.(type) {
-			case []interface{}:
-				oldCount = len(v)
-				oldObjectList = v
-			case *schema.Set:
-				oldCount = v.Len()
-				oldObjectList = v.List()
-			}
-			switch v := newParamVal.(type) {
-			case []interface{}:
-				newCount = len(v)
-			case *schema.Set:
-				newCount = v.Len()
-			}
-
-			// If old count is greater than new count, and origin is not empty,
-			// check if there are objects in old value that are not in origin
-			if oldCount > newCount && !isOriginEmpty(originVal) {
-				// Count how many objects in old value are not in origin
-				remoteAdditionsCount := 0
-				for _, oldItem := range oldObjectList {
-					if itemMap, ok := oldItem.(map[string]interface{}); ok {
-						if !isObjectInOrigin(itemMap, originVal) {
-							remoteAdditionsCount++
-						}
-					}
-				}
-				// If the number of remote additions is at least the difference between old and new count,
-				// then the removed object is likely a remote addition
-				if remoteAdditionsCount >= (oldCount - newCount) {
-					log.Printf("[DEBUG][handleObjectElementRemoval] Object '%s' cannot be found but old count (%d) > new count (%d) and has %d "+
-						"remote additions, suppressing diff (remote addition)", objectHash, oldCount, newCount, remoteAdditionsCount)
-					return true
-				}
-			}
-		}
-
-		// If we can't determine, default to suppressing diff to be safe
-		log.Printf("[DEBUG][handleObjectElementRemoval] Cannot find object '%s' in old state, suppressing diff", objectHash)
-		return true
+		return handleObjectElementRemovalWhenOldObjectNil(baseField, objectHash, oldVal, originVal, d)
 	}
 
-	// Check if this object was in origin
-	if isObjectInOrigin(oldObject, originVal) {
-		log.Printf("[DEBUG][handleObjectElementRemoval] Object '%s' was in origin, NOT suppressing diff (allow removal)", objectHash)
-		return false // NOT suppressing - allow removal of origin elements
+	// Check removal logic: (tfstate - RawConfig) ∩ (origin - RawConfig)
+	oldParamVal, newParamVal := d.GetChange(baseField)
+	localRemovals := calculateLocalRemovals(originVal, oldParamVal, newParamVal)
+	log.Printf("[DEBUG][handleObjectElementRemoval] oldObject=%v, localRemovals=%v", oldObject, formatObjectSliceForLog(localRemovals))
+
+	tfstateSlice := convertToObjectSlice(oldParamVal)
+	rawConfigSlice := convertToObjectSlice(newParamVal)
+
+	// Find the full object for checking
+	searchParams := removalObjectSearchParams{
+		d:              d,
+		baseField:      baseField,
+		objectHash:     objectHash,
+		oldVal:         oldVal,
+		oldObject:      oldObject,
+		tfstateSlice:   tfstateSlice,
+		rawConfigSlice: rawConfigSlice,
 	}
+	fullObject := findFullObjectForRemoval(searchParams)
 
-	// If object was not in origin, it means it was added remotely (console)
-	// We should suppress the diff to ignore remote-only additions
-	log.Printf("[DEBUG][handleObjectElementRemoval] Object '%s' was not in origin (remote addition), suppressing diff (ignore remote removal)",
-		objectHash)
-	return true // Suppress diff - ignore removal of remote-only elements
-}
+	// Check if the object is in localRemovals
+	objectInLocalRemovals := checkObjectInLocalRemovals(fullObject, oldObject, localRemovals)
 
-// handleObjectElementAddition handles the case when an object element is being added or modified
-func handleObjectElementAddition(baseField, objectHash string, originVal interface{}, d *schema.ResourceData) bool {
-	// Try to get the object from new state first
-	newObject := getObjectFromState(d, baseField, objectHash)
-
-	// If not found in new state, try to get from old state (console value)
-	// This handles the case when object was added remotely
-	if newObject == nil {
-		log.Printf("[DEBUG][handleObjectElementAddition] Cannot find object '%s' in new state, trying old state", objectHash)
-		oldObject := getObjectFromOldState(d, baseField, objectHash)
-		if oldObject != nil {
-			// Object exists in old state but not in new state
-			// Check if it was in origin
-			if !isOriginEmpty(originVal) && isObjectInOrigin(oldObject, originVal) {
-				log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' exists in old state and was in origin, not suppressing diff (allow "+
-					"removal)", objectHash)
-				return false
-			}
-			// Object was added remotely, suppress the diff
-			log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' exists in old state but not in new state (remote addition), suppressing "+
-				"diff", objectHash)
-			return true
-		}
-		log.Printf("[DEBUG][handleObjectElementAddition] Cannot find object '%s' in either new or old state", objectHash)
+	if objectInLocalRemovals {
+		log.Printf("[DEBUG][handleObjectElementRemoval] Object '%s' (oldVal='%s') is in (tfstate - RawConfig) ∩ (origin - RawConfig), "+
+			"NOT suppressing diff (local removal)", objectHash, oldVal)
 		return false
 	}
 
-	// If origin is nil or empty, this is the first time setting the value
-	if isOriginEmpty(originVal) {
-		return handleFirstTimeObjectSetting(baseField, newObject, d)
+	log.Printf("[DEBUG][handleObjectElementRemoval] Object '%s' (oldVal='%s') is not in (tfstate - RawConfig) ∩ (origin - RawConfig), "+
+		"suppressing diff (remote addition)", objectHash, oldVal)
+	return true
+}
+
+// findTargetObjectForAddition finds the target object for addition checking
+func findTargetObjectForAddition(d *schema.ResourceData, baseField, objectHash string, oldObject map[string]interface{},
+	tfstateSlice, localRemovals []map[string]interface{}) map[string]interface{} {
+	// First, try to get the object from state attributes by objectHash
+	targetObject := findTargetObjectFromState(d, baseField, objectHash, tfstateSlice)
+	if targetObject != nil {
+		return targetObject
 	}
 
-	// Check if this object is in origin
-	if isObjectInOrigin(newObject, originVal) {
-		// If the object is unchanged, don't suppress diff
-		// This ensures Terraform knows the config value still exists
-		oldObject := getObjectFromOldState(d, baseField, objectHash)
-		if oldObject != nil && reflect.DeepEqual(oldObject, newObject) {
-			log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' unchanged and in origin, not suppressing diff to preserve config value",
-				objectHash)
+	// If we couldn't find the object from state attributes, try to use oldObject to find it in tfstateSlice
+	if len(oldObject) > 0 {
+		for _, tfstateObjMap := range tfstateSlice {
+			matches := true
+			for key, val := range oldObject {
+				if tfstateVal, ok := tfstateObjMap[key]; !ok || !reflect.DeepEqual(val, tfstateVal) {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				log.Printf("[DEBUG][findTargetObjectForAddition] Found full object matching oldObject: %v", tfstateObjMap)
+				return tfstateObjMap
+			}
+		}
+
+		// Try direct comparison with oldObject (partial match) against localRemovals
+		for _, localRemovalObj := range localRemovals {
+			matches := true
+			for key, val := range oldObject {
+				if localRemovalVal, ok := localRemovalObj[key]; !ok || !reflect.DeepEqual(val, localRemovalVal) {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				log.Printf("[DEBUG][findTargetObjectForAddition] Found matching object in localRemovals by partial oldObject: %v",
+					localRemovalObj)
+				return localRemovalObj
+			}
+		}
+	}
+
+	return nil
+}
+
+// handleObjectElementAdditionWhenNewObjectNil handles the case when newObject is nil
+func handleObjectElementAdditionWhenNewObjectNil(baseField, objectHash string, oldObject map[string]interface{},
+	originVal interface{}, d *schema.ResourceData) bool {
+	log.Printf("[DEBUG][handleObjectElementAdditionWhenNewObjectNil] Cannot find object '%s' in new state (object is in rawconfig but not in state)",
+		objectHash)
+
+	// If object is in old state but not in new state, it was removed from script
+	if oldObject != nil {
+		if !isOriginEmpty(originVal) && isObjectInOrigin(oldObject, originVal) {
+			log.Printf("[DEBUG][handleObjectElementAdditionWhenNewObjectNil] Object '%s' exists in old state and was in origin, "+
+				"not suppressing diff (allow removal)", objectHash)
 			return false
 		}
-		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' was in origin, suppressing diff", objectHash)
+		log.Printf("[DEBUG][handleObjectElementAdditionWhenNewObjectNil] Object '%s' exists in old state but not in new state (remote addition), "+
+			"suppressing diff", objectHash)
 		return true
 	}
 
-	// If object was not in origin, check if it exists in remote state (console added)
-	// If it exists in remote state, suppress the diff (ignore remote addition)
-	if checkObjectInRemoteState(baseField, newObject, d) {
-		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' was not in origin but exists in remote state, suppressing diff (ignore "+
-			"remote addition)", objectHash)
-		return true
+	// Try to reconstruct the object from state attributes
+	reconstructedObject := getObjectFromState(d, baseField, objectHash)
+	if len(reconstructedObject) > 0 {
+		if !isOriginEmpty(originVal) && isObjectInOrigin(reconstructedObject, originVal) {
+			log.Printf("[DEBUG][handleObjectElementAdditionWhenNewObjectNil] Object '%s' is in rawconfig and origin but not in remote "+
+				"state (restoring origin config), not suppressing diff", objectHash)
+			return false
+		}
+	} else if !isOriginEmpty(originVal) {
+		log.Printf("[DEBUG][handleObjectElementAdditionWhenNewObjectNil] Object '%s' is in rawconfig but not in remote state, "+
+			"and origin is not empty, not suppressing diff (might be restoring origin config)", objectHash)
+		return false
 	}
 
-	// If object was not in origin and not in remote state, don't suppress (this is a local addition)
-	log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' was not in origin and not in remote state, not suppressing diff (local addition)",
+	log.Printf("[DEBUG][handleObjectElementAdditionWhenNewObjectNil] Cannot find object '%s' in either new or old state, not suppressing diff",
 		objectHash)
 	return false
 }
 
-// handleFirstTimeObjectSetting handles the case when origin is empty or nil for objects
-func handleFirstTimeObjectSetting(baseField string, newObject map[string]interface{}, d *schema.ResourceData) bool {
-	// Check if this object exists in remote state
-	return checkObjectInRemoteState(baseField, newObject, d)
+// handleObjectElementAddition handles the case when an object element is being added or modified
+func handleObjectElementAddition(baseField, objectHash string, originVal interface{}, d *schema.ResourceData) bool {
+	// First, check if this object is being removed (in localRemovals)
+	oldParamVal, newParamVal := d.GetChange(baseField)
+	localRemovals := calculateLocalRemovals(originVal, oldParamVal, newParamVal)
+	tfstateSlice := convertToObjectSlice(oldParamVal)
+
+	// Try to get the object from old state to check if it's in localRemovals
+	oldObject := getObjectFromOldState(d, baseField, objectHash)
+	if oldObject == nil {
+		oldObject = make(map[string]interface{})
+		if d.State() != nil && d.State().Attributes != nil {
+			for key, val := range d.State().Attributes {
+				if strings.HasPrefix(key, fmt.Sprintf("%s.%s.", baseField, objectHash)) {
+					fieldName := strings.TrimPrefix(key, fmt.Sprintf("%s.%s.", baseField, objectHash))
+					oldObject[fieldName] = val
+				}
+			}
+		}
+	}
+
+	log.Printf("[DEBUG][handleObjectElementAddition] Checking if object '%s' is in localRemovals, oldObject=%v, localRemovals=%v",
+		objectHash, oldObject, formatObjectSliceForLog(localRemovals))
+
+	// Try to find the target object to check if it's in localRemovals
+	targetObject := findTargetObjectForAddition(d, baseField, objectHash, oldObject, tfstateSlice, localRemovals)
+
+	// Check if the target object is in localRemovals
+	if targetObject != nil {
+		if ObjectSliceContains(localRemovals, targetObject) {
+			log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is in (tfstate - RawConfig) ∩ (origin - RawConfig), "+
+				"NOT suppressing diff (local removal)", objectHash)
+			return false
+		}
+		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is NOT in localRemovals", objectHash)
+	} else {
+		log.Printf("[DEBUG][handleObjectElementAddition] Could not find target object for objectHash '%s', continuing with normal logic",
+			objectHash)
+	}
+
+	// Try to get the object from new state first
+	newObject := getObjectFromState(d, baseField, objectHash)
+
+	// If not found in new state, handle the nil case
+	if newObject == nil {
+		return handleObjectElementAdditionWhenNewObjectNil(baseField, objectHash, oldObject, originVal, d)
+	}
+
+	// If origin is nil or empty, check addition logic
+	if isOriginEmpty(originVal) {
+		oldParamVal, newParamVal := d.GetChange(baseField)
+		localAdditions := calculateLocalAdditions(originVal, oldParamVal, newParamVal)
+
+		if ObjectSliceContains(localAdditions, newObject) {
+			log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is in (RawConfig - tfstate) ∩ (RawConfig - origin) and origin is empty, "+
+				"NOT suppressing diff (local addition)", objectHash)
+			return false
+		}
+
+		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is not in (RawConfig - tfstate) ∩ (RawConfig - origin) and origin is empty, "+
+			"suppressing diff (remote addition)", objectHash)
+		return true
+	}
+
+	// Check if this object is in origin
+	if isObjectInOrigin(newObject, originVal) {
+		return handleObjectElementAdditionWhenInOrigin(baseField, objectHash, newObject, oldObject, d)
+	}
+
+	// Check addition logic: (RawConfig - tfstate) ∩ (RawConfig - origin)
+	localAdditions := calculateLocalAdditions(originVal, oldParamVal, newParamVal)
+
+	if ObjectSliceContains(localAdditions, newObject) {
+		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is in (RawConfig - tfstate) ∩ (RawConfig - origin), "+
+			"NOT suppressing diff (local addition)", objectHash)
+		return false
+	}
+
+	log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is not in (RawConfig - tfstate) ∩ (RawConfig - origin), "+
+		"suppressing diff (remote addition)", objectHash)
+	return true
+}
+
+// handleObjectElementAdditionWhenInOrigin handles the case when the object is in origin
+func handleObjectElementAdditionWhenInOrigin(baseField, objectHash string, newObject, oldObject map[string]interface{}, d *schema.ResourceData) bool {
+	// Check if it exists in remote state by matching object content
+	oldParamVal, _ := d.GetChange(baseField)
+	var oldObjectList []interface{}
+	if oldParamVal != nil {
+		switch v := oldParamVal.(type) {
+		case []interface{}:
+			oldObjectList = v
+		case *schema.Set:
+			oldObjectList = v.List()
+		}
+	}
+
+	// Check if newObject exists in remote state by content matching
+	objectInRemoteState := false
+	for _, oldItem := range oldObjectList {
+		if oldItemMap, ok := oldItem.(map[string]interface{}); ok {
+			if reflect.DeepEqual(oldItemMap, newObject) {
+				objectInRemoteState = true
+				log.Printf("[DEBUG][handleObjectElementAdditionWhenInOrigin] Object '%s' found in remote state by content matching: %v",
+					objectHash, newObject)
+				break
+			}
+		}
+	}
+
+	if !objectInRemoteState {
+		log.Printf("[DEBUG][handleObjectElementAdditionWhenInOrigin] Object '%s' (content: %v) is in rawconfig and origin but not in remote "+
+			"state (restoring origin config), not suppressing diff",
+			objectHash, newObject)
+		return false
+	}
+
+	// Object exists in both origin and remote state
+	if oldObject != nil && reflect.DeepEqual(oldObject, newObject) {
+		log.Printf("[DEBUG][handleObjectElementAdditionWhenInOrigin] Object '%s' unchanged and in origin and remote state, "+
+			"not suppressing diff to preserve config value", objectHash)
+		return false
+	}
+
+	log.Printf("[DEBUG][handleObjectElementAdditionWhenInOrigin] Object '%s' was in origin and remote state but changed, "+
+		"suppressing diff", objectHash)
+	return true
 }
 
 // isObjectInOrigin checks if an object exists in origin value
@@ -1329,67 +1864,46 @@ func convertToObjectSlice(val interface{}) []map[string]interface{} {
 	return result
 }
 
-// checkLocalAdditions checks if there are locally added elements
-func checkLocalAdditions(newScriptSlice, consoleSlice []map[string]interface{}) bool {
-	localAdditions := FindObjectSliceElementsNotInAnother(newScriptSlice, consoleSlice)
-	if len(localAdditions) > 0 {
-		log.Printf("[DEBUG][diffObjectSliceParam] New script contains elements not in console (locally added): %d, not suppressing diff",
-			len(localAdditions))
-		return true
-	}
-	return false
-}
-
-// checkLocalRemovals checks if there are locally removed elements
-func checkLocalRemovals(originSlice, newScriptSlice []map[string]interface{}) bool {
-	localRemovals := FindObjectSliceElementsNotInAnother(originSlice, newScriptSlice)
-	if len(localRemovals) > 0 {
-		log.Printf("[DEBUG][diffObjectSliceParam] New script has elements decreased compared to origin (locally removed), not suppressing diff")
-		return true
-	}
-	return false
-}
-
 // diffObjectSliceParam is used to check whether the parameters of the current object slice type have been modified
 // other than those changed in the console.
-// The following scenarios will determine whether the parameter has changed (method return false):
-//  1. The new value of the script adds new elements compared to the console value (locally added elements).
-//  2. The new value of the script has elements decreased compared to the origin value (locally removed elements).
+// Only show diff in the following two scenarios (return false to not suppress diff):
+//  1. New additions: (RawConfig - tfstate) ∩ (RawConfig - origin)
+//     Elements that are in RawConfig but not in tfstate AND not in origin
+//  2. Removals: (tfstate - RawConfig) ∩ (origin - RawConfig)
+//     Elements that are in tfstate but not in RawConfig AND in origin but not in RawConfig
 //
-// The following scenarios will suppress the diff (method return true):
-//  1. The new value of the script is a subset of the console value AND
-//     the new value of the script has no elements decreased compared to the origin value.
+// All other scenarios will suppress the diff (return true).
 func diffObjectSliceParam(paramKey string, d *schema.ResourceData) bool {
 	originParamKey := fmt.Sprintf("%s_origin", paramKey)
 	originVal := d.Get(originParamKey)
 	originSlice := convertToObjectSlice(originVal)
 
-	// If origin is empty, this is the first time setting the value
-	if len(originSlice) == 0 {
-		log.Printf("[DEBUG][diffObjectSliceParam] Origin is empty, allowing change (first time setting)")
-		return false
-	}
-
 	// Get old and new values from GetChange
 	oldParamVal, newParamVal := d.GetChange(paramKey)
-	consoleSlice := convertToObjectSlice(oldParamVal)
-	newScriptSlice := convertToObjectSlice(newParamVal)
+	tfstateSlice := convertToObjectSlice(oldParamVal)   // tfstate (remote state)
+	rawConfigSlice := convertToObjectSlice(newParamVal) // RawConfig (script config)
 
-	log.Printf("[DEBUG][diffObjectSliceParam] paramKey='%s', originSlice length=%d, consoleSlice length=%d, newScriptSlice length=%d",
-		paramKey, len(originSlice), len(consoleSlice), len(newScriptSlice))
+	log.Printf("[DEBUG][diffObjectSliceParam] paramKey='%s', originSlice length=%d, tfstateSlice length=%d, rawConfigSlice length=%d",
+		paramKey, len(originSlice), len(tfstateSlice), len(rawConfigSlice))
 
-	// Check if only care about elements that are in new script but NOT in console (locally added)
-	if checkLocalAdditions(newScriptSlice, consoleSlice) {
+	// Scenario 1: New additions - (RawConfig - tfstate) ∩ (RawConfig - origin)
+	localAdditions := calculateLocalAdditions(originVal, oldParamVal, newParamVal)
+	if len(localAdditions) > 0 {
+		log.Printf("[DEBUG][diffObjectSliceParam] Found local additions (RawConfig - tfstate) ∩ (RawConfig - origin): %d, not suppressing diff",
+			len(localAdditions))
 		return false
 	}
 
-	// Check if new script has elements decreased compared to origin (locally removed)
-	if checkLocalRemovals(originSlice, newScriptSlice) {
+	// Scenario 2: Removals - (tfstate - RawConfig) ∩ (origin - RawConfig)
+	localRemovals := calculateLocalRemovals(originVal, oldParamVal, newParamVal)
+	if len(localRemovals) > 0 {
+		log.Printf("[DEBUG][diffObjectSliceParam] Found local removals (tfstate - RawConfig) ∩ (origin - RawConfig): %d, not suppressing diff",
+			len(localRemovals))
 		return false
 	}
 
-	// Both conditions are met, suppress the diff
-	log.Printf("[DEBUG][diffObjectSliceParam] No local additions and no local removals, suppressing diff")
+	// No local additions or removals, suppress the diff
+	log.Printf("[DEBUG][diffObjectSliceParam] No local additions or removals, suppressing diff")
 	return true
 }
 
@@ -1413,4 +1927,21 @@ func ObjectSliceContains(slice []map[string]interface{}, target map[string]inter
 		}
 	}
 	return false
+}
+
+// formatObjectSliceForLog formats an object slice for logging purposes
+func formatObjectSliceForLog(slice []map[string]interface{}) string {
+	if len(slice) == 0 {
+		return "[]"
+	}
+	var result []string
+	for _, obj := range slice {
+		// Try to extract name field if it exists, otherwise use the whole object
+		if name, ok := obj["name"].(string); ok {
+			result = append(result, name)
+		} else {
+			result = append(result, fmt.Sprintf("%v", obj))
+		}
+	}
+	return fmt.Sprintf("[%s]", strings.Join(result, ", "))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Optimize the current MySQL database batch user authorization resource:

- The current resource does not support managing only local user authorizations: When other collaborating accounts create user authorizations or create them via the console, the local system will prompt for changes or cause additional deletions of user authorizations not belonging to the local management scope during deletion.
- The current Refresh+DiffSuppress management cannot effectively add remote management configurations (for user privileges management) without local changes: Use a query to retrieve remote data during Update, and filter it directly during Order (do not retain remote data). This will ensure that changes are displayed as additions or deletions, rather than changes (see example below).
 
Manage the remote privileges and change user privileges at the same time (History (current) Refresh+DiffSuppress)
```
Terraform will perform the following actions:

  # huaweicloud_rds_mysql_database_privilege.test will be updated in-place
  ~ resource "huaweicloud_rds_mysql_database_privilege" "test" {
        id          = "a43d46b77e2647cf99d55b0a37784e2bin01/tf_test_randx"
        # (3 unchanged attributes hidden)

      ~ users {
          - name     = "tf_test_account_2" -> null
            # (1 unchanged attribute hidden)
        }

        # (6 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Now
```
Terraform will perform the following actions:

  # huaweicloud_rds_mysql_database_privilege.test will be updated in-place
  ~ resource "huaweicloud_rds_mysql_database_privilege" "test" {
        id          = "a43d46b77e2647cf99d55b0a37784e2bin01/tf_test_randx"
        # (3 unchanged attributes hidden)

      - users {
          - name     = "tf_test_account_2" -> null
          - readonly = false -> null
        } -> null

        # (5 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

code coverage for basic test:
<img width="1046" height="351" alt="image" src="https://github.com/user-attachments/assets/70e7ddd8-8ba0-4447-bc0f-d7acddd750bf" />

No new remote authorizations were added after the resource was created.
<img width="1589" height="1316" alt="image" src="https://github.com/user-attachments/assets/cd87c5e4-3a66-4b5d-ae7f-a2e3c78fd475" />

After the resource is created, manually add an authorization on the remote end.
<img width="2209" height="1009" alt="image" src="https://github.com/user-attachments/assets/5473b626-4755-4b8e-90f4-2e59e9c3023e" />

The change was made if there were other additional authorizations on the remote end (adding a new authorization), and a new local configuration was added while keeping the remote configuration unchanged.
<img width="2186" height="1327" alt="image" src="https://github.com/user-attachments/assets/fa4e02fb-efff-4f28-9730-47071ba28a98" />

Make changes if there are other additional authorizations on the remote end (remove an existing locally managed authorization), and remove a local configuration while keeping the remote configuration unchanged.
<img width="2312" height="1326" alt="image" src="https://github.com/user-attachments/assets/cf530e06-ae33-4f62-a3b2-7da6e9325899" />

Misaligned updates (index misalignment) add an authorization not at the end of the list. It displays one change and one addition, but in actual processing, only the addition is handled (misaligned display only for List types).
（before）
<img width="1301" height="595" alt="image" src="https://github.com/user-attachments/assets/420da40e-6157-4917-b011-21eb1e4ce713" />
（operating）
<img width="2285" height="1328" alt="image" src="https://github.com/user-attachments/assets/871f8d31-cd07-48c2-8288-b4377af113f4" />

Misaligned update (index misalignment): Removes an authorization that is not at the end of the list. It displays one change and one deletion, but in actual processing, only deletions are handled (misalignment only applies to List types).
（before）
<img width="1318" height="648" alt="image" src="https://github.com/user-attachments/assets/c8b7408f-0b02-482e-86e1-e9c7ee66e08c" />
（operating）
<img width="2290" height="1325" alt="image" src="https://github.com/user-attachments/assets/2fdf9579-0007-4502-871a-88eb4a7899fb" />

No changes after import and all privileges are managed even if some of privileges are not belongs local script.
<img width="2324" height="1295" alt="image" src="https://github.com/user-attachments/assets/ef1e6041-13c9-43c7-9f56-6d0ad1273620" />
<img width="1560" height="526" alt="image" src="https://github.com/user-attachments/assets/0e56fbdb-1fd7-412e-9390-7e01c63badbc" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. optimize the privilege management resource codes of MySQL database.
2. upgrade the acceptance test to coverage user privileges update and with difference read only settings.
3. update the checkdeleted feature and returns 404 error when all of local manged privileges are deleted.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o rds -f TestAccDataMysqlDatabasePrivileges_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rds" -v -coverprofile="./huaweicloud/services/acceptance/rds/rds_coverage.cov" -coverpkg="./huaweicloud/services/rds" -run TestAccDataMysqlDatabasePrivileges_basic -timeout 360m -parallel 10
=== RUN   TestAccDataMysqlDatabasePrivileges_basic
=== PAUSE TestAccDataMysqlDatabasePrivileges_basic
=== CONT  TestAccDataMysqlDatabasePrivileges_basic
--- PASS: TestAccDataMysqlDatabasePrivileges_basic (613.60s)
PASS
coverage: 10.8% of statements in ./huaweicloud/services/rds
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       613.747s        coverage: 10.8% of statements in ./huaweicloud/services/rds
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1907" height="1307" alt="image" src="https://github.com/user-attachments/assets/50124379-7d0c-4bb0-8a8c-dde487dffe4b" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
