### PR TITLE
refactor(cc): refact cc bandwidth package resource

### DIFF
--- a/docs/resources/cc_bandwidth_package.md
+++ b/docs/resources/cc_bandwidth_package.md
@@ -2,18 +2,21 @@
 subcategory: "Cloud Connect (CC)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_cc_bandwidth_package"
-description: ""
+description: |-
+  Manages a bandwidth package resource of Cloud connect within HuaweiCloud.
 ---
 
 # huaweicloud_cc_bandwidth_package
 
-Manages a bandwidth package resource of Cloud Connect within HuaweiCloud.  
+Manages a bandwidth package resource of Cloud connect within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
+variable "name" {}
+
 resource "huaweicloud_cc_bandwidth_package" "test" {
-  name           = "demo"
+  name           = var.name
   local_area_id  = "Chinese-Mainland"
   remote_area_id = "Chinese-Mainland"
   charge_mode    = "bandwidth"
@@ -35,46 +38,44 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `name` - (Required, String) The bandwidth package name.  
-  The name can contain a maximum of `64` characters.
+* `name` - (Required, String) The bandwidth package name.
 
-* `local_area_id` - (Required, String, ForceNew) The local area ID.  
-  Valid values are **Chinese-Mainland**, **Asia-Pacific**, **Africa**, **Western-Latin-America**,
-   **Eastern-Latin-America** and **Northern-Latin-America**.
+* `local_area_id` - (Required, String, NonUpdatable) Specifies the local area ID. Valid values are:
+  + **Chinese-Mainland**: Chinese mainland
+  + **Asia-Pacific**: Asia Pacific
+  + **Africa**: Africa
+  + **Western-Latin-America**: Western Latin America
+  + **Eastern-Latin-America**: Eastern Latin America
+  + **Northern-Latin-America**: Northern Latin America
 
-  Changing this parameter will create a new resource.
+* `remote_area_id` - (Required, String, NonUpdatable) Specifies the remote area ID. Valid values are:
+  + **Chinese-Mainland**: Chinese mainland
+  + **Asia-Pacific**: Asia Pacific
+  + **Africa**: Africa
+  + **Western-Latin-America**: Western Latin America
+  + **Eastern-Latin-America**: Eastern Latin America
+  + **Northern-Latin-America**: Northern Latin America
 
-* `remote_area_id` - (Required, String, ForceNew) The remote area ID.  
-  Valid values are **Chinese-Mainland**, **Asia-Pacific**, **Africa**, **Western-Latin-America**,
-   **Eastern-Latin-America** and **Northern-Latin-America**.
-
-  Changing this parameter will create a new resource.
-
-* `charge_mode` - (Required, String, ForceNew) Billing option of the bandwidth package.  
+* `charge_mode` - (Required, String, NonUpdatable) Specifies the billing option of the bandwidth package.
   Valid value is **bandwidth**.
 
-  Changing this parameter will create a new resource.
-
-* `billing_mode` - (Required, String) Billing mode of the bandwidth package.  
-  The options are as follows:
-    + **3**: pay-per-use for the Chinese Mainland website.
-    + **4**: pay-per-use for the International website.
-    + **5**: 95th percentile bandwidth billing for the Chinese Mainland website.
-    + **6**: 95th percentile bandwidth billing for the International website.
+* `billing_mode` - (Required, String) Specifies the billing mode of the bandwidth package. Valid values are:
+  + **3**: pay-per-use on the Chinese mainland website
+  + **4**: pay-per-use on the International website
+  + **5**: 95th percentile bandwidth billing on the Chinese mainland website
+  + **6**: 95th percentile bandwidth billing on the International website
 
   -> This argument can only be modified to **5** and **6**.
 
-* `bandwidth` - (Required, Int) Bandwidth in the bandwidth package.  
+* `bandwidth` - (Required, Int) Specifies the bandwidth capacity specified for the bandwidth package.
 
-* `project_id` - (Optional, String, ForceNew) Project ID.
+* `project_id` - (Optional, String, NonUpdatable) Specifies the project ID.
   If omitted, the provider-level project ID will be used.
-  Changing this parameter will create a new resource.
 
-* `interflow_mode` - (Optional, String, ForceNew) Interflow mode of the bandwidth package.
-  Valid values are **Area** and **Region**, defaults to **Area**. Changing this parameter will create a new resource.
+* `interflow_mode` - (Optional, String, NonUpdatable) Specifies the bandwidth package applicability.
+  Valid values are **Area** and **Region**, defaults to **Area**.
 
-* `spec_code` - (Optional, String, ForceNew) Specification code of the bandwidth package.
-  Changing this parameter will create a new resource.
+* `spec_code` - (Optional, String, NonUpdatable) Specifies the specification code of the bandwidth package.
   If the value of `interflow_mode` is **Area**, the values are as follows:
   + **bandwidth.aftoela**: Southern Africa-Eastern Latin America on both the Chinese Mainland website and International
     website.
@@ -111,18 +112,18 @@ The following arguments are supported:
   If the value of `interflow_mode` is **Region**, the value depends on the specified interflow regions,
   e.g. **Beijing4toGuangzhou**.
 
-* `description` - (Optional, String) The description about the bandwidth package.  
-  The description can contain a maximum of 85 characters.
+* `description` - (Optional, String) Specifies the description about the bandwidth package.
+  Angle brackets (`<>`) are not allowed.
 
-* `enterprise_project_id` - (Optional, String) ID of the enterprise project that the bandwidth package
-  belongs to. Value 0 indicates the default enterprise project.
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project that the bandwidth package
+  belongs to.
 
-* `resource_id` - (Optional, String) ID of the resource that the bandwidth package is bound to.  
+* `resource_id` - (Optional, String) Specifies the ID of the resource that the bandwidth package is bound to.
 
-* `resource_type` - (Optional, String) Type of the resource that the bandwidth package is bound to.  
+* `resource_type` - (Optional, String) Specifies the type of the resource that the bandwidth package is bound to.
    Valid value is **cloud_connection**.
 
-* `tags` - (Optional, Map) The key/value pairs to associate with the bandwidth package.
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the bandwidth package.
 
 ## Attribute Reference
 
@@ -130,14 +131,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
 
-* `status` - Bandwidth package status.  
+* `status` - The bandwidth package status.
   The valid value are as follows:
-    + **ACTIVE**: Bandwidth packages are available.
+  + **ACTIVE**: Bandwidth packages are available.
 
 ## Import
 
 The bandwidth package can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_cc_bandwidth_package.test 0ce123456a00f2591fabc00385ff1234
+$ terraform import huaweicloud_cc_bandwidth_package.test <id>
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refact cc bandwidth package resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- The document content has been improved.
- The coding style has been modified, but the original logic has not been changed.
- The test cases have been simplified.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cc -f TestAccBandwidthPackage_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cc" -v -coverprofile="./huaweicloud/services/acceptance/cc/cc_coverage.cov" -coverpkg="./huaweicloud/services/cc" -run TestAccBandwidthPackage_ -timeout 360m -parallel 10
=== RUN   TestAccBandwidthPackage_basic
=== PAUSE TestAccBandwidthPackage_basic
=== RUN   TestAccBandwidthPackage_regionalInterflow
=== PAUSE TestAccBandwidthPackage_regionalInterflow
=== CONT  TestAccBandwidthPackage_basic
=== CONT  TestAccBandwidthPackage_regionalInterflow
--- PASS: TestAccBandwidthPackage_regionalInterflow (14.88s)
--- PASS: TestAccBandwidthPackage_basic (50.35s)
PASS
coverage: 8.7% of statements in ./huaweicloud/services/cc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        50.450s coverage: 8.7% of statements in ./huaweicloud/services/cc
```
<img width="1441" height="78" alt="image" src="https://github.com/user-attachments/assets/ead50a96-87d0-44e3-bd03-0e7bf0c3f91a" />



* [X] Documentation updated.
* [X] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="723" height="198" alt="image" src="https://github.com/user-attachments/assets/8e648fbb-7871-426f-bf16-23b0ed11c69c" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
