### PR TITLE
test(organizations/trusted_service): optimize tests for resource and data source

### DIFF
--- a/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_trusted_services_test.go
+++ b/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_trusted_services_test.go
@@ -1,6 +1,7 @@
 package organizations
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,9 +9,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceOrganizationsTrustedServices_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_organizations_trusted_services.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataTrustedServices_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_organizations_trusted_services.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -21,24 +24,24 @@ func TestAccDataSourceOrganizationsTrustedServices_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceOrganizationsTrustedServices_basic(),
+				Config: testAccDataTrustedServices_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "trusted_services.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "trusted_services.0.service_principal"),
-					resource.TestCheckResourceAttrSet(dataSource, "trusted_services.0.enabled_at"),
+					resource.TestMatchResourceAttr(all, "trusted_services.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "trusted_services.0.service_principal"),
+					resource.TestCheckResourceAttrSet(all, "trusted_services.0.enabled_at"),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceOrganizationsTrustedServices_basic() string {
-	return `
+const testAccDataTrustedServices_basic = `
 resource "huaweicloud_organizations_trusted_service" "test" {
   service = "service.SecMaster"
 }
 
-data "huaweicloud_organizations_trusted_services" "test" {}
-`
+data "huaweicloud_organizations_trusted_services" "test" {
+  depends_on = [huaweicloud_organizations_trusted_service.test]
 }
+`

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_delegated_administrator_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_delegated_administrator_test.go
@@ -115,15 +115,17 @@ func TestAccDelegatedAdministrator_basic(t *testing.T) {
 func testDelegatedAdministrator_basic(name string) string {
 	return fmt.Sprintf(`
 
-%[1]s
+resource "huaweicloud_organizations_trusted_service" "test" {
+  service = "service.SecMaster"
+}
 
 data "huaweicloud_organizations_accounts" "test" {
-  name = "%[2]s"
+  name = "%[1]s"
 }
 
 resource "huaweicloud_organizations_delegated_administrator" "test" {
   account_id        = data.huaweicloud_organizations_accounts.test.accounts.0.id
   service_principal = huaweicloud_organizations_trusted_service.test.service
 }
-`, testTrustedService_basic(), name)
+`, name)
 }

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_trusted_service_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_trusted_service_test.go
@@ -82,14 +82,11 @@ func buildGetTrustedServiceQueryParams(marker string) string {
 }
 
 func TestAccTrustedService_basic(t *testing.T) {
-	var obj interface{}
+	var (
+		obj   interface{}
+		rName = "huaweicloud_organizations_trusted_service.test"
 
-	rName := "huaweicloud_organizations_trusted_service.test"
-
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getTrustedServiceResourceFunc,
+		rc = acceptance.InitResourceCheck(rName, &obj, getTrustedServiceResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -102,7 +99,7 @@ func TestAccTrustedService_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testTrustedService_basic(),
+				Config: testAccTrustedService_basic,
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "service", "service.SecMaster"),
@@ -118,10 +115,8 @@ func TestAccTrustedService_basic(t *testing.T) {
 	})
 }
 
-func testTrustedService_basic() string {
-	return `
+const testAccTrustedService_basic = `
 resource "huaweicloud_organizations_trusted_service" "test" {
   service = "service.SecMaster"
 }
 `
-}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old test cases suffer from several design problems:

- Redundant naming
- Insufficiently precise checks

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the check items and functions naming
2. supplement some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o organizations -f TestAccTrustedService_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccTrustedService_basic -timeout 360m -parallel 10
=== RUN   TestAccTrustedService_basic
=== PAUSE TestAccTrustedService_basic
=== CONT  TestAccTrustedService_basic
--- PASS: TestAccTrustedService_basic (19.48s)
PASS
coverage: 6.6% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     19.590s coverage: 6.6% of statements in ./huaweicloud/services/organizations
```

```
./scripts/coverage.sh -o organizations -f TestAccDataTrustedServices_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDataTrustedServices_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTrustedServices_basic
=== PAUSE TestAccDataTrustedServices_basic
=== CONT  TestAccDataTrustedServices_basic
--- PASS: TestAccDataTrustedServices_basic (17.60s)
PASS
coverage: 7.8% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     17.701s coverage: 7.8% of statements in ./huaweicloud/services/organizations
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
