### PR TITLE
fix(cc): fix the updating billing mode error

### DIFF
--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_bandwidth_package_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_bandwidth_package_test.go
@@ -93,7 +93,7 @@ func TestAccBandwidthPackage_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "local_area_id", "Chinese-Mainland"),
 					resource.TestCheckResourceAttr(rName, "remote_area_id", "Chinese-Mainland"),
 					resource.TestCheckResourceAttr(rName, "charge_mode", "bandwidth"),
-					resource.TestCheckResourceAttr(rName, "billing_mode", "3"),
+					resource.TestCheckResourceAttr(rName, "billing_mode", "5"),
 					resource.TestCheckResourceAttr(rName, "bandwidth", "5"),
 					resource.TestCheckResourceAttr(rName, "description", "This is an accaptance test"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
@@ -170,7 +170,7 @@ resource "huaweicloud_cc_bandwidth_package" "test" {
   local_area_id         = "Chinese-Mainland"
   remote_area_id        = "Chinese-Mainland"
   charge_mode           = "bandwidth"
-  billing_mode          = 3
+  billing_mode          = 5
   bandwidth             = 5
   description           = "This is an accaptance test"
   resource_id           = huaweicloud_cc_connection.test_another.id

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go
@@ -295,6 +295,10 @@ func resourceBandwidthPackageUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
+	// Editing the `billing_mode` field has special restrictions:
+	// 1. When an edit API request is initiated, the value of `billing_mode` can only be one of [`1`, `2`, `5`, `6`, `7`, `8`].
+	// 2. When an edit API request includes `billing_mode`, the API requires `bandwidth` to be passed in.
+	// For the reasons mentioned above, the `billing_mode` need to be edited by calling the API separately.
 	if d.HasChange("billing_mode") {
 		err = updateBandwidthPackage(client, cfg.DomainID, bandWidthId, buildUpdateBandwidthPackageBillingModeParams(d))
 		if err != nil {
@@ -462,9 +466,9 @@ func deleteBandwidthPackageTags(client *golangsdk.ServiceClient, d *schema.Resou
 func buildUpdateBandwidthPackageBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"bandwidth_package": map[string]interface{}{
-			"name":        utils.ValueIgnoreEmpty(d.Get("name")),
+			"name":        d.Get("name"),
+			"bandwidth":   d.Get("bandwidth"),
 			"description": utils.ValueIgnoreEmpty(d.Get("description")),
-			"bandwidth":   utils.ValueIgnoreEmpty(d.Get("bandwidth")),
 		},
 	}
 	return bodyParams
@@ -473,7 +477,8 @@ func buildUpdateBandwidthPackageBodyParams(d *schema.ResourceData) map[string]in
 func buildUpdateBandwidthPackageBillingModeParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"bandwidth_package": map[string]interface{}{
-			"billing_mode": utils.ValueIgnoreEmpty(d.Get("billing_mode")),
+			"billing_mode": d.Get("billing_mode"),
+			"bandwidth":    d.Get("bandwidth"),
 		},
 	}
 	return bodyParams


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix the updating billing mode error

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Before making the changes, an error occurred when editing the billing_mode field:
```
error updating CC bandwidth package: Bad request with: [PUT https://cc.myhuaweicloud.com/v3/0970d7b7d400f2470fbec00316a03560/ccaas/bandwidth-packages/e08cff30a47d4769a03a5f1e0e849cff], request_id: d38d32fbc96b4bdeb341233ea1d38d32fbc96b4bdeb341233ea1c0c895, error message: {"error_msg":"The parameter 'bandwidth' is needed.","error_code":"CC.1001","request_id":"d38d32fbc96b4bdeb341233ea1c0c895"}
```

- The API restricts the editing field `billing_mode`, with the following limitations:
  - 1. When an edit API request is initiated, the value of `billing_mode` can only be one of [`1`, `2`, `5`, `6`, `7`, `8`].
  - 2. When an edit API request includes `billing_mode`, the API requires `bandwidth` to be passed in.

**This PR addresses the aforementioned limitations by making code modifications that allow for normal editing of billing_mode.**


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cc -f TestAccBandwidthPackage_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cc" -v -coverprofile="./huaweicloud/services/acceptance/cc/cc_coverage.cov" -coverpkg="./huaweicloud/services/cc" -run TestAccBandwidthPackage_basic -timeout 360m -parallel 10
=== RUN   TestAccBandwidthPackage_basic
=== PAUSE TestAccBandwidthPackage_basic
=== CONT  TestAccBandwidthPackage_basic
--- PASS: TestAccBandwidthPackage_basic (50.40s)
PASS
coverage: 8.9% of statements in ./huaweicloud/services/cc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        50.504s coverage: 8.9% of statements in ./huaweicloud/services/cc
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
