### PR TITLE
fix(dds/instance): fix status code is 400 when missing CheckDeleted check

### DIFF
--- a/huaweicloud/services/dds/resource_huaweicloud_dds_instance_v3.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_instance_v3.go
@@ -29,6 +29,11 @@ import (
 
 type ctxType string
 
+var (
+	// DBS.280110: The instance does not exist.
+	instanceNotFoundCodes = []string{"DBS.280110"}
+)
+
 // @API DDS POST /v3/{project_id}/instances
 // @API DDS GET /v3/{project_id}/instances
 // @API DDS POST /v3/{project_id}/instances/{instance_id}/tags/action
@@ -976,7 +981,11 @@ func resourceDdsInstanceV3Read(ctx context.Context, d *schema.ResourceData, meta
 	}
 	allPages, err := instances.List(client, &opts).AllPages()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving DdsInstance")
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", instanceNotFoundCodes...),
+			"error retrieving DDS instance",
+		)
 	}
 	instanceList, err := instances.ExtractInstances(allPages)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When an instance does not exist, the query instance list interface returns a status code of `400` with the error code `DBS.280110`. The code is missing a CheckDeleted check for this situation.
<img width="1373" height="840" alt="image" src="https://github.com/user-attachments/assets/ac6689f0-df4d-40f4-8c25-bb178c910ada" />

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
supplement the CheckDeleted scenario.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
