### PR TITLE
test(organizations): optimize test for some resources

### DIFF
--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_accepter_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_accepter_test.go
@@ -43,14 +43,10 @@ func getAccountInviteAccepterResourceFunc(cfg *config.Config, state *terraform.R
 }
 
 func TestAccAccountInviteAccepter_basic(t *testing.T) {
-	var obj interface{}
-
-	rName := "huaweicloud_organizations_account_invite_accepter.test"
-
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getAccountInviteAccepterResourceFunc,
+	var (
+		obj   interface{}
+		rName = "huaweicloud_organizations_account_invite_accepter.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getAccountInviteAccepterResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -64,7 +60,7 @@ func TestAccAccountInviteAccepter_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccountInviteAccepter_basic(),
+				Config: testAccAccountInviteAccepter_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "invitation_id", acceptance.HW_ORGANIZATIONS_INVITATION_ID),
@@ -88,7 +84,7 @@ func TestAccAccountInviteAccepter_basic(t *testing.T) {
 	})
 }
 
-func testAccountInviteAccepter_basic() string {
+func testAccAccountInviteAccepter_basic() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_organizations_account_invite_accepter" "test" {
   invitation_id                 = "%s"

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_decliner_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_decliner_test.go
@@ -21,14 +21,14 @@ func TestAccAccountInviteDecliner_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccountInviteDecliner_basic(),
+				Config: testAccAccountInviteDecliner_basic(),
 				Check:  resource.ComposeTestCheckFunc(),
 			},
 		},
 	})
 }
 
