### PR TITLE
fix(ccm): rename ccm private datasource name

### DIFF
--- a/docs/data-sources/ccm_private_certificate_quota.md
+++ b/docs/data-sources/ccm_private_certificate_quota.md
@@ -1,19 +1,19 @@
 ---
 subcategory: "Cloud Certificate Manager (CCM)"
 layout: "huaweicloud"
-page_title: "HuaweiCloud: huaweicloud_ccm_private_ca_quota"
+page_title: "HuaweiCloud: huaweicloud_ccm_private_certificate_quota"
 description: |-
-  Use this data source to get the quota of CCM private CA.
+  Use this data source to get the quota of CCM private certificate.
 ---
 
-# huaweicloud_ccm_private_ca_quota
+# huaweicloud_ccm_private_certificate_quota
 
-Use this data source to get the quota of CCM private CA.
+Use this data source to get the quota of CCM private certificate.
 
 ## Example Usage
 
 ```hcl
-data "huaweicloud_ccm_private_ca_quota" "test" {}
+data "huaweicloud_ccm_private_certificate_quota" "test" {}
 ```
 
 ## Argument Reference

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -773,7 +773,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ccm_csr_private_key":              ccm.DataSourceCcmCsrPrivateKey(),
 			"huaweicloud_ccm_private_cas":                  ccm.DataSourcePrivateCas(),
 			"huaweicloud_ccm_private_ca_export":            ccm.DataSourcePrivateCaExport(),
-			"huaweicloud_ccm_private_ca_quota":             ccm.DataSourceCcmPrivateCaQuota(),
+			"huaweicloud_ccm_private_certificate_quota":    ccm.DataSourceCcmPrivateCertificateQuota(),
 			"huaweicloud_ccm_private_ca_tags":              ccm.DataSourceCcmPrivateCaTags(),
 			"huaweicloud_ccm_private_cas_by_tags":          ccm.DataSourcePrivateCasByTags(),
 			"huaweicloud_ccm_private_certificates":         ccm.DataSourcePrivateCertificates(),

--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_quota_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_quota_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceCcmPrivateCaQuota_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_ccm_private_ca_quota.test"
+func TestAccDataSourceCcmPrivateCertificateQuota_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_ccm_private_certificate_quota.test"
 	dc := acceptance.InitDataSourceCheck(dataSource)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -19,7 +19,7 @@ func TestAccDataSourceCcmPrivateCaQuota_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceCcmPrivateCaQuota_basic,
+				Config: testDataSourceDataSourceCcmPrivateCertificateQuota_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.resources.0.type"),
@@ -31,6 +31,6 @@ func TestAccDataSourceCcmPrivateCaQuota_basic(t *testing.T) {
 	})
 }
 
-const testDataSourceDataSourceCcmPrivateCaQuota_basic = `
-data "huaweicloud_ccm_private_ca_quota" "test" {}
+const testDataSourceDataSourceCcmPrivateCertificateQuota_basic = `
+data "huaweicloud_ccm_private_certificate_quota" "test" {}
 `

--- a/huaweicloud/services/ccm/data_source_huaweicloud_ccm_private_certificate_quota.go
+++ b/huaweicloud/services/ccm/data_source_huaweicloud_ccm_private_certificate_quota.go
@@ -15,9 +15,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/schemas"
 )
 
-func DataSourceCcmPrivateCaQuota() *schema.Resource {
+func DataSourceCcmPrivateCertificateQuota() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceCcmPrivateCaQuotaRead,
+		ReadContext: dataSourceCcmPrivateCertificateQuotaRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -63,20 +63,20 @@ func DataSourceCcmPrivateCaQuota() *schema.Resource {
 	}
 }
 
-type PrivateCaQuotaDSWrapper struct {
+type PrivateCertificateQuotaDSWrapper struct {
 	*schemas.ResourceDataWrapper
 	Config *config.Config
 }
 
-func newPrivateCaQuotaDSWrapper(d *schema.ResourceData, meta interface{}) *PrivateCaQuotaDSWrapper {
-	return &PrivateCaQuotaDSWrapper{
+func newPrivateCertificateQuotaDSWrapper(d *schema.ResourceData, meta interface{}) *PrivateCertificateQuotaDSWrapper {
+	return &PrivateCertificateQuotaDSWrapper{
 		ResourceDataWrapper: schemas.NewSchemaWrapper(d),
 		Config:              meta.(*config.Config),
 	}
 }
 
-func dataSourceCcmPrivateCaQuotaRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	wrapper := newPrivateCaQuotaDSWrapper(d, meta)
+func dataSourceCcmPrivateCertificateQuotaRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	wrapper := newPrivateCertificateQuotaDSWrapper(d, meta)
 	shoCerQuoRst, err := wrapper.ShowCertificateQuota()
 	if err != nil {
 		return diag.FromErr(err)
@@ -97,7 +97,7 @@ func dataSourceCcmPrivateCaQuotaRead(_ context.Context, d *schema.ResourceData, 
 }
 
 // @API CCM GET /v1/private-certificates/quotas
-func (w *PrivateCaQuotaDSWrapper) ShowCertificateQuota() (*gjson.Result, error) {
+func (w *PrivateCertificateQuotaDSWrapper) ShowCertificateQuota() (*gjson.Result, error) {
 	client, err := w.NewClient(w.Config, "ccm")
 	if err != nil {
 		return nil, err
@@ -111,7 +111,7 @@ func (w *PrivateCaQuotaDSWrapper) ShowCertificateQuota() (*gjson.Result, error) 
 		Result()
 }
 
-func (w *PrivateCaQuotaDSWrapper) showCertificateQuotaToSchema(body *gjson.Result) error {
+func (w *PrivateCertificateQuotaDSWrapper) showCertificateQuotaToSchema(body *gjson.Result) error {
 	d := w.ResourceData
 	mErr := multierror.Append(nil,
 		d.Set("region", w.Config.GetRegion(w.ResourceData)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

rename ccm private datasource name

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- This datasource has not yet been released in the new version.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o ccm -f TestAccDataSourceCcmPrivateCertificateQuota_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ccm" -v -coverprofile="./huaweicloud/services/acceptance/ccm/ccm_coverage.cov" -coverpkg="./huaweicloud/services/ccm" -run TestAccDataSourceCcmPrivateCertificateQuota_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCcmPrivateCertificateQuota_basic
=== PAUSE TestAccDataSourceCcmPrivateCertificateQuota_basic
=== CONT  TestAccDataSourceCcmPrivateCertificateQuota_basic
--- PASS: TestAccDataSourceCcmPrivateCertificateQuota_basic (15.38s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       15.475s coverage: 4.5% of statements in ./huaweicloud/services/ccm
```
<img width="1377" height="61" alt="image" src="https://github.com/user-attachments/assets/bf8f8f16-1797-4383-bcf1-6c625f35f6b7" />


* [X] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
