### PR TITLE
fix(iam): add V3 prefix to resource `provider mapping` helper function names for API version clarity

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_mapping_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_mapping_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getProviderMappingFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getV3ProviderMappingFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := cfg.IAMNoVersionClient(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client without version: %s", err)
@@ -38,12 +38,12 @@ func getProviderMappingFunc(cfg *config.Config, state *terraform.ResourceState) 
 	return utils.FlattenResponse(getMappingResp)
 }
 
-func TestAccProviderMapping_basic(t *testing.T) {
+func TestAccV3ProviderMapping_basic(t *testing.T) {
 	var (
 		obj interface{}
 
 		resourceName = "huaweicloud_identity_provider_mapping.test"
-		rc           = acceptance.InitResourceCheck(resourceName, &obj, getProviderMappingFunc)
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getV3ProviderMappingFunc)
 
 		name = acceptance.RandomAccResourceName()
 	)
@@ -57,17 +57,24 @@ func TestAccProviderMapping_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProviderMapping_basic_step1(name),
+				Config: testAccV3ProviderMapping_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					// nothing to check
 				),
 			},
 			{
-				Config: testAccProviderMapping_basic_step2(name),
+				Config: testAccV3ProviderMapping_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					// nothing to check
+					resource.TestCheckResourceAttrPair(resourceName, "provider_id", "huaweicloud_identity_provider.test", "id"),
+				),
+			},
+			{
+				Config: testAccV3ProviderMapping_basic_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "provider_id", "huaweicloud_identity_provider.test", "id"),
 				),
 			},
 			{
@@ -79,7 +86,7 @@ func TestAccProviderMapping_basic(t *testing.T) {
 	})
 }
 
-func testAccProviderMapping_basic_step1(name string) string {
+func testAccV3ProviderMapping_basic_step1(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_provider" "test" {
   name     = "%[1]s"
@@ -123,7 +130,7 @@ resource "huaweicloud_identity_provider_mapping" "test" {
 `, name)
 }
 
-func testAccProviderMapping_basic_step2(name string) string {
+func testAccV3ProviderMapping_basic_step2(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_provider" "test" {
   name     = "%[1]s"
@@ -157,6 +164,49 @@ resource "huaweicloud_identity_provider_mapping" "test" {
           },
           {
             "type": "Group"
+          }
+        ]
+      }
+    ]
+  RULES
+}
+`, name)
+}
+
+func testAccV3ProviderMapping_basic_step3(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_provider" "test" {
+  name     = "%[1]s"
+  protocol = "oidc"
+}
+
+resource "huaweicloud_identity_provider_mapping" "test" {
+  provider_id = huaweicloud_identity_provider.test.id
+
+  mapping_rules = <<RULES
+    [
+      {
+        "local": [
+          {
+            "user": {
+              "name": "{0}"
+            }
+          },
+          {
+            "group": {
+              "name": "finance"
+            }
+          }
+        ],
+        "remote": [
+          {
+            "type": "Email"
+          },
+          {
+            "type": "Department",
+            "not_any_of": [
+              "contractor"
+            ]
           }
         ]
       }

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_provider_mapping.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_provider_mapping.go
@@ -67,6 +67,57 @@ func ResourceV3ProviderMapping() *schema.Resource {
 	}
 }
 
+func createV3ProviderMapping(client *golangsdk.ServiceClient, mappingID string, mappingOpts interface{}) error {
+	createMappingHttpUrl := "v3/OS-FEDERATION/mappings/{id}"
+	createMappingPath := client.Endpoint + createMappingHttpUrl
+	createMappingPath = strings.ReplaceAll(createMappingPath, "{id}", mappingID)
+
+	createMappingOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         mappingOpts,
+	}
+
+	_, err := client.Request("PUT", createMappingPath, &createMappingOpt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func updateV3ProviderMapping(client *golangsdk.ServiceClient, mappingID string, mappingOpts interface{}) error {
+	updateMappingHttpUrl := "v3/OS-FEDERATION/mappings/{id}"
+	updateMappingPath := client.Endpoint + updateMappingHttpUrl
+	updateMappingPath = strings.ReplaceAll(updateMappingPath, "{id}", mappingID)
+
+	updateMappingOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         mappingOpts,
+	}
+
+	_, err := client.Request("PATCH", updateMappingPath, &updateMappingOpt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func buildV3ProviderMappingOpts(mappingRules string) (interface{}, error) {
+	var rules interface{}
+	err := json.Unmarshal([]byte(mappingRules), &rules)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling rules, please check the format of the mapping rules: %s", err)
+	}
+
+	res := map[string]interface{}{
+		"mapping": map[string]interface{}{
+			"rules": rules,
+		},
+	}
+	return res, nil
+}
+
 func resourceV3ProviderMappingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.IAMNoVersionClient(cfg.GetRegion(d))
@@ -96,15 +147,15 @@ func resourceV3ProviderMappingCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	mappingRules := d.Get("mapping_rules").(string)
-	mappingOpts, err := buildMappingOpts(mappingRules)
+	mappingOpts, err := buildV3ProviderMappingOpts(mappingRules)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	// Create the mapping if it does not exist, otherwise update it.
 	if len(filterData) == 0 {
-		err = createMapping(client, mappingID, mappingOpts)
+		err = createV3ProviderMapping(client, mappingID, mappingOpts)
 	} else {
-		err = updateMapping(client, mappingID, mappingOpts)
+		err = updateV3ProviderMapping(client, mappingID, mappingOpts)
 	}
 	if err != nil {
 		return diag.Errorf("error in creating/updating mapping: %s", err)
@@ -112,57 +163,6 @@ func resourceV3ProviderMappingCreate(ctx context.Context, d *schema.ResourceData
 
 	d.SetId(mappingID)
 	return resourceV3ProviderMappingRead(ctx, d, meta)
-}
-
-func createMapping(client *golangsdk.ServiceClient, mappingID string, mappingOpts interface{}) error {
-	createMappingHttpUrl := "v3/OS-FEDERATION/mappings/{id}"
-	createMappingPath := client.Endpoint + createMappingHttpUrl
-	createMappingPath = strings.ReplaceAll(createMappingPath, "{id}", mappingID)
-
-	createMappingOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         mappingOpts,
-	}
-
-	_, err := client.Request("PUT", createMappingPath, &createMappingOpt)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func updateMapping(client *golangsdk.ServiceClient, mappingID string, mappingOpts interface{}) error {
-	updateMappingHttpUrl := "v3/OS-FEDERATION/mappings/{id}"
-	updateMappingPath := client.Endpoint + updateMappingHttpUrl
-	updateMappingPath = strings.ReplaceAll(updateMappingPath, "{id}", mappingID)
-
-	updateMappingOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         mappingOpts,
-	}
-
-	_, err := client.Request("PATCH", updateMappingPath, &updateMappingOpt)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func buildMappingOpts(mappingRules string) (interface{}, error) {
-	var rules interface{}
-	err := json.Unmarshal([]byte(mappingRules), &rules)
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling rules, please check the format of the mapping rules: %s", err)
-	}
-
-	res := map[string]interface{}{
-		"mapping": map[string]interface{}{
-			"rules": rules,
-		},
-	}
-	return res, nil
 }
 
 func resourceV3ProviderMappingRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -224,13 +224,13 @@ func resourceV3ProviderMappingUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	mappingRules := d.Get("mapping_rules").(string)
-	mappingRuleOpts, err := buildMappingOpts(mappingRules)
+	mappingRuleOpts, err := buildV3ProviderMappingOpts(mappingRules)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	mappingID := d.Id()
-	err = updateMapping(client, mappingID, mappingRuleOpts)
+	err = updateV3ProviderMapping(client, mappingID, mappingRuleOpts)
 	if err != nil {
 		return diag.Errorf("failed to update the provider mapping rules: %s", err)
 	}
@@ -253,12 +253,12 @@ func resourceV3ProviderMappingDelete(_ context.Context, d *schema.ResourceData, 
 	}
 
 	mappingID := d.Id()
-	opts, err := buildMappingOpts(defaultMapping)
+	opts, err := buildV3ProviderMappingOpts(defaultMapping)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	err = updateMapping(client, mappingID, opts)
+	err = updateV3ProviderMapping(client, mappingID, opts)
 	if err != nil {
 		return diag.Errorf("error resetting provider mapping rules to default value" +
 			"(the mapping rules can not be deleted, it can be reset to default value).")


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename resource functions with V3 prefix to align with IAM v3 API naming.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```release-note
1. change `provider mapping` resource implement.
2. change `provider mapping` resource acceptance case.
3. change `provider` resource implement.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV3ProviderMapping_basic -timeout 360m -parallel 10
=== RUN   TestAccV3ProviderMapping_basic
=== PAUSE TestAccV3ProviderMapping_basic
=== CONT  TestAccV3ProviderMapping_basic
--- PASS: TestAccV3ProviderMapping_basic (42.02s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       42.145s coverage: 4.6% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.