### PR TITLE
feat(cc): cc bandwidth package resource support prepaid mode

### DIFF
--- a/docs/resources/cc_bandwidth_package.md
+++ b/docs/resources/cc_bandwidth_package.md
@@ -12,6 +12,8 @@ Manages a bandwidth package resource of Cloud connect within HuaweiCloud.
 
 ## Example Usage
 
+## Postpaid Example Usage
+
 ```hcl
 variable "name" {}
 
@@ -23,6 +25,33 @@ resource "huaweicloud_cc_bandwidth_package" "test" {
   billing_mode   = 3
   bandwidth      = 5
   description    = "This is a demo"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+## Prepaid Example Usage
+
+```hcl
+variable "name" {}
+
+resource "huaweicloud_cc_bandwidth_package" "test" {
+  name           = var.name
+  local_area_id  = "Chinese-Mainland"
+  remote_area_id = "Chinese-Mainland"
+  charge_mode    = "bandwidth"
+  billing_mode   = 1
+  bandwidth      = 5
+  description    = "This is a demo"
+
+  prepaid_options {
+    period_type   = "month"
+    period_num    = 1
+    is_auto_renew = true
+  }
 
   tags = {
     foo = "bar"
@@ -60,12 +89,19 @@ The following arguments are supported:
   Valid value is **bandwidth**.
 
 * `billing_mode` - (Required, String) Specifies the billing mode of the bandwidth package. Valid values are:
+  + **1**: yearly/monthly on the Chinese mainland website
+  + **2**: yearly/monthly on the International website
   + **3**: pay-per-use on the Chinese mainland website
   + **4**: pay-per-use on the International website
   + **5**: 95th percentile bandwidth billing on the Chinese mainland website
   + **6**: 95th percentile bandwidth billing on the International website
 
-  -> This argument can only be modified to **5** and **6**.
+  -> Below is a detailed usage guide for the `billing_mode` field:
+  <br/>1. The value **​​1** and **2** indicate instances of the prepaid type.
+  <br/>2. The value **​​3**, **4**, **5** and **6** indicate instances of the postpaid type.
+  <br/>3. This field can only be edited when its value is **3** or **4**; otherwise, editing it will result in an error.
+  <br/>4. The value of this field can only be edited to **1**, **2**, **5**, or **6**.
+  <br/>5. When the value of this field is configured as **1** or **2**, the `prepaid_options` field must be configured.
 
 * `bandwidth` - (Required, Int) Specifies the bandwidth capacity specified for the bandwidth package.
 
@@ -125,6 +161,31 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the bandwidth package.
 
+* `prepaid_options` - (Optional, List) Specifies the payment attributes.
+  The [prepaid_options](#prepaid_options_struct) structure is documented below.
+
+  -> Below is a detailed usage guide for the `prepaid_options` field:
+  <br/>1. The field `prepaid_options` must be used in conjunction with the `billing_mode` field. Editing this field
+  separately makes no sense.
+  <br/>2. The field `prepaid_options` is required when the value of `billing_mode` is **1** or **2**.
+  <br/>3. For prepaid type instances, this field does not support repeated editing. For example, when the value of
+  `billing_mode` is already **1** or **2**, editing the value of `prepaid_options` has no effect or meaning.
+
+<a name="prepaid_options_struct"></a>
+The `prepaid_options` block supports:
+
+* `period_type` - (Required, String) Specifies the unit of a subscription period. Valid values are:
+  + **month**: The unit of the subscription period is month.
+  + **year**: The unit of the subscription period is year.
+
+* `period_num` - (Required, Int) Specifies the number of subscription periods.
+  The value ranges from `1` to `9`, if `period_type` is set to **month**.
+  The value ranges from `1` to `3`, if `period_type` is set to **year**.
+
+* `is_auto_renew` - (Optional, Bool) Specifies whether to enable auto renewal.
+  + **true**: Auto renewal is enabled.
+  + **false**: Auto renewal is disabled.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -135,10 +196,44 @@ In addition to all arguments above, the following attributes are exported:
   The valid value are as follows:
   + **ACTIVE**: Bandwidth packages are available.
 
+* `created_at` - The time when the resource was created.
+
+* `updated_at` - The time when the resource was updated.
+
+* `order_id` - The order ID of the bandwidth package.
+
+* `product_id` - The product ID of the bandwidth package.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
 ## Import
 
 The bandwidth package can be imported using the `id`, e.g.
 
 ```bash
 $ terraform import huaweicloud_cc_bandwidth_package.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `prepaid_options`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the instance. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_cc_bandwidth_package" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      prepaid_options,
+    ]
+  }
+}
 ```

--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_bandwidth_package_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_bandwidth_package_test.go
@@ -26,6 +26,8 @@ func getBandwidthPackageResourceFunc(cfg *config.Config, state *terraform.Resour
 	return cc.GetBandwidthPackage(client, cfg.DomainID, state.Primary.ID)
 }
 
+// This test case is used to test creating an postpaid instance, editing general parameters, changing the `bandwidth`
+// in postpaid mode, changing the another postpaid mode, and changing the `bandwidth` again.
 func TestAccBandwidthPackage_basic(t *testing.T) {
 	var (
 		obj   interface{}
@@ -57,51 +59,64 @@ func TestAccBandwidthPackage_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "charge_mode", "bandwidth"),
 					resource.TestCheckResourceAttr(rName, "billing_mode", "3"),
 					resource.TestCheckResourceAttr(rName, "bandwidth", "5"),
-					resource.TestCheckResourceAttr(rName, "description", "This is an accaptance test"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "resource_type", "cloud_connection"),
+					resource.TestCheckResourceAttr(rName, "spec_code", "bandwidth.cmtocm"),
+					resource.TestCheckResourceAttr(rName, "interflow_mode", "Area"),
+					resource.TestCheckResourceAttrPair(rName, "resource_id", "huaweicloud_cc_connection.test", "id"),
 					resource.TestCheckResourceAttrSet(rName, "project_id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 				),
 			},
 			{
 				Config: testBandwidthPackage_basic_update1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update1", name)),
 					resource.TestCheckResourceAttr(rName, "local_area_id", "Chinese-Mainland"),
 					resource.TestCheckResourceAttr(rName, "remote_area_id", "Chinese-Mainland"),
 					resource.TestCheckResourceAttr(rName, "charge_mode", "bandwidth"),
 					resource.TestCheckResourceAttr(rName, "billing_mode", "3"),
 					resource.TestCheckResourceAttr(rName, "bandwidth", "6"),
-					resource.TestCheckResourceAttr(rName, "description", "This is an accaptance test update"),
-					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform_test"),
+					resource.TestCheckResourceAttr(rName, "description", "test description update1"),
+					resource.TestCheckResourceAttr(rName, "tags.foo_update1", "bar_update1"),
 					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
-					resource.TestCheckResourceAttr(rName, "resource_type", "cloud_connection"),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
-					resource.TestCheckResourceAttrPair(rName, "resource_id", "huaweicloud_cc_connection.test", "id"),
+					resource.TestCheckResourceAttr(rName, "resource_type", "cloud_connection"),
+					resource.TestCheckResourceAttr(rName, "spec_code", "bandwidth.cmtocm"),
+					resource.TestCheckResourceAttr(rName, "interflow_mode", "Area"),
+					resource.TestCheckResourceAttrPair(rName, "resource_id", "huaweicloud_cc_connection.test_another", "id"),
 					resource.TestCheckResourceAttrSet(rName, "project_id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 				),
 			},
 			{
 				Config: testBandwidthPackage_basic_update2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update2", name)),
 					resource.TestCheckResourceAttr(rName, "local_area_id", "Chinese-Mainland"),
 					resource.TestCheckResourceAttr(rName, "remote_area_id", "Chinese-Mainland"),
 					resource.TestCheckResourceAttr(rName, "charge_mode", "bandwidth"),
 					resource.TestCheckResourceAttr(rName, "billing_mode", "5"),
 					resource.TestCheckResourceAttr(rName, "bandwidth", "5"),
-					resource.TestCheckResourceAttr(rName, "description", "This is an accaptance test"),
-					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "description", "test description update2"),
+					resource.TestCheckResourceAttr(rName, "tags.foo_update2", "bar_update2"),
 					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(rName, "resource_type", "cloud_connection"),
+					resource.TestCheckResourceAttr(rName, "spec_code", "bandwidth.cmtocm"),
+					resource.TestCheckResourceAttr(rName, "interflow_mode", "Area"),
 					resource.TestCheckResourceAttrPair(rName, "resource_id", "huaweicloud_cc_connection.test_another", "id"),
 					resource.TestCheckResourceAttrSet(rName, "project_id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 				),
 			},
 			{
@@ -115,6 +130,10 @@ func TestAccBandwidthPackage_basic(t *testing.T) {
 
 func testBandwidthPackage_basic(name string) string {
 	return fmt.Sprintf(`
+resource "huaweicloud_cc_connection" "test" {
+  name = "%[1]s"
+}
+
 resource "huaweicloud_cc_bandwidth_package" "test" {
   name                  = "%[1]s"
   local_area_id         = "Chinese-Mainland"
@@ -122,7 +141,11 @@ resource "huaweicloud_cc_bandwidth_package" "test" {
   charge_mode           = "bandwidth"
   billing_mode          = 3
   bandwidth             = 5
-  description           = "This is an accaptance test"
+  description           = "test description"
+  resource_id           = huaweicloud_cc_connection.test.id
+  resource_type         = "cloud_connection"
+  interflow_mode        = "Area"
+  spec_code             = "bandwidth.cmtocm"
   enterprise_project_id = "%[2]s"
 
   tags = {
@@ -135,25 +158,26 @@ resource "huaweicloud_cc_bandwidth_package" "test" {
 
 func testBandwidthPackage_basic_update1(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_cc_connection" "test" {
-  name = "%[1]s"
+resource "huaweicloud_cc_connection" "test_another" {
+  name = "%[1]s_another"
 }
 
 resource "huaweicloud_cc_bandwidth_package" "test" {
-  name                  = "%[1]s_update"
+  name                  = "%[1]s_update1"
   local_area_id         = "Chinese-Mainland"
   remote_area_id        = "Chinese-Mainland"
   charge_mode           = "bandwidth"
   billing_mode          = 3
   bandwidth             = 6
-  description           = "This is an accaptance test update"
-  resource_id           = huaweicloud_cc_connection.test.id
+  description           = "test description update1"
+  resource_id           = huaweicloud_cc_connection.test_another.id
   resource_type         = "cloud_connection"
+  interflow_mode        = "Area"
+  spec_code             = "bandwidth.cmtocm"
   enterprise_project_id = "%[2]s"
 
   tags = {
-    foo   = "bar"
-    owner = "terraform_test"
+    foo_update1 = "bar_update1"
   }
 }
 `, name, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
@@ -166,20 +190,317 @@ resource "huaweicloud_cc_connection" "test_another" {
 }
 
 resource "huaweicloud_cc_bandwidth_package" "test" {
-  name                  = "%[1]s"
+  name                  = "%[1]s_update2"
   local_area_id         = "Chinese-Mainland"
   remote_area_id        = "Chinese-Mainland"
   charge_mode           = "bandwidth"
   billing_mode          = 5
   bandwidth             = 5
-  description           = "This is an accaptance test"
+  description           = "test description update2"
   resource_id           = huaweicloud_cc_connection.test_another.id
+  resource_type         = "cloud_connection"
+  interflow_mode        = "Area"
+  spec_code             = "bandwidth.cmtocm"
+  enterprise_project_id = "%[2]s"
+
+  tags = {
+    foo_update2 = "bar_update2"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
+}
+
+// This test case is used to test creating an postpaid instance, editing general parameters, changing to pretpaid mode,
+// and changing the `bandwidth`.
+func TestAccBandwidthPackage_postpaidToPrepaid(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_cc_bandwidth_package.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBandwidthPackageResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMigrateEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBandwidthPackage_postpaidToPrepaid(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "local_area_id", "Chinese-Mainland"),
+					resource.TestCheckResourceAttr(rName, "remote_area_id", "Chinese-Mainland"),
+					resource.TestCheckResourceAttr(rName, "charge_mode", "bandwidth"),
+					resource.TestCheckResourceAttr(rName, "billing_mode", "3"),
+					resource.TestCheckResourceAttr(rName, "bandwidth", "5"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "resource_type", "cloud_connection"),
+					resource.TestCheckResourceAttrPair(rName, "resource_id", "huaweicloud_cc_connection.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "project_id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "interflow_mode"),
+					resource.TestCheckResourceAttrSet(rName, "spec_code"),
+				),
+			},
+			{
+				Config: testBandwidthPackage_postpaidToPrepaid_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "local_area_id", "Chinese-Mainland"),
+					resource.TestCheckResourceAttr(rName, "remote_area_id", "Chinese-Mainland"),
+					resource.TestCheckResourceAttr(rName, "charge_mode", "bandwidth"),
+					resource.TestCheckResourceAttr(rName, "billing_mode", "1"),
+					resource.TestCheckResourceAttr(rName, "bandwidth", "6"),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "tags.foo_update", "bar_update"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "resource_type", "cloud_connection"),
+					resource.TestCheckResourceAttrPair(rName, "resource_id", "huaweicloud_cc_connection.test_another", "id"),
+					resource.TestCheckResourceAttrSet(rName, "project_id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "interflow_mode"),
+					resource.TestCheckResourceAttrSet(rName, "spec_code"),
+					resource.TestCheckResourceAttrSet(rName, "order_id"),
+					resource.TestCheckResourceAttrSet(rName, "product_id"),
+					resource.TestCheckResourceAttrSet(rName, "prepaid_options.0.is_auto_renew"),
+					resource.TestCheckResourceAttrSet(rName, "prepaid_options.0.period_num"),
+					resource.TestCheckResourceAttrSet(rName, "prepaid_options.0.period_type"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"prepaid_options",
+				},
+			},
+		},
+	})
+}
+
+func testBandwidthPackage_postpaidToPrepaid(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cc_connection" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_cc_bandwidth_package" "test" {
+  name                  = "%[1]s"
+  local_area_id         = "Chinese-Mainland"
+  remote_area_id        = "Chinese-Mainland"
+  charge_mode           = "bandwidth"
+  billing_mode          = 3
+  bandwidth             = 5
+  description           = "test description"
+  resource_id           = huaweicloud_cc_connection.test.id
   resource_type         = "cloud_connection"
   enterprise_project_id = "%[2]s"
 
   tags = {
     foo = "bar"
     key = "value"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testBandwidthPackage_postpaidToPrepaid_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cc_connection" "test_another" {
+  name = "%[1]s_another"
+}
+
+resource "huaweicloud_cc_bandwidth_package" "test" {
+  name                  = "%[1]s_update"
+  local_area_id         = "Chinese-Mainland"
+  remote_area_id        = "Chinese-Mainland"
+  charge_mode           = "bandwidth"
+  billing_mode          = 1
+  bandwidth             = 6
+  description           = "test description update"
+  resource_id           = huaweicloud_cc_connection.test_another.id
+  resource_type         = "cloud_connection"
+  enterprise_project_id = "%[2]s"
+
+  prepaid_options {
+    period_type   = "month"
+    period_num    = 1
+    is_auto_renew = true
+  }
+
+  tags = {
+    foo_update = "bar_update"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
+}
+
+// This test case is used to test creating an prepaid instance, editing general parameters and changing the `bandwidth`.
+func TestAccBandwidthPackage_prepaid(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_cc_bandwidth_package.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBandwidthPackageResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMigrateEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBandwidthPackage_prepaid(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "local_area_id", "Chinese-Mainland"),
+					resource.TestCheckResourceAttr(rName, "remote_area_id", "Chinese-Mainland"),
+					resource.TestCheckResourceAttr(rName, "charge_mode", "bandwidth"),
+					resource.TestCheckResourceAttr(rName, "billing_mode", "1"),
+					resource.TestCheckResourceAttr(rName, "bandwidth", "6"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "resource_type", "cloud_connection"),
+					resource.TestCheckResourceAttrPair(rName, "resource_id", "huaweicloud_cc_connection.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "project_id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "interflow_mode"),
+					resource.TestCheckResourceAttrSet(rName, "spec_code"),
+					resource.TestCheckResourceAttrSet(rName, "prepaid_options.0.is_auto_renew"),
+					resource.TestCheckResourceAttrSet(rName, "prepaid_options.0.period_num"),
+					resource.TestCheckResourceAttrSet(rName, "prepaid_options.0.period_type"),
+				),
+			},
+			{
+				Config: testBandwidthPackage_prepaid_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "local_area_id", "Chinese-Mainland"),
+					resource.TestCheckResourceAttr(rName, "remote_area_id", "Chinese-Mainland"),
+					resource.TestCheckResourceAttr(rName, "charge_mode", "bandwidth"),
+					resource.TestCheckResourceAttr(rName, "billing_mode", "1"),
+					resource.TestCheckResourceAttr(rName, "bandwidth", "5"),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "tags.foo_update", "bar_update"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "resource_type", "cloud_connection"),
+					resource.TestCheckResourceAttrPair(rName, "resource_id", "huaweicloud_cc_connection.test_another", "id"),
+					resource.TestCheckResourceAttrSet(rName, "project_id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "interflow_mode"),
+					resource.TestCheckResourceAttrSet(rName, "spec_code"),
+					resource.TestCheckResourceAttrSet(rName, "order_id"),
+					resource.TestCheckResourceAttrSet(rName, "product_id"),
+					resource.TestCheckResourceAttrSet(rName, "prepaid_options.0.is_auto_renew"),
+					resource.TestCheckResourceAttrSet(rName, "prepaid_options.0.period_num"),
+					resource.TestCheckResourceAttrSet(rName, "prepaid_options.0.period_type"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"prepaid_options",
+				},
+			},
+		},
+	})
+}
+
+func testBandwidthPackage_prepaid(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cc_connection" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_cc_bandwidth_package" "test" {
+  name                  = "%[1]s"
+  local_area_id         = "Chinese-Mainland"
+  remote_area_id        = "Chinese-Mainland"
+  charge_mode           = "bandwidth"
+  billing_mode          = 1
+  bandwidth             = 6
+  description           = "test description"
+  resource_id           = huaweicloud_cc_connection.test.id
+  resource_type         = "cloud_connection"
+  enterprise_project_id = "%[2]s"
+
+  prepaid_options {
+    period_type   = "month"
+    period_num    = 1
+    is_auto_renew = true
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testBandwidthPackage_prepaid_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cc_connection" "test_another" {
+  name = "%[1]s_another"
+}
+
+resource "huaweicloud_cc_bandwidth_package" "test" {
+  name                  = "%[1]s_update"
+  local_area_id         = "Chinese-Mainland"
+  remote_area_id        = "Chinese-Mainland"
+  charge_mode           = "bandwidth"
+  billing_mode          = 1
+  bandwidth             = 5
+  description           = "test description update"
+  resource_id           = huaweicloud_cc_connection.test_another.id
+  resource_type         = "cloud_connection"
+  enterprise_project_id = "%[2]s"
+
+  prepaid_options {
+    period_type   = "month"
+    period_num    = 1
+    is_auto_renew = true
+  }
+
+  tags = {
+    foo_update = "bar_update"
   }
 }
 `, name, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go
@@ -2,12 +2,15 @@ package cc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -43,6 +46,12 @@ func ResourceBandwidthPackage() *schema.Resource {
 		DeleteContext: resourceBandwidthPackageDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		CustomizeDiff: customdiff.All(
@@ -117,6 +126,13 @@ func ResourceBandwidthPackage() *schema.Resource {
 				Computed: true,
 			},
 			"tags": common.TagsSchema(),
+			// The prepaid parameters do not return a value.
+			"prepaid_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     prepaidOptionsSchema(),
+			},
 			"enable_force_new": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -127,8 +143,58 @@ func ResourceBandwidthPackage() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"order_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
+}
+
+func prepaidOptionsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"period_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"period_num": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"is_auto_renew": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func waitforPrepaidOrderCompleted(ctx context.Context, cfg *config.Config, d *schema.ResourceData,
+	orderId string, timeout time.Duration) error {
+	bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating BSS v2 client: %s", err)
+	}
+
+	if err = common.WaitOrderComplete(ctx, bssClient, orderId, timeout); err != nil {
+		return err
+	}
+
+	_, err = common.WaitOrderAllResourceComplete(ctx, bssClient, orderId, timeout)
+	return err
 }
 
 func resourceBandwidthPackageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -167,6 +233,13 @@ func resourceBandwidthPackageCreate(ctx context.Context, d *schema.ResourceData,
 	}
 	d.SetId(id)
 
+	// We need to wait for the prepaid order to be completed; otherwise, a "404" error may occur when querying.
+	if orderId := utils.PathSearch("bandwidth_package.order_id", respBody, "").(string); orderId != "" {
+		if err := waitforPrepaidOrderCompleted(ctx, cfg, d, orderId, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.Errorf("error waiting for CC prepaid bandwidth package creation to complete (%s): %v", id, err)
+		}
+	}
+
 	return resourceBandwidthPackageRead(ctx, d, meta)
 }
 
@@ -176,6 +249,24 @@ func buildCreateBandwidthPackageProjectIdParam(d *schema.ResourceData, cfg *conf
 	}
 
 	return cfg.GetProjectID(cfg.GetRegion(d))
+}
+
+func buildCreateBandwidthPackagePrepaidOptionsParam(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"period_type":   rawMap["period_type"],
+		"period_num":    rawMap["period_num"],
+		"is_auto_renew": rawMap["is_auto_renew"],
+		"is_auto_pay":   true,
+	}
 }
 
 func buildCreateBandwidthPackageBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
@@ -195,6 +286,7 @@ func buildCreateBandwidthPackageBodyParams(d *schema.ResourceData, cfg *config.C
 			"resource_id":           utils.ValueIgnoreEmpty(d.Get("resource_id")),
 			"resource_type":         utils.ValueIgnoreEmpty(d.Get("resource_type")),
 			"tags":                  utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
+			"prepaid_options":       buildCreateBandwidthPackagePrepaidOptionsParam(d.Get("prepaid_options").([]interface{})),
 		},
 	}
 }
@@ -249,102 +341,13 @@ func resourceBandwidthPackageRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("resource_type", utils.PathSearch("bandwidth_package.resource_type", respBody, nil)),
 		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("bandwidth_package.tags", respBody, nil))),
 		d.Set("status", utils.PathSearch("bandwidth_package.status", respBody, nil)),
+		d.Set("created_at", utils.PathSearch("bandwidth_package.created_at", respBody, nil)),
+		d.Set("updated_at", utils.PathSearch("bandwidth_package.updated_at", respBody, nil)),
+		d.Set("order_id", utils.PathSearch("bandwidth_package.order_id", respBody, nil)),
+		d.Set("product_id", utils.PathSearch("bandwidth_package.product_id", respBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
-}
-
-func resourceBandwidthPackageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg         = meta.(*config.Config)
-		region      = cfg.GetRegion(d)
-		bandWidthId = d.Id()
-	)
-
-	client, err := cfg.NewServiceClient("cc", region)
-	if err != nil {
-		return diag.Errorf("error creating CC client: %s", err)
-	}
-
-	if d.HasChanges("resource_id", "resource_type") {
-		idOld, idNew := d.GetChange("resource_id")
-		typeOld, typeNew := d.GetChange("resource_type")
-
-		err = disassociateBandwidthPackage(client, cfg.DomainID, bandWidthId, idOld.(string), typeOld.(string))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
-		err = associateBandwidthPackage(client, cfg.DomainID, bandWidthId, idNew.(string), typeNew.(string))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChanges("name", "description", "bandwidth") {
-		err = updateBandwidthPackage(client, cfg.DomainID, bandWidthId, buildUpdateBandwidthPackageBodyParams(d))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("tags") {
-		err = updateBandwidthPackageTags(client, d, cfg.DomainID)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	// Editing the `billing_mode` field has special restrictions:
-	// 1. When an edit API request is initiated, the value of `billing_mode` can only be one of [`1`, `2`, `5`, `6`, `7`, `8`].
-	// 2. When an edit API request includes `billing_mode`, the API requires `bandwidth` to be passed in.
-	// For the reasons mentioned above, the `billing_mode` need to be edited by calling the API separately.
-	if d.HasChange("billing_mode") {
-		err = updateBandwidthPackage(client, cfg.DomainID, bandWidthId, buildUpdateBandwidthPackageBillingModeParams(d))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("enterprise_project_id") {
-		migrateOpts := config.MigrateResourceOpts{
-			ResourceId:   bandWidthId,
-			ResourceType: "bwp",
-			RegionId:     region,
-			ProjectId:    client.ProjectID,
-		}
-		if err := cfg.MigrateEnterpriseProject(ctx, d, migrateOpts); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	return resourceBandwidthPackageRead(ctx, d, meta)
-}
-
-func associateBandwidthPackage(client *golangsdk.ServiceClient, domainId, id, resourceId, resourceType string) error {
-	if resourceId == "" || resourceType == "" {
-		return nil
-	}
-
-	requestPath := client.Endpoint + "v3/{domain_id}/ccaas/bandwidth-packages/{id}/associate"
-	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", domainId)
-	requestPath = strings.ReplaceAll(requestPath, "{id}", id)
-	requestOpt := golangsdk.RequestOpts{
-		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
-		KeepResponseBody: true,
-		JSONBody: map[string]interface{}{
-			"bandwidth_package": map[string]interface{}{
-				"resource_id":   resourceId,
-				"resource_type": resourceType,
-			},
-		},
-	}
-
-	_, err := client.Request("POST", requestPath, &requestOpt)
-	if err != nil {
-		return fmt.Errorf("error associating CC bandwidth package: %s", err)
-	}
-	return nil
 }
 
 func disassociateBandwidthPackage(client *golangsdk.ServiceClient, domainId, id, resourceId, resourceType string) error {
@@ -367,13 +370,49 @@ func disassociateBandwidthPackage(client *golangsdk.ServiceClient, domainId, id,
 	}
 
 	_, err := client.Request("POST", requestPath, &requestOpt)
-	if err != nil {
-		return fmt.Errorf("error disassociating CC bandwidth package: %s", err)
+	return err
+}
+
+func associateBandwidthPackage(client *golangsdk.ServiceClient, domainId, id, resourceId, resourceType string) error {
+	if resourceId == "" || resourceType == "" {
+		return nil
 	}
+
+	requestPath := client.Endpoint + "v3/{domain_id}/ccaas/bandwidth-packages/{id}/associate"
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", domainId)
+	requestPath = strings.ReplaceAll(requestPath, "{id}", id)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"bandwidth_package": map[string]interface{}{
+				"resource_id":   resourceId,
+				"resource_type": resourceType,
+			},
+		},
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	return err
+}
+
+func updateBandwidthPackageBindingObject(client *golangsdk.ServiceClient, cfg *config.Config, d *schema.ResourceData) error {
+	idOld, idNew := d.GetChange("resource_id")
+	typeOld, typeNew := d.GetChange("resource_type")
+
+	if err := disassociateBandwidthPackage(client, cfg.DomainID, d.Id(), idOld.(string), typeOld.(string)); err != nil {
+		return fmt.Errorf("error disassociating CC bandwidth package in update operation: %s", err)
+	}
+
+	if err := associateBandwidthPackage(client, cfg.DomainID, d.Id(), idNew.(string), typeNew.(string)); err != nil {
+		return fmt.Errorf("error associating CC bandwidth package in update operation: %s", err)
+	}
+
 	return nil
 }
 
-func updateBandwidthPackage(client *golangsdk.ServiceClient, domainId, id string, params map[string]interface{}) error {
+func updateBandwidthPackage(client *golangsdk.ServiceClient, domainId, id string,
+	params map[string]interface{}) (interface{}, error) {
 	requestPath := client.Endpoint + "v3/{domain_id}/ccaas/bandwidth-packages/{id}"
 	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", domainId)
 	requestPath = strings.ReplaceAll(requestPath, "{id}", id)
@@ -383,11 +422,211 @@ func updateBandwidthPackage(client *golangsdk.ServiceClient, domainId, id string
 		JSONBody:         utils.RemoveNil(params),
 	}
 
-	_, err := client.Request("PUT", requestPath, &requestOpt)
+	resp, err := client.Request("PUT", requestPath, &requestOpt)
 	if err != nil {
-		return fmt.Errorf("error updating CC bandwidth package: %s", err)
+		return nil, err
 	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func buildUpdateBandwidthPackageNameAndDescription(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"bandwidth_package": map[string]interface{}{
+			"name":        d.Get("name"),
+			"description": utils.ValueIgnoreEmpty(d.Get("description")),
+		},
+	}
+	return bodyParams
+}
+
+func buildUpdateBandwidthPackagePostpaidBillingMode(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"bandwidth_package": map[string]interface{}{
+			"billing_mode": d.Get("billing_mode"),
+			"bandwidth":    d.Get("bandwidth"),
+		},
+	}
+	return bodyParams
+}
+
+func buildUpdateBandwidthPackagePrepaidOptions(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"period_type":   rawMap["period_type"],
+		"period_num":    rawMap["period_num"],
+		"is_auto_renew": rawMap["is_auto_renew"],
+		"is_auto_pay":   true,
+	}
+}
+
+func buildUpdateBandwidthPackagePrepaidBillingMode(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"bandwidth_package": map[string]interface{}{
+			"billing_mode":    d.Get("billing_mode"),
+			"prepaid_options": buildUpdateBandwidthPackagePrepaidOptions(d.Get("prepaid_options").([]interface{})),
+		},
+	}
+	return bodyParams
+}
+
+func updateBandwidthPackageBillingMode(ctx context.Context, client *golangsdk.ServiceClient, cfg *config.Config,
+	d *schema.ResourceData) error {
+	var (
+		billingMode             = d.Get("billing_mode").(string)
+		postBillingModeArray    = []string{"5", "6"}
+		prepaidBillingModeArray = []string{"1", "2"}
+	)
+
+	if utils.StrSliceContains(postBillingModeArray, billingMode) {
+		// When updating to postpaid billing mode, the request body must include both `billing_mode` and `bandwidth`.
+		_, err := updateBandwidthPackage(client, cfg.DomainID, d.Id(), buildUpdateBandwidthPackagePostpaidBillingMode(d))
+		if err != nil {
+			return fmt.Errorf("error updating CC postpaid bandwidth package billing mode: %s", err)
+		}
+	}
+
+	if utils.StrSliceContains(prepaidBillingModeArray, billingMode) {
+		// When updating to prepaid billing mode, the request body must include both `billing_mode` and `prepaid_options`.
+		// This operation will generate a new order, and we need to track its completion.
+		respBody, err := updateBandwidthPackage(client, cfg.DomainID, d.Id(), buildUpdateBandwidthPackagePrepaidBillingMode(d))
+		if err != nil {
+			return fmt.Errorf("error updating CC prepaid bandwidth package billing mode: %s", err)
+		}
+
+		if orderId := utils.PathSearch("bandwidth_package.order_id", respBody, "").(string); orderId != "" {
+			if err := waitforPrepaidOrderCompleted(ctx, cfg, d, orderId, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return fmt.Errorf(`error waiting for CC prepaid bandwidth package billing mode update to complete (%s):
+				 %v`, d.Id(), err)
+			}
+		}
+	}
+
 	return nil
+}
+
+func buildUpdateBandwidthPackagePostpaidBandwidth(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"bandwidth_package": map[string]interface{}{
+			"bandwidth": d.Get("bandwidth"),
+		},
+	}
+	return bodyParams
+}
+
+func buildUpdateBandwidthPackagePrepaidBandwidth(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"bandwidth_package": map[string]interface{}{
+			"bandwidth": d.Get("bandwidth"),
+			"prepaid_options": map[string]interface{}{
+				"is_auto_pay": true,
+			},
+		},
+	}
+	return bodyParams
+}
+
+func updateBandwidthPackageBandwidth(ctx context.Context, client *golangsdk.ServiceClient, cfg *config.Config,
+	d *schema.ResourceData) error {
+	var (
+		billingMode             = d.Get("billing_mode").(string)
+		postBillingModeArray    = []string{"3", "4", "5", "6"}
+		prepaidBillingModeArray = []string{"1", "2"}
+	)
+
+	if utils.StrSliceContains(postBillingModeArray, billingMode) {
+		// When updating the postpaid bandwidth value, the request body only need `bandwidth` field.
+		_, err := updateBandwidthPackage(client, cfg.DomainID, d.Id(), buildUpdateBandwidthPackagePostpaidBandwidth(d))
+		if err != nil {
+			return fmt.Errorf("error updating CC postpaid bandwidth package bandwidth value: %s", err)
+		}
+	}
+
+	if utils.StrSliceContains(prepaidBillingModeArray, billingMode) {
+		// When updating the prepaid bandwidth value, the request body must include both `bandwidth` and `is_auto_pay` fields.
+		// This operation will generate a new order, and we need to track its completion.
+		respBody, err := updateBandwidthPackage(client, cfg.DomainID, d.Id(), buildUpdateBandwidthPackagePrepaidBandwidth(d))
+		if err != nil {
+			return fmt.Errorf("error updating CC prepaid bandwidth package bandwidth value: %s", err)
+		}
+
+		if orderId := utils.PathSearch("bandwidth_package.order_id", respBody, "").(string); orderId != "" {
+			if err := waitforPrepaidOrderCompleted(ctx, cfg, d, orderId, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return fmt.Errorf("error waiting for CC prepaid bandwidth package bandwidth value update to complete (%s): %v", d.Id(), err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceBandwidthPackageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		bandWidthId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("cc", region)
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	if d.HasChanges("resource_id", "resource_type") {
+		if err := updateBandwidthPackageBindingObject(client, cfg, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Editing the `name` and `description` is unaffected by postpaid and prepaid status; each is requested separately.
+	if d.HasChanges("name", "description") {
+		_, err := updateBandwidthPackage(client, cfg.DomainID, bandWidthId, buildUpdateBandwidthPackageNameAndDescription(d))
+		if err != nil {
+			return diag.Errorf("error updating CC bandwidth package name and description: %s", err)
+		}
+	}
+
+	// It is necessary to distinguish the type of `billind_mode` change and handle them differently.
+	if d.HasChange("billing_mode") {
+		if err := updateBandwidthPackageBillingMode(ctx, client, cfg, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("bandwidth") {
+		if err := updateBandwidthPackageBandwidth(ctx, client, cfg, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		err = updateBandwidthPackageTags(client, d, cfg.DomainID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("enterprise_project_id") {
+		migrateOpts := config.MigrateResourceOpts{
+			ResourceId:   bandWidthId,
+			ResourceType: "bwp",
+			RegionId:     region,
+			ProjectId:    client.ProjectID,
+		}
+		if err := cfg.MigrateEnterpriseProject(ctx, d, migrateOpts); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceBandwidthPackageRead(ctx, d, meta)
 }
 
 func updateBandwidthPackageTags(client *golangsdk.ServiceClient, d *schema.ResourceData, domainId string) error {
@@ -463,32 +702,72 @@ func deleteBandwidthPackageTags(client *golangsdk.ServiceClient, d *schema.Resou
 	return nil
 }
 
-func buildUpdateBandwidthPackageBodyParams(d *schema.ResourceData) map[string]interface{} {
-	bodyParams := map[string]interface{}{
-		"bandwidth_package": map[string]interface{}{
-			"name":        d.Get("name"),
-			"bandwidth":   d.Get("bandwidth"),
-			"description": utils.ValueIgnoreEmpty(d.Get("description")),
-		},
+func deletePostpaidBandwidthPackage(client *golangsdk.ServiceClient, cfg *config.Config, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v3/{domain_id}/ccaas/bandwidth-packages/{id}"
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", cfg.DomainID)
+	requestPath = strings.ReplaceAll(requestPath, "{id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+		KeepResponseBody: true,
 	}
-	return bodyParams
+
+	_, err := client.Request("DELETE", requestPath, &requestOpt)
+	return err
 }
 
-func buildUpdateBandwidthPackageBillingModeParams(d *schema.ResourceData) map[string]interface{} {
-	bodyParams := map[string]interface{}{
-		"bandwidth_package": map[string]interface{}{
-			"billing_mode": d.Get("billing_mode"),
-			"bandwidth":    d.Get("bandwidth"),
-		},
+func deleteBandwidthPackage(client *golangsdk.ServiceClient, cfg *config.Config, d *schema.ResourceData) error {
+	var (
+		billingMode             = d.Get("billing_mode").(string)
+		prepaidBillingModeArray = []string{"1", "2"}
+	)
+
+	// Instances of the prepaid class can only be deleted by unsubscribing.
+	if utils.StrSliceContains(prepaidBillingModeArray, billingMode) {
+		err := common.UnsubscribePrePaidResource(d, cfg, []string{d.Id()})
+		if err != nil {
+			return fmt.Errorf("error unsubscribing CC prepaid bandwidth package: %s", err)
+		}
+
+		return nil
 	}
-	return bodyParams
+
+	if err := deletePostpaidBandwidthPackage(client, cfg, d); err != nil {
+		return fmt.Errorf("error deleting CC postpaid bandwidth package: %s", err)
+	}
+
+	return nil
 }
 
-func resourceBandwidthPackageDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func waitingForBandwidthPackageDeleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration, cfg *config.Config) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := GetBandwidthPackage(client, cfg.DomainID, d.Id())
+			if err != nil {
+				var errDefault404 golangsdk.ErrDefault404
+				if errors.As(err, &errDefault404) {
+					return "success", "COMPLETED", nil
+				}
+				return nil, "ERROR", err
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceBandwidthPackageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg          = meta.(*config.Config)
 		region       = cfg.GetRegion(d)
-		httpUrl      = "v3/{domain_id}/ccaas/bandwidth-packages/{id}"
 		product      = "cc"
 		resourceId   = d.Get("resource_id").(string)
 		resourceType = d.Get("resource_type").(string)
@@ -504,17 +783,13 @@ func resourceBandwidthPackageDelete(_ context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error disassociating CC bandwidth package: %s", err)
 	}
 
-	requestPath := client.Endpoint + httpUrl
-	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", cfg.DomainID)
-	requestPath = strings.ReplaceAll(requestPath, "{id}", d.Id())
-	requestOpt := golangsdk.RequestOpts{
-		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
-		KeepResponseBody: true,
+	if err := deleteBandwidthPackage(client, cfg, d); err != nil {
+		return diag.FromErr(err)
 	}
 
-	_, err = client.Request("DELETE", requestPath, &requestOpt)
-	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error deleting CC bandwidth package")
+	// We need to confirm that the resource was successfully deleted.
+	if err := waitingForBandwidthPackageDeleted(ctx, client, d, d.Timeout(schema.TimeoutDelete), cfg); err != nil {
+		return diag.Errorf("error waiting for CC bandwidth package (%s) deleted: %s", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CC bandwidth package resource support prepaid mode

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- There are many scenarios for updating bandwidth package instances, which can be roughly divided into the following 3 categories：
  - Editing the name and description can be requested separately.
  - Editing the billing mode to postpaid type, and updating the value of bandwidth.
  - Editing the billing mode to prepaid type, and updating the value of bandwidth.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cc -f TestAccBandwidthPackage_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cc" -v -coverprofile="./huaweicloud/services/acceptance/cc/cc_coverage.cov" -coverpkg="./huaweicloud/services/cc" -run TestAccBandwidthPackage_ -timeout 360m -parallel 10
=== RUN   TestAccBandwidthPackage_basic
=== PAUSE TestAccBandwidthPackage_basic
=== RUN   TestAccBandwidthPackage_postpaidToPrepaid
=== PAUSE TestAccBandwidthPackage_postpaidToPrepaid
=== RUN   TestAccBandwidthPackage_prepaid
=== PAUSE TestAccBandwidthPackage_prepaid
=== RUN   TestAccBandwidthPackage_regionalInterflow
=== PAUSE TestAccBandwidthPackage_regionalInterflow
=== CONT  TestAccBandwidthPackage_basic
=== CONT  TestAccBandwidthPackage_prepaid
=== CONT  TestAccBandwidthPackage_postpaidToPrepaid
=== CONT  TestAccBandwidthPackage_regionalInterflow
--- PASS: TestAccBandwidthPackage_regionalInterflow (22.49s)
--- PASS: TestAccBandwidthPackage_basic (59.15s)
--- PASS: TestAccBandwidthPackage_postpaidToPrepaid (120.26s)
--- PASS: TestAccBandwidthPackage_prepaid (149.67s)
PASS
coverage: 10.9% of statements in ./huaweicloud/services/cc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        149.770s        coverage: 10.9% of statements in ./huaweicloud/services/cc
```
<img width="1382" height="55" alt="image" src="https://github.com/user-attachments/assets/a38e2462-076f-4f36-ae42-ec9678bff2a5" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