-func testAccountInviteDecliner_basic() string {
+func testAccAccountInviteDecliner_basic() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_organizations_account_invite_decliner" "test" {
   invitation_id = "%s"

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_test.go
@@ -72,14 +72,11 @@ func getAccountInviteResourceFunc(cfg *config.Config, state *terraform.ResourceS
 }
 
 func TestAccAccountInvite_basic(t *testing.T) {
-	var obj interface{}
+	var (
+		obj interface{}
 
-	rName := "huaweicloud_organizations_account_invite.test"
-
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getAccountInviteResourceFunc,
+		rName = "huaweicloud_organizations_account_invite.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getAccountInviteResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -93,7 +90,7 @@ func TestAccAccountInvite_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccountInvite_basic(),
+				Config: testAccAccountInvite_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "account_id",
@@ -117,7 +114,7 @@ func TestAccAccountInvite_basic(t *testing.T) {
 	})
 }
 
-func testAccountInvite_basic() string {
+func testAccAccountInvite_basic() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_organizations_account_invite" "test" {
   account_id                = "%[1]s"

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_delegated_administrator_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_delegated_administrator_test.go
@@ -73,14 +73,10 @@ func buildGetDelegatedAdministratorQueryParams(servicePrincipal string) string {
 }
 
 func TestAccDelegatedAdministrator_basic(t *testing.T) {
-	var obj interface{}
-
-	rName := "huaweicloud_organizations_delegated_administrator.test"
-
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getDelegatedAdministratorResourceFunc,
+	var (
+		obj   interface{}
+		rName = "huaweicloud_organizations_delegated_administrator.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getDelegatedAdministratorResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -94,7 +90,7 @@ func TestAccDelegatedAdministrator_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDelegatedAdministrator_basic(acceptance.HW_ORGANIZATIONS_ACCOUNT_NAME),
+				Config: testDelegatedAdministrator_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "account_id",
@@ -112,9 +108,8 @@ func TestAccDelegatedAdministrator_basic(t *testing.T) {
 	})
 }
 
-func testDelegatedAdministrator_basic(name string) string {
+func testDelegatedAdministrator_basic() string {
 	return fmt.Sprintf(`
-
 resource "huaweicloud_organizations_trusted_service" "test" {
   service = "service.SecMaster"
 }
@@ -124,8 +119,8 @@ data "huaweicloud_organizations_accounts" "test" {
 }
 
 resource "huaweicloud_organizations_delegated_administrator" "test" {
-  account_id        = data.huaweicloud_organizations_accounts.test.accounts.0.id
+  account_id        = try(data.huaweicloud_organizations_accounts.test.accounts[0].id, "")
   service_principal = huaweicloud_organizations_trusted_service.test.service
 }
-`, name)
+`, acceptance.HW_ORGANIZATIONS_ACCOUNT_NAME)
 }

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_organization_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_organization_test.go
@@ -42,14 +42,10 @@ func resourceOrganizationRead(cfg *config.Config, _ *terraform.ResourceState) (i
 }
 
 func TestAccOrganization_basic(t *testing.T) {
-	var obj interface{}
-
-	rName := "huaweicloud_organizations_organization.test"
-
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		resourceOrganizationRead,
+	var (
+		obj   interface{}
+		rName = "huaweicloud_organizations_organization.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, resourceOrganizationRead)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -61,12 +57,13 @@ func TestAccOrganization_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testOrganization_basic(),
+				Config: testAccOrganization_basic_step1,
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "root_tags.key1", "value1"),
-					resource.TestCheckResourceAttr(rName, "root_tags.key2", "value2"),
 					resource.TestCheckResourceAttr(rName, "enabled_policy_types.0", "service_control_policy"),
+					resource.TestCheckResourceAttr(rName, "root_tags.%", "2"),
+					resource.TestCheckResourceAttr(rName, "root_tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "root_tags.owner", "terraform"),
 					resource.TestCheckResourceAttrSet(rName, "urn"),
 					resource.TestCheckResourceAttrSet(rName, "master_account_id"),
 					resource.TestCheckResourceAttrSet(rName, "master_account_name"),
@@ -77,12 +74,12 @@ func TestAccOrganization_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testOrganization_basic_update(),
+				Config: testAccOrganization_basic_step2,
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "root_tags.key3", "value3"),
-					resource.TestCheckResourceAttr(rName, "root_tags.key4", "value4"),
 					resource.TestCheckResourceAttr(rName, "enabled_policy_types.0", "tag_policy"),
+					resource.TestCheckResourceAttr(rName, "root_tags.%", "1"),
+					resource.TestCheckResourceAttr(rName, "root_tags.owner", "terraform_update"),
 				),
 			},
 			{
@@ -94,28 +91,23 @@ func TestAccOrganization_basic(t *testing.T) {
 	})
 }
 
-func testOrganization_basic() string {
-	return `
+const testAccOrganization_basic_step1 = `
 resource "huaweicloud_organizations_organization" "test" {
   enabled_policy_types = ["service_control_policy"]
 
   root_tags = {
-    "key1" = "value1"
-    "key2" = "value2"
+    foo   = "bar"
+    owner = "terraform"
   }
 }
 `
-}
 
-func testOrganization_basic_update() string {
-	return `
+const testAccOrganization_basic_step2 = `
 resource "huaweicloud_organizations_organization" "test" {
   enabled_policy_types = ["tag_policy"]
 
   root_tags = {
-    "key3" = "value3"
-    "key4" = "value4"
+    owner = "terraform_update"
   }
 }
 `
-}

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_organizational_unit_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_organizational_unit_test.go
@@ -46,16 +46,13 @@ func getOrganizationalUnitResourceFunc(cfg *config.Config, state *terraform.Reso
 }
 
 func TestAccOrganizationalUnit_basic(t *testing.T) {
-	var obj interface{}
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
 
-	name := acceptance.RandomAccResourceName()
-	updateName := acceptance.RandomAccResourceName()
-	rName := "huaweicloud_organizations_organizational_unit.test"
-
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getOrganizationalUnitResourceFunc,
+		obj   interface{}
+		rName = "huaweicloud_organizations_organizational_unit.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getOrganizationalUnitResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -68,23 +65,24 @@ func TestAccOrganizationalUnit_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testOrganizationalUnit_basic(name),
+				Config: testAccOrganizationalUnit_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "tags.key1", "value1"),
-					resource.TestCheckResourceAttr(rName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(rName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttrSet(rName, "urn"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
 				),
 			},
 			{
-				Config: testOrganizationalUnit_basic_update(updateName),
+				Config: testAccOrganizationalUnit_basic_step2(updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
-					resource.TestCheckResourceAttr(rName, "tags.key3", "value3"),
-					resource.TestCheckResourceAttr(rName, "tags.key4", "value4"),
+					resource.TestCheckResourceAttr(rName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(rName, "tags.foo1", "bar_update"),
 				),
 			},
 			{
@@ -97,7 +95,7 @@ func TestAccOrganizationalUnit_basic(t *testing.T) {
 	})
 }
 
-func testOrganizationalUnit_basic(name string) string {
+func testAccOrganizationalUnit_basic_step1(name string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_organizations_organization" "test" {}
 
@@ -106,14 +104,14 @@ resource "huaweicloud_organizations_organizational_unit" "test" {
   parent_id = data.huaweicloud_organizations_organization.test.root_id
 
   tags = {
-    "key1" = "value1"
-    "key2" = "value2"
+    foo   = "bar"
+    owner = "terraform"
   }
 }
 `, name)
 }
 
-func testOrganizationalUnit_basic_update(name string) string {
+func testAccOrganizationalUnit_basic_step2(name string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_organizations_organization" "test" {}
 
@@ -122,8 +120,7 @@ resource "huaweicloud_organizations_organizational_unit" "test" {
   parent_id = data.huaweicloud_organizations_organization.test.root_id
 
   tags = {
-    "key3" = "value3"
-    "key4" = "value4"
+    foo1 = "bar_update"
   }
 }
 `, name)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old resource test cases suffer from several design problems:

- Redundant naming
- Insufficiently precise checks

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the check items and functions naming
2. supplement some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o organizations -f TestAccAccountAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccAccountAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccAccountAssociate_basic
=== PAUSE TestAccAccountAssociate_basic
=== CONT  TestAccAccountAssociate_basic
--- PASS: TestAccAccountAssociate_basic (31.37s)
PASS
coverage: 14.4% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     31.460s coverage: 14.4% of statements in ./huaweicloud/services/organizations
```

```
./scripts/coverage.sh -o organizations -f TestAccAccountInviteAccepter_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccAccountInviteAccepter_basic -timeout 360m -parallel 10
=== RUN   TestAccAccountInviteAccepter_basic
=== PAUSE TestAccAccountInviteAccepter_basic
=== CONT  TestAccAccountInviteAccepter_basic
--- PASS: TestAccAccountInviteAccepter_basic (35.38s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     35.492s coverage: 6.1% of statements in ./huaweicloud/services/organizations
```

```
./scripts/coverage.sh -o organizations -f TestAccAccountInviteDecliner_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccAccountInviteDecliner_basic -timeout 360m -parallel 10
=== RUN   TestAccAccountInviteDecliner_basic
=== PAUSE TestAccAccountInviteDecliner_basic
=== CONT  TestAccAccountInviteDecliner_basic
--- PASS: TestAccAccountInviteDecliner_basic (18.81s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     18.921s coverage: 4.2% of statements in ./huaweicloud/services/organizations
```

```
 ./scripts/coverage.sh -o organizations -f TestAccAccountInvite_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccAccountInvite_basic -timeout 360m -parallel 10
=== RUN   TestAccAccountInvite_basic
=== PAUSE TestAccAccountInvite_basic
=== CONT  TestAccAccountInvite_basic
--- PASS: TestAccAccountInvite_basic (20.14s)
PASS
coverage: 6.9% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     20.268s coverage: 6.9% of statements in ./huaweicloud/services/organizations
```

```
./scripts/coverage.sh -o organizations -f TestAccDelegatedAdministrator_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDelegatedAdministrator_basic -timeout 360m -parallel 10
=== RUN   TestAccDelegatedAdministrator_basic
=== PAUSE TestAccDelegatedAdministrator_basic
=== CONT  TestAccDelegatedAdministrator_basic
--- PASS: TestAccDelegatedAdministrator_basic (19.64s)
PASS
coverage: 12.9% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     19.763s coverage: 12.9% of statements in ./huaweicloud/services/organizations
```
```
./scripts/coverage.sh -o organizations -f TestAccOrganization_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccOrganization_basic -timeout 360m -parallel 10
=== RUN   TestAccOrganization_basic
=== PAUSE TestAccOrganization_basic
=== CONT  TestAccOrganization_basic
--- PASS: TestAccOrganization_basic (39.32s)
PASS
coverage: 13.9% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     39.421s coverage: 13.9% of statements in ./huaweicloud/services/organizations
```
```
./scripts/coverage.sh -o organizations -f TestAccOrganizationalUnit_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccOrganizationalUnit_basic -timeout 360m -parallel 10
=== RUN   TestAccOrganizationalUnit_basic
=== PAUSE TestAccOrganizationalUnit_basic
=== CONT  TestAccOrganizationalUnit_basic
--- PASS: TestAccOrganizationalUnit_basic (33.99s)
PASS
coverage: 13.0% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     34.105s coverage: 13.0% of statements in ./huaweicloud/services/organizations
```

```
./scripts/coverage.sh -o organizations -f TestAccPolicyAttach_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccPolicyAttach_basic -timeout 360m -parallel 10
=== RUN   TestAccPolicyAttach_basic
=== PAUSE TestAccPolicyAttach_basic
=== CONT  TestAccPolicyAttach_basic
--- PASS: TestAccPolicyAttach_basic (21.81s)
PASS
coverage: 16.2% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     21.917s coverage: 16.2% of statements in ./huaweicloud/services/organizations
```

```
./scripts/coverage.sh -o organizations -f TestAccPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccPolicy_basic
=== PAUSE TestAccPolicy_basic
=== CONT  TestAccPolicy_basic
--- PASS: TestAccPolicy_basic (28.45s)
PASS
coverage: 10.8% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     28.550s coverage: 10.8% of statements in ./huaweicloud/services/organizations
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
