### PR TITLE
test(orgainzations): optimize test for some data sources

### DIFF
--- a/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_quotas_test.go
+++ b/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_quotas_test.go
@@ -1,6 +1,8 @@
 package organizations
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,35 +10,80 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceOrganizationsQuotas_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_organizations_quotas.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataQuotas_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_organizations_quotas.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceOrganizationsQuotas_basic(),
+				Config: testAccDataQuotas_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "quotas.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.resources.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.resources.0.type"),
-					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.resources.0.quota"),
-					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.resources.0.min"),
-					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.resources.0.max"),
-					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.resources.0.used"),
+					resource.TestMatchResourceAttr(all, "quotas.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(all, "quotas.0.resources.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "quotas.0.resources.0.type"),
+					resource.TestCheckOutput("is_organizational_unit_used", "true"),
+					resource.TestCheckOutput("is_quotas_max_set", "true"),
+					resource.TestCheckOutput("is_quotas_min_set", "true"),
+					resource.TestCheckOutput("is_quotas_quota_set", "true"),
+					resource.TestCheckOutput("is_quotas_used_set", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceOrganizationsQuotas_basic() string {
-	return `
-data "huaweicloud_organizations_quotas" "test" {}
-`
+func testAccDataQuotas_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_organizations_organization" "test" {}
+
+resource "huaweicloud_organizations_organizational_unit" "test" {
+  name      = "%[1]s"
+  parent_id = data.huaweicloud_organizations_organization.test.root_id
+}
+`, name)
+}
+
+func testAccDataQuotas_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_organizations_quotas" "test" {
+  depends_on = [huaweicloud_organizations_organizational_unit.test]
+}
+
+locals {
+  all_used_quotas = [for v in flatten(data.huaweicloud_organizations_quotas.test.quotas[*].resources[*]) : v if v.used > 0]
+}
+
+output "is_organizational_unit_used" {
+  value = length(local.all_used_quotas) > 0 && contains(local.all_used_quotas[*].type, "organizational_unit")
+}
+
+output "is_quotas_max_set" {
+  value = length(local.all_used_quotas) > 0 && local.all_used_quotas[0].max > 0
+}
+
+output "is_quotas_min_set" {
+  value = length(local.all_used_quotas) > 0 && local.all_used_quotas[0].min > 0
+}
+
+output "is_quotas_quota_set" {
+  value = length(local.all_used_quotas) > 0 && local.all_used_quotas[0].quota > 0
+}
+
+output "is_quotas_used_set" {
+  value = length(local.all_used_quotas) > 0 && local.all_used_quotas[0].used > 0
+}
+`, testAccDataQuotas_base(name))
 }

--- a/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_services_test.go
+++ b/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_services_test.go
@@ -1,6 +1,7 @@
 package organizations
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,9 +9,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceOrganizationsServices_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_organizations_services.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataServices_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_organizations_services.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -19,16 +22,16 @@ func TestAccDataSourceOrganizationsServices_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceOrganizationsServices_basic(),
+				Config: testAccDataServices_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "services.#"),
+					resource.TestMatchResourceAttr(all, "services.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceDataSourceOrganizationsServices_basic() string {
-	return `data "huaweicloud_organizations_services" "test" {}`
-}
+const testAccDataServices_basic = `
+data "huaweicloud_organizations_services" "test" {}
+`

--- a/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_tag_policy_services_test.go
+++ b/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_tag_policy_services_test.go
@@ -1,6 +1,7 @@
 package organizations
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,9 +9,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceOrganizationsTagPolicyServices_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_organizations_tag_policy_services.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataTagPolicyServices_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_organizations_tag_policy_services.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -21,22 +24,20 @@ func TestAccDataSourceOrganizationsTagPolicyServices_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceOrganizationsTagPolicyServices_basic(),
+				Config: testAccDataTagPolicyServices_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "services.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "services.0.service_name"),
-					resource.TestCheckResourceAttrSet(dataSource, "services.0.resource_types.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "services.0.resource_types.0"),
-					resource.TestCheckResourceAttrSet(dataSource, "services.0.support_all"),
+					resource.TestMatchResourceAttr(all, "services.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "services.0.service_name"),
+					resource.TestMatchResourceAttr(all, "services.0.resource_types.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "services.0.resource_types.0"),
+					resource.TestCheckResourceAttrSet(all, "services.0.support_all"),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceOrganizationsTagPolicyServices_basic() string {
-	return `
+const testAccDataTagPolicyServices_basic = `
 data "huaweicloud_organizations_tag_policy_services" "test" {}
 `
-}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The old data source (`huaweicloud_organizations_quotas`|`huaweicloud_organizations_resource_tags`|`huaweicloud_organizations_services`|`huaweicloud_organizations_tag_policy_services`) test cases suffer from several design problems:

- Redundant naming
- Insufficiently precise checks

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the check items and functions naming
3. supplement some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o organizations -f TestAccDataQuotas_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDataQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataQuotas_basic
=== PAUSE TestAccDataQuotas_basic
=== CONT  TestAccDataQuotas_basic
--- PASS: TestAccDataQuotas_basic (18.95s)
PASS
coverage: 10.8% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     19.054s coverage: 10.8% of statements in ./huaweicloud/services/organizations
```
```
./scripts/coverage.sh -o organizations -f TestAccDataResourceTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDataResourceTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataResourceTags_basic
=== PAUSE TestAccDataResourceTags_basic
=== CONT  TestAccDataResourceTags_basic
--- PASS: TestAccDataResourceTags_basic (19.01s)
PASS
coverage: 11.0% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     19.121s coverage: 11.0% of statements in ./huaweicloud/services/organizations
```

```
./scripts/coverage.sh -o organizations -f TestAccDataServices_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDataServices_basic -timeout 360m -parallel 10
=== RUN   TestAccDataServices_basic
=== PAUSE TestAccDataServices_basic
=== CONT  TestAccDataServices_basic
--- PASS: TestAccDataServices_basic (16.13s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     16.230s coverage: 4.0% of statements in ./huaweicloud/services/organizations
```

```
./scripts/coverage.sh -o organizations -f TestAccDataTagPolicyServices_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDataTagPolicyServices_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTagPolicyServices_basic
=== PAUSE TestAccDataTagPolicyServices_basic
=== CONT  TestAccDataTagPolicyServices_basic
--- PASS: TestAccDataTagPolicyServices_basic (15.57s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     15.669s coverage: 4.1% of statements in ./huaweicloud/services/organizations
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
