### PR TITLE
feat(apig/application): change app_key and app_secret attributes to optional parameters

### DIFF
--- a/docs/resources/apig_application.md
+++ b/docs/resources/apig_application.md
@@ -52,8 +52,20 @@ The following arguments are supported:
   The application code must start with a letter, digit, plus sign (+) or slash (/).  
   Only letters, digits and following special special characters are allowed: `!@#$%+-_/=`.
 
+* `app_key` - (Optional, String) Specifies the APP key.  
+  The valid length is limited from `8` to `200`, only English letters, digits, underscores (_) and
+  hyphens (-) are allowed.  
+  The key must start with a letter or digit.
+
+* `app_secret` - (Optional, String) Specifies the APP secret.  
+  The valid length is limited from `8` to `128`, only English letters, digits, special characters (`_-!@#$%`)
+  are allowed.  
+  The secret must start with a letter or digit.
+
 * `secret_action` - (Optional, String) Specifies the secret action to be done for the application.  
-  The valid action is **RESET**.
+  The valid action is **RESET**.  
+  When updating, if the `app_secret` parameter is specified in the script, using this parameter will reset the value of
+  the `app_secret`. Please use `lifecycle.ignore_changes` or manually synchronize the changes.
 
   -> The `secret_action` is a one-time action.
 
@@ -66,10 +78,6 @@ In addition to all arguments above, the following attributes are exported:
 * `registration_time` - the registration time.
 
 * `updated_at` - The latest update time of the application.
-
-* `app_key` - App key.
-
-* `app_secret` - App secret.
 
 ## Import
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application.go
@@ -75,6 +75,19 @@ func ResourceApigApplicationV2() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The array of one or more application codes that the application has.",
 			},
+			"app_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The APP key.",
+			},
+			"app_secret": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The APP secret.",
+			},
 			"secret_action": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -87,17 +100,6 @@ func ResourceApigApplicationV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The registration time.",
-			},
-			"app_key": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The APP key.",
-			},
-			"app_secret": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Sensitive:   true,
-				Description: "The APP secret.",
 			},
 			"updated_at": {
 				Type:        schema.TypeString,
@@ -134,6 +136,8 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 		opts = applications.AppOpts{
 			Name:        d.Get("name").(string),
 			Description: d.Get("description").(string),
+			AppKey:      d.Get("app_key").(string),
+			AppSecret:   d.Get("app_secret").(string),
 		}
 	)
 	resp, err := applications.Create(client, instanceId, opts).Extract()
@@ -269,10 +273,12 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 		appId      = d.Id()
 	)
 
-	if d.HasChanges("name", "description") {
+	if d.HasChanges("name", "description", "app_key", "app_secret") {
 		opt := applications.AppOpts{
 			Name:        d.Get("name").(string),
 			Description: d.Get("description").(string),
+			AppKey:      d.Get("app_key").(string),
+			AppSecret:   d.Get("app_secret").(string),
 		}
 		_, err = applications.Update(client, instanceId, appId, opt).Extract()
 		if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The resource `huaweicloud_apig_application` now supports the `app_key` and `app_secret` parameters, therefore their behavior needs to be modified to `Optional` and `Computed`.

If `app_key` and `app_secret` are not specified during creation, the system will automatically generate them.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports app_key and app_secret parameters
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccApplication_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApplication_basic -timeout 360m -parallel 10
=== RUN   TestAccApplication_basic
=== PAUSE TestAccApplication_basic
=== CONT  TestAccApplication_basic
--- PASS: TestAccApplication_basic (56.01s)
PASS
coverage: 2.7% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      56.155s coverage: 2.7% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
