### PR TITLE
refactor: test(cbr): vault supports mange incremental resources and local only

### DIFF
--- a/huaweicloud/utils/resource_diff.go
+++ b/huaweicloud/utils/resource_diff.go
@@ -191,11 +191,12 @@ func ContainsAllKeyValues(objA, objB map[string]interface{}) bool {
 			if !ContainsAllKeyValues(aMap, bMap) {
 				return false
 			}
-		} else {
-			// Non-map types are compared directly via DeepEqual().
-			if !reflect.DeepEqual(bVal, aVal) {
-				return false
-			}
+			continue
+		}
+
+		// Non-map types are compared directly via DeepEqual().
+		if !reflect.DeepEqual(bVal, aVal) {
+			return false
 		}
 	}
 	return true
@@ -489,20 +490,31 @@ func TakeObjectsDifferent(objA, objB map[string]interface{}) map[string]interfac
 // SuppressStrSliceDiffs is a method that makes the string slice type parameter ignore the changes made on the console and
 // only allow the local script to take effect. It identifies elements that are decreased compared to origin and
 // elements that are newly added remotely.
-func SuppressStrSliceDiffs() schema.SchemaDiffSuppressFunc {
+// The optional originConfig parameter supports cross-structure origin detection with format:
+// "{origin_root_field}|{locator_key}.{origin_field_name}"
+// Example: "resources_origin|server_id.excludes" means:
+// - origin is in resources_origin list
+// - locate by server_id key from current structure
+// - origin field name is excludes
+func SuppressStrSliceDiffs(originConfig ...string) schema.SchemaDiffSuppressFunc {
+	var originConfigStr string
+	if len(originConfig) > 0 {
+		originConfigStr = originConfig[0]
+	}
 	return func(paramKey, o, n string, d *schema.ResourceData) bool {
-		log.Printf("[DEBUG][SuppressStrSliceDiffs] Called with paramKey='%s', oldVal='%s', newVal='%s'", paramKey, o, n)
+		log.Printf("[DEBUG][SuppressStrSliceDiffs] Called with paramKey='%s', oldVal='%s', newVal='%s', originConfig='%s'",
+			paramKey, o, n, originConfigStr)
 
 		// Handle TypeSet length field
 		if strings.HasSuffix(paramKey, ".#") {
 			log.Printf("[DEBUG][SuppressStrSliceDiffs] Processing TypeSet length field: %s", paramKey)
-			return diffStrSliceLength(paramKey, o, n, d)
+			return diffStrSliceLength(paramKey, o, n, d, originConfigStr)
 		}
 
 		// Handle TypeSet element fields (e.g., {set_param_key}.1234567890)
 		if strings.Contains(paramKey, ".") && !strings.HasSuffix(paramKey, ".%") {
 			log.Printf("[DEBUG][SuppressStrSliceDiffs] Processing TypeSet element field: %s", paramKey)
-			return diffStrSliceElement(paramKey, o, n, d)
+			return diffStrSliceElement(paramKey, o, n, d, originConfigStr)
 		}
 
 		if strings.HasSuffix(paramKey, ".%") {
@@ -511,67 +523,330 @@ func SuppressStrSliceDiffs() schema.SchemaDiffSuppressFunc {
 		}
 
 		log.Printf("[DEBUG][SuppressStrSliceDiffs] Processing main field: %s", paramKey)
-		result := diffStrSliceParam(paramKey, o, n, d)
+		result := diffStrSliceParam(paramKey, o, n, d, originConfigStr)
 		log.Printf("[DEBUG][SuppressStrSliceDiffs] Final result: %v", result)
 		return result
 	}
 }
 
+// parseOriginConfig parses the origin configuration string
+// Format: "{origin_root_field}|{locator_key}.{origin_field_name}"
+// Example: "resources_origin|server_id.excludes"
+// Returns: originRootField, locatorKey, originFieldName
+func parseOriginConfig(originConfig string) (originRootField, locatorKey, originFieldName string) {
+	if originConfig == "" {
+		return "", "", ""
+	}
+
+	parts := strings.Split(originConfig, "|")
+	if len(parts) != 2 {
+		return "", "", ""
+	}
+
+	originRootField = parts[0]
+	locatorAndField := strings.Split(parts[1], ".")
+	if len(locatorAndField) != 2 {
+		return
+	}
+
+	locatorKey = locatorAndField[0]
+	originFieldName = locatorAndField[1]
+
+	return
+}
+
+// getCrossStructureOriginValue retrieves origin value using cross-structure detection
+// For paramKey like "resources.0.excludes", it will:
+// 1. Get server_id from resources.0.server_id (or use oldLocatorValue if provided)
+// 2. Build JMESPath: resources_origin[?server_id == 'xxx']|[0].excludes
+// 3. Return the origin excludes value
+// If oldLocatorValue is provided, it will be used instead of getting from current state
+func getCrossStructureOriginValue(d *schema.ResourceData, paramKey, originConfig string, oldLocatorValue ...string) interface{} {
+	originRootField, locatorKey, originFieldName := parseOriginConfig(originConfig)
+	if originRootField == "" || locatorKey == "" || originFieldName == "" {
+		return nil
+	}
+
+	// Parse paramKey to get parent path (e.g., "resources.0" from "resources.0.excludes")
+	parts := strings.Split(paramKey, ".")
+	if len(parts) < 2 {
+		return nil
+	}
+
+	parentPath := strings.Join(parts[:len(parts)-1], ".")
+
+	// Get locator value - use oldLocatorValue if provided, otherwise get from current state
+	var locatorValueStr string
+	var ok bool
+	if len(oldLocatorValue) > 0 && oldLocatorValue[0] != "" {
+		// Use provided old locator value (from tfstate)
+		locatorValueStr = oldLocatorValue[0]
+		log.Printf("[DEBUG][getCrossStructureOriginValue] Using provided old locator value '%s' for path '%s'", locatorValueStr, parentPath)
+	} else {
+		// Get locator value from parent (e.g., server_id from resources.0)
+		locatorValue := d.Get(fmt.Sprintf("%s.%s", parentPath, locatorKey))
+		if locatorValue == nil {
+			log.Printf("[DEBUG][getCrossStructureOriginValue] Locator key '%s' not found at path '%s'", locatorKey, parentPath)
+			return nil
+		}
+
+		locatorValueStr, ok = locatorValue.(string)
+		if !ok {
+			log.Printf("[DEBUG][getCrossStructureOriginValue] Locator value is not a string: %T", locatorValue)
+			return nil
+		}
+	}
+
+	// Get origin root list
+	originRootVal := d.Get(originRootField)
+	if originRootVal == nil {
+		log.Printf("[DEBUG][getCrossStructureOriginValue] Origin root field '%s' not found", originRootField)
+		return nil
+	}
+
+	// Build JMESPath expression: [?locatorKey == 'locatorValue']|[0].originFieldName
+	// Escape single quotes in locatorValueStr to prevent JMESPath injection
+	escapedLocatorValue := strings.ReplaceAll(locatorValueStr, "'", "\\'")
+	jmesPath := fmt.Sprintf("[?%s == '%s']|[0].%s", locatorKey, escapedLocatorValue, originFieldName)
+	log.Printf("[DEBUG][getCrossStructureOriginValue] JMESPath: %s", jmesPath)
+
+	// Convert originRootVal to []interface{} for PathSearch
+	var originRootList []interface{}
+	switch v := originRootVal.(type) {
+	case []interface{}:
+		originRootList = v
+	default:
+		log.Printf("[DEBUG][getCrossStructureOriginValue] Unexpected origin root type: %T, expected []interface{}", originRootVal)
+		return nil
+	}
+
+	if len(originRootList) == 0 {
+		log.Printf("[DEBUG][getCrossStructureOriginValue] Origin root list is empty")
+		return nil
+	}
+
+	// Use PathSearch to get origin value
+	originVal := PathSearch(jmesPath, originRootList, nil)
+	log.Printf("[DEBUG][getCrossStructureOriginValue] Found origin value: %v (type: %T)", originVal, originVal)
+
+	return originVal
+}
+
+// getOldLocatorValueFromState gets the old locator value from tfstate
+// This is used when the locator field (e.g., server_id) has changed
+func getOldLocatorValueFromState(d *schema.ResourceData, paramKey, originConfig string) string {
+	_, locatorKey, _ := parseOriginConfig(originConfig)
+	if locatorKey == "" {
+		return ""
+	}
+
+	// Parse paramKey to get parent path (e.g., "resources.0" from "resources.0.excludes")
+	parts := strings.Split(paramKey, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+
+	parentPath := strings.Join(parts[:len(parts)-1], ".")
+
+	// Get old locator value from tfstate using GetChange
+	locatorKeyPath := fmt.Sprintf("%s.%s", parentPath, locatorKey)
+	oldLocatorVal, _ := d.GetChange(locatorKeyPath)
+	if oldLocatorVal != nil {
+		if oldLocatorValStr, ok := oldLocatorVal.(string); ok && oldLocatorValStr != "" {
+			log.Printf("[DEBUG][getOldLocatorValueFromState] Found old locator value '%s' from GetChange('%s')", oldLocatorValStr, locatorKeyPath)
+			return oldLocatorValStr
+		}
+	}
+
+	// Fallback: try to get from state attributes directly
+	if d.State() != nil && d.State().Attributes != nil {
+		if stateLocatorValStr, ok := d.State().Attributes[locatorKeyPath]; ok && stateLocatorValStr != "" {
+			log.Printf("[DEBUG][getOldLocatorValueFromState] Found old locator value '%s' at path '%s'", stateLocatorValStr, locatorKeyPath)
+			return stateLocatorValStr
+		}
+	}
+
+	return ""
+}
+
+// getOriginValueForStrSliceLength gets the origin value for string slice length diff
+func getOriginValueForStrSliceLength(baseField, originConfig string, d *schema.ResourceData) interface{} {
+	var originVal interface{}
+	if originConfig != "" {
+		// Try to get old locator value from tfstate
+		// For nested fields like "resources.0.excludes", get old server_id from tfstate
+		oldLocatorValue := getOldLocatorValueFromState(d, baseField, originConfig)
+		originVal = getCrossStructureOriginValue(d, baseField, originConfig, oldLocatorValue)
+	}
+
+	// Fallback to nested paths if cross-structure detection didn't work
+	if originVal == nil {
+		parts := strings.Split(baseField, ".")
+		if len(parts) >= 3 {
+			// Nested case: {parent}.{index}.{field} (e.g., "resources.0.excludes")
+			parentField := parts[0]
+			indexStr := parts[1]
+			fieldName := strings.Join(parts[2:], ".")
+
+			// Try pattern 1: {parent}_origin.{index}.{field}
+			originParamKey1 := fmt.Sprintf("%s_origin.%s.%s", parentField, indexStr, fieldName)
+			originVal = getNestedOriginValue(d, originParamKey1)
+
+			// Try pattern 2: {parent}.{index}.{field}_origin
+			if originVal == nil {
+				originParamKey2 := fmt.Sprintf("%s.%s.%s_origin", parentField, indexStr, fieldName)
+				originVal = d.Get(originParamKey2)
+			}
+		}
+
+		// Fallback to simple pattern: {baseField}_origin
+		if originVal == nil {
+			originParamKey := fmt.Sprintf("%s_origin", baseField)
+			originVal = d.Get(originParamKey)
+		}
+	}
+	return originVal
+}
+
+// checkParentFieldInRawConfig checks if parent field exists in rawConfig
+func checkParentFieldInRawConfig(baseField string, d *schema.ResourceData) bool {
+	if !strings.Contains(baseField, ".") {
+		return false
+	}
+
+	parts := strings.Split(baseField, ".")
+	if len(parts) < 2 {
+		return false
+	}
+
+	parentField := parts[0]
+	parentRawConfigVal := GetNestedObjectFromRawConfig(d.GetRawConfig(), parentField)
+	log.Printf("[DEBUG][diffStrSliceLength] Parent field '%s' rawConfigVal=%v (type=%T)",
+		parentField, parentRawConfigVal, parentRawConfigVal)
+
+	// If parent field is nil or empty in rawConfig, it means user didn't configure it
+	// This is a remote-only addition, we should suppress diff
+	if parentRawConfigVal == nil {
+		log.Printf("[DEBUG][diffStrSliceLength] Parent field '%s' is nil in rawConfig, suppressing diff (remote-only addition)",
+			parentField)
+		return true // Suppress diff - ignore remote-only addition
+	}
+
+	// Check if it's an empty list/set
+	var parentRawConfigSlice []interface{}
+	switch v := parentRawConfigVal.(type) {
+	case []interface{}:
+		parentRawConfigSlice = v
+	case *schema.Set:
+		parentRawConfigSlice = v.List()
+	default:
+		// Try to convert to slice if it's a map with length
+		if m, ok := v.(map[string]interface{}); ok {
+			if len(m) == 0 {
+				log.Printf("[DEBUG][diffStrSliceLength] Parent field '%s' is empty map in rawConfig, suppressing "+
+					"diff (remote-only addition)", parentField)
+				return true
+			}
+		}
+	}
+
+	log.Printf("[DEBUG][diffStrSliceLength] Parent field '%s' rawConfigSlice length=%d", parentField, len(parentRawConfigSlice))
+	// If parent field is empty in rawConfig, this is a remote-only addition, suppress diff
+	if len(parentRawConfigSlice) == 0 {
+		log.Printf("[DEBUG][diffStrSliceLength] Parent field '%s' is empty in rawConfig, suppressing diff (remote-only addition)",
+			parentField)
+		return true // Suppress diff - ignore remote-only addition
+	}
+
+	return false
+}
+
+// handleNilOriginForStrSliceLength handles the case when origin is nil
+func handleNilOriginForStrSliceLength(baseField string, oldCount, newCount int, d *schema.ResourceData) bool {
+	if oldCount == 0 && newCount == 0 {
+		log.Printf("[DEBUG][diffStrSliceLength] Origin is nil and both oldCount and newCount are 0, suppressing diff to avoid null display")
+		return true
+	}
+
+	// If newCount is 0 but oldCount > 0, check if this is an explicit local removal
+	// Use GetRawConfig to check if the parent field is missing in user's actual config
+	if newCount == 0 && oldCount > 0 {
+		// Check if the parent field is missing in user's actual config
+		// For nested fields like "resources.0.includes", check if "resources" is missing in config
+		if checkParentFieldInRawConfig(baseField, d) {
+			return true // Suppress diff - ignore remote-only addition
+		}
+		// If parent field exists in config, this is an explicit removal
+		log.Printf("[DEBUG][diffStrSliceLength] Origin is nil but newCount=0 and oldCount=%d, NOT suppressing diff (explicit removal)",
+			oldCount)
+		return false
+	}
+
+	return false
+}
+
+// getOriginCountAndIsEmpty gets origin count and whether it's empty
+func getOriginCountAndIsEmpty(originVal interface{}) (int, bool) {
+	switch v := originVal.(type) {
+	case []interface{}:
+		return len(v), len(v) == 0
+	case *schema.Set:
+		return v.Len(), v.Len() == 0
+	default:
+		return 0, true
+	}
+}
+
+// handleEmptyOriginForStrSliceLength handles the case when origin is empty
+func handleEmptyOriginForStrSliceLength(baseField string, newCount int, d *schema.ResourceData) bool {
+	// Get current remote state to check if this is a remote-only change
+	currentVal := d.Get(baseField)
+	if currentVal == nil {
+		return false
+	}
+
+	var currentCount int
+	switch v := currentVal.(type) {
+	case []interface{}:
+		currentCount = len(v)
+	case *schema.Set:
+		currentCount = v.Len()
+	default:
+		currentCount = 0
+	}
+
+	// If new count is less than current count, this might be a remote removal
+	// that should be suppressed (unless it's a local removal)
+	if newCount < currentCount {
+		return true
+	}
+
+	return false
+}
+
 // diffStrSliceLength handles the length field of TypeList or TypeSet
-func diffStrSliceLength(paramKey, oldVal, newVal string, d *schema.ResourceData) bool {
+func diffStrSliceLength(paramKey, oldVal, newVal string, d *schema.ResourceData, originConfig string) bool {
 	baseField := strings.TrimSuffix(paramKey, ".#")
 
 	// Get the origin value
-	originParamKey := fmt.Sprintf("%s_origin", baseField)
-	originVal := d.Get(originParamKey)
+	originVal := getOriginValueForStrSliceLength(baseField, originConfig, d)
 
 	// Get current values
 	oldCount, _ := strconv.Atoi(oldVal)
 	newCount, _ := strconv.Atoi(newVal)
 
 	// If origin is empty or nil, this is the first time setting the value
+	// However, if both oldCount and newCount are 0 (empty lists), suppress diff to avoid showing null
 	if originVal == nil {
-		return false
+		return handleNilOriginForStrSliceLength(baseField, oldCount, newCount, d)
 	}
 
 	// Check if origin is effectively empty
-	var originCount int
-	var isEmpty bool
-	switch v := originVal.(type) {
-	case []interface{}:
-		originCount = len(v)
-		isEmpty = len(v) == 0
-	case *schema.Set:
-		originCount = v.Len()
-		isEmpty = v.Len() == 0
-	default:
-		originCount = 0
-		isEmpty = true
-	}
+	originCount, isEmpty := getOriginCountAndIsEmpty(originVal)
 
 	// If origin is empty, check if this is a remote-only change that should be suppressed
 	if isEmpty {
-		// Get current remote state to check if this is a remote-only change
-		currentVal := d.Get(baseField)
-		if currentVal != nil {
-			var currentCount int
-			switch v := currentVal.(type) {
-			case []interface{}:
-				currentCount = len(v)
-			case *schema.Set:
-				currentCount = v.Len()
-			default:
-				currentCount = 0
-			}
-
-			// If new count is less than current count, this might be a remote removal
-			// that should be suppressed (unless it's a local removal)
-			if newCount < currentCount {
-				return true
-			}
-		}
-
-		return false
+		return handleEmptyOriginForStrSliceLength(baseField, newCount, d)
 	}
 
 	// Check if there are actual changes that require length difference to be shown
@@ -589,18 +864,157 @@ func diffStrSliceLength(paramKey, oldVal, newVal string, d *schema.ResourceData)
 	return true
 }
 
+// handleCrossStructureOriginDetection handles cross-structure origin detection with locator change logic
+// Returns: (originVal, handled) where handled indicates if the function should return early with a bool result
+func handleCrossStructureOriginDetection(d *schema.ResourceData, baseField, originConfig, oldVal, newVal string) (interface{}, bool) {
+	// Try to get old locator value from tfstate
+	// For nested fields like "resources.0.excludes", get old server_id from tfstate
+	oldLocatorValue := getOldLocatorValueFromState(d, baseField, originConfig)
+
+	// Check if locator (server_id) has changed
+	_, locatorKey, _ := parseOriginConfig(originConfig)
+	if locatorKey == "" {
+		// No locator key, use old locator value directly
+		originVal := getCrossStructureOriginValue(d, baseField, originConfig, oldLocatorValue)
+		return originVal, false
+	}
+
+	// Get new locator value
+	newLocatorValue := getNewLocatorValue(d, baseField, locatorKey)
+
+	// Check if locator has changed
+	if newLocatorValue != "" && oldLocatorValue != "" && oldLocatorValue != newLocatorValue {
+		params := locatorChangeParams{
+			d:               d,
+			baseField:       baseField,
+			originConfig:    originConfig,
+			oldLocatorValue: oldLocatorValue,
+			newLocatorValue: newLocatorValue,
+			oldVal:          oldVal,
+			newVal:          newVal,
+		}
+		return handleLocatorChange(params)
+	}
+
+	// Locator hasn't changed, use old locator value
+	originVal := getCrossStructureOriginValue(d, baseField, originConfig, oldLocatorValue)
+	return originVal, false
+}
+
+// locatorChangeParams contains parameters for handleLocatorChange
+type locatorChangeParams struct {
+	d               *schema.ResourceData
+	baseField       string
+	originConfig    string
+	oldLocatorValue string
+	newLocatorValue string
+	oldVal          string
+	newVal          string
+}
+
+// handleLocatorChange handles the case when locator has changed
+func handleLocatorChange(params locatorChangeParams) (interface{}, bool) {
+	log.Printf("[DEBUG][diffStrSliceElement] Locator has changed from '%s' to '%s', using new locator value for "+
+		"origin lookup", params.oldLocatorValue, params.newLocatorValue)
+	originVal := getCrossStructureOriginValue(params.d, params.baseField, params.originConfig, params.newLocatorValue)
+	if originVal != nil {
+		log.Printf("[DEBUG][diffStrSliceElement] Found origin value using new locator value: %v", originVal)
+	}
+
+	// Get origin for oldVal using old locator value
+	oldOriginVal := getCrossStructureOriginValue(params.d, params.baseField, params.originConfig, params.oldLocatorValue)
+	// Get origin for newVal using new locator value (already got above)
+	newOriginVal := originVal
+
+	// Pass both origin values to handleElementAddition
+	result := handleElementAdditionWithLocatorChange(params.oldVal, params.newVal, oldOriginVal, newOriginVal, params.baseField, params.d)
+	return result, true
+}
+
+// getNewLocatorValue gets the new locator value from ResourceData
+func getNewLocatorValue(d *schema.ResourceData, baseField, locatorKey string) string {
+	parts := strings.Split(baseField, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+
+	parentPath := strings.Join(parts[:len(parts)-1], ".")
+	locatorKeyPath := fmt.Sprintf("%s.%s", parentPath, locatorKey)
+	newLocatorVal := d.Get(locatorKeyPath)
+	if newLocatorVal == nil {
+		return ""
+	}
+
+	newLocatorValStr, ok := newLocatorVal.(string)
+	if !ok || newLocatorValStr == "" {
+		return ""
+	}
+
+	return newLocatorValStr
+}
+
 // diffStrSliceElement handles individual slice elements. And for the TypeSet, there are indexes of each element,
 // so we need to handle them separately.
-func diffStrSliceElement(paramKey, oldVal, newVal string, d *schema.ResourceData) bool {
+func diffStrSliceElement(paramKey, oldVal, newVal string, d *schema.ResourceData, originConfig string) bool {
 	parts := strings.Split(paramKey, ".")
-	if len(parts) != 2 {
+
+	// Handle nested paths like "resources.0.excludes.0"
+	// For nested paths, we need to find the corresponding origin value
+	var baseField string
+	var originVal interface{}
+
+	// Get baseField (e.g., "resources.0.excludes" from "resources.0.excludes.0")
+	if len(parts) < 2 {
 		log.Printf("[DEBUG][diffStrSliceElement] Invalid paramKey format: %s", paramKey)
 		return false
 	}
-	baseField := parts[0]
+	baseField = strings.Join(parts[:len(parts)-1], ".")
 
-	originParamKey := fmt.Sprintf("%s_origin", baseField)
-	originVal := d.Get(originParamKey)
+	// Try cross-structure origin detection first
+	if originConfig != "" {
+		var handled bool
+		var result interface{}
+		result, handled = handleCrossStructureOriginDetection(d, baseField, originConfig, oldVal, newVal)
+		if handled {
+			return result.(bool)
+		}
+		originVal = result
+	}
+
+	// Fallback to nested paths if cross-structure detection didn't work
+	if originVal == nil {
+		if len(parts) == 2 {
+			// Simple case: {baseField}.{index} (e.g., "excludes.0")
+			baseField = parts[0]
+			originParamKey := fmt.Sprintf("%s_origin", baseField)
+			originVal = d.Get(originParamKey)
+		} else if len(parts) >= 3 {
+			// Nested case: {parent}.{index}.{field}.{elementIndex} (e.g., "resources.0.excludes.0")
+			// Try to find origin using {parent}_origin.{index}.{field} pattern first
+			parentField := parts[0]
+			indexStr := parts[1]
+			fieldName := strings.Join(parts[2:len(parts)-1], ".")
+
+			// Try pattern 1: {parent}_origin.{index}.{field} (e.g., "resources_origin.0.excludes")
+			originParamKey1 := fmt.Sprintf("%s_origin.%s.%s", parentField, indexStr, fieldName)
+			originVal = getNestedOriginValue(d, originParamKey1)
+
+			// Try pattern 2: {parent}.{index}.{field}_origin (e.g., "resources.0.excludes_origin")
+			if originVal == nil {
+				originParamKey2 := fmt.Sprintf("%s.%s.%s_origin", parentField, indexStr, fieldName)
+				originVal = d.Get(originParamKey2)
+			}
+
+			// Fallback: use the last part as baseField (for backward compatibility)
+			if originVal == nil {
+				baseField = strings.Join(parts[:len(parts)-1], ".")
+				originParamKey := fmt.Sprintf("%s_origin", baseField)
+				originVal = d.Get(originParamKey)
+			} else {
+				baseField = strings.Join(parts[:len(parts)-1], ".")
+			}
+		}
+	}
 
 	log.Printf("[DEBUG][diffStrSliceElement] baseField='%s', oldVal='%s', newVal='%s', originVal=%v",
 		baseField, oldVal, newVal, originVal)
@@ -614,6 +1028,51 @@ func diffStrSliceElement(paramKey, oldVal, newVal string, d *schema.ResourceData
 	return handleElementAddition(oldVal, newVal, originVal, baseField, d)
 }
 
+// getNestedOriginValue retrieves a nested origin value from ResourceData
+func getNestedOriginValue(d *schema.ResourceData, path string) interface{} {
+	parts := strings.Split(path, ".")
+	if len(parts) < 2 {
+		return d.Get(path)
+	}
+
+	// Get the root field (e.g., "resources_origin")
+	rootVal := d.Get(parts[0])
+	if rootVal == nil {
+		return nil
+	}
+
+	// Navigate through the nested structure
+	current := rootVal
+	for i := 1; i < len(parts); i++ {
+		part := parts[i]
+
+		// Check if part is a numeric index
+		index, err := strconv.Atoi(part)
+		if err == nil {
+			// It's a list index
+			list, ok := current.([]interface{})
+			if !ok || index < 0 || index >= len(list) {
+				return nil
+			}
+			current = list[index]
+			continue
+		}
+
+		// It's a map key
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		val, exists := m[part]
+		if !exists {
+			return nil
+		}
+		current = val
+	}
+
+	return current
+}
+
 // handleElementRemoval handles the case when an element is being removed
 func handleElementRemoval(oldVal string, originVal interface{}, baseField string, d *schema.ResourceData) bool {
 	log.Printf("[DEBUG][handleElementRemoval] Element '%s' is being removed, checking if should suppress diff", oldVal)
@@ -622,6 +1081,75 @@ func handleElementRemoval(oldVal string, originVal interface{}, baseField string
 	if isElementInOrigin(oldVal, originVal) {
 		log.Printf("[DEBUG][handleElementRemoval] Element '%s' was in origin, NOT suppressing diff (allow removal)", oldVal)
 		return false // NOT suppressing - allow removal of origin elements
+	}
+
+	// If origin is empty or nil, we need to check if this is an explicit local removal
+	// Get rawConfig to check if user explicitly removed this element
+	newParamVal := d.Get(baseField)
+	var rawConfigSlice []interface{}
+	switch v := newParamVal.(type) {
+	case []interface{}:
+		rawConfigSlice = v
+	case *schema.Set:
+		rawConfigSlice = v.List()
+	}
+
+	log.Printf("[DEBUG][handleElementRemoval] rawConfigSlice length=%d for baseField='%s'", len(rawConfigSlice), baseField)
+
+	// If rawConfig is empty (user explicitly removed all elements), this is a local removal
+	// Even if origin is nil, we should NOT suppress diff to allow the removal
+	if len(rawConfigSlice) == 0 {
+		log.Printf("[DEBUG][handleElementRemoval] Element '%s' removal is explicit (rawConfig is empty), NOT suppressing diff (allow removal)",
+			oldVal)
+		return false // NOT suppressing - allow explicit removal
+	}
+
+	// Check if the parent field is missing in user's actual config
+	// For nested fields like "resources.0.includes", check if "resources" is missing in config
+	// Use GetRawConfig to get the actual user config (not filled with remote values)
+	if strings.Contains(baseField, ".") {
+		parts := strings.Split(baseField, ".")
+		if len(parts) >= 2 {
+			parentField := parts[0]
+			parentRawConfigVal := GetNestedObjectFromRawConfig(d.GetRawConfig(), parentField)
+			log.Printf("[DEBUG][handleElementRemoval] Parent field '%s' rawConfigVal=%v (type=%T)",
+				parentField, parentRawConfigVal, parentRawConfigVal)
+
+			// If parent field is nil or empty in rawConfig, it means user didn't configure it
+			// This is an explicit removal (user removed the entire parent field)
+			if parentRawConfigVal == nil {
+				log.Printf("[DEBUG][handleElementRemoval] Parent field '%s' is nil in rawConfig, Element '%s' removal is explicit, "+
+					"NOT suppressing diff (allow removal)", parentField, oldVal)
+				return false // NOT suppressing - allow explicit removal
+			}
+
+			// Check if it's an empty list/set
+			var parentRawConfigSlice []interface{}
+			switch v := parentRawConfigVal.(type) {
+			case []interface{}:
+				parentRawConfigSlice = v
+			case *schema.Set:
+				parentRawConfigSlice = v.List()
+			default:
+				// Try to convert to slice if it's a map with length
+				if m, ok := v.(map[string]interface{}); ok {
+					if len(m) == 0 {
+						log.Printf("[DEBUG][handleElementRemoval] Parent field '%s' is empty map in rawConfig, Element '%s' removal is explicit, "+
+							"NOT suppressing diff (allow removal)", parentField, oldVal)
+						return false
+					}
+				}
+			}
+
+			log.Printf("[DEBUG][handleElementRemoval] Parent field '%s' rawConfigSlice length=%d", parentField, len(parentRawConfigSlice))
+			// If parent field is empty in rawConfig, it means user didn't configure it
+			// This is a remote-only addition, we should suppress diff (same logic as diffStrSliceLength)
+			if len(parentRawConfigSlice) == 0 {
+				log.Printf("[DEBUG][handleElementRemoval] Parent field '%s' is empty in rawConfig, Element '%s' is remote-only addition, "+
+					"suppressing diff", parentField, oldVal)
+				return true // Suppress diff - ignore remote-only addition
+			}
+		}
 	}
 
 	// If origin is empty or nil, check if this element exists in remote state
@@ -637,6 +1165,172 @@ func handleElementRemoval(oldVal string, originVal interface{}, baseField string
 	return true
 }
 
+// handleElementAdditionWithLocatorChange handles the case when locator (e.g., server_id) has changed
+// oldVal belongs to the old locator, newVal belongs to the new locator
+func handleElementAdditionWithLocatorChange(oldVal, newVal string, oldOriginVal, newOriginVal interface{}, baseField string,
+	d *schema.ResourceData) bool {
+	// Check if oldVal is in old origin
+	oldValInOldOrigin := isElementInOrigin(oldVal, oldOriginVal)
+	// Check if newVal is in new origin
+	newValInNewOrigin := isElementInOrigin(newVal, newOriginVal)
+
+	// If oldVal is in old origin but not in user's config, user wants to remove it, don't suppress diff
+	if oldValInOldOrigin {
+		rawConfigVal := GetNestedObjectFromRawConfig(d.GetRawConfig(), baseField)
+		var rawConfigSlice []interface{}
+		if rawConfigVal != nil {
+			switch v := rawConfigVal.(type) {
+			case []interface{}:
+				rawConfigSlice = v
+			case *schema.Set:
+				rawConfigSlice = v.List()
+			}
+		}
+		oldValInRawConfig := false
+		for _, item := range rawConfigSlice {
+			if str, ok := item.(string); ok && str == oldVal {
+				oldValInRawConfig = true
+				break
+			}
+		}
+		if !oldValInRawConfig {
+			log.Printf("[DEBUG][handleElementAdditionWithLocatorChange] oldVal '%s' is in old origin but not in user's config "+
+				"(user wants to remove it), not suppressing diff", oldVal)
+			return false
+		}
+	}
+
+	// If newVal is in new origin, suppress diff (user wants to keep it)
+	if newValInNewOrigin {
+		log.Printf("[DEBUG][handleElementAdditionWithLocatorChange] newVal '%s' is in new origin, suppressing diff", newVal)
+		return true
+	}
+
+	// If newVal is not in new origin, don't suppress diff (user wants to add it)
+	log.Printf("[DEBUG][handleElementAdditionWithLocatorChange] newVal '%s' is not in new origin, not suppressing diff", newVal)
+	return false
+}
+
+// getRawConfigSlice gets the rawConfig slice from ResourceData
+func getRawConfigSlice(baseField string, d *schema.ResourceData) []interface{} {
+	rawConfigVal := GetNestedObjectFromRawConfig(d.GetRawConfig(), baseField)
+	if rawConfigVal == nil {
+		return nil
+	}
+
+	switch v := rawConfigVal.(type) {
+	case []interface{}:
+		return v
+	case *schema.Set:
+		return v.List()
+	default:
+		return nil
+	}
+}
+
+// checkValueInRawConfig checks if a value exists in rawConfig slice
+func checkValueInRawConfig(value string, rawConfigSlice []interface{}) bool {
+	for _, item := range rawConfigSlice {
+		if str, ok := item.(string); ok && str == value {
+			return true
+		}
+	}
+	return false
+}
+
+// handleNewValInOrigin handles the case when newVal is in origin
+func handleNewValInOrigin(oldVal, newVal string, originVal interface{}, baseField string, d *schema.ResourceData) (suppress, handled bool) {
+	// If the element is unchanged (oldVal == newVal), don't suppress diff
+	// This ensures Terraform knows the config value still exists
+	if oldVal == newVal {
+		log.Printf("[DEBUG][handleElementAddition] Element '%s' unchanged and in origin, not suppressing diff to preserve config value",
+			newVal)
+		return false, true // handled, don't suppress
+	}
+
+	// If oldVal and newVal are different but both in origin, this might be index misalignment
+	// Check if oldVal is also in origin - if so, check if oldVal is in user's config
+	// If oldVal is not in user's config, user wants to remove it, don't suppress diff
+	if isElementInOrigin(oldVal, originVal) {
+		// Both oldVal and newVal are in origin but different - check user's config
+		rawConfigSlice := getRawConfigSlice(baseField, d)
+		oldValInRawConfig := checkValueInRawConfig(oldVal, rawConfigSlice)
+		if !oldValInRawConfig {
+			log.Printf("[DEBUG][handleElementAddition] Both oldVal '%s' and newVal '%s' are in origin, but oldVal is not in user's config "+
+				"(user wants to remove it), not suppressing diff", oldVal, newVal)
+			return false, true // handled, don't suppress
+		}
+	}
+
+	log.Printf("[DEBUG][handleElementAddition] Element '%s' was in origin, suppressing diff", newVal)
+	return true, true // handled, suppress
+}
+
+// handleOldValInOriginButNewValNot handles the case when oldVal is in origin but newVal is not
+func handleOldValInOriginButNewValNot(oldVal, newVal string, baseField string, d *schema.ResourceData) bool {
+	// Check user's config (rawConfig) to determine user intent
+	rawConfigSlice := getRawConfigSlice(baseField, d)
+
+	// Check if newVal is in user's config (user wants to add it)
+	newValInRawConfig := checkValueInRawConfig(newVal, rawConfigSlice)
+
+	// Check if oldVal is in user's config (user wants to keep it)
+	oldValInRawConfig := checkValueInRawConfig(oldVal, rawConfigSlice)
+
+	// If newVal is in rawConfig, user wants to add it, don't suppress diff
+	if newValInRawConfig {
+		log.Printf("[DEBUG][handleElementAddition] oldVal '%s' is in origin but newVal '%s' is not in origin. "+
+			"However, newVal is in user's config (user wants to add it), not suppressing diff", oldVal, newVal)
+		return false
+	}
+
+	// If oldVal is not in rawConfig, user wants to remove it, don't suppress diff
+	if !oldValInRawConfig {
+		log.Printf("[DEBUG][handleElementAddition] oldVal '%s' is in origin but newVal '%s' is not in origin. "+
+			"However, oldVal is not in user's config (user wants to remove it), not suppressing diff", oldVal, newVal)
+		return false
+	}
+
+	// oldVal is in origin but newVal is not - check remote state
+	// Note: checkElementInRemoteState checks tfstate (old value), not API response (new value)
+	// If oldVal is in tfstate but newVal is not, newVal is from API (remote change)
+	oldValInRemote := checkElementInRemoteState(baseField, oldVal, d)
+	newValInRemote := checkElementInRemoteState(baseField, newVal, d)
+	log.Printf("[DEBUG][handleElementAddition] oldVal '%s' is in origin but newVal '%s' is not. "+
+		"oldVal in remote (tfstate): %v, newVal in remote (tfstate): %v", oldVal, newVal, oldValInRemote, newValInRemote)
+
+	// If oldVal is in origin and in tfstate, but newVal is not in tfstate,
+	// this means newVal is from API response (remote change), suppress diff
+	// This handles the case where the remote value changed but we want to keep the origin value
+	if oldValInRemote && !newValInRemote {
+		log.Printf("[DEBUG][handleElementAddition] oldVal '%s' is in origin and tfstate but newVal '%s' is not in tfstate (newVal is from API), "+
+			"suppressing diff (remote-only change)", oldVal, newVal)
+		return true
+	}
+
+	// If both oldVal and newVal are in remote state (tfstate), this means both values exist in tfstate
+	// But since oldVal is in origin and newVal is not, this is a remote change that should be suppressed
+	// However, if newVal is also in tfstate, it might be from a different resource, so we should not suppress
+	// Actually, if both are in tfstate, newVal might be from a different index in the same field
+	// In this case, we should suppress diff because oldVal is in origin (user's last config)
+	if oldValInRemote && newValInRemote {
+		log.Printf("[DEBUG][handleElementAddition] Both oldVal '%s' and newVal '%s' are in tfstate, but oldVal is in origin, "+
+			"suppressing diff (remote-only change)", oldVal, newVal)
+		return true
+	}
+
+	// If oldVal is not in tfstate but newVal is, this is unexpected
+	// This might happen if the state was corrupted or modified externally
+	// In this case, we should not suppress diff to allow the update
+	if !oldValInRemote && newValInRemote {
+		log.Printf("[DEBUG][handleElementAddition] oldVal '%s' is not in tfstate but newVal '%s' is, not suppressing diff (allow update)",
+			oldVal, newVal)
+		return false
+	}
+
+	return false
+}
+
 // handleElementAddition handles the case when an element is being added or modified
 func handleElementAddition(oldVal, newVal string, originVal interface{}, baseField string, d *schema.ResourceData) bool {
 	// If origin is nil or empty, this is the first time setting the value
@@ -644,16 +1338,26 @@ func handleElementAddition(oldVal, newVal string, originVal interface{}, baseFie
 		return handleFirstTimeSetting(oldVal, newVal, baseField, d)
 	}
 
+	// If oldVal is empty, this is a new element being added (not a modification)
+	// Even if it's in origin, we should not suppress diff to avoid showing null values
+	if oldVal == "" {
+		log.Printf("[DEBUG][handleElementAddition] Element '%s' is being added (oldVal is empty), not suppressing diff to avoid null display",
+			newVal)
+		return false
+	}
+
 	// Check if this element is in origin
 	if isElementInOrigin(newVal, originVal) {
-		// If the element is unchanged (oldVal == newVal), don't suppress diff
-		// This ensures Terraform knows the config value still exists
-		if oldVal == newVal {
-			log.Printf("[DEBUG][handleElementAddition] Element '%s' unchanged and in origin, not suppressing diff to preserve config value", newVal)
-			return false
+		suppress, handled := handleNewValInOrigin(oldVal, newVal, originVal, baseField, d)
+		if handled {
+			return suppress
 		}
-		log.Printf("[DEBUG][handleElementAddition] Element '%s' was in origin, suppressing diff", newVal)
-		return true
+	}
+
+	// If newVal is not in origin, check if oldVal is in origin
+	// If oldVal is in origin but newVal is not, this might be a remote change
+	if isElementInOrigin(oldVal, originVal) {
+		return handleOldValInOriginButNewValNot(oldVal, newVal, baseField, d)
 	}
 
 	// If element was not in origin, don't suppress (this is a local addition)
@@ -668,8 +1372,38 @@ func handleFirstTimeSetting(oldVal, newVal, baseField string, d *schema.Resource
 		log.Printf("[DEBUG][handleFirstTimeSetting] This is a CREATE scenario (oldVal=''), using main diffStrSliceParam logic")
 		return false // Let the main logic handle this
 	}
-	// If oldVal is not empty, this is an UPDATE scenario - check remote state
-	log.Printf("[DEBUG][handleFirstTimeSetting] This is an UPDATE scenario (oldVal='%s'), checking if new value exists in remote state", oldVal)
+	// If oldVal is not empty and newVal is different, this is a replacement/modification
+	// We need to check if both oldVal and newVal exist in remote state
+	// If both exist, this might be a remote-only change (suppress diff)
+	// If only oldVal exists, this is a local replacement (don't suppress diff)
+	// If only newVal exists, this is a local addition (don't suppress diff)
+	if oldVal != newVal {
+		log.Printf("[DEBUG][handleFirstTimeSetting] This is a REPLACEMENT scenario (oldVal='%s', newVal='%s'), checking remote state",
+			oldVal, newVal)
+		oldValInRemote := checkElementInRemoteState(baseField, oldVal, d)
+		newValInRemote := checkElementInRemoteState(baseField, newVal, d)
+		log.Printf("[DEBUG][handleFirstTimeSetting] oldVal in remote: %v, newVal in remote: %v", oldValInRemote, newValInRemote)
+
+		// If both oldVal and newVal exist in remote state, this might be a remote-only change
+		// But we should not suppress diff if newVal is not in remote (local addition)
+		if !newValInRemote {
+			log.Printf("[DEBUG][handleFirstTimeSetting] newVal '%s' is not in remote state, NOT suppressing diff (local addition)", newVal)
+			return false // Don't suppress - this is a local addition
+		}
+		// If newVal exists in remote but oldVal doesn't, this is a local replacement
+		// We should not suppress diff to allow the replacement
+		if newValInRemote && !oldValInRemote {
+			log.Printf("[DEBUG][handleFirstTimeSetting] newVal '%s' is in remote but oldVal '%s' is not, NOT suppressing diff (local replacement)",
+				newVal, oldVal)
+			return false // Don't suppress - this is a local replacement
+		}
+		// If both exist in remote, this might be a remote-only change, suppress diff
+		log.Printf("[DEBUG][handleFirstTimeSetting] Both oldVal and newVal exist in remote state, suppressing diff (remote-only change)")
+		return true
+	}
+	// If oldVal == newVal, check if it exists in remote state
+	log.Printf("[DEBUG][handleFirstTimeSetting] This is an UPDATE scenario (oldVal='%s' == newVal), checking if value exists in remote state",
+		oldVal)
 	return checkElementInRemoteState(baseField, newVal, d)
 }
 
@@ -752,60 +1486,101 @@ func isElementInOrigin(element string, originVal interface{}) bool {
 //	Origin: ["a", "b", "c"]
 //	Console: ["a", "b", "c", "d", "e"] (remotely added "d", "e")
 //	Script: ["a", "b", "c"] -> Same as origin, ignore remote additions
-func diffStrSliceParam(paramKey, oldVal, newVal string, d *schema.ResourceData) bool {
-	var (
-		originSlice, consoleSlice, newScriptSlice []string
-		originParamKey                            = fmt.Sprintf("%s_origin", paramKey)
-	)
+//
+// getOriginValueForStrSliceParam gets the origin value for diffStrSliceParam
+func getOriginValueForStrSliceParam(paramKey string, d *schema.ResourceData, originConfig string) interface{} {
+	var originVal interface{}
+	if originConfig != "" {
+		// Try to get old locator value from tfstate
+		// For nested fields like "resources.0.excludes", get old server_id from tfstate
+		oldLocatorValue := getOldLocatorValueFromState(d, paramKey, originConfig)
+		originVal = getCrossStructureOriginValue(d, paramKey, originConfig, oldLocatorValue)
+	}
 
-	// Get the origin value (last local configuration) - this is the key fix
-	originVal := d.Get(originParamKey)
-	if originVal != nil {
-		// Handle different types that originVal might be
-		switch v := originVal.(type) {
-		case []interface{}:
-			for _, item := range v {
-				if str, ok := item.(string); ok && str != "" {
-					originSlice = append(originSlice, str)
-				}
+	// Fallback to nested paths if cross-structure detection didn't work
+	if originVal == nil {
+		parts := strings.Split(paramKey, ".")
+		if len(parts) >= 3 {
+			// Nested case: {parent}.{index}.{field} (e.g., "resources.0.excludes")
+			parentField := parts[0]
+			indexStr := parts[1]
+			fieldName := strings.Join(parts[2:], ".")
+
+			// Try pattern 1: {parent}_origin.{index}.{field}
+			originParamKey1 := fmt.Sprintf("%s_origin.%s.%s", parentField, indexStr, fieldName)
+			originVal = getNestedOriginValue(d, originParamKey1)
+
+			// Try pattern 2: {parent}.{index}.{field}_origin
+			if originVal == nil {
+				originParamKey2 := fmt.Sprintf("%s.%s.%s_origin", parentField, indexStr, fieldName)
+				originVal = d.Get(originParamKey2)
 			}
-		case *schema.Set:
-			for _, item := range v.List() {
-				if str, ok := item.(string); ok && str != "" {
-					originSlice = append(originSlice, str)
-				}
-			}
-		case string:
-			if v != "" {
-				originSlice = strings.Split(v, ",")
-				originSlice = removeEmptyStrings(originSlice)
-			}
-		default:
-			log.Printf("[DEBUG][diffStrSliceParam] Unexpected originVal type: %T", originVal)
+		}
+
+		// Fallback to simple pattern: {paramKey}_origin
+		if originVal == nil {
+			originParamKey := fmt.Sprintf("%s_origin", paramKey)
+			originVal = d.Get(originParamKey)
 		}
 	}
+	return originVal
+}
 
-	// If origin is empty, this is the first time setting the value
-	// In this case, we should allow the change (not suppress diff)
-	if len(originSlice) == 0 {
-		log.Printf("[DEBUG][diffStrSliceParam] Origin is empty, allowing change (first time setting)")
-		return false
+// convertOriginValToSlice converts originVal to []string
+func convertOriginValToSlice(originVal interface{}) []string {
+	var originSlice []string
+	if originVal == nil {
+		return originSlice
 	}
 
-	// Parse the old and new values from GetChange
-	// oldVal and newVal are already strings from Terraform's diff suppression
-	// They represent the serialized form of the lists
-	if oldVal != "" {
-		consoleSlice = strings.Split(oldVal, ",")
-		consoleSlice = removeEmptyStrings(consoleSlice)
+	// Handle different types that originVal might be
+	switch v := originVal.(type) {
+	case []interface{}:
+		for _, item := range v {
+			if str, ok := item.(string); ok && str != "" {
+				originSlice = append(originSlice, str)
+			}
+		}
+	case *schema.Set:
+		for _, item := range v.List() {
+			if str, ok := item.(string); ok && str != "" {
+				originSlice = append(originSlice, str)
+			}
+		}
+	case string:
+		if v != "" {
+			originSlice = strings.Split(v, ",")
+			originSlice = removeEmptyStrings(originSlice)
+		}
+	default:
+		log.Printf("[DEBUG][diffStrSliceParam] Unexpected originVal type: %T", originVal)
 	}
-	if newVal != "" {
-		newScriptSlice = strings.Split(newVal, ",")
-		newScriptSlice = removeEmptyStrings(newScriptSlice)
-	}
+	return originSlice
+}
 
+// handleEmptyOriginForStrSliceParam handles the case when origin is empty
+func handleEmptyOriginForStrSliceParam(paramKey, oldVal, newVal string, d *schema.ResourceData) bool {
+	log.Printf("[DEBUG][diffStrSliceParam] Origin is empty, checking if should suppress diff for empty values")
+	// If both old and new values are empty, suppress diff (avoid showing null for new elements)
+	if oldVal == "" && newVal == "" {
+		log.Printf("[DEBUG][diffStrSliceParam] Both oldVal and newVal are empty, suppressing diff to avoid null display")
+		return true
+	}
+	// If newVal is empty but oldVal is not, this might be a removal - check remote state
+	if newVal == "" && oldVal != "" {
+		log.Printf("[DEBUG][diffStrSliceParam] newVal is empty but oldVal is not, checking remote state")
+		// Get baseField from paramKey for checkElementInRemoteState
+		baseField := paramKey
+		return checkElementInRemoteState(baseField, "", d)
+	}
+	log.Printf("[DEBUG][diffStrSliceParam] Origin is empty, allowing change (first time setting)")
+	return false
+}
+
+// checkLocalChangesForStrSliceParam checks for local additions and removals
+func checkLocalChangesForStrSliceParam(originSlice, consoleSlice, newScriptSlice []string) bool {
 	log.Printf("[DEBUG][diffStrSliceParam] paramKey='%s', originSlice=%v, consoleSlice=%v, newScriptSlice=%v",
-		paramKey, originSlice, consoleSlice, newScriptSlice)
+		"", originSlice, consoleSlice, newScriptSlice)
 
 	// Check if only care about elements that are in new script but NOT in console (locally added)
 	// This means we ignore elements that are in console but NOT in new script (remotely added)
@@ -830,6 +1605,32 @@ func diffStrSliceParam(paramKey, oldVal, newVal string, d *schema.ResourceData) 
 	return true
 }
 
+func diffStrSliceParam(paramKey, oldVal, newVal string, d *schema.ResourceData, originConfig string) bool {
+	// Get the origin value (last local configuration)
+	originVal := getOriginValueForStrSliceParam(paramKey, d, originConfig)
+	originSlice := convertOriginValToSlice(originVal)
+
+	// If origin is empty, handle empty origin case
+	if len(originSlice) == 0 {
+		return handleEmptyOriginForStrSliceParam(paramKey, oldVal, newVal, d)
+	}
+
+	// Parse the old and new values from GetChange
+	// oldVal and newVal are already strings from Terraform's diff suppression
+	// They represent the serialized form of the lists
+	var consoleSlice, newScriptSlice []string
+	if oldVal != "" {
+		consoleSlice = strings.Split(oldVal, ",")
+		consoleSlice = removeEmptyStrings(consoleSlice)
+	}
+	if newVal != "" {
+		newScriptSlice = strings.Split(newVal, ",")
+		newScriptSlice = removeEmptyStrings(newScriptSlice)
+	}
+
+	return checkLocalChangesForStrSliceParam(originSlice, consoleSlice, newScriptSlice)
+}
+
 // removeEmptyStrings removes empty strings from a slice
 func removeEmptyStrings(slice []string) []string {
 	result := make([]string, 0, len(slice))
@@ -843,24 +1644,33 @@ func removeEmptyStrings(slice []string) []string {
 
 // checkElementInRemoteState checks if an element exists in remote state
 func checkElementInRemoteState(baseField, elementValue string, d *schema.ResourceData) bool {
-	// Get the current remote state value
-	currentVal := d.Get(baseField)
-	if currentVal != nil {
-		switch v := currentVal.(type) {
-		case []interface{}:
-			for _, item := range v {
-				if str, ok := item.(string); ok && str == elementValue {
-					log.Printf("[DEBUG][checkElementInRemoteState] Element '%s' already exists in remote state, suppressing diff",
-						elementValue)
-					return true
-				}
+	// Get the remote state value (old value from GetChange)
+	oldParamVal, _ := d.GetChange(baseField)
+	var remoteStateSlice []interface{}
+	switch v := oldParamVal.(type) {
+	case []interface{}:
+		remoteStateSlice = v
+	case *schema.Set:
+		remoteStateSlice = v.List()
+	default:
+		// Fallback to Get if GetChange doesn't work
+		currentVal := d.Get(baseField)
+		if currentVal != nil {
+			switch v := currentVal.(type) {
+			case []interface{}:
+				remoteStateSlice = v
+			case *schema.Set:
+				remoteStateSlice = v.List()
 			}
-		case *schema.Set:
-			if v.Contains(elementValue) {
-				log.Printf("[DEBUG][checkElementInRemoteState] Element '%s' already exists in remote state, suppressing diff",
-					elementValue)
-				return true
-			}
+		}
+	}
+
+	// Check if element exists in remote state
+	for _, item := range remoteStateSlice {
+		if str, ok := item.(string); ok && str == elementValue {
+			log.Printf("[DEBUG][checkElementInRemoteState] Element '%s' already exists in remote state, suppressing diff",
+				elementValue)
+			return true
 		}
 	}
 
@@ -875,6 +1685,14 @@ func checkElementInRemoteState(baseField, elementValue string, d *schema.Resourc
 func SuppressObjectSliceDiffs() schema.SchemaDiffSuppressFunc {
 	return func(paramKey, o, n string, d *schema.ResourceData) bool {
 		log.Printf("[DEBUG][SuppressObjectSliceDiffs] Called with paramKey='%s', oldVal='%s', newVal='%s'", paramKey, o, n)
+
+		// Skip nested string slice fields (includes, excludes) that have their own DiffSuppressFunc
+		// These fields should be handled by their own SuppressStrSliceDiffs
+		if strings.Contains(paramKey, ".includes") || strings.Contains(paramKey, ".excludes") {
+			log.Printf("[DEBUG][SuppressObjectSliceDiffs] Skipping nested string slice field '%s' (let field's own DiffSuppressFunc handle it)",
+				paramKey)
+			return false
+		}
 
 		// Handle TypeSet length field
 		if strings.HasSuffix(paramKey, ".#") {
@@ -900,9 +1718,206 @@ func SuppressObjectSliceDiffs() schema.SchemaDiffSuppressFunc {
 	}
 }
 
+// isStringSliceField checks if the field is a string slice (not an object slice)
+func isStringSliceField(oldVal, newVal interface{}) bool {
+	log.Printf("[DEBUG][isStringSliceField] Checking field type, oldVal type=%T, newVal type=%T", oldVal, newVal)
+
+	// Check oldVal first
+	if oldVal != nil {
+		switch v := oldVal.(type) {
+		case []interface{}:
+			log.Printf("[DEBUG][isStringSliceField] oldVal is []interface{}, length=%d", len(v))
+			// If it's a non-empty slice and first element is a string, it's a string slice
+			if len(v) > 0 {
+				_, isString := v[0].(string)
+				log.Printf("[DEBUG][isStringSliceField] First element type check: isString=%v, element=%v", isString, v[0])
+				if isString {
+					return true
+				}
+			}
+		case *schema.Set:
+			list := v.List()
+			log.Printf("[DEBUG][isStringSliceField] oldVal is *schema.Set, length=%d", len(list))
+			if len(list) > 0 {
+				_, isString := list[0].(string)
+				log.Printf("[DEBUG][isStringSliceField] First element type check: isString=%v, element=%v", isString, list[0])
+				if isString {
+					return true
+				}
+			}
+		default:
+			log.Printf("[DEBUG][isStringSliceField] oldVal is unexpected type: %T", v)
+		}
+	}
+
+	// Check newVal if oldVal didn't give us a clear answer
+	if newVal != nil {
+		switch v := newVal.(type) {
+		case []interface{}:
+			log.Printf("[DEBUG][isStringSliceField] newVal is []interface{}, length=%d", len(v))
+			if len(v) > 0 {
+				_, isString := v[0].(string)
+				log.Printf("[DEBUG][isStringSliceField] First element type check: isString=%v, element=%v", isString, v[0])
+				if isString {
+					return true
+				}
+			}
+		case *schema.Set:
+			list := v.List()
+			log.Printf("[DEBUG][isStringSliceField] newVal is *schema.Set, length=%d", len(list))
+			if len(list) > 0 {
+				_, isString := list[0].(string)
+				log.Printf("[DEBUG][isStringSliceField] First element type check: isString=%v, element=%v", isString, list[0])
+				if isString {
+					return true
+				}
+			}
+		default:
+			log.Printf("[DEBUG][isStringSliceField] newVal is unexpected type: %T", v)
+		}
+	}
+
+	log.Printf("[DEBUG][isStringSliceField] Field is NOT a string slice")
+	return false
+}
+
+// checkExplicitRemovalForObjectSlice checks if this is an explicit local removal
+func checkExplicitRemovalForObjectSlice(rawConfigSlice, originSlice []map[string]interface{}, originVal interface{}, oldCount, newCount int) bool {
+	// If rawConfig is empty but origin is not empty, this is an explicit local removal
+	// (user removed all elements in config), we should NOT suppress diff to allow the removal
+	if len(rawConfigSlice) == 0 && len(originSlice) > 0 && oldCount > 0 {
+		log.Printf("[DEBUG][diffObjectSliceLength] RawConfig is empty but origin has %d elements and oldCount=%d, "+
+			"NOT suppressing diff (explicit removal)",
+			len(originSlice), oldCount)
+		return true
+	}
+
+	// If origin is nil and newCount is 0 but oldCount > 0, this is an explicit local removal
+	// (user removed all elements in config), we should NOT suppress diff to allow the removal
+	if originVal == nil && newCount == 0 && oldCount > 0 {
+		log.Printf("[DEBUG][diffObjectSliceLength] Origin is nil but newCount=0 and oldCount=%d, NOT suppressing diff (explicit removal)",
+			oldCount)
+		return true
+	}
+
+	return false
+}
+
+// checkLocalAdditionsForObjectSlice checks for local additions
+func checkLocalAdditionsForObjectSlice(
+	originVal interface{},
+	oldParamVal, newParamVal interface{},
+	rawConfigSlice, tfstateSlice, originSlice []map[string]interface{},
+) bool {
+	// Check 1: (RawConfig - tfstate) ∩ (RawConfig - origin)
+	// If not empty, it means there are local additions
+	localAdditions := calculateLocalAdditions(originVal, oldParamVal, newParamVal)
+	rawConfigMinusTfstate := FindObjectSliceElementsNotInAnother(rawConfigSlice, tfstateSlice)
+	rawConfigMinusOrigin := FindObjectSliceElementsNotInAnother(rawConfigSlice, originSlice)
+
+	log.Printf("[DEBUG][diffObjectSliceLength] 4. (RawConfig - tfstate): %v", formatObjectSliceForLog(rawConfigMinusTfstate))
+	log.Printf("[DEBUG][diffObjectSliceLength] 5. (RawConfig - origin): %v", formatObjectSliceForLog(rawConfigMinusOrigin))
+	log.Printf("[DEBUG][diffObjectSliceLength] 6. (RawConfig - tfstate) ∩ (RawConfig - origin): %v", formatObjectSliceForLog(localAdditions))
+
+	if len(localAdditions) > 0 {
+		log.Printf("[DEBUG][diffObjectSliceLength] Found local additions (RawConfig - tfstate) ∩ (RawConfig - origin): %d, NOT suppressing diff",
+			len(localAdditions))
+		return true
+	}
+
+	return false
+}
+
+// calculateRemoteAdditions calculates remote additions (elements in tfstate - RawConfig but not in localRemovals)
+func calculateRemoteAdditions(tfstateMinusRawConfig, localRemovals []map[string]interface{}) []map[string]interface{} {
+	remoteAdditions := make([]map[string]interface{}, 0)
+	for _, elem := range tfstateMinusRawConfig {
+		if !ObjectSliceContains(localRemovals, elem) {
+			remoteAdditions = append(remoteAdditions, elem)
+		}
+	}
+	return remoteAdditions
+}
+
+// localRemovalsCheckParams contains parameters for checkLocalRemovalsForObjectSlice
+type localRemovalsCheckParams struct {
+	originVal      interface{}
+	oldParamVal    interface{}
+	newParamVal    interface{}
+	tfstateSlice   []map[string]interface{}
+	rawConfigSlice []map[string]interface{}
+	originSlice    []map[string]interface{}
+	oldCount       int
+	newCount       int
+}
+
+// checkLocalRemovalsForObjectSlice checks for local removals
+func checkLocalRemovalsForObjectSlice(params localRemovalsCheckParams) bool {
+	// Check 2: (tfstate - RawConfig) ∩ (origin - RawConfig)
+	// If not empty, it means there are local removals
+	localRemovals := calculateLocalRemovals(params.originVal, params.oldParamVal, params.newParamVal)
+	tfstateMinusRawConfig := FindObjectSliceElementsNotInAnother(params.tfstateSlice, params.rawConfigSlice)
+	originMinusRawConfig := FindObjectSliceElementsNotInAnother(params.originSlice, params.rawConfigSlice)
+
+	log.Printf("[DEBUG][diffObjectSliceLength] 7. (tfstate - RawConfig): %v", formatObjectSliceForLog(tfstateMinusRawConfig))
+	log.Printf("[DEBUG][diffObjectSliceLength] 8. (origin - RawConfig): %v", formatObjectSliceForLog(originMinusRawConfig))
+	log.Printf("[DEBUG][diffObjectSliceLength] 9. (tfstate - RawConfig) ∩ (origin - RawConfig): %v", formatObjectSliceForLog(localRemovals))
+
+	if len(localRemovals) == 0 {
+		return false
+	}
+
+	// Check if all removed elements are local removals
+	// If there are remote additions (elements in tfstate - RawConfig but not in localRemovals),
+	// we should suppress the length diff to allow element-level suppression
+	remoteAdditions := calculateRemoteAdditions(tfstateMinusRawConfig, localRemovals)
+
+	log.Printf("[DEBUG][diffObjectSliceLength] Remote additions (elements in tfstate - RawConfig but not in localRemovals): %v",
+		formatObjectSliceForLog(remoteAdditions))
+
+	if len(remoteAdditions) > 0 {
+		// There are both local removals and remote additions
+		// We need to NOT suppress the length diff to show the deletion operation
+		// The adjusted old count (excluding remote additions) should be used conceptually:
+		// adjustedOldCount = oldCount - len(remoteAdditions) = 4 - 1 = 3
+		// This means we want to show "3 -> 2" conceptually, but Terraform will show "4 -> 2"
+		// However, we can suppress remote additions at element level, so only local removals are shown
+		// Note: We cannot modify oldVal/newVal in diff suppression functions, but we can control
+		// which elements are shown/hidden at element level
+		adjustedOldCount := params.oldCount - len(remoteAdditions)
+		log.Printf("[DEBUG][diffObjectSliceLength] Found local removals (%d) and remote additions (%d), "+
+			"adjusted old count: %d -> %d (conceptually %d -> %d)",
+			len(localRemovals), len(remoteAdditions), params.oldCount, params.newCount, adjustedOldCount, params.newCount)
+		log.Printf("[DEBUG][diffObjectSliceLength] NOT suppressing length diff to show deletion operation, " +
+			"remote additions will be suppressed at element level")
+		return true
+	}
+
+	// All removed elements are local removals, don't suppress
+	log.Printf("[DEBUG][diffObjectSliceLength] Found local removals (tfstate - RawConfig) ∩ (origin - RawConfig): %d, NOT suppressing diff",
+		len(localRemovals))
+	return true
+}
+
 // diffObjectSliceLength handles the length field of TypeList or TypeSet for object slices
 func diffObjectSliceLength(paramKey, oldVal, newVal string, d *schema.ResourceData) bool {
 	baseField := strings.TrimSuffix(paramKey, ".#")
+
+	// Get old and new values from GetChange to check field type
+	oldParamVal, newParamVal := d.GetChange(baseField)
+
+	log.Printf("[DEBUG][diffObjectSliceLength] Checking field type for '%s', oldParamVal type=%T, newParamVal type=%T",
+		baseField, oldParamVal, newParamVal)
+
+	// Check if this is a string slice field (not an object slice)
+	// If the field contains string elements, it's a string slice and should be handled by its own DiffSuppressFunc
+	isStringSlice := isStringSliceField(oldParamVal, newParamVal)
+	log.Printf("[DEBUG][diffObjectSliceLength] isStringSliceField result for '%s': %v", baseField, isStringSlice)
+	if isStringSlice {
+		log.Printf("[DEBUG][diffObjectSliceLength] Field '%s' is a string slice, skipping object slice diff suppression "+
+			"(let field's own DiffSuppressFunc handle it)", baseField)
+		return false
+	}
 
 	// Get the origin value
 	originParamKey := fmt.Sprintf("%s_origin", baseField)
@@ -918,11 +1933,17 @@ func diffObjectSliceLength(paramKey, oldVal, newVal string, d *schema.ResourceDa
 		return true
 	}
 
-	// Get old and new values from GetChange
-	oldParamVal, newParamVal := d.GetChange(baseField)
-	tfstateSlice := convertToObjectSlice(oldParamVal)   // tfstate (remote state)
-	rawConfigSlice := convertToObjectSlice(newParamVal) // RawConfig (script config)
-	originSlice := convertToObjectSlice(originVal)      // origin
+	tfstateSlice := convertToObjectSlice(oldParamVal) // tfstate (remote state)
+
+	// Use GetRawConfig to get the actual user config (not filled with remote values)
+	rawConfigVal := GetNestedObjectFromRawConfig(d.GetRawConfig(), baseField)
+	rawConfigSlice := convertToObjectSlice(rawConfigVal) // RawConfig (script config)
+	originSlice := convertToObjectSlice(originVal)       // origin
+
+	// Check if this is an explicit local removal
+	if checkExplicitRemovalForObjectSlice(rawConfigSlice, originSlice, originVal, oldCount, newCount) {
+		return false
+	}
 
 	log.Printf("[DEBUG][diffObjectSliceLength] paramKey='%s', oldCount=%d, newCount=%d, originSlice length=%d, tfstateSlice length=%d, "+
 		"rawConfigSlice length=%d",
@@ -933,66 +1954,23 @@ func diffObjectSliceLength(paramKey, oldVal, newVal string, d *schema.ResourceDa
 	log.Printf("[DEBUG][diffObjectSliceLength] 2. tfstate: %v", formatObjectSliceForLog(tfstateSlice))
 	log.Printf("[DEBUG][diffObjectSliceLength] 3. origin: %v", formatObjectSliceForLog(originSlice))
 
-	// Check 1: (RawConfig - tfstate) ∩ (RawConfig - origin)
-	// If not empty, it means there are local additions
-	localAdditions := calculateLocalAdditions(originVal, oldParamVal, newParamVal)
-	rawConfigMinusTfstate := FindObjectSliceElementsNotInAnother(rawConfigSlice, tfstateSlice)
-	rawConfigMinusOrigin := FindObjectSliceElementsNotInAnother(rawConfigSlice, originSlice)
-
-	log.Printf("[DEBUG][diffObjectSliceLength] 4. (RawConfig - tfstate): %v", formatObjectSliceForLog(rawConfigMinusTfstate))
-	log.Printf("[DEBUG][diffObjectSliceLength] 5. (RawConfig - origin): %v", formatObjectSliceForLog(rawConfigMinusOrigin))
-	log.Printf("[DEBUG][diffObjectSliceLength] 6. (RawConfig - tfstate) ∩ (RawConfig - origin): %v", formatObjectSliceForLog(localAdditions))
-
-	if len(localAdditions) > 0 {
-		log.Printf("[DEBUG][diffObjectSliceLength] Found local additions (RawConfig - tfstate) ∩ (RawConfig - origin): %d, NOT suppressing diff",
-			len(localAdditions))
+	// Check 1: local additions
+	if checkLocalAdditionsForObjectSlice(originVal, oldParamVal, newParamVal, rawConfigSlice, tfstateSlice, originSlice) {
 		return false
 	}
 
-	// Check 2: (tfstate - RawConfig) ∩ (origin - RawConfig)
-	// If not empty, it means there are local removals
-	localRemovals := calculateLocalRemovals(originVal, oldParamVal, newParamVal)
-	tfstateMinusRawConfig := FindObjectSliceElementsNotInAnother(tfstateSlice, rawConfigSlice)
-	originMinusRawConfig := FindObjectSliceElementsNotInAnother(originSlice, rawConfigSlice)
-
-	log.Printf("[DEBUG][diffObjectSliceLength] 7. (tfstate - RawConfig): %v", formatObjectSliceForLog(tfstateMinusRawConfig))
-	log.Printf("[DEBUG][diffObjectSliceLength] 8. (origin - RawConfig): %v", formatObjectSliceForLog(originMinusRawConfig))
-	log.Printf("[DEBUG][diffObjectSliceLength] 9. (tfstate - RawConfig) ∩ (origin - RawConfig): %v", formatObjectSliceForLog(localRemovals))
-
-	// Check if all removed elements are local removals
-	// If there are remote additions (elements in tfstate - RawConfig but not in localRemovals),
-	// we should suppress the length diff to allow element-level suppression
-	remoteAdditions := make([]map[string]interface{}, 0)
-	for _, elem := range tfstateMinusRawConfig {
-		if !ObjectSliceContains(localRemovals, elem) {
-			remoteAdditions = append(remoteAdditions, elem)
-		}
+	// Check 2: local removals
+	removalsParams := localRemovalsCheckParams{
+		originVal:      originVal,
+		oldParamVal:    oldParamVal,
+		newParamVal:    newParamVal,
+		tfstateSlice:   tfstateSlice,
+		rawConfigSlice: rawConfigSlice,
+		originSlice:    originSlice,
+		oldCount:       oldCount,
+		newCount:       newCount,
 	}
-
-	log.Printf("[DEBUG][diffObjectSliceLength] Remote additions (elements in tfstate - RawConfig but not in localRemovals): %v",
-		formatObjectSliceForLog(remoteAdditions))
-
-	if len(localRemovals) > 0 {
-		if len(remoteAdditions) > 0 {
-			// There are both local removals and remote additions
-			// We need to NOT suppress the length diff to show the deletion operation
-			// The adjusted old count (excluding remote additions) should be used conceptually:
-			// adjustedOldCount = oldCount - len(remoteAdditions) = 4 - 1 = 3
-			// This means we want to show "3 -> 2" conceptually, but Terraform will show "4 -> 2"
-			// However, we can suppress remote additions at element level, so only local removals are shown
-			// Note: We cannot modify oldVal/newVal in diff suppression functions, but we can control
-			// which elements are shown/hidden at element level
-			adjustedOldCount := oldCount - len(remoteAdditions)
-			log.Printf("[DEBUG][diffObjectSliceLength] Found local removals (%d) and remote additions (%d), "+
-				"adjusted old count: %d -> %d (conceptually %d -> %d)",
-				len(localRemovals), len(remoteAdditions), oldCount, newCount, adjustedOldCount, newCount)
-			log.Printf("[DEBUG][diffObjectSliceLength] NOT suppressing length diff to show deletion operation, " +
-				"remote additions will be suppressed at element level")
-			return false
-		}
-		// All removed elements are local removals, don't suppress
-		log.Printf("[DEBUG][diffObjectSliceLength] Found local removals (tfstate - RawConfig) ∩ (origin - RawConfig): %d, NOT suppressing diff",
-			len(localRemovals))
+	if checkLocalRemovalsForObjectSlice(removalsParams) {
 		return false
 	}
 
@@ -1160,16 +2138,16 @@ func diffObjectSliceElement(paramKey, oldVal, newVal string, d *schema.ResourceD
 	}
 
 	// Check if the target object is in localRemovals
-	if targetObject != nil {
+	if targetObject == nil {
+		log.Printf("[DEBUG][diffObjectSliceElement] Could not find target object for objectHash '%s' (oldVal='%s'), continuing with normal logic",
+			objectHash, oldVal)
+	} else {
 		if ObjectSliceContains(localRemovals, targetObject) {
 			log.Printf("[DEBUG][diffObjectSliceElement] Object '%s' (paramKey='%s') is in (tfstate - RawConfig) ∩ (origin - RawConfig), "+
 				"NOT suppressing diff (local removal)", objectHash, paramKey)
 			return false
 		}
 		log.Printf("[DEBUG][diffObjectSliceElement] Object '%s' (paramKey='%s') is NOT in localRemovals", objectHash, paramKey)
-	} else {
-		log.Printf("[DEBUG][diffObjectSliceElement] Could not find target object for objectHash '%s' (oldVal='%s'), continuing with normal logic",
-			objectHash, oldVal)
 	}
 
 	// Handle element removal case
@@ -1494,20 +2472,28 @@ func handleObjectElementRemoval(baseField, objectHash, oldVal string, originVal 
 	return true
 }
 
-// findTargetObjectForAddition finds the target object for addition checking
-func findTargetObjectForAddition(d *schema.ResourceData, baseField, objectHash string, oldObject map[string]interface{},
-	tfstateSlice, localRemovals []map[string]interface{}) map[string]interface{} {
+// targetObjectSearchParams contains parameters for findTargetObjectForAddition
+type targetObjectSearchParams struct {
+	d             *schema.ResourceData
+	baseField     string
+	objectHash    string
+	oldObject     map[string]interface{}
+	tfstateSlice  []map[string]interface{}
+	localRemovals []map[string]interface{}
+}
+
+func findTargetObjectForAddition(params targetObjectSearchParams) map[string]interface{} {
 	// First, try to get the object from state attributes by objectHash
-	targetObject := findTargetObjectFromState(d, baseField, objectHash, tfstateSlice)
+	targetObject := findTargetObjectFromState(params.d, params.baseField, params.objectHash, params.tfstateSlice)
 	if targetObject != nil {
 		return targetObject
 	}
 
 	// If we couldn't find the object from state attributes, try to use oldObject to find it in tfstateSlice
-	if len(oldObject) > 0 {
-		for _, tfstateObjMap := range tfstateSlice {
+	if len(params.oldObject) > 0 {
+		for _, tfstateObjMap := range params.tfstateSlice {
 			matches := true
-			for key, val := range oldObject {
+			for key, val := range params.oldObject {
 				if tfstateVal, ok := tfstateObjMap[key]; !ok || !reflect.DeepEqual(val, tfstateVal) {
 					matches = false
 					break
@@ -1520,9 +2506,9 @@ func findTargetObjectForAddition(d *schema.ResourceData, baseField, objectHash s
 		}
 
 		// Try direct comparison with oldObject (partial match) against localRemovals
-		for _, localRemovalObj := range localRemovals {
+		for _, localRemovalObj := range params.localRemovals {
 			matches := true
-			for key, val := range oldObject {
+			for key, val := range params.oldObject {
 				if localRemovalVal, ok := localRemovalObj[key]; !ok || !reflect.DeepEqual(val, localRemovalVal) {
 					matches = false
 					break
@@ -1601,19 +2587,27 @@ func handleObjectElementAddition(baseField, objectHash string, originVal interfa
 		objectHash, oldObject, formatObjectSliceForLog(localRemovals))
 
 	// Try to find the target object to check if it's in localRemovals
-	targetObject := findTargetObjectForAddition(d, baseField, objectHash, oldObject, tfstateSlice, localRemovals)
+	searchParams := targetObjectSearchParams{
+		d:             d,
+		baseField:     baseField,
+		objectHash:    objectHash,
+		oldObject:     oldObject,
+		tfstateSlice:  tfstateSlice,
+		localRemovals: localRemovals,
+	}
+	targetObject := findTargetObjectForAddition(searchParams)
 
 	// Check if the target object is in localRemovals
-	if targetObject != nil {
+	if targetObject == nil {
+		log.Printf("[DEBUG][handleObjectElementAddition] Could not find target object for objectHash '%s', continuing with normal logic",
+			objectHash)
+	} else {
 		if ObjectSliceContains(localRemovals, targetObject) {
 			log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is in (tfstate - RawConfig) ∩ (origin - RawConfig), "+
 				"NOT suppressing diff (local removal)", objectHash)
 			return false
 		}
 		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is NOT in localRemovals", objectHash)
-	} else {
-		log.Printf("[DEBUG][handleObjectElementAddition] Could not find target object for objectHash '%s', continuing with normal logic",
-			objectHash)
 	}
 
 	// Try to get the object from new state first
@@ -1635,23 +2629,168 @@ func handleObjectElementAddition(baseField, objectHash string, originVal interfa
 			return false
 		}
 
+		// When origin is empty, check if newObject is in rawConfig but not in tfstate
+		// This indicates a local addition, not a remote addition
+		// Use GetRawConfig to get the actual user config (not filled with remote values)
+		rawConfigVal := GetNestedObjectFromRawConfig(d.GetRawConfig(), baseField)
+		rawConfigSlice := convertToObjectSlice(rawConfigVal)
+		tfstateSlice := convertToObjectSlice(oldParamVal)
+
+		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - rawConfigSlice length: %d, tfstateSlice length: %d",
+			objectHash, len(rawConfigSlice), len(tfstateSlice))
+		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - newObject: %v", objectHash, newObject)
+
+		// Normalize newObject format (from flat to nested) for comparison
+		normalizedNewObject := normalizeObjectFromState(newObject)
+		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - normalizedNewObject: %v", objectHash, normalizedNewObject)
+
+		// Check if normalizedNewObject is in rawConfig (using GetRawConfig)
+		// First try exact match with ObjectSliceContains
+		newObjectInRawConfig := ObjectSliceContains(rawConfigSlice, normalizedNewObject)
+		// Check if normalizedNewObject is in tfstate
+		newObjectInTfstate := ObjectSliceContains(tfstateSlice, normalizedNewObject)
+
+		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - exact match in rawConfig: %v, in tfstate: %v",
+			objectHash, newObjectInRawConfig, newObjectInTfstate)
+
+		// If exact match found in rawConfig but not in tfstate, this is a local addition
+		if newObjectInRawConfig && !newObjectInTfstate {
+			log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is in rawConfig but not in tfstate (exact match), "+
+				"this is a local addition, NOT suppressing diff", objectHash)
+			return false // Don't suppress - this is a local addition
+		}
+
+		// If exact match failed, try generic matching with all rawConfig objects
+		// This handles cases where format differences prevent exact matching
+		if !newObjectInRawConfig && len(rawConfigSlice) > 0 {
+			log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - trying generic matching with rawConfigSlice (length: %d)",
+				objectHash, len(rawConfigSlice))
+			for i, rawConfigObj := range rawConfigSlice {
+				matchResult := objectsMatchGeneric(normalizedNewObject, rawConfigObj)
+				log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - comparing with rawConfigSlice[%d]: %v, match: %v",
+					objectHash, i, rawConfigObj, matchResult)
+				if matchResult {
+					// Found a match in rawConfig, check if it's also in tfstate
+					rawConfigObjInTfstate := ObjectSliceContains(tfstateSlice, rawConfigObj)
+					if !rawConfigObjInTfstate {
+						log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' matches an object in rawConfigSlice but not in tfstate, "+
+							"this is a local addition, NOT suppressing diff", objectHash)
+						return false // Don't suppress - this is a local addition
+					}
+				}
+			}
+		}
+
+		// If rawConfig is not empty and normalizedNewObject is not in tfstate, check if rawConfig has objects not in tfstate
+		// This handles the case where format differences prevent direct matching
+		if len(rawConfigSlice) > 0 && !newObjectInTfstate {
+			// Check if any object in rawConfig has the same structure as normalizedNewObject
+			// Since format might differ, we check if rawConfig has objects that are not in tfstate
+			rawConfigMinusTfstate := FindObjectSliceElementsNotInAnother(rawConfigSlice, tfstateSlice)
+			log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - rawConfigMinusTfstate length: %d",
+				objectHash, len(rawConfigMinusTfstate))
+
+			// Check if normalizedNewObject matches any object in rawConfigMinusTfstate
+			// This handles the case where the object is a local addition but format differences prevented matching
+			if len(rawConfigMinusTfstate) > 0 {
+				// Use generic object matching (doesn't rely on specific field names)
+				for i, rawConfigObj := range rawConfigMinusTfstate {
+					matchResult := objectsMatchGeneric(normalizedNewObject, rawConfigObj)
+					log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - comparing with rawConfigMinusTfstate[%d]: %v, match: %v",
+						objectHash, i, rawConfigObj, matchResult)
+					if matchResult {
+						log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' matches an object in rawConfigMinusTfstate, "+
+							"this is a local addition, NOT suppressing diff", objectHash)
+						return false // Don't suppress - this is a local addition
+					}
+				}
+			}
+		}
+
 		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is not in (RawConfig - tfstate) ∩ (RawConfig - origin) and origin is empty, "+
 			"suppressing diff (remote addition)", objectHash)
 		return true
 	}
 
-	// Check if this object is in origin
-	if isObjectInOrigin(newObject, originVal) {
-		return handleObjectElementAdditionWhenInOrigin(baseField, objectHash, newObject, oldObject, d)
+	// Normalize newObject format (from flat to nested) for comparison
+	normalizedNewObject := normalizeObjectFromState(newObject)
+	log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - normalizedNewObject: %v", objectHash, normalizedNewObject)
+
+	// Check if this object is in origin (using normalized object)
+	if isObjectInOrigin(normalizedNewObject, originVal) {
+		return handleObjectElementAdditionWhenInOrigin(baseField, objectHash, normalizedNewObject, oldObject, d)
 	}
 
 	// Check addition logic: (RawConfig - tfstate) ∩ (RawConfig - origin)
 	localAdditions := calculateLocalAdditions(originVal, oldParamVal, newParamVal)
 
-	if ObjectSliceContains(localAdditions, newObject) {
+	// Use normalized object for comparison
+	if ObjectSliceContains(localAdditions, normalizedNewObject) {
 		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is in (RawConfig - tfstate) ∩ (RawConfig - origin), "+
 			"NOT suppressing diff (local addition)", objectHash)
 		return false
+	}
+
+	// If exact match failed, try generic matching with localAdditions
+	// This handles cases where format differences prevent exact matching
+	if len(localAdditions) > 0 {
+		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - trying generic matching with localAdditions (length: %d)",
+			objectHash, len(localAdditions))
+		for i, localAdditionObj := range localAdditions {
+			matchResult := objectsMatchGeneric(normalizedNewObject, localAdditionObj)
+			log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - comparing with localAdditions[%d]: %v, match: %v",
+				objectHash, i, localAdditionObj, matchResult)
+			if matchResult {
+				log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' matches an object in localAdditions, "+
+					"this is a local addition, NOT suppressing diff", objectHash)
+				return false // Don't suppress - this is a local addition
+			}
+		}
+	}
+
+	// Also check if normalizedNewObject is in rawConfig but not in tfstate
+	// Use GetRawConfig to get the actual user config (not filled with remote values)
+	rawConfigVal := GetNestedObjectFromRawConfig(d.GetRawConfig(), baseField)
+	rawConfigSliceForCheck := convertToObjectSlice(rawConfigVal)
+	tfstateSliceForCheck := convertToObjectSlice(oldParamVal)
+
+	log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - rawConfigSlice length: %d, tfstateSlice length: %d",
+		objectHash, len(rawConfigSliceForCheck), len(tfstateSliceForCheck))
+
+	// Check if normalizedNewObject is in rawConfig (using GetRawConfig)
+	newObjectInRawConfig := ObjectSliceContains(rawConfigSliceForCheck, normalizedNewObject)
+	// Check if normalizedNewObject is in tfstate
+	newObjectInTfstate := ObjectSliceContains(tfstateSliceForCheck, normalizedNewObject)
+
+	log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - exact match in rawConfig: %v, in tfstate: %v",
+		objectHash, newObjectInRawConfig, newObjectInTfstate)
+
+	// If exact match found in rawConfig but not in tfstate, this is a local addition
+	if newObjectInRawConfig && !newObjectInTfstate {
+		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is in rawConfig but not in tfstate (exact match), "+
+			"this is a local addition, NOT suppressing diff", objectHash)
+		return false // Don't suppress - this is a local addition
+	}
+
+	// If exact match failed, try generic matching with all rawConfig objects
+	// This handles cases where format differences prevent exact matching
+	if !newObjectInRawConfig && len(rawConfigSliceForCheck) > 0 {
+		log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - trying generic matching with rawConfigSlice (length: %d)",
+			objectHash, len(rawConfigSliceForCheck))
+		for i, rawConfigObj := range rawConfigSliceForCheck {
+			matchResult := objectsMatchGeneric(normalizedNewObject, rawConfigObj)
+			log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' - comparing with rawConfigSlice[%d]: %v, match: %v",
+				objectHash, i, rawConfigObj, matchResult)
+			if matchResult {
+				// Found a match in rawConfig, check if it's also in tfstate
+				rawConfigObjInTfstate := ObjectSliceContains(tfstateSliceForCheck, rawConfigObj)
+				if !rawConfigObjInTfstate {
+					log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' matches an object in rawConfigSlice but not in tfstate, "+
+						"this is a local addition, NOT suppressing diff", objectHash)
+					return false // Don't suppress - this is a local addition
+				}
+			}
+		}
 	}
 
 	log.Printf("[DEBUG][handleObjectElementAddition] Object '%s' is not in (RawConfig - tfstate) ∩ (RawConfig - origin), "+
@@ -1660,7 +2799,8 @@ func handleObjectElementAddition(baseField, objectHash string, originVal interfa
 }
 
 // handleObjectElementAdditionWhenInOrigin handles the case when the object is in origin
-func handleObjectElementAdditionWhenInOrigin(baseField, objectHash string, newObject, oldObject map[string]interface{}, d *schema.ResourceData) bool {
+func handleObjectElementAdditionWhenInOrigin(baseField, objectHash string, newObject, oldObject map[string]interface{},
+	d *schema.ResourceData) bool {
 	// Check if it exists in remote state by matching object content
 	oldParamVal, _ := d.GetChange(baseField)
 	var oldObjectList []interface{}
@@ -1917,6 +3057,314 @@ func FindObjectSliceElementsNotInAnother(source, target []map[string]interface{}
 		}
 	}
 	return result
+}
+
+// normalizeObjectFromState normalizes an object from state attributes format (flat) to nested format
+// Example: map[excludes.#:1 excludes.0:xxx] -> map[excludes:[xxx]]
+// indexedValue represents a value with its index in a list field
+type indexedValue struct {
+	index int
+	value interface{}
+}
+
+// processCountField processes count fields like "excludes.#"
+func processCountField(key string, val interface{}, normalized map[string]interface{}, processedFields, listFields map[string]bool) bool {
+	if !strings.HasSuffix(key, ".#") {
+		return false
+	}
+
+	fieldName := strings.TrimSuffix(key, ".#")
+	listFields[fieldName] = true
+	count, ok := val.(int)
+	if ok && count == 0 {
+		// Empty list, set to empty slice (explicit empty list)
+		normalized[fieldName] = []interface{}{}
+		processedFields[fieldName] = true
+	}
+	// If count > 0, we'll process it in the indexed field section
+	return true
+}
+
+// collectIndexedValues collects all indexed values for a given field name
+func collectIndexedValues(fieldName string, obj map[string]interface{}) []indexedValue {
+	var indexedValues []indexedValue
+	for k, v := range obj {
+		if strings.HasPrefix(k, fieldName+".") && k != fieldName+".#" {
+			// Extract the index and value
+			fieldParts := strings.SplitN(k, ".", 2)
+			if len(fieldParts) == 2 {
+				if idx, err := strconv.Atoi(fieldParts[1]); err == nil {
+					indexedValues = append(indexedValues, indexedValue{index: idx, value: v})
+				}
+			}
+		}
+	}
+	// Sort by index to maintain order
+	sort.Slice(indexedValues, func(i, j int) bool {
+		return indexedValues[i].index < indexedValues[j].index
+	})
+	return indexedValues
+}
+
+// processIndexedField processes indexed fields like "excludes.0", "excludes.1", etc.
+func processIndexedField(
+	key string,
+	normalized map[string]interface{},
+	processedFields, listFields map[string]bool,
+	obj map[string]interface{},
+) bool {
+	parts := strings.Split(key, ".")
+	if len(parts) < 2 {
+		return false
+	}
+
+	fieldName := parts[0]
+	indexStr := parts[1]
+
+	// Check if indexStr is a number (index)
+	if _, err := strconv.Atoi(indexStr); err != nil {
+		return false
+	}
+
+	listFields[fieldName] = true
+	// This is an indexed field, collect all indices for this field
+	if processedFields[fieldName] {
+		return true
+	}
+
+	// Collect all values for this field with their indices
+	indexedValues := collectIndexedValues(fieldName, obj)
+
+	// Extract values in order
+	values := make([]interface{}, len(indexedValues))
+	for i, iv := range indexedValues {
+		values[i] = iv.value
+	}
+
+	// Set the field (only if we have values or if count was explicitly 0)
+	// If count field exists and is 0, it's already set to empty slice above
+	if len(values) > 0 || normalized[fieldName] == nil {
+		normalized[fieldName] = values
+	}
+	processedFields[fieldName] = true
+	return true
+}
+
+// processRegularField processes regular (non-indexed) fields
+func processRegularField(key string, val interface{}, normalized map[string]interface{}, processedFields, listFields map[string]bool) {
+	// Skip count fields and indexed fields (already processed)
+	if strings.HasSuffix(key, ".#") {
+		return
+	}
+
+	parts := strings.Split(key, ".")
+	if len(parts) >= 2 {
+		fieldName := parts[0]
+		if listFields[fieldName] {
+			return // Already processed as list field
+		}
+	}
+
+	// Regular field (not indexed), copy as-is
+	if !processedFields[key] {
+		normalized[key] = val
+		processedFields[key] = true
+	}
+}
+
+func normalizeObjectFromState(obj map[string]interface{}) map[string]interface{} {
+	if obj == nil {
+		return nil
+	}
+
+	normalized := make(map[string]interface{})
+
+	// Track which fields we've processed to avoid duplicates
+	processedFields := make(map[string]bool)
+	// Track list fields that have count fields (like "excludes.#")
+	listFields := make(map[string]bool)
+
+	// First pass: identify list fields and collect their values
+	for key, val := range obj {
+		// Check if this is a count field like "excludes.#"
+		if processCountField(key, val, normalized, processedFields, listFields) {
+			continue
+		}
+
+		// Check if this is an indexed field like "excludes.0", "excludes.1", etc.
+		if processIndexedField(key, normalized, processedFields, listFields, obj) {
+			continue
+		}
+	}
+
+	// Second pass: copy regular fields (not list fields)
+	for key, val := range obj {
+		processRegularField(key, val, normalized, processedFields, listFields)
+	}
+
+	return normalized
+}
+
+// objectsMatchGeneric checks if two objects match using a generic approach
+// It compares objects by their field values without relying on specific field names
+func objectsMatchGeneric(obj1, obj2 map[string]interface{}) bool {
+	if obj1 == nil || obj2 == nil {
+		return false
+	}
+
+	// First, try deep equal (works if objects are already normalized)
+	if reflect.DeepEqual(obj1, obj2) {
+		return true
+	}
+
+	// If deep equal fails, try field-level comparison
+	// Count matching fields and total fields
+	matchingFields := 0
+	totalFields := 0
+
+	// Collect all unique field names from both objects
+	allFields := make(map[string]bool)
+	for key := range obj1 {
+		allFields[key] = true
+	}
+	for key := range obj2 {
+		allFields[key] = true
+	}
+
+	// Compare each field
+	for field := range allFields {
+		val1, ok1 := obj1[field]
+		val2, ok2 := obj2[field]
+
+		// Skip internal fields that might differ due to format
+		if strings.HasSuffix(field, "_origin") || strings.HasSuffix(field, ".#") {
+			continue
+		}
+
+		totalFields++
+
+		// Both objects have the field
+		if ok1 && ok2 {
+			// Normalize values for comparison (handle slices, maps, etc.)
+			if valuesMatchGeneric(val1, val2) {
+				matchingFields++
+			}
+		} else if !ok1 && !ok2 {
+			// Neither object has the field, consider it matching
+			matchingFields++
+		}
+		// If only one object has the field, it's a mismatch
+	}
+
+	// If no fields to compare, return false
+	if totalFields == 0 {
+		return false
+	}
+
+	// If most fields match (>= 80%), consider objects matching
+	// This handles cases where minor format differences exist
+	matchRatio := float64(matchingFields) / float64(totalFields)
+	return matchRatio >= 0.8
+}
+
+// valuesMatchGeneric compares two values generically, handling different types
+func valuesMatchGeneric(val1, val2 interface{}) bool {
+	// Handle nil cases
+	if val1 == nil && val2 == nil {
+		return true
+	}
+
+	// Normalize nil and empty slices/maps to be equivalent
+	val1Normalized := normalizeValueForComparison(val1)
+	val2Normalized := normalizeValueForComparison(val2)
+
+	if val1Normalized == nil && val2Normalized == nil {
+		return true
+	}
+	if val1Normalized == nil || val2Normalized == nil {
+		return false
+	}
+
+	// Try direct deep equal first
+	if reflect.DeepEqual(val1Normalized, val2Normalized) {
+		return true
+	}
+
+	// Handle slices - compare elements
+	if slice1, ok1 := val1Normalized.([]interface{}); ok1 {
+		if slice2, ok2 := val2Normalized.([]interface{}); ok2 {
+			return slicesMatchGeneric(slice1, slice2)
+		}
+		return false
+	}
+
+	// Handle maps - compare recursively
+	if map1, ok1 := val1Normalized.(map[string]interface{}); ok1 {
+		if map2, ok2 := val2Normalized.(map[string]interface{}); ok2 {
+			return objectsMatchGeneric(map1, map2)
+		}
+		return false
+	}
+
+	// For other types, try string comparison as fallback
+	str1 := fmt.Sprintf("%v", val1Normalized)
+	str2 := fmt.Sprintf("%v", val2Normalized)
+	return str1 == str2
+}
+
+// normalizeValueForComparison normalizes values for comparison
+// It treats nil, empty slices, and empty maps as equivalent
+func normalizeValueForComparison(val interface{}) interface{} {
+	if val == nil {
+		return nil
+	}
+
+	// Normalize empty slices to nil
+	if slice, ok := val.([]interface{}); ok {
+		if len(slice) == 0 {
+			return nil
+		}
+		return slice
+	}
+
+	// Normalize empty maps to nil
+	if m, ok := val.(map[string]interface{}); ok {
+		if len(m) == 0 {
+			return nil
+		}
+		return m
+	}
+
+	return val
+}
+
+// slicesMatchGeneric compares two slices generically
+func slicesMatchGeneric(slice1, slice2 []interface{}) bool {
+	if len(slice1) != len(slice2) {
+		return false
+	}
+
+	// Try exact match first
+	if reflect.DeepEqual(slice1, slice2) {
+		return true
+	}
+
+	// If exact match fails, check if all elements in slice1 exist in slice2
+	// This handles cases where order might differ
+	for _, elem1 := range slice1 {
+		found := false
+		for _, elem2 := range slice2 {
+			if valuesMatchGeneric(elem1, elem2) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
 }
 
 // ObjectSliceContains checks if a target object is present in a slice of objects

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -203,6 +203,10 @@ func FildSliceIntersection(source, target []interface{}) []interface{} {
 // FindSliceElementsNotInAnother returns elements from source that are not in target
 // This is equivalent to source - target (set difference)
 func FindSliceElementsNotInAnother(source, target []interface{}) []interface{} {
+	if len(target) < 1 {
+		return source
+	}
+
 	var result []interface{}
 	for _, sv := range source {
 		if !SliceContains(target, sv) {
@@ -213,6 +217,10 @@ func FindSliceElementsNotInAnother(source, target []interface{}) []interface{} {
 }
 
 func FindStrSliceElementsNotInAnother(source, target []string) []string {
+	if len(target) < 1 {
+		return source
+	}
+
 	var result []string
 	for _, sv := range source {
 		if !StrSliceContains(target, sv) {
@@ -231,6 +239,15 @@ func SliceContains(slice []interface{}, target interface{}) bool {
 		}
 	}
 	return false
+}
+
+func SliceContainsAnother(slice []interface{}, target []interface{}) bool {
+	for _, v := range target {
+		if !SliceContains(slice, v) {
+			return false
+		}
+	}
+	return true
 }
 
 // StrSliceContains checks if a given string is contained in a slice


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

To enable local management of vault parameters:
+ `resources`
+ `resources.*.includes`
+ `resources.*.excludes`
Two methods `utils.SuppressObjectSliceDiffs()` and `utils.SuppressStrSliceDiffs()` are introduced for DiffSuppressFunc to identify differences between **local**, **remote**, and **previous script configuration** values.

The final change request body is calculated based on the differences between these three values. (Note that the disks managed by server type vault, changing the binding information without changing the binding on the primary server does not require deleting the resource; it can be overwritten by adding the resource again. And this requires the next request body to include the remotely managed disk information.)

When expression `((local- previous - remote) > 0 && ((local - previous - remote) ∩ remote) < 1)` is **true**, it indicates a local addition is needed, and the added content is:
```
(remote ∪ local) - (previous- local)
```

When expression `((previous - local) ∩ remote) > 0` is true, it indicates a local deletion is needed, and the deleted content is:
```
(previous - local) ∩ remote
```

Furthermore, the `GetRawConfig` method in `utils.RefreshObjectParamOriginValues()` retrieves historical local script configuration information during misaligned updates, making it less accurate than `GetRawPlan`.

The `SuppressStrSliceDiffs` method allows filtering of historical objects using specific parameters.
The cross-structure origin detection with following format:
```
{origin_root_field}|{locator_key}.{origin_field_name}
```
For example: `resources_origin|server_id.excludes`
That means:
- origin is in resources_origin list
- locate by server_id key from current structure
- origin field name is excludes

**Which issue this PR fixes**:

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

fixes #7382 
fixes #7886 

**Special notes for your reviewer**:

Remove the associated disk volumes from server type vault and the remote side have some extra server disk association.
<img width="2393" height="1336" alt="image" src="https://github.com/user-attachments/assets/0ca514a5-aac9-407f-8b76-a8d9da65faea" />
<img width="2249" height="1331" alt="image" src="https://github.com/user-attachments/assets/9a623d45-6e67-4814-88e6-63533d2168a0" />
<img width="2047" height="593" alt="image" src="https://github.com/user-attachments/assets/a458526e-6365-4964-9423-4e4fa9f5238e" />

Supplement the new disk volumes association to server type vault and the remote side have some extra server disk association.
<img width="2057" height="1332" alt="image" src="https://github.com/user-attachments/assets/8dfbd314-27c9-4a09-a13b-24348b7d4de6" />
<img width="779" height="819" alt="image" src="https://github.com/user-attachments/assets/d901f657-81ca-4d63-835f-f1c5b24f27f4" />
<img width="2397" height="1327" alt="image" src="https://github.com/user-attachments/assets/2397011b-f200-4fd6-90c3-c27ba3503264" />
<img width="1072" height="865" alt="image" src="https://github.com/user-attachments/assets/0f16d3b4-445b-449f-aa4b-c52ef183cc6b" />
<img width="2378" height="1325" alt="image" src="https://github.com/user-attachments/assets/a2bed828-7dbf-4243-9b35-6e8912679884" />

Remove the associated disk volumes from disk type vault and the remote side have some extra disk association.
<img width="2026" height="1330" alt="image" src="https://github.com/user-attachments/assets/964b9495-8f14-4c0e-b161-569a9390ae72" />
<img width="2070" height="1311" alt="image" src="https://github.com/user-attachments/assets/a342eb79-f7e5-42c5-9c1d-8c512399fd42" />

Update the associated disk volumes under disk type vault and the remote side have some extra disk association.
<img width="2114" height="1306" alt="image" src="https://github.com/user-attachments/assets/0d184e7d-b86b-4678-888a-13c85cd43571" />


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. vault supports mange incremental resources and local only
2. supplement the test step for volumes' associate and dissociate
3. origin refresh function using RawPlan to obtain the local configuration
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cbr -f TestAccVault_backupServer
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccVault_backupServer -timeout 360m -parallel 10
=== RUN   TestAccVault_backupServer
=== PAUSE TestAccVault_backupServer
=== CONT  TestAccVault_backupServer
--- PASS: TestAccVault_backupServer (523.71s)
PASS
coverage: 16.1% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       523.790s        coverage: 16.1% of statements in ./huaweicloud/services/cbr
```
```
./scripts/coverage.sh -o cbr -f TestAccVault_volume
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccVault_volume -timeout 360m -parallel 10
=== RUN   TestAccVault_volume
=== PAUSE TestAccVault_volume
=== CONT  TestAccVault_volume
--- PASS: TestAccVault_volume (83.02s)
PASS
coverage: 14.2% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       83.154s coverage: 14.2% of statements in ./huaweicloud/services/cbr
```
```
./scripts/coverage.sh -o cbr -f TestAccVault_replicationServer
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccVault_replicationServer -timeout 360m -parallel 10
=== RUN   TestAccVault_replicationServer
=== PAUSE TestAccVault_replicationServer
=== CONT  TestAccVault_replicationServer
--- PASS: TestAccVault_replicationServer (21.40s)
PASS
coverage: 8.9% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       21.478s coverage: 8.9% of statements in ./huaweicloud/services/cbr
```
```
./scripts/coverage.sh -o cbr -f TestAccVault_prePaidServer
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccVault_prePaidServer -timeout 360m -parallel 10
=== RUN   TestAccVault_prePaidServer
=== PAUSE TestAccVault_prePaidServer
=== CONT  TestAccVault_prePaidServer
--- PASS: TestAccVault_prePaidServer (454.93s)
PASS
coverage: 16.4% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       455.010s        coverage: 16.4% of statements in ./huaweicloud/services/cbr
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
