### PR TITLE
feat(ccm): new resource to cancel certificate request

### DIFF
--- a/docs/resources/ccm_certificate_cancel_request.md
+++ b/docs/resources/ccm_certificate_cancel_request.md
@@ -1,0 +1,39 @@
+---
+subcategory: "Cloud Certificate Manager (CCM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ccm_certificate_cancel_request"
+description: |-
+  Manages a CCM SSL certificate cancel request resource within HuaweiCloud.
+---
+
+# huaweicloud_ccm_certificate_cancel_request
+
+Manages a CCM SSL certificate cancel request resource within HuaweiCloud.
+
+-> Destroying this resource will not clear the cancellation status of the CCM SSL certificate, but will only remove
+the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "certificate_id" {}
+
+resource "huaweicloud_ccm_certificate_cancel_request" "test" {
+  certificate_id = var.certificate_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `certificate_id` - (Required, String, NonUpdatable) Specifies the CCM SSL certificate ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also the CCM SSL certificate ID).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2820,6 +2820,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ccm_certificate":                ccm.ResourceCCMCertificate(),
 			"huaweicloud_ccm_csr":                        ccm.ResourceCsr(),
 			"huaweicloud_ccm_certificate_apply":          ccm.ResourceCertificateApply(),
+			"huaweicloud_ccm_certificate_cancel_request": ccm.ResourceCertificateCancelRequest(),
 			"huaweicloud_ccm_certificate_deploy":         ccm.ResourceCertificateDeploy(),
 			"huaweicloud_ccm_certificate_import":         ccm.ResourceCertificateImport(),
 			"huaweicloud_ccm_certificate_push":           ccm.ResourceCertificatePush(),

--- a/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_certificate_cancel_request_test.go
+++ b/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_certificate_cancel_request_test.go
@@ -1,0 +1,34 @@
+package ccm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceCertificateCancelRequest_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCCMSSLCertificateId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceResourceCertificateCancelRequest_basic(),
+			},
+		},
+	})
+}
+
+func testResourceResourceCertificateCancelRequest_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ccm_certificate_cancel_request" "test" {
+  certificate_id  = "%s"
+}
+`, acceptance.HW_CCM_SSL_CERTIFICATE_ID)
+}

--- a/huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_cancel_request.go
+++ b/huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_cancel_request.go
@@ -1,0 +1,97 @@
+package ccm
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SCM POST /v3/scm/certificates/{certificate_id}/cancel-cert
+func ResourceCertificateCancelRequest() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCertificateCancelRequestCreate,
+		UpdateContext: resourceCertificateCancelRequestUpdate,
+		ReadContext:   resourceCertificateCancelRequestRead,
+		DeleteContext: resourceCertificateCancelRequestDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"certificate_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"certificate_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceCertificateCancelRequestCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		httpUrl       = "v3/scm/certificates/{certificate_id}/cancel-cert"
+		product       = "scm"
+		certificateID = d.Get("certificate_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CCM client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{certificate_id}", certificateID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error canceling CCM SSL certificate: %s", err)
+	}
+
+	d.SetId(certificateID)
+
+	return resourceCertificateCancelRequestRead(ctx, d, meta)
+}
+
+func resourceCertificateCancelRequestRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCertificateCancelRequestUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCertificateCancelRequestDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `Deleting this resource will not clear the cancellation status of the CCM SSL certificate, but will only
+	remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to cancel certificate request

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o ccm -f TestAccResourceCertificateCancelRequest_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ccm" -v -coverprofile="./huaweicloud/services/acceptance/ccm/ccm_coverage.cov" -coverpkg="./huaweicloud/services/ccm" -run TestAccResourceCertificateCancelRequest_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceCertificateCancelRequest_basic
=== PAUSE TestAccResourceCertificateCancelRequest_basic
=== CONT  TestAccResourceCertificateCancelRequest_basic
--- PASS: TestAccResourceCertificateCancelRequest_basic (15.41s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       15.516s coverage: 4.1% of statements in ./huaweicloud/services/ccm
```
<img width="1386" height="53" alt="image" src="https://github.com/user-attachments/assets/67b853bd-365c-4251-a898-75f7f4b41f9a" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
