### PR TITLE
fix(iam): add V3 prefix to resource `provider conversion` helper function names for API version clarity

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3420,8 +3420,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_unscoped_token_with_id_token": iam.ResourceIdentityUnscopedTokenWithIdToken(),
 			"huaweicloud_identity_policy":                       iam.ResourceIdentityPolicy(),
 			"huaweicloud_identity_policy_agency_attach":         iam.ResourceIdentityPolicyAgencyAttach(),
+			"huaweicloud_identity_provider_conversion":          iam.ResourceV3ProviderConversion(),
 			"huaweicloud_identity_temporary_access_key":         iam.ResourceIdentityTemporaryAccessKey(),
-			"huaweicloud_identity_provider_conversion":          iam.ResourceV3Conversion(),
 
 			"huaweicloud_identityv5_user":                        iam.ResourceV5User(),
 			"huaweicloud_identityv5_user_password":               iam.ResourceIdentityV5UserPassword(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_conversion_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_conversion_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getProviderConversionFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getV3ProviderConversionFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := c.IAMNoVersionClient(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client without version: %s", err)
@@ -23,12 +23,12 @@ func getProviderConversionFunc(c *config.Config, state *terraform.ResourceState)
 	return mappings.Get(client, conversionID)
 }
 
-func TestAccProviderConversion_basic(t *testing.T) {
+func TestAccV3ProviderConversion_basic(t *testing.T) {
 	var (
 		obj interface{}
 
 		resourceName = "huaweicloud_identity_provider_conversion.test"
-		rc           = acceptance.InitResourceCheck(resourceName, &obj, getProviderConversionFunc)
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getV3ProviderConversionFunc)
 
 		name = acceptance.RandomAccResourceName()
 	)
@@ -42,7 +42,7 @@ func TestAccProviderConversion_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProviderConversion_basic_step1(name),
+				Config: testAccV3ProviderConversion_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "conversion_rules.#", "1"),
@@ -50,7 +50,7 @@ func TestAccProviderConversion_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProviderConversion_basic_step2(name),
+				Config: testAccV3ProviderConversion_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "conversion_rules.#", "2"),
@@ -68,7 +68,7 @@ func TestAccProviderConversion_basic(t *testing.T) {
 	})
 }
 
-func testAccProviderConversion_basic_step1(name string) string {
+func testAccV3ProviderConversion_basic_step1(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_provider" "test" {
   name     = "%[1]s"
@@ -90,7 +90,7 @@ resource "huaweicloud_identity_provider_conversion" "test" {
 `, name)
 }
 
-func testAccProviderConversion_basic_step2(name string) string {
+func testAccV3ProviderConversion_basic_step2(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_provider" "test" {
   name     = "%[1]s"

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_provider.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_provider.go
@@ -316,7 +316,7 @@ func createProtocol(client *golangsdk.ServiceClient, d *schema.ResourceData) err
 
 	// Create default mapping
 	defaultConversionRules := getDefaultConversionOpts()
-	mappingID := generateMappingID(providerID)
+	mappingID := generateV3ProviderMappingID(providerID)
 	_, err := mappings.Create(client, mappingID, *defaultConversionRules)
 	if err != nil {
 		return fmt.Errorf("error in creating default conversion rule: %s", err)
@@ -388,11 +388,10 @@ func resourceV3IdentityProviderRead(_ context.Context, d *schema.ResourceData, m
 	)
 
 	// Query and set conversion rules
-	mappingID := generateMappingID(providerID)
+	mappingID := generateV3ProviderMappingID(providerID)
 	conversions, err := mappings.Get(client, mappingID)
 	if err == nil {
-		conversionRules := flattenConversionRulesAttr(conversions)
-		err = d.Set("conversion_rules", conversionRules)
+		err = d.Set("conversion_rules", flattenV3ProviderConversionRules(conversions))
 		mErr = multierror.Append(mErr, err)
 	}
 
@@ -435,7 +434,7 @@ func resourceV3IdentityProviderRead(_ context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func flattenConversionRulesAttr(conversions *mappings.IdentityMapping) []interface{} {
+func flattenV3ProviderConversionRules(conversions *mappings.IdentityMapping) []interface{} {
 	conversionRules := make([]interface{}, 0, len(conversions.Rules))
 	for _, v := range conversions.Rules {
 		localRules := make([]map[string]interface{}, 0, len(v.Local))
@@ -475,7 +474,7 @@ func flattenConversionRulesAttr(conversions *mappings.IdentityMapping) []interfa
 	return conversionRules
 }
 
-func generateMappingID(providerID string) string {
+func generateV3ProviderMappingID(providerID string) string {
 	return "mapping_" + providerID
 }
 

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_provider_mapping.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_provider_mapping.go
@@ -74,7 +74,7 @@ func resourceV3ProviderMappingCreate(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("error creating IAM client without version: %s", err)
 	}
 	providerID := d.Get("provider_id").(string)
-	mappingID := generateMappingID(providerID)
+	mappingID := generateV3ProviderMappingID(providerID)
 
 	// Check if the mappingID exists, update if it exists, otherwise create it.
 	r, err := mappings.List(client).AllPages()


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename resource functions with V3 prefix to align with IAM v3 API naming.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```release-note
1. change the `provider conversion` implement.
2. change the `provider conversion` test case.
3. change the `provider` implement.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV3ProviderConversion_basic -timeout 360m -parallel 10
=== RUN   TestAccV3ProviderConversion_basic
=== PAUSE TestAccV3ProviderConversion_basic
=== CONT  TestAccV3ProviderConversion_basic
    acceptance.go:1653: Skipping test because it requires the admin privileges
--- SKIP: TestAccV3ProviderConversion_basic (0.00s)
PASS
coverage: 1.7% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       0.139s  coverage: 1.7% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.