### PR TITLE
test(organizations): optimize test for data sources

### DIFF
--- a/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_received_invitations_test.go
+++ b/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_received_invitations_test.go
@@ -2,6 +2,7 @@ package organizations
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,9 +10,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceOrganizationsReceivedInvitations_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_organizations_received_invitations.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataReceivedInvitations_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_organizations_received_invitations.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -23,35 +26,37 @@ func TestAccDataSourceOrganizationsReceivedInvitations_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceOrganizationsReceivedInvitations_basic(),
+				Config: testAccDataReceivedInvitations_basic(),
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.id"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.urn"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.status"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.organization_id"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.management_account_id"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.management_account_name"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.target.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.target.0.type"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.target.0.entity"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.created_at"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.updated_at"),
+					resource.TestMatchResourceAttr(all, "handshakes.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.id"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.urn"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.status"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.organization_id"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.management_account_id"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.management_account_name"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.target.#"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.target.0.type"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.target.0.entity"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.created_at"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.updated_at"),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceDataSourceOrganizationsReceivedInvitations_basic() string {
+func testAccDataReceivedInvitations_basic() string {
 	return fmt.Sprintf(`
-resource "huaweicloud_organizations_account_invite_accepter" "test" {
+resource "huaweicloud_organizations_account_invite_decliner" "test" {
   invitation_id = "%s"
 }
 
+# Without any filter parameters.
 data "huaweicloud_organizations_received_invitations" "test" {
-  depends_on = [huaweicloud_organizations_account_invite_accepter.test]
+  depends_on = [huaweicloud_organizations_account_invite_decliner.test]
 }
 `, acceptance.HW_ORGANIZATIONS_INVITATION_ID)
 }

--- a/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_sent_invitations_test.go
+++ b/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_sent_invitations_test.go
@@ -2,6 +2,7 @@ package organizations
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,9 +10,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDataSourceOrganizationsSentInvitations_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_organizations_sent_invitations.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+func TestAccDataSentInvitations_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_organizations_sent_invitations.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -23,33 +26,35 @@ func TestAccDataSourceOrganizationsSentInvitations_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceOrganizationsSentInvitations_basic(),
+				Config: testAccDataSentInvitations_basic(),
 				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.id"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.urn"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.status"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.organization_id"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.management_account_id"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.management_account_name"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.target.#"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.target.0.type"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.target.0.entity"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.created_at"),
-					resource.TestCheckResourceAttrSet(dataSource, "handshakes.0.updated_at"),
+					resource.TestMatchResourceAttr(all, "handshakes.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.id"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.urn"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.status"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.organization_id"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.management_account_id"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.management_account_name"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.target.#"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.target.0.type"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.target.0.entity"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.created_at"),
+					resource.TestCheckResourceAttrSet(all, "handshakes.0.updated_at"),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceOrganizationsSentInvitations_basic() string {
+func testAccDataSentInvitations_basic() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_organizations_account_invite" "test" {
   account_id = "%[1]s"
 }
 
+# Without any filter parameters.
 data "huaweicloud_organizations_sent_invitations" "test" {
   depends_on = [huaweicloud_organizations_account_invite.test]
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The old data source (huaweicloud_organizations_received_invitations|huaweicloud_organizations_account_invite) test cases suffer from several design problems:

- Redundant naming
- Insufficiently precise checks

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the check items and functions naming
2. supplement some test scenarios
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o organizations -f TestAccDataReceivedInvitations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDataReceivedInvitations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataReceivedInvitations_basic
=== PAUSE TestAccDataReceivedInvitations_basic
=== CONT  TestAccDataReceivedInvitations_basic
--- PASS: TestAccDataReceivedInvitations_basic (17.15s)
PASS
coverage: 5.4% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     17.266s coverage: 5.4% of statements in ./huaweicloud/services/organizations
```

```
./scripts/coverage.sh -o organizations -f TestAccDataSentInvitations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDataSentInvitations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSentInvitations_basic
=== PAUSE TestAccDataSentInvitations_basic
=== CONT  TestAccDataSentInvitations_basic
--- PASS: TestAccDataSentInvitations_basic (17.21s)
PASS
coverage: 8.1% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     17.321s coverage: 8.1% of statements in ./huaweicloud/services/organizations
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
