### PR TITLE
feat(css): add new data source to get the list of endpoint connections

### DIFF
--- a/docs/data-sources/css_vpcep_connections.md
+++ b/docs/data-sources/css_vpcep_connections.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_css_vpcep_connections"
+description: |-
+  Use this data source to get the list of endpoint connections.
+---
+
+# huaweicloud_css_vpcep_connections
+
+Use this data source to get the list of endpoint connections.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_css_vpcep_connections" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the cluster ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `connections` - The cluster VPC endpoint connection information.
+  The [connections](#connections_struct) structure is documented below.
+
+* `permissions` - The permissions of the cluster VPC endpoint whitelist.
+  The [permissions](#permissions_struct) structure is documented below.
+
+* `vpc_service_name` - The name of the VPC endpoint service.
+
+* `vpcep_update_switch` - Whether to update VPC endpoint.
+
+<a name="connections_struct"></a>
+The `connections` block supports:
+
+* `id` - The cluster VPC endpoint ID.
+
+* `status` - The cluster VPC endpoint status.
+
+* `max_session` - The maximum number of connections to a VPC endpoint.
+
+* `specification_name` - The cluster VPC endpoint name.
+
+* `created_at` - The creation time.
+
+* `update_at` - The update time.
+
+* `domain_id` - The account ID of the owner.
+
+* `vpcep_ip` - The IPv4 address of a cluster VPC endpoint.
+
+* `vpcep_ipv6_address` - The IPv6 address of a cluster VPC endpoint.
+
+* `vpcep_dns_name` - The private domain name of a cluster VPC endpoint.
+
+<a name="permissions_struct"></a>
+The `permissions` block supports:
+
+* `id` - The ID of the permission.
+
+* `permission` - The permission details for the VPCEP connection whitelist.
+
+* `permission_type` - The VPC endpoint permission type.
+
+* `created_at` - The creation time.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1027,6 +1027,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_css_resize_flavors":            css.DataSourceResizeFlavors(),
 			"huaweicloud_css_scan_tasks":                css.DataSourceCssScanTasks(),
 			"huaweicloud_css_snapshots":                 css.DataSourceCssSnapshots(),
+			"huaweicloud_css_vpcep_connections":         css.DataSourceVpcepserviceConnections(),
 
 			"huaweicloud_dataarts_studio_data_connections": dataarts.DataSourceDataConnections(),
 			"huaweicloud_dataarts_studio_workspaces":       dataarts.DataSourceDataArtsStudioWorkspaces(),

--- a/huaweicloud/services/acceptance/css/data_source_huaweicloud_css_vpcep_connections_test.go
+++ b/huaweicloud/services/acceptance/css/data_source_huaweicloud_css_vpcep_connections_test.go
@@ -1,0 +1,51 @@
+package css
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceVpcepserviceConnections_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_css_vpcep_connections.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCSSClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceVpcepserviceConnections_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "connections.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "connections.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "connections.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "connections.0.max_session"),
+					resource.TestCheckResourceAttrSet(dataSource, "connections.0.specification_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "connections.0.vpcep_ip"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.permission"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.permission_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "permissions.0.created_at"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceVpcepserviceConnections_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_css_vpcep_connections" "test" {
+  cluster_id = "%s"
+}
+`, acceptance.HW_CSS_CLUSTER_ID)
+}

--- a/huaweicloud/services/css/data_source_huaweicloud_css_vpcep_connections.go
+++ b/huaweicloud/services/css/data_source_huaweicloud_css_vpcep_connections.go
@@ -1,0 +1,228 @@
+package css
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSS GET /v1.0/{project_id}/clusters/{cluster_id}/vpcepservice/connections
+func DataSourceVpcepserviceConnections() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVpcepConnectionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"connections": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"max_session": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"specification_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpcep_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpcep_ipv6_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpcep_dns_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"vpc_service_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"permissions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"permission": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"permission_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"vpcep_update_switch": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceVpcepConnectionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg               = meta.(*config.Config)
+		region            = cfg.GetRegion(d)
+		httpUrl           = "v1.0/{project_id}/clusters/{cluster_id}/vpcepservice/connections?limit={limit}"
+		clusterId         = d.Get("cluster_id").(string)
+		offset            = 0
+		limit             = 100
+		result            = make([]interface{}, 0)
+		permissions       = make([]interface{}, 0)
+		vpcServiceName    = ""
+		vpcepUpdateSwitch bool
+	)
+
+	client, err := cfg.NewServiceClient("css", region)
+	if err != nil {
+		return diag.Errorf("error creating CSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
+	getPath = strings.ReplaceAll(getPath, "{limit}", strconv.Itoa(limit))
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", getPath, offset)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving endpoint connections: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		vpcServiceName = utils.PathSearch("vpcServiceName", getRespBody, "").(string)
+		vpcepUpdateSwitch = utils.PathSearch("vpcepUpdateSwitch", getRespBody, false).(bool)
+		permissions = utils.PathSearch("permissions", getRespBody, make([]interface{}, 0)).([]interface{})
+		connections := utils.PathSearch("connections", getRespBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, connections...)
+		if len(connections) < limit {
+			break
+		}
+
+		offset += len(connections)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("vpc_service_name", vpcServiceName),
+		d.Set("vpcep_update_switch", vpcepUpdateSwitch),
+		d.Set("connections", flattenVpcepserviceConnections(result)),
+		d.Set("permissions", flattenVpcepservicePermissions(permissions)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenVpcepserviceConnections(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"id":                 utils.PathSearch("id", v, nil),
+			"status":             utils.PathSearch("status", v, nil),
+			"max_session":        utils.PathSearch("maxSession", v, nil),
+			"specification_name": utils.PathSearch("specificationName", v, nil),
+			"created_at":         utils.PathSearch("created_at", v, nil),
+			"update_at":          utils.PathSearch("update_at", v, nil),
+			"domain_id":          utils.PathSearch("domain_id", v, nil),
+			"vpcep_ip":           utils.PathSearch("vpcepIp", v, nil),
+			"vpcep_ipv6_address": utils.PathSearch("vpcepIpv6Address", v, nil),
+			"vpcep_dns_name":     utils.PathSearch("vpcepDnsName", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenVpcepservicePermissions(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"id":              utils.PathSearch("id", v, nil),
+			"permission":      utils.PathSearch("permission", v, nil),
+			"permission_type": utils.PathSearch("permission_type", v, nil),
+			"created_at":      utils.PathSearch("created_at", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get the list of endpoint connections.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccDataSourceVpcepserviceConnections_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccDataSourceVpcepserviceConnections_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceVpcepserviceConnections_basic
=== PAUSE TestAccDataSourceVpcepserviceConnections_basic
=== CONT  TestAccDataSourceVpcepserviceConnections_basic
--- PASS: TestAccDataSourceVpcepserviceConnections_basic (21.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       21.899s
```
<img width="1208" height="23" alt="image" src="https://github.com/user-attachments/assets/2d5abc1f-ea5d-4650-aca3-65892de70792" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
