### PR TITLE
fix(as): only send delete_publicip on update when explicitly changed

### DIFF
--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
@@ -105,6 +105,7 @@ func TestAccASGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "status", "PAUSED"),
+					resource.TestCheckResourceAttr(resourceName, "delete_publicip", "true"),
 					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.weight", "1"),
 				),
 			},
@@ -284,7 +285,6 @@ resource "huaweicloud_as_group" "acc_as_group"{
   vpc_id                   = huaweicloud_vpc.test.id
   max_instance_number      = 5
   description              = "this is a basic AS group"
-  delete_publicip          = false
   delete_volume            = true
 
   networks {

--- a/huaweicloud/services/as/resource_huaweicloud_as_group.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_group.go
@@ -206,7 +206,7 @@ func ResourceASGroup() *schema.Resource {
 			"delete_publicip": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Computed: true,
 			},
 			"delete_volume": {
 				Type:     schema.TypeBool,
@@ -759,12 +759,16 @@ func resourceASGroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		HealthPeriodicAuditGrace:  d.Get("health_periodic_audit_grace_period").(int),
 		InstanceTerminatePolicy:   d.Get("instance_terminate_policy").(string),
 		MultiAZPriorityPolicy:     d.Get("multi_az_scaling_policy").(string),
-		IsDeletePublicip:          utils.Bool(d.Get("delete_publicip").(bool)),
 		IsDeleteVolume:            utils.Bool(d.Get("delete_volume").(bool)),
 		Description:               utils.String(d.Get("description").(string)),
 		EnterpriseProjectID:       conf.GetEnterpriseProjectID(d),
 	}
 
+	if d.HasChange("delete_publicip") {
+		if v := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "delete_publicip"); v != nil {
+			updateOpts.IsDeletePublicip = utils.Bool(v.(bool))
+		}
+	}
 	if d.HasChange("agency_name") {
 		updateOpts.IamAgencyName = d.Get("agency_name").(string)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the schema default value and mark delete_publicip as computed to avoid drift when the field is omitted in config.
Use raw config with change detection in AS group update to prevent unintended delete_publicip from being sent. 

**Which issue this PR fixes**:
https://github.com/huaweicloud/terraform-provider-huaweicloud/issues/7219

**Special notes for your reviewer**:
nothing

**Release note**:
```release-note
1. change the provider implement.
2. change the provider test case.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/as" -v -coverprofile="./huaweicloud/services/acceptance/as/as_coverage.cov" -coverpkg="./huaweicloud/services/as" -run TestAccASGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccASGroup_basic
=== PAUSE TestAccASGroup_basic
=== CONT  TestAccASGroup_basic
--- PASS: TestAccASGroup_basic (185.74s)
PASS
coverage: 16.7% of statements in ./huaweicloud/services/as
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        1793.683s       coverage: 16.7% of statements in ./huaweicloud/services/as
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.