### PR TITLE
chore(iam): optimize the function names of v3 resources

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3394,8 +3394,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_app_whitelist_policy_process":                   hss.ResourceAppWhitelistPolicyProcess(),
 			"huaweicloud_hss_associated_asset_importance":                    hss.ResourceAssociatedAssetImportance(),
 
-			"huaweicloud_identity_access_key":                   iam.ResourceAccessKey(),
-			"huaweicloud_identity_acl":                          iam.ResourceAcl(),
+			"huaweicloud_identity_access_key":                   iam.ResourceV3AccessKey(),
+			"huaweicloud_identity_acl":                          iam.ResourceV3Acl(),
 			"huaweicloud_identity_agency":                       iam.ResourceV3Agency(),
 			"huaweicloud_identity_group":                        iam.ResourceV3Group(),
 			"huaweicloud_identity_group_membership":             iam.ResourceV3GroupMembership(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_access_key_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_access_key_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getAccessKeyResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getV3AccessKeyResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	iamClient, err := c.IAMV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
@@ -23,12 +23,12 @@ func getAccessKeyResourceFunc(c *config.Config, state *terraform.ResourceState) 
 	return credentials.Get(iamClient, state.Primary.ID).Extract()
 }
 
-func TestAccAccessKey_basic(t *testing.T) {
+func TestAccV3AccessKey_basic(t *testing.T) {
 	var (
 		obj interface{}
 
 		resourceName = "huaweicloud_identity_access_key.test"
-		rc           = acceptance.InitResourceCheck(resourceName, &obj, getAccessKeyResourceFunc)
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getV3AccessKeyResourceFunc)
 
 		name       = acceptance.RandomAccResourceNameWithDash()
 		updateName = acceptance.RandomAccResourceNameWithDash()
@@ -50,7 +50,7 @@ func TestAccAccessKey_basic(t *testing.T) {
 		CheckDestroy: rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessKey_basic_step1(name),
+				Config: testAccV3AccessKey_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "status", "active"),
@@ -61,7 +61,7 @@ func TestAccAccessKey_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAccessKey_basic_step2(updateName),
+				Config: testAccV3AccessKey_basic_step2(updateName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "status", "inactive"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -73,7 +73,7 @@ func TestAccAccessKey_basic(t *testing.T) {
 	})
 }
 
-func testAccAccessKey_basic_base(name string) string {
+func testAccV3AccessKey_basic_base(name string) string {
 	return fmt.Sprintf(`
 resource "random_string" "test" {
   length           = 10
@@ -92,7 +92,7 @@ resource "huaweicloud_identity_user" "test" {
 `, name)
 }
 
-func testAccAccessKey_basic_step1(name string) string {
+func testAccV3AccessKey_basic_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -101,10 +101,10 @@ resource "huaweicloud_identity_access_key" "test" {
   description = "Created by terraform script"
   secret_file = abspath("./credentials.csv")
 }
-`, testAccAccessKey_basic_base(name))
+`, testAccV3AccessKey_basic_base(name))
 }
 
-func testAccAccessKey_basic_step2(name string) string {
+func testAccV3AccessKey_basic_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -119,15 +119,15 @@ resource "huaweicloud_identity_access_key" "test" {
     when    = destroy
   }
 }
-`, testAccAccessKey_basic_base(name))
+`, testAccV3AccessKey_basic_base(name))
 }
 
-func TestAccAccessKey_withoutSecretFileInput(t *testing.T) {
+func TestAccV3AccessKey_withoutSecretFileInput(t *testing.T) {
 	var (
 		obj interface{}
 
 		resourceName = "huaweicloud_identity_access_key.test"
-		rc           = acceptance.InitResourceCheck(resourceName, &obj, getAccessKeyResourceFunc)
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getV3AccessKeyResourceFunc)
 
 		name = acceptance.RandomAccResourceNameWithDash()
 	)
@@ -148,7 +148,7 @@ func TestAccAccessKey_withoutSecretFileInput(t *testing.T) {
 		CheckDestroy: rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessKey_withoutSecretFileInput_step1(name),
+				Config: testAccV3AccessKey_withoutSecretFileInput_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "status", "active"),
@@ -162,7 +162,7 @@ func TestAccAccessKey_withoutSecretFileInput(t *testing.T) {
 	})
 }
 
-func testAccAccessKey_withoutSecretFileInput_base(name string) string {
+func testAccV3AccessKey_withoutSecretFileInput_base(name string) string {
 	return fmt.Sprintf(`
 resource "random_string" "test" {
   length           = 10
@@ -181,7 +181,7 @@ resource "huaweicloud_identity_user" "test" {
 `, name)
 }
 
-func testAccAccessKey_withoutSecretFileInput_step1(name string) string {
+func testAccV3AccessKey_withoutSecretFileInput_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -198,15 +198,15 @@ resource "huaweicloud_identity_access_key" "test" {
     when    = destroy
   }
 }
-`, testAccAccessKey_withoutSecretFileInput_base(name), name)
+`, testAccV3AccessKey_withoutSecretFileInput_base(name), name)
 }
 
-func TestAccAccessKey_withIncorrectSecretFileInput(t *testing.T) {
+func TestAccV3AccessKey_withIncorrectSecretFileInput(t *testing.T) {
 	var (
 		obj interface{}
 
 		resourceName = "huaweicloud_identity_access_key.test"
-		rc           = acceptance.InitResourceCheck(resourceName, &obj, getAccessKeyResourceFunc)
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getV3AccessKeyResourceFunc)
 
 		name = acceptance.RandomAccResourceNameWithDash()
 	)
@@ -227,7 +227,7 @@ func TestAccAccessKey_withIncorrectSecretFileInput(t *testing.T) {
 		CheckDestroy: rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessKey_withIncorrectSecretFileInput_step1(name),
+				Config: testAccV3AccessKey_withIncorrectSecretFileInput_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "status", "active"),
@@ -241,7 +241,7 @@ func TestAccAccessKey_withIncorrectSecretFileInput(t *testing.T) {
 	})
 }
 
-func testAccAccessKey_withIncorrectSecretFileInput_base(name string) string {
+func testAccV3AccessKey_withIncorrectSecretFileInput_base(name string) string {
 	return fmt.Sprintf(`
 resource "random_string" "test" {
   length           = 10
@@ -260,7 +260,7 @@ resource "huaweicloud_identity_user" "test" {
 `, name)
 }
 
-func testAccAccessKey_withIncorrectSecretFileInput_step1(name string) string {
+func testAccV3AccessKey_withIncorrectSecretFileInput_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -271,5 +271,5 @@ resource "huaweicloud_identity_access_key" "test" {
   description = "Created by terraform script"
   secret_file = "/null/credentials.csv" # Invalid storage path
 }
-`, testAccAccessKey_withIncorrectSecretFileInput_base(name))
+`, testAccV3AccessKey_withIncorrectSecretFileInput_base(name))
 }

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_acl_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_acl_test.go
@@ -13,24 +13,24 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 )
 
-func getAclResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getV3AclResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := cfg.IAMV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
 
-	return iam.GetAclByDomainId(client, state.Primary.Attributes["type"], cfg.DomainID)
+	return iam.GetV3AclByDomainId(client, state.Primary.Attributes["type"], cfg.DomainID)
 }
 
-func TestAccAcl_basic(t *testing.T) {
+func TestAccV3Acl_basic(t *testing.T) {
 	var (
 		obj interface{}
 
 		aclByConsole = "huaweicloud_identity_acl.test.0"
-		rcByConsole  = acceptance.InitResourceCheck(aclByConsole, &obj, getAclResourceFunc)
+		rcByConsole  = acceptance.InitResourceCheck(aclByConsole, &obj, getV3AclResourceFunc)
 
 		aclByApi = "huaweicloud_identity_acl.test.1"
-		rcByApi  = acceptance.InitResourceCheck(aclByApi, &obj, getAclResourceFunc)
+		rcByApi  = acceptance.InitResourceCheck(aclByApi, &obj, getV3AclResourceFunc)
 	)
 
 	// the runner public IP must includes the IP address of your current machine and make sure the first IP address is
@@ -49,7 +49,7 @@ func TestAccAcl_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAcl_basic_step1(),
+				Config: testAccV3Acl_basic_step1(),
 				Check: resource.ComposeTestCheckFunc(
 					rcByConsole.CheckResourceExists(),
 					resource.TestCheckResourceAttr(aclByConsole, "type", "console"),
@@ -90,7 +90,7 @@ func TestAccAcl_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAcl_basic_step2(),
+				Config: testAccV3Acl_basic_step2(),
 				Check: resource.ComposeTestCheckFunc(
 					rcByConsole.CheckResourceExists(),
 					resource.TestCheckResourceAttr(aclByConsole, "type", "console"),
@@ -144,7 +144,7 @@ func TestAccAcl_basic(t *testing.T) {
 	})
 }
 
-func testAccAcl_basic_step1() string {
+func testAccV3Acl_basic_step1() string {
 	return fmt.Sprintf(`
 variable "acl_types" {
   type    = list(string)
@@ -186,7 +186,7 @@ resource "huaweicloud_identity_acl" "test" {
 `, acceptance.HW_RUNNER_PUBLIC_IPS)
 }
 
-func testAccAcl_basic_step2() string {
+func testAccV3Acl_basic_step2() string {
 	return fmt.Sprintf(`
 variable "acl_types" {
   type    = list(string)

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_agency_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_agency_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getAgencyResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getV3AgencyResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := c.IAMV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
@@ -22,15 +22,15 @@ func getAgencyResourceFunc(c *config.Config, state *terraform.ResourceState) (in
 	return agency.Get(client, state.Primary.ID).Extract()
 }
 
-func TestAccAgency_basic(t *testing.T) {
+func TestAccV3Agency_basic(t *testing.T) {
 	var (
 		obj interface{}
 
 		createWithRoleAssignments = "huaweicloud_identity_agency.create_with_role_assignments"
-		rcWithRoleAssignments     = acceptance.InitResourceCheck(createWithRoleAssignments, &obj, getAgencyResourceFunc)
+		rcWithRoleAssignments     = acceptance.InitResourceCheck(createWithRoleAssignments, &obj, getV3AgencyResourceFunc)
 
 		createWithoutRoleAssignments = "huaweicloud_identity_agency.create_without_role_assignments"
-		rcWithoutRoleAssignments     = acceptance.InitResourceCheck(createWithoutRoleAssignments, &obj, getAgencyResourceFunc)
+		rcWithoutRoleAssignments     = acceptance.InitResourceCheck(createWithoutRoleAssignments, &obj, getV3AgencyResourceFunc)
 
 		name = acceptance.RandomAccResourceName()
 	)
@@ -49,7 +49,7 @@ func TestAccAgency_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgency_basic_step1(name),
+				Config: testAccV3Agency_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rcWithRoleAssignments.CheckResourceExists(),
 					resource.TestCheckResourceAttr(createWithRoleAssignments, "name", name+"_create_with_role_assignments"),
@@ -75,7 +75,7 @@ func TestAccAgency_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAgency_basic_step2(name),
+				Config: testAccV3Agency_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rcWithRoleAssignments.CheckResourceExists(),
 					resource.TestCheckResourceAttr(createWithRoleAssignments, "name", name+"_create_with_role_assignments"),
@@ -119,7 +119,7 @@ func TestAccAgency_basic(t *testing.T) {
 	})
 }
 
-func testAccAgency_basic_step1(name string) string {
+func testAccV3Agency_basic_step1(name string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_enterprise_projects" "test" {
   enterprise_project_id = "%[1]s"
@@ -166,7 +166,7 @@ resource "huaweicloud_identity_agency" "create_without_role_assignments" {
 	)
 }
 
-func testAccAgency_basic_step2(name string) string {
+func testAccV3Agency_basic_step2(name string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_enterprise_projects" "test" {
   enterprise_project_id = "%[1]s"

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_access_key.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_access_key.go
@@ -23,12 +23,12 @@ import (
 // @API IAM DELETE /v3.0/OS-CREDENTIAL/credentials/{access_key}
 // @API IAM GET /v3.0/OS-CREDENTIAL/credentials/{access_key}
 // @API IAM GET /v3.0/OS-USER/users/{user_id}
-func ResourceAccessKey() *schema.Resource {
+func ResourceV3AccessKey() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAccessKeyCreate,
-		ReadContext:   resourceAccessKeyRead,
-		UpdateContext: resourceAccessKeyUpdate,
-		DeleteContext: resourceAccessKeyDelete,
+		CreateContext: resourceV3AccessKeyCreate,
+		ReadContext:   resourceV3AccessKeyRead,
+		UpdateContext: resourceV3AccessKeyUpdate,
+		DeleteContext: resourceV3AccessKeyDelete,
 
 		Schema: map[string]*schema.Schema{
 			"user_id": {
@@ -90,7 +90,7 @@ func ResourceAccessKey() *schema.Resource {
 	}
 }
 
-func storeAccessKeyToCsvFile(path string, cred *credentials.Credential) error {
+func storeV3AccessKeyToCsvFile(path string, cred *credentials.Credential) error {
 	var (
 		csvFile *os.File
 		data    = [][]string{
@@ -121,7 +121,7 @@ func storeAccessKeyToCsvFile(path string, cred *credentials.Credential) error {
 	return nil
 }
 
-func resourceAccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV3AccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg    = meta.(*config.Config)
 		mErr   *multierror.Error
@@ -158,7 +158,7 @@ func resourceAccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta i
 		outputFile = customStoragePath.(string)
 	}
 
-	if err := storeAccessKeyToCsvFile(outputFile, accessKey); err != nil {
+	if err := storeV3AccessKeyToCsvFile(outputFile, accessKey); err != nil {
 		// When the CSV file fails to be saved, the secret key is stored in tfstate to prevent the value from being lost.
 		mErr = multierror.Append(mErr, d.Set("secret", accessKey.SecretKey))
 		diags = append(diags, diag.Diagnostic{
@@ -187,10 +187,10 @@ func resourceAccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
-	return append(diags, resourceAccessKeyRead(ctx, d, meta)...)
+	return append(diags, resourceV3AccessKeyRead(ctx, d, meta)...)
 }
 
-func resourceAccessKeyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV3AccessKeyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg         = meta.(*config.Config)
 		accessKeyId = d.Id()
@@ -216,7 +216,7 @@ func resourceAccessKeyRead(_ context.Context, d *schema.ResourceData, meta inter
 	return nil
 }
 
-func resourceAccessKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV3AccessKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg         = meta.(*config.Config)
 		accessKeyId = d.Id()
@@ -237,10 +237,10 @@ func resourceAccessKeyUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
-	return resourceAccessKeyRead(ctx, d, meta)
+	return resourceV3AccessKeyRead(ctx, d, meta)
 }
 
-func resourceAccessKeyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV3AccessKeyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg         = meta.(*config.Config)
 		accessKeyId = d.Id()

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_acl.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_acl.go
@@ -18,20 +18,20 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var resourceAclNonUpdatableParams = []string{"type"}
+var v3AclNonUpdatableParams = []string{"type"}
 
 // @API IAM GET /v3.0/OS-SECURITYPOLICY/domains/{domain_id}/api-acl-policy
 // @API IAM PUT /v3.0/OS-SECURITYPOLICY/domains/{domain_id}/api-acl-policy
 // @API IAM GET /v3.0/OS-SECURITYPOLICY/domains/{domain_id}/console-acl-policy
 // @API IAM PUT /v3.0/OS-SECURITYPOLICY/domains/{domain_id}/console-acl-policy
-func ResourceAcl() *schema.Resource {
+func ResourceV3Acl() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAclCreate,
-		ReadContext:   resourceAclRead,
-		UpdateContext: resourceAclUpdate,
-		DeleteContext: resourceAclDelete,
+		CreateContext: resourceV3AclCreate,
+		ReadContext:   resourceV3AclRead,
+		UpdateContext: resourceV3AclUpdate,
+		DeleteContext: resourceV3AclDelete,
 
-		CustomizeDiff: config.FlexibleForceNew(resourceAclNonUpdatableParams),
+		CustomizeDiff: config.FlexibleForceNew(v3AclNonUpdatableParams),
 
 		Schema: map[string]*schema.Schema{
 			"type": {
@@ -140,7 +140,7 @@ func ResourceAcl() *schema.Resource {
 	}
 }
 
-func buildIpCidersOrder(d *schema.ResourceData) []interface{} {
+func buildV3AclIpCidersOrder(d *schema.ResourceData) []interface{} {
 	ipCiders, ok := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "ip_cidrs").([]interface{})
 	if !ok || ipCiders == nil {
 		return nil
@@ -156,7 +156,7 @@ func buildIpCidersOrder(d *schema.ResourceData) []interface{} {
 	return result
 }
 
-func buildIpRangesOrder(d *schema.ResourceData) []interface{} {
+func buildV3AclIpRangesOrder(d *schema.ResourceData) []interface{} {
 	ipRanges, ok := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "ip_ranges").([]interface{})
 	if !ok || ipRanges == nil {
 		return nil
@@ -172,7 +172,7 @@ func buildIpRangesOrder(d *schema.ResourceData) []interface{} {
 	return result
 }
 
-func resourceAclCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV3AclCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg      = meta.(*config.Config)
 		err      error
@@ -190,22 +190,22 @@ func resourceAclCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", domainId, d.Get("type").(string)))
-	err = updateAclPolicy(client, d, domainId)
+	err = updateV3AclPolicy(client, d, domainId)
 	if err != nil {
 		return diag.Errorf("error creating identity ACL: %s", err)
 	}
 
-	if err = d.Set("ip_ciders_order", buildIpCidersOrder(d)); err != nil {
+	if err = d.Set("ip_ciders_order", buildV3AclIpCidersOrder(d)); err != nil {
 		log.Printf("[ERROR] error setting the ip_ciders_order field after creating ACL: %s", err)
 	}
-	if err = d.Set("ip_ranges_order", buildIpRangesOrder(d)); err != nil {
+	if err = d.Set("ip_ranges_order", buildV3AclIpRangesOrder(d)); err != nil {
 		log.Printf("[ERROR] error setting the ip_ranges_order field after creating ACL: %s", err)
 	}
 
-	return resourceAclRead(ctx, d, meta)
+	return resourceV3AclRead(ctx, d, meta)
 }
 
-func orderIpCidersByIpCidersOrderOrigin(ipCiders, ipCidersOrigin []interface{}) []interface{} {
+func orderV3AclIpCidersByIpCidersOrderOrigin(ipCiders, ipCidersOrigin []interface{}) []interface{} {
 	if len(ipCidersOrigin) == 0 {
 		return ipCiders
 	}
@@ -229,12 +229,12 @@ func orderIpCidersByIpCidersOrderOrigin(ipCiders, ipCidersOrigin []interface{}) 
 	return sortedIpCiders
 }
 
-func flattenIpCiders(ipCiders, ipCidersOrigin []interface{}) []interface{} {
+func flattenV3AclIpCiders(ipCiders, ipCidersOrigin []interface{}) []interface{} {
 	if len(ipCiders) < 1 {
 		return nil
 	}
 
-	sortedIpCiders := orderIpCidersByIpCidersOrderOrigin(ipCiders, ipCidersOrigin)
+	sortedIpCiders := orderV3AclIpCidersByIpCidersOrderOrigin(ipCiders, ipCidersOrigin)
 	result := make([]interface{}, 0, len(sortedIpCiders))
 	for _, ipCider := range sortedIpCiders {
 		result = append(result, map[string]interface{}{
@@ -246,7 +246,7 @@ func flattenIpCiders(ipCiders, ipCidersOrigin []interface{}) []interface{} {
 	return result
 }
 
-func orderIpRangesByIpRangesOrderOrigin(ipRanges, ipRangesOrigin []interface{}) []interface{} {
+func orderV3AclIpRangesByIpRangesOrderOrigin(ipRanges, ipRangesOrigin []interface{}) []interface{} {
 	if len(ipRangesOrigin) == 0 {
 		return ipRanges
 	}
@@ -270,12 +270,12 @@ func orderIpRangesByIpRangesOrderOrigin(ipRanges, ipRangesOrigin []interface{}) 
 	return sortedIpRanges
 }
 
-func flattenIpRanges(ipRanges, ipRangesOrigin []interface{}) []interface{} {
+func flattenV3AclIpRanges(ipRanges, ipRangesOrigin []interface{}) []interface{} {
 	if len(ipRanges) < 1 {
 		return nil
 	}
 
-	sortedIpRanges := orderIpRangesByIpRangesOrderOrigin(ipRanges, ipRangesOrigin)
+	sortedIpRanges := orderV3AclIpRangesByIpRangesOrderOrigin(ipRanges, ipRangesOrigin)
 	result := make([]interface{}, 0, len(sortedIpRanges))
 	for _, ipRange := range sortedIpRanges {
 		result = append(result, map[string]interface{}{
@@ -287,7 +287,7 @@ func flattenIpRanges(ipRanges, ipRangesOrigin []interface{}) []interface{} {
 	return result
 }
 
-func GetAclByDomainId(client *golangsdk.ServiceClient, aclType, domainId string) (*acl.ACLPolicy, error) {
+func GetV3AclByDomainId(client *golangsdk.ServiceClient, aclType, domainId string) (*acl.ACLPolicy, error) {
 	var (
 		result *acl.ACLPolicy
 		err    error
@@ -331,7 +331,7 @@ func GetAclByDomainId(client *golangsdk.ServiceClient, aclType, domainId string)
 	return result, nil
 }
 
-func resourceAclRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV3AclRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		mErr     = &multierror.Error{}
 		cfg      = meta.(*config.Config)
@@ -342,7 +342,7 @@ func resourceAclRead(_ context.Context, d *schema.ResourceData, meta interface{}
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
-	aclPolicy, err := GetAclByDomainId(iamClient, d.Get("type").(string), domainId)
+	aclPolicy, err := GetV3AclByDomainId(iamClient, d.Get("type").(string), domainId)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error fetching identity ACL")
 	}
@@ -355,7 +355,7 @@ func resourceAclRead(_ context.Context, d *schema.ResourceData, meta interface{}
 				"description": v.Description,
 			})
 		}
-		mErr = multierror.Append(mErr, d.Set("ip_cidrs", flattenIpCiders(addressNetmasks, d.Get("ip_ciders_order").([]interface{}))))
+		mErr = multierror.Append(mErr, d.Set("ip_cidrs", flattenV3AclIpCiders(addressNetmasks, d.Get("ip_ciders_order").([]interface{}))))
 	}
 	if len(aclPolicy.AllowIPRanges) > 0 {
 		ipRanges := make([]interface{}, 0, len(aclPolicy.AllowIPRanges))
@@ -365,7 +365,7 @@ func resourceAclRead(_ context.Context, d *schema.ResourceData, meta interface{}
 				"description": v.Description,
 			})
 		}
-		mErr = multierror.Append(mErr, d.Set("ip_ranges", flattenIpRanges(ipRanges, d.Get("ip_ranges_order").([]interface{}))))
+		mErr = multierror.Append(mErr, d.Set("ip_ranges", flattenV3AclIpRanges(ipRanges, d.Get("ip_ranges_order").([]interface{}))))
 	}
 
 	if err = mErr.ErrorOrNil(); err != nil {
@@ -374,7 +374,7 @@ func resourceAclRead(_ context.Context, d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceAclUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV3AclUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg      = meta.(*config.Config)
 		domainId = cfg.DomainID
@@ -390,21 +390,21 @@ func resourceAclUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
-	if err := updateAclPolicy(client, d, domainId); err != nil {
+	if err := updateV3AclPolicy(client, d, domainId); err != nil {
 		return diag.Errorf("error updating identity ACL: %s", err)
 	}
 
-	if err = d.Set("ip_ciders_order", buildIpCidersOrder(d)); err != nil {
+	if err = d.Set("ip_ciders_order", buildV3AclIpCidersOrder(d)); err != nil {
 		log.Printf("[ERROR] error setting the ip_ciders_order field after updating ACL: %s", err)
 	}
-	if err = d.Set("ip_ranges_order", buildIpRangesOrder(d)); err != nil {
+	if err = d.Set("ip_ranges_order", buildV3AclIpRangesOrder(d)); err != nil {
 		log.Printf("[ERROR] error setting the ip_ranges_order field after updating ACL: %s", err)
 	}
 
-	return resourceAclRead(ctx, d, meta)
+	return resourceV3AclRead(ctx, d, meta)
 }
 
-func resourceAclDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV3AclDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg      = meta.(*config.Config)
 		domainId = cfg.DomainID
@@ -442,7 +442,7 @@ func resourceAclDelete(_ context.Context, d *schema.ResourceData, meta interface
 	return nil
 }
 
-func updateAclPolicy(client *golangsdk.ServiceClient, d *schema.ResourceData, domainId string) error {
+func updateV3AclPolicy(client *golangsdk.ServiceClient, d *schema.ResourceData, domainId string) error {
 	var (
 		updateOpts = &acl.ACLPolicy{}
 		err        error


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Optimize the function names which supplement the v3 prefix for the v3 resources' function
e.g.
`ResourceAccessKey()` -> `ResourceV3AccessKey()`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. optimize the function names which supplement the v3 prefix for the v3 resources' function
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV3AccessKey
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV3AccessKey -timeout 360m -parallel 10
=== RUN   TestAccV3AccessKey_basic
=== PAUSE TestAccV3AccessKey_basic
=== RUN   TestAccV3AccessKey_withoutSecretFileInput
=== PAUSE TestAccV3AccessKey_withoutSecretFileInput
=== RUN   TestAccV3AccessKey_withIncorrectSecretFileInput
=== PAUSE TestAccV3AccessKey_withIncorrectSecretFileInput
=== CONT  TestAccV3AccessKey_basic
=== CONT  TestAccV3AccessKey_withIncorrectSecretFileInput
=== CONT  TestAccV3AccessKey_withoutSecretFileInput
--- PASS: TestAccV3AccessKey_withIncorrectSecretFileInput (23.30s)
--- PASS: TestAccV3AccessKey_withoutSecretFileInput (23.54s)
--- PASS: TestAccV3AccessKey_basic (34.23s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       34.358s coverage: 3.7% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccV3Acl_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV3Acl_basic -timeout 360m -parallel 10
=== RUN   TestAccV3Acl_basic
=== PAUSE TestAccV3Acl_basic
=== CONT  TestAccV3Acl_basic
--- PASS: TestAccV3Acl_basic (21.58s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       21.687s coverage: 3.8% of statements in ./huaweicloud/services/iam
```
```
./scripts/coverage.sh -o iam -f TestAccV3Agency_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV3Agency_basic -timeout 360m -parallel 10
=== RUN   TestAccV3Agency_basic
=== PAUSE TestAccV3Agency_basic
=== CONT  TestAccV3Agency_basic
--- PASS: TestAccV3Agency_basic (207.40s)
PASS
coverage: 7.6% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       207.536s        coverage: 7.6% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
