### PR TITLE
refactor(organizations): optimize codes and docs for organizational unit

### DIFF
--- a/docs/data-sources/organizations_organizational_units.md
+++ b/docs/data-sources/organizations_organizational_units.md
@@ -2,20 +2,21 @@
 subcategory: "Organizations"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_organizations_organizational_units"
-description: ""
+description: |-
+  Use this data source to get the list of child organizational units under the specified parent OU within HuaweiCloud.
 ---
 
 # huaweicloud_organizations_organizational_units
 
-Use this data source to get the list of child organizational units under the specified parent OU.
+Use this data source to get the list of child organizational units under the specified parent OU within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
-data "huaweicloud_organizations_organization" "org" {}
+variable "parent_id" {}
 
 data "huaweicloud_organizations_organizational_units" "test" {
-  parent_id = data.huaweicloud_organizations_organization.org.root_id
+  parent_id = var.parent_id
 }
 ```
 
@@ -31,7 +32,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `children` - The list of child organizational units.
+* `children` - The list of child organizational units.  
   The [children](#OrganizationalUnits) structure is documented below.
 
 <a name="OrganizationalUnits"></a>

--- a/docs/resources/organizations_organizational_unit.md
+++ b/docs/resources/organizations_organizational_unit.md
@@ -2,7 +2,8 @@
 subcategory: "Organizations"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_organizations_organizational_unit"
-description: ""
+description: |-
+  Manages an Organizations organizational unit resource within HuaweiCloud.
 ---
 
 # huaweicloud_organizations_organizational_unit
@@ -12,10 +13,11 @@ Manages an Organizations organizational unit resource within HuaweiCloud.
 ## Example Usage
 
 ```hcl
+  variable "organizational_unit_name" {}
   variable "parent_id" {}
   
   resource "huaweicloud_organizations_organizational_unit" "test"{
-    name      = "organizational_unit_test_name"
+    name      = var.organizational_unit_name
     parent_id = var.parent_id
   }
 ```
@@ -31,7 +33,7 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `tags` - (Optional, Map) Specifies the key/value to attach to the organizational unit.
+* `tags` - (Optional, Map) Specifies the key/value pairs associated with the organizational unit.
 
 ## Attribute Reference
 
@@ -58,8 +60,8 @@ the organizational unit, or the resource definition should be updated to align w
 can ignore changes as below.
 
 ```hcl
-resource "huaweicloud_organizations_organizational_unit" "instance_1" {
-    ...
+resource "huaweicloud_organizations_organizational_unit" "test" {
+  ...
 
   lifecycle {
     ignore_changes = [

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_organizational_unit_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_organizational_unit_test.go
@@ -2,47 +2,23 @@ package organizations
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations"
 )
 
 func getOrganizationalUnitResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	// getOrganizationalUnit: Query Organizations organizational unit
-	var (
-		region                       = acceptance.HW_REGION_NAME
-		getOrganizationalUnitHttpUrl = "v1/organizations/organizational-units/{organizational_unit_id}"
-		getOrganizationalUnitProduct = "organizations"
-	)
-	getOrganizationalUnitClient, err := cfg.NewServiceClient(getOrganizationalUnitProduct, region)
+	client, err := cfg.NewServiceClient("organizations", acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Organizations Client: %s", err)
+		return nil, fmt.Errorf("error creating Organizations client: %s", err)
 	}
 
-	getOrganizationalUnitPath := getOrganizationalUnitClient.Endpoint + getOrganizationalUnitHttpUrl
-	getOrganizationalUnitPath = strings.ReplaceAll(getOrganizationalUnitPath, "{organizational_unit_id}",
-		state.Primary.ID)
-
-	getOrganizationalUnitOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-	}
-	getOrganizationalUnitResp, err := getOrganizationalUnitClient.Request("GET",
-		getOrganizationalUnitPath, &getOrganizationalUnitOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving Organizations organizational unit: %s", err)
-	}
-	return utils.FlattenResponse(getOrganizationalUnitResp)
+	return organizations.GetOrganizationalUnit(client, state.Primary.ID)
 }
 
 func TestAccOrganizationalUnit_basic(t *testing.T) {

--- a/huaweicloud/services/organizations/data_source_huaweicloud_organizations_organizational_units.go
+++ b/huaweicloud/services/organizations/data_source_huaweicloud_organizations_organizational_units.go
@@ -1,22 +1,15 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product Organizations
-// ---------------------------------------------------------------
-
 package organizations
 
 import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -29,108 +22,125 @@ func DataSourceOrganizationalUnits() *schema.Resource {
 			"parent_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `Specifies the ID of root or organizational unit.`,
+				Description: `The ID of root or organizational unit.`,
 			},
 			"children": {
 				Type:        schema.TypeList,
-				Elem:        organizationalUnitsOrganizationalUnitSchema(),
+				Elem:        organizationalUnitsSchema(),
 				Computed:    true,
-				Description: `List of OUs in an organization.`,
+				Description: `The list of child organizational units.`,
 			},
 		},
 	}
 }
 
-func organizationalUnitsOrganizationalUnitSchema() *schema.Resource {
+func organizationalUnitsSchema() *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Unique ID of an OU`,
+				Description: `The ID of the organizational unit.`,
 			},
 			"name": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Name of the OU`,
+				Description: `The name of the organizational unit.`,
 			},
 			"urn": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Uniform resource name of the OU`,
+				Description: `The uniform resource name of the organizational unit.`,
 			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Time when the OU was created`,
+				Description: `The time when the organizational unit was created.`,
 			},
 		},
 	}
 	return &sc
 }
 
-func dataSourceOrganizationalUnitsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+func listOrganizationalUnits(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/organizations/organizational-units"
+		// The default value of limit is 200
+		limit  = 200
+		marker = ""
+		result []interface{}
+		opt    = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+	)
 
-	listOrganizationalUnitsHttpUrl := "v1/organizations/organizational-units"
-	listOrganizationalUnitsProduct := "organizations"
-	listOrganizationalUnitsClient, err := cfg.NewServiceClient(listOrganizationalUnitsProduct, region)
+	listPath := client.Endpoint + httpUrl
+	listPath = fmt.Sprintf("%s?limit=%v%s", listPath, limit, buildListOrganizationalUnitsQueryParams(d))
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s&marker=%v", listPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", listPathWithMarker, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		ous := utils.PathSearch("organizational_units", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, ous...)
+		if len(ous) < limit {
+			break
+		}
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func dataSourceOrganizationalUnitsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("organizations", region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	listOrganizationalUnitsPath := listOrganizationalUnitsClient.Endpoint + listOrganizationalUnitsHttpUrl
-	listOrganizationalUnitsOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-
-	var childrenOUs []interface{}
-	var marker string
-	var queryPath string
-
-	for {
-		queryPath = listOrganizationalUnitsPath + buildListOrganizationalUnitsQueryParams(d, marker)
-		listOrganizationalUnitsResp, err := listOrganizationalUnitsClient.Request("GET", queryPath, &listOrganizationalUnitsOpt)
-		if err != nil {
-			return common.CheckDeletedDiag(d, err, "error retrieving Organizational Units")
-		}
-
-		listOrganizationalUnitsRespBody, err := utils.FlattenResponse(listOrganizationalUnitsResp)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
-		onePageOUs := flattenOrganizationalUnitResp(listOrganizationalUnitsRespBody)
-		childrenOUs = append(childrenOUs, onePageOUs...)
-		marker = utils.PathSearch("page_info.next_marker", listOrganizationalUnitsRespBody, "").(string)
-		if marker == "" {
-			break
-		}
+	ous, err := listOrganizationalUnits(client, d)
+	if err != nil {
+		return diag.Errorf("error querying organizational units: %s", err)
 	}
 
 	uuid, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
+
 	d.SetId(uuid)
 
-	mErr := multierror.Append(nil,
-		d.Set("children", childrenOUs),
-	)
-
-	return diag.FromErr(mErr.ErrorOrNil())
+	return diag.FromErr(d.Set("children", flattenOrganizationalUnits(ous)))
 }
 
-func flattenOrganizationalUnitResp(resp interface{}) []interface{} {
-	if resp == nil {
+func flattenOrganizationalUnits(ous []interface{}) []interface{} {
+	if len(ous) == 0 {
 		return nil
 	}
 
-	curJson := utils.PathSearch("organizational_units", resp, make([]interface{}, 0))
-	curArray := curJson.([]interface{})
-	rst := make([]interface{}, 0, len(curArray))
-	for _, v := range curArray {
+	rst := make([]interface{}, 0, len(ous))
+	for _, v := range ous {
 		rst = append(rst, map[string]interface{}{
 			"id":         utils.PathSearch("id", v, nil),
 			"name":       utils.PathSearch("name", v, nil),
@@ -141,17 +151,10 @@ func flattenOrganizationalUnitResp(resp interface{}) []interface{} {
 	return rst
 }
 
-func buildListOrganizationalUnitsQueryParams(d *schema.ResourceData, marker string) string {
-	// the default value of limit is 200
-	res := "?limit=200"
-
-	if marker != "" {
-		res = fmt.Sprintf("%s&marker=%v", res, marker)
-	}
-
+func buildListOrganizationalUnitsQueryParams(d *schema.ResourceData) string {
 	if v, ok := d.GetOk("parent_id"); ok {
-		res = fmt.Sprintf("%s&parent_id=%v", res, v)
+		return fmt.Sprintf("&parent_id=%v", v)
 	}
 
-	return res
+	return ""
 }

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_organizational_unit.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_organizational_unit.go
@@ -1,12 +1,8 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product Organizations
-// ---------------------------------------------------------------
-
 package organizations
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 
@@ -41,68 +37,63 @@ func ResourceOrganizationalUnit() *schema.Resource {
 		CustomizeDiff: config.MergeDefaultTags(),
 
 		Schema: map[string]*schema.Schema{
+			// Required parameters.
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `Specifies the name of the organizational unit.`,
+				Description: `The name of the organizational unit.`,
 			},
 			"parent_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				Description: `Specifies the ID of the root or organizational unit in which you
+				Description: `The ID of the root or organizational unit in which you
 want to create a new organizational unit.`,
 			},
+			// Optional parameters.
+			"tags": common.TagsSchema(`The key/value pairs associated with the organizational unit.`),
+			// Attributes.
 			"urn": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the uniform resource name of the organizational unit.`,
+				Description: `The uniform resource name of the organizational unit.`,
 			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the time when the OU was created.`,
+				Description: `The time when the OU was created.`,
 			},
-			"tags": common.TagsSchema(),
 		},
 	}
 }
 
 func resourceOrganizationalUnitCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// createOrganizationalUnit: create Organizations organizational unit
 	var (
-		createOrganizationalUnitHttpUrl = "v1/organizations/organizational-units"
-		createOrganizationalUnitProduct = "organizations"
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/organizations/organizational-units"
 	)
-	createOrganizationalUnitClient, err := cfg.NewServiceClient(createOrganizationalUnitProduct, region)
+	client, err := cfg.NewServiceClient("organizations", region)
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	createOrganizationalUnitPath := createOrganizationalUnitClient.Endpoint + createOrganizationalUnitHttpUrl
-
-	createOrganizationalUnitOpt := golangsdk.RequestOpts{
+	createPath := client.Endpoint + httpUrl
+	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			201,
-		},
+		JSONBody:         utils.RemoveNil(buildCreateOrganizationalUnitBodyParams(d)),
 	}
-	createOrganizationalUnitOpt.JSONBody = utils.RemoveNil(buildCreateOrganizationalUnitBodyParams(d))
-	createOrganizationalUnitResp, err := createOrganizationalUnitClient.Request("POST",
-		createOrganizationalUnitPath, &createOrganizationalUnitOpt)
+	resp, err := client.Request("POST", createPath, &opt)
 	if err != nil {
-		return diag.Errorf("error creating Organizations organizational unit: %s", err)
+		return diag.Errorf("error creating organizational unit: %s", err)
 	}
 
-	createOrganizationalUnitRespBody, err := utils.FlattenResponse(createOrganizationalUnitResp)
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	unitId := utils.PathSearch("organizational_unit.id", createOrganizationalUnitRespBody, "").(string)
+	unitId := utils.PathSearch("organizational_unit.id", respBody, "").(string)
 	if unitId == "" {
 		return diag.Errorf("unable to find the organizational unit ID from the API response")
 	}
@@ -121,48 +112,58 @@ func buildCreateOrganizationalUnitBodyParams(d *schema.ResourceData) map[string]
 	return bodyParams
 }
 
-func resourceOrganizationalUnitRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	var mErr *multierror.Error
-
-	// getOrganizationalUnit: Query Organizations organizational unit
-	var (
-		getOrganizationalUnitHttpUrl = "v1/organizations/organizational-units/{organizational_unit_id}"
-		getOrganizationalUnitProduct = "organizations"
-	)
-	getOrganizationalUnitClient, err := cfg.NewServiceClient(getOrganizationalUnitProduct, region)
-	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
-	}
-
-	getOrganizationalUnitPath := getOrganizationalUnitClient.Endpoint + getOrganizationalUnitHttpUrl
-	getOrganizationalUnitPath = strings.ReplaceAll(getOrganizationalUnitPath, "{organizational_unit_id}", d.Id())
-
-	getOrganizationalUnitOpt := golangsdk.RequestOpts{
+func GetOrganizationalUnit(client *golangsdk.ServiceClient, ouId string) (interface{}, error) {
+	httpUrl := "v1/organizations/organizational-units/{organizational_unit_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{organizational_unit_id}", ouId)
+	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
-	getOrganizationalUnitResp, err := getOrganizationalUnitClient.Request("GET",
-		getOrganizationalUnitPath, &getOrganizationalUnitOpt)
-
+	resp, err := client.Request("GET", getPath, &opt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving Organizations organizational unit")
+		return nil, err
 	}
 
-	getOrganizationalUnitRespBody, err := utils.FlattenResponse(getOrganizationalUnitResp)
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
-		return diag.FromErr(err)
+		return nil, err
 	}
 
-	organizationalUnit := utils.PathSearch("organizational_unit", getOrganizationalUnitRespBody, nil)
+	organizationalUnit := utils.PathSearch("organizational_unit", respBody, nil)
 	if organizationalUnit == nil {
-		log.Printf("[WARN] failed to get organizational unit, organizational_unit %s is not found "+
-			"in API response", d.Id())
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/organizations/organizational-units/{organizational_unit_id}",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the organizational unit (%s) does not exist", ouId)),
+			},
+		}
+	}
+
+	return organizationalUnit, nil
+}
+
+func resourceOrganizationalUnitRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		ouId   = d.Id()
+		mErr   *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient("organizations", region)
+	if err != nil {
+		return diag.Errorf("error creating client: %s", err)
+	}
+
+	organizationalUnit, err := GetOrganizationalUnit(client, ouId)
+	if err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+			fmt.Sprintf("error retrieving organizational unit (%s)", ouId),
+		)
 	}
 
 	mErr = multierror.Append(
@@ -172,9 +173,9 @@ func resourceOrganizationalUnitRead(_ context.Context, d *schema.ResourceData, m
 		d.Set("created_at", utils.PathSearch("created_at", organizationalUnit, nil)),
 	)
 
-	tagMap, err := getTags(getOrganizationalUnitClient, unitType, d.Id())
+	tagMap, err := getTags(client, unitType, ouId)
 	if err != nil {
-		log.Printf("[WARN] error fetching tags of Organizations organizational unit (%s): %s", d.Id(), err)
+		log.Printf("[WARN] error fetching tags of organizational unit (%s): %s", ouId, err)
 	} else {
 		mErr = multierror.Append(mErr, d.Set("tags", tagMap))
 	}
@@ -183,44 +184,38 @@ func resourceOrganizationalUnitRead(_ context.Context, d *schema.ResourceData, m
 }
 
 func resourceOrganizationalUnitUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// updateOrganizationalUnit: update Organizations organizational unit
 	var (
-		updateOrganizationalUnitHttpUrl = "v1/organizations/organizational-units/{organizational_unit_id}"
-		updateOrganizationalUnitProduct = "organizations"
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/organizations/organizational-units/{organizational_unit_id}"
+		ouId    = d.Id()
 	)
-	updateOrganizationalUnitClient, err := cfg.NewServiceClient(updateOrganizationalUnitProduct, region)
+	client, err := cfg.NewServiceClient("organizations", region)
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
 	if d.HasChange("name") {
-		updateOrganizationalUnitPath := updateOrganizationalUnitClient.Endpoint + updateOrganizationalUnitHttpUrl
-		updateOrganizationalUnitPath = strings.ReplaceAll(updateOrganizationalUnitPath,
-			"{organizational_unit_id}", d.Id())
-
-		updateOrganizationalUnitOpt := golangsdk.RequestOpts{
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{organizational_unit_id}", ouId)
+		opt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
+			JSONBody:         utils.RemoveNil(buildUpdateOrganizationalUnitBodyParams(d)),
 		}
-		updateOrganizationalUnitOpt.JSONBody = utils.RemoveNil(buildUpdateOrganizationalUnitBodyParams(d))
-		_, err = updateOrganizationalUnitClient.Request("PATCH",
-			updateOrganizationalUnitPath, &updateOrganizationalUnitOpt)
+
+		_, err = client.Request("PATCH", updatePath, &opt)
 		if err != nil {
-			return diag.Errorf("error updating Organizations organizational unit: %s", err)
+			return diag.Errorf("error updating organizational unit (%s): %s", ouId, err)
 		}
 	}
 
 	if d.HasChange("tags") {
-		err = updateTags(d, updateOrganizationalUnitClient, unitType, d.Id(), "tags")
+		err = updateTags(d, client, unitType, ouId, "tags")
 		if err != nil {
-			return diag.FromErr(err)
+			return diag.Errorf("error updating tags of organizational unit (%s): %s", ouId, err)
 		}
 	}
+
 	return resourceOrganizationalUnitRead(ctx, d, meta)
 }
 
@@ -232,33 +227,29 @@ func buildUpdateOrganizationalUnitBodyParams(d *schema.ResourceData) map[string]
 }
 
 func resourceOrganizationalUnitDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// deleteOrganizationalUnit: Delete Organizations organizational unit
 	var (
-		deleteOrganizationalUnitHttpUrl = "v1/organizations/organizational-units/{organizational_unit_id}"
-		deleteOrganizationalUnitProduct = "organizations"
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/organizations/organizational-units/{organizational_unit_id}"
+		ouId    = d.Id()
 	)
-	deleteOrganizationalUnitClient, err := cfg.NewServiceClient(deleteOrganizationalUnitProduct, region)
+	client, err := cfg.NewServiceClient("organizations", region)
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	deleteOrganizationalUnitPath := deleteOrganizationalUnitClient.Endpoint + deleteOrganizationalUnitHttpUrl
-	deleteOrganizationalUnitPath = strings.ReplaceAll(deleteOrganizationalUnitPath,
-		"{organizational_unit_id}", d.Id())
-
-	deleteOrganizationalUnitOpt := golangsdk.RequestOpts{
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{organizational_unit_id}", ouId)
+	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			204,
-		},
 	}
-	_, err = deleteOrganizationalUnitClient.Request("DELETE", deleteOrganizationalUnitPath,
-		&deleteOrganizationalUnitOpt)
+	_, err = client.Request("DELETE", deletePath, &opt)
 	if err != nil {
-		return diag.Errorf("error deleting Organizations organizational unit: %s", err)
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+			fmt.Sprintf("error deleting organizational unit (%s)", ouId),
+		)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The current code has the following issues and needs optimization:

- Redundant method naming
- Some error messages are inaccurate
- Some content in the documentation is inaccurately described
- Some code is not standardized
- CheckDeleted does not cover scenarios where the organization does not exist
- Some meaningless comments

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. optimize codes and documentations of the resource and data source.
2. delete meaningless comments.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o organizations -f TestAccOrganizationalUnit_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccOrganizationalUnit_basic -timeout 360m -parallel 10
=== RUN   TestAccOrganizationalUnit_basic
=== PAUSE TestAccOrganizationalUnit_basic
=== CONT  TestAccOrganizationalUnit_basic
--- PASS: TestAccOrganizationalUnit_basic (34.24s)
PASS
coverage: 12.8% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     34.335s coverage: 12.8% of statements in ./huaweicloud/services/organizations
```
```
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations/resource_huaweicloud_organizations_organizational_unit.go (81.6%)
```

```
./scripts/coverage.sh -o organizations -f TestAccDataOrganizationalUnits_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDataOrganizationalUnits_basic -timeout 360m -parallel 10
=== RUN   TestAccDataOrganizationalUnits_basic
=== PAUSE TestAccDataOrganizationalUnits_basic
=== CONT  TestAccDataOrganizationalUnits_basic
--- PASS: TestAccDataOrganizationalUnits_basic (18.75s)
PASS
coverage: 11.7% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     18.860s coverage: 11.7% of statements in ./huaweicloud/services/organizations
```
```
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations/data_source_huaweicloud_organizations_organizational_units.go (82.2%)
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
