### PR TITLE
fix(iam): add V3 prefix to resourc helper function names for API version clarity

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getProviderResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getV3ProviderResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := c.IAMNoVersionClient(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client without version: %s", err)
@@ -21,15 +21,15 @@ func getProviderResourceFunc(c *config.Config, state *terraform.ResourceState) (
 	return providers.Get(client, state.Primary.ID)
 }
 
-func TestAccProvider_basic(t *testing.T) {
+func TestAccV3Provider_basic(t *testing.T) {
 	var (
 		obj interface{}
 
 		protocolSaml   = "huaweicloud_identity_provider.protocol_saml"
-		rcProtocolSaml = acceptance.InitResourceCheck(protocolSaml, &obj, getProviderResourceFunc)
+		rcProtocolSaml = acceptance.InitResourceCheck(protocolSaml, &obj, getV3ProviderResourceFunc)
 
 		protocolOidc   = "huaweicloud_identity_provider.protocol_oidc"
-		rcProtocolOidc = acceptance.InitResourceCheck(protocolOidc, &obj, getProviderResourceFunc)
+		rcProtocolOidc = acceptance.InitResourceCheck(protocolOidc, &obj, getV3ProviderResourceFunc)
 
 		name = acceptance.RandomAccResourceName()
 	)
@@ -46,7 +46,7 @@ func TestAccProvider_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProvider_basic_step1(name),
+				Config: testAccV3Provider_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rcProtocolSaml.CheckResourceExists(),
 					resource.TestCheckResourceAttr(protocolSaml, "name", name+"_saml"),
@@ -59,7 +59,7 @@ func TestAccProvider_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProvider_basic_step2(name),
+				Config: testAccV3Provider_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rcProtocolSaml.CheckResourceExists(),
 					resource.TestCheckResourceAttr(protocolSaml, "name", name+"_saml"),
@@ -73,7 +73,7 @@ func TestAccProvider_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProvider_basic_step3(name),
+				Config: testAccV3Provider_basic_step3(name),
 				Check: resource.ComposeTestCheckFunc(
 					rcProtocolOidc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(protocolOidc, "name", name+"_oidc"),
@@ -97,7 +97,7 @@ func TestAccProvider_basic(t *testing.T) {
 	})
 }
 
-func testAccProvider_basic_step1(name string) string {
+func testAccV3Provider_basic_step1(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_provider" "protocol_saml" {
   name     = "%[1]s_saml"
@@ -134,7 +134,7 @@ resource "huaweicloud_identity_provider" "protocol_oidc" {
 `, name)
 }
 
-func testAccProvider_basic_step2(name string) string {
+func testAccV3Provider_basic_step2(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_provider" "protocol_saml" {
   name     = "%[1]s_saml"
@@ -172,7 +172,7 @@ resource "huaweicloud_identity_provider" "protocol_oidc" {
 `, name)
 }
 
-func testAccProvider_basic_step3(name string) string {
+func testAccV3Provider_basic_step3(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_provider" "protocol_saml" {
   name     = "%[1]s_saml"

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_provider_conversion.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_provider_conversion.go
@@ -262,7 +262,7 @@ func resourceV3ProviderConversionDelete(_ context.Context, d *schema.ResourceDat
 	}
 
 	conversionID := d.Id()
-	opts := getDefaultConversionOpts()
+	opts := getDefaultV3ProviderConversionOpts()
 	_, err = mappings.Update(client, conversionID, *opts)
 
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename resource functions with V3 prefix to align with IAM v3 API naming.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. change the `iam provider` resource implement.
2. change the `iam provider` resource acceptance case.
```

## PR Checklist
* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV3Provider_basic -timeout 360m -parallel 10
=== RUN   TestAccV3Provider_basic
=== PAUSE TestAccV3Provider_basic
=== CONT  TestAccV3Provider_basic
--- PASS: TestAccV3Provider_basic (44.00s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       44.114s coverage: 4.2% of statements in ./huaweicloud/services/iam
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.