### PR TITLE
refactor(organizations): optimize codes and docs for invite account

### DIFF
--- a/docs/data-sources/organizations_received_invitations.md
+++ b/docs/data-sources/organizations_received_invitations.md
@@ -3,12 +3,12 @@ subcategory: "Organizations"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_organizations_received_invitations"
 description: |-
-  Use this data source to get the list of received invitations.
+  Use this data source to get the list of received invitations within HuaweiCloud.
 ---
 
 # huaweicloud_organizations_received_invitations
 
-Use this data source to get the list of received invitations.
+Use this data source to get the list of received invitations within HuaweiCloud.
 
 ## Example Usage
 
@@ -20,7 +20,7 @@ data "huaweicloud_organizations_received_invitations" "test"{}
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the resource.
+* `region` - (Optional, String) Specifies the region where the received invitations are located.  
   If omitted, the provider-level region will be used.
 
 ## Attribute Reference
@@ -41,7 +41,11 @@ The `handshakes` block supports:
 * `urn` - Indicates the uniform resource name of the invitation (handshake).
 
 * `status` - Indicates the current state of the invitation (handshake).
-  It can be **pending**, **accepted**, **cancelled**, **declined**, or **expired**.
+  + **pending**
+  + **accepted**
+  + **cancelled**
+  + **declined**
+  + **expired**
 
 * `organization_id` - Indicates the unique ID of an organization.
 
@@ -49,22 +53,19 @@ The `handshakes` block supports:
 
 * `management_account_name` - Indicates the name of the organization's management account.
 
-* `target` - Indicates the unique ID of the invited account.
+* `target` - Indicates the target information of the invited account.
 
   The [target](#handshakes_target_struct) structure is documented below.
 
 * `created_at` - Indicates the date and time when an invitation (handshake) request was made.
 
 * `updated_at` - Indicates the date and time when an invitation (handshake) request was updated.
-  The update method can be **accepted**, **canceled**, **declined**, or **expired**.
 
 * `notes` - Indicates the additional information that you want to include in the email to the recipient account owner.
 
 <a name="handshakes_target_struct"></a>
 The `target` block supports:
 
-* `type` - Indicates the type of the invited account. It can be account or email.
+* `type` - Indicates the type of the invited account.
 
-* `entity` - Indicates the value of the invited account.
-  + If you choose **type:account**, you must provide the account ID.
-  + If you choose **type:email**, you must specify the email address that is associated with the account.
+* `entity` - Indicates the ID of the invited account.

--- a/docs/data-sources/organizations_sent_invitations.md
+++ b/docs/data-sources/organizations_sent_invitations.md
@@ -3,12 +3,12 @@ subcategory: "Organizations"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_organizations_sent_invitations"
 description: |-
-  Use this data source to get the list of sent invitations.
+  Use this data source to get the list of sent invitations within HuaweiCloud.
 ---
 
 # huaweicloud_organizations_sent_invitations
 
-Use this data source to get the list of sent invitations.
+Use this data source to get the list of sent invitations within HuaweiCloud.
 
 ## Example Usage
 
@@ -20,7 +20,7 @@ data "huaweicloud_organizations_sent_invitations" "test"{}
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the resource.
+* `region` - (Optional, String) Specifies the region where the sent invitations are located.  
   If omitted, the provider-level region will be used.
 
 ## Attribute Reference
@@ -41,7 +41,11 @@ The `handshakes` block supports:
 * `urn` - Indicates the uniform resource name of the invitation (handshake).
 
 * `status` - Indicates the current state of the invitation (handshake).
-  It can be **pending**, **accepted**, **cancelled**, **declined**, or **expired**.
+  + **pending**
+  + **accepted**
+  + **cancelled**
+  + **declined**
+  + **expired**
 
 * `organization_id` - Indicates the unique ID of an organization.
 
@@ -49,22 +53,19 @@ The `handshakes` block supports:
 
 * `management_account_name` - Indicates the name of the organization's management account.
 
-* `target` - Indicates the unique ID of the invited account.
+* `target` - Indicates the target information to be invited.
 
   The [target](#handshakes_target_struct) structure is documented below.
 
 * `created_at` - Indicates the date and time when an invitation (handshake) request was made.
 
 * `updated_at` - Indicates the date and time when an invitation (handshake) request was updated.
-  The update method can be **accepted**, **canceled**, **declined**, or **expired**.
 
-* `notes` - Indicates the additional information that you want to include in the email to the recipient account owner.
+* `notes` - Indicates the additional information included in the email to the recipient account owner.
 
 <a name="handshakes_target_struct"></a>
 The `target` block supports:
 
-* `type` - Indicates the type of the invited account. It can be account or email.
+* `type` - Indicates the type of the account.
 
-* `entity` - Indicates the value of the invited account.
-  + If you choose **type:account**, you must provide the account ID.
-  + If you choose **type:email**, you must specify the email address that is associated with the account.
+* `entity` - Indicates the ID of the account.

--- a/docs/resources/organizations_account_invite.md
+++ b/docs/resources/organizations_account_invite.md
@@ -2,7 +2,8 @@
 subcategory: "Organizations"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_organizations_account_invite"
-description: ""
+description: |-
+  Manages an Organizations account invite resource within HuaweiCloud.
 ---
 
 # huaweicloud_organizations_account_invite
@@ -12,7 +13,7 @@ Manages an Organizations account invite resource within HuaweiCloud.
 ## Example Usage
 
 ```hcl
-variable account_id {}
+variable "account_id" {}
 
 resource "huaweicloud_organizations_account_invite" "test"{
   account_id = var.account_id
@@ -28,7 +29,8 @@ The following arguments are supported:
   Changing this parameter will create a new resource.
 
 * `remove_account_on_destroy` - (Optional, Bool) Specifies whether to remove the invited account when delete the
-  invitation (handshake). Defaults to false.
+  invitation (handshake).  
+  Defaults to **false**.
 
 ## Attribute Reference
 
@@ -50,6 +52,8 @@ In addition to all arguments above, the following attributes are exported:
   declined, or expired.
 
 * `status` - Indicates the current state of the invitation (handshake).
+  + **active**
+  + **cancelled**
 
 ## Import
 

--- a/docs/resources/organizations_account_invite_accepter.md
+++ b/docs/resources/organizations_account_invite_accepter.md
@@ -2,7 +2,8 @@
 subcategory: "Organizations"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_organizations_account_invite_accepter"
-description: ""
+description: |-
+  Manages an Organizations account invite accepter resource within HuaweiCloud.
 ---
 
 # huaweicloud_organizations_account_invite_accepter
@@ -12,7 +13,7 @@ Manages an Organizations account invite accepter resource within HuaweiCloud.
 ## Example Usage
 
 ```hcl
-variable invitation_id {}
+variable "invitation_id" {}
 
 resource "huaweicloud_organizations_account_invite_accepter" "test"{
   invitation_id = var.invitation_id
@@ -28,7 +29,8 @@ The following arguments are supported:
   Changing this parameter will create a new resource.
 
 * `leave_organization_on_destroy` - (Optional, Bool) Specifies whether to leave the organization when delete the
-  invitation (handshake). Defaults to false.
+  invitation (handshake).  
+  Defaults to **false**.
 
 ## Attribute Reference
 

--- a/docs/resources/organizations_account_invite_decliner.md
+++ b/docs/resources/organizations_account_invite_decliner.md
@@ -3,17 +3,21 @@ subcategory: "Organizations"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_organizations_account_invite_decliner"
 description: |-
-  Manages an Organizations account invite decliner resource within HuaweiCloud.
+  Use this resource to decline the received Organizations account invitation within HuaweiCloud.
 ---
 
 # huaweicloud_organizations_account_invite_decliner
 
-Manages an Organizations account invite decliner resource within HuaweiCloud.
+Use this resource to decline the received Organizations account invitation within HuaweiCloud.
+
+-> This resource is only a one-time action resource for declining the received account invitation. Deleting this
+   resource will not decline the received account invitation, but will only remove the resource information from the
+   tfstate file.
 
 ## Example Usage
 
 ```hcl
-variable invitation_id {}
+variable "invitation_id" {}
 
 resource "huaweicloud_organizations_account_invite_decliner" "test"{
   invitation_id = var.invitation_id

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2553,11 +2553,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_organizations_policies":                 organizations.DataSourcePolicies(),
 			"huaweicloud_organizations_policy_attached_entities": organizations.DataSourceOrganizationsPolicyAttachedEntities(),
 			"huaweicloud_organizations_quotas":                   organizations.DataSourceOrganizationsQuotas(),
-			"huaweicloud_organizations_received_invitations":     organizations.DataSourceOrganizationsReceivedInvitations(),
+			"huaweicloud_organizations_received_invitations":     organizations.DataSourceReceivedInvitations(),
 			"huaweicloud_organizations_resource_instances":       organizations.DataSourceOrganizationsResourceInstances(),
 			"huaweicloud_organizations_resource_tags":            organizations.DataSourceOrganizationsTags(),
 			"huaweicloud_organizations_services":                 organizations.DataSourceOrganizationsServices(),
-			"huaweicloud_organizations_sent_invitations":         organizations.DataSourceOrganizationsSentInvitations(),
+			"huaweicloud_organizations_sent_invitations":         organizations.DataSourceSentInvitations(),
 			"huaweicloud_organizations_tag_policy_services":      organizations.DataSourceOrganizationsTagPolicyServices(),
 			"huaweicloud_organizations_trusted_services":         organizations.DataSourceTrustedServices(),
 

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_accepter_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_accepter_test.go
@@ -2,44 +2,23 @@ package organizations
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations"
 )
 
 func getAccountInviteAccepterResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	// getAccountInviteAccepter: Query Organizations account invite accepter
-	var (
-		region                          = acceptance.HW_REGION_NAME
-		getAccountInviteAccepterHttpUrl = "v1/organizations/handshakes/{handshake_id}"
-		getAccountInviteAccepterProduct = "organizations"
-	)
-	getAccountInviteAccepterClient, err := cfg.NewServiceClient(getAccountInviteAccepterProduct, region)
+	getAccountInviteAccepterClient, err := cfg.NewServiceClient("organizations", acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Organizations Client: %s", err)
+		return nil, fmt.Errorf("error creating Organizations client: %s", err)
 	}
 
-	getAccountInviteAccepterPath := getAccountInviteAccepterClient.Endpoint + getAccountInviteAccepterHttpUrl
-	getAccountInviteAccepterPath = strings.ReplaceAll(getAccountInviteAccepterPath, "{handshake_id}",
-		state.Primary.ID)
-
-	getAccountInviteAccepterOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	getAccountInviteAccepterResp, err := getAccountInviteAccepterClient.Request("GET",
-		getAccountInviteAccepterPath, &getAccountInviteAccepterOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving AccountInviteAccepter: %s", err)
-	}
-	return utils.FlattenResponse(getAccountInviteAccepterResp)
+	return organizations.GetAccountInviteById(getAccountInviteAccepterClient, state.Primary.ID)
 }
 
 func TestAccAccountInviteAccepter_basic(t *testing.T) {

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_test.go
@@ -2,73 +2,23 @@ package organizations
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations"
 )
 
 func getAccountInviteResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	// getAccountInvite: Query Organizations account invite
-	var (
-		region                  = acceptance.HW_REGION_NAME
-		getAccountHttpUrl       = "v1/organizations/accounts/{account_id}"
-		getAccountInviteHttpUrl = "v1/organizations/handshakes/{handshake_id}"
-		getAccountInviteProduct = "organizations"
-	)
-	getAccountInviteClient, err := cfg.NewServiceClient(getAccountInviteProduct, region)
+	client, err := cfg.NewServiceClient("organizations", acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Organizations Client: %s", err)
+		return nil, fmt.Errorf("error creating Organizations client: %s", err)
 	}
 
-	getAccountInvitePath := getAccountInviteClient.Endpoint + getAccountInviteHttpUrl
-	getAccountInvitePath = strings.ReplaceAll(getAccountInvitePath, "{handshake_id}", state.Primary.ID)
-
-	getAccountInviteOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	getAccountInviteResp, err := getAccountInviteClient.Request("GET", getAccountInvitePath,
-		&getAccountInviteOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving AccountInvite: %s", err)
-	}
-
-	getAccountInviteRespBody, err := utils.FlattenResponse(getAccountInviteResp)
-	if err != nil {
-		return nil, err
-	}
-
-	status := utils.PathSearch("handshake.status", getAccountInviteRespBody, "")
-	if status == "cancelled" || status == "expired" {
-		return nil, fmt.Errorf("failed to get Organizations AccountInvite")
-	}
-
-	accountID := utils.PathSearch("handshake.target.entity", getAccountInviteRespBody, "")
-
-	// the handshake will always exist, so it is necessary to check whether the account can be obtained if the
-	// status is accepted
-	if status == "accepted" {
-		getAccountPath := getAccountInviteClient.Endpoint + getAccountHttpUrl
-		getAccountPath = strings.ReplaceAll(getAccountPath, "{account_id}", accountID.(string))
-
-		getAccountOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-		}
-		_, err = getAccountInviteClient.Request("GET", getAccountPath, &getAccountOpt)
-
-		if err != nil {
-			return nil, fmt.Errorf("failed to get Organizations AccountInvite")
-		}
-	}
-
-	return getAccountInviteRespBody, nil
+	return organizations.GetAccountInvite(client, state.Primary.ID)
 }
 
 func TestAccAccountInvite_basic(t *testing.T) {

--- a/huaweicloud/services/organizations/data_source_huaweicloud_organizations_received_invitations.go
+++ b/huaweicloud/services/organizations/data_source_huaweicloud_organizations_received_invitations.go
@@ -15,68 +15,68 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/schemas"
 )
 
-func DataSourceOrganizationsReceivedInvitations() *schema.Resource {
+func DataSourceReceivedInvitations() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceOrganizationsReceivedInvitationsRead,
+		ReadContext: dataSourceReceivedInvitationsRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+				Description: `The region where the received invitations are located.`,
 			},
 			"handshakes": {
 				Type:        schema.TypeList,
 				Computed:    true,
-				Description: `Indicates the list of invitations (handshakes).`,
+				Description: `The list of invitations (handshakes).`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the unique ID of an invitation (handshake).`,
+							Description: `The unique ID of an invitation (handshake).`,
 						},
 						"urn": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the uniform resource name of the invitation (handshake).`,
+							Description: `The uniform resource name of the invitation (handshake).`,
 						},
 						"status": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the current state of the invitation (handshake).`,
+							Description: `The current state of the invitation (handshake).`,
 						},
 						"organization_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the unique ID of an organization.`,
+							Description: `The unique ID of an organization.`,
 						},
 						"management_account_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the unique ID of the organization's management account.`,
+							Description: `The unique ID of the organization's management account.`,
 						},
 						"management_account_name": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the name of the organization's management account.`,
+							Description: `The name of the organization's management account.`,
 						},
 						"target": {
 							Type:        schema.TypeList,
 							Computed:    true,
-							Description: `Indicates the unique ID of the invited account.`,
+							Description: `The target information of the invited account.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"type": {
 										Type:        schema.TypeString,
 										Computed:    true,
-										Description: `Indicates the type of the invited account. It can be account or email.`,
+										Description: `The type of the invited account.`,
 									},
 									"entity": {
 										Type:        schema.TypeString,
 										Computed:    true,
-										Description: `Indicates the value of the invited account.`,
+										Description: `The ID of the invited account.`,
 									},
 								},
 							},
@@ -84,17 +84,17 @@ func DataSourceOrganizationsReceivedInvitations() *schema.Resource {
 						"created_at": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the date and time when an invitation (handshake) request was made.`,
+							Description: `The date and time when an invitation (handshake) request was made.`,
 						},
 						"updated_at": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the date and time when an invitation (handshake) request was updated.`,
+							Description: `The date and time when an invitation (handshake) request was updated.`,
 						},
 						"notes": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the additional information that you want to include in the email to the recipient account owner.`,
+							Description: `The additional information that you want to include in the email to the recipient account owner.`,
 						},
 					},
 				},
@@ -115,7 +115,7 @@ func newReceivedInvitationsDSWrapper(d *schema.ResourceData, meta interface{}) *
 	}
 }
 
-func dataSourceOrganizationsReceivedInvitationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceReceivedInvitationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	wrapper := newReceivedInvitationsDSWrapper(d, meta)
 	lisRecHanRst, err := wrapper.ListReceivedHandshakes()
 	if err != nil {

--- a/huaweicloud/services/organizations/data_source_huaweicloud_organizations_sent_invitations.go
+++ b/huaweicloud/services/organizations/data_source_huaweicloud_organizations_sent_invitations.go
@@ -15,68 +15,68 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/schemas"
 )
 
-func DataSourceOrganizationsSentInvitations() *schema.Resource {
+func DataSourceSentInvitations() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceOrganizationsSentInvitationsRead,
+		ReadContext: dataSourceSentInvitationsRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+				Description: `The region where the sent invitations are located.`,
 			},
 			"handshakes": {
 				Type:        schema.TypeList,
 				Computed:    true,
-				Description: `Indicates the list of invitations (handshakes).`,
+				Description: `The list of invitations (handshakes).`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the unique ID of an invitation (handshake).`,
+							Description: `The unique ID of an invitation (handshake).`,
 						},
 						"urn": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the uniform resource name of the invitation (handshake).`,
+							Description: `The uniform resource name of the invitation (handshake).`,
 						},
 						"status": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the current state of the invitation (handshake).`,
+							Description: `The current state of the invitation (handshake).`,
 						},
 						"organization_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the unique ID of an organization.`,
+							Description: `The unique ID of an organization.`,
 						},
 						"management_account_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the unique ID of the organization's management account.`,
+							Description: `The unique ID of the organization's management account.`,
 						},
 						"management_account_name": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the name of the organization's management account.`,
+							Description: `The name of the organization's management account.`,
 						},
 						"target": {
 							Type:        schema.TypeList,
 							Computed:    true,
-							Description: `Indicates the unique ID of the invited account.`,
+							Description: `The target information to be invited.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"type": {
 										Type:        schema.TypeString,
 										Computed:    true,
-										Description: `Indicates the type of the invited account. It can be account or email.`,
+										Description: `The type of the account.`,
 									},
 									"entity": {
 										Type:        schema.TypeString,
 										Computed:    true,
-										Description: `Indicates the value of the invited account.`,
+										Description: `The ID of the account.`,
 									},
 								},
 							},
@@ -84,17 +84,17 @@ func DataSourceOrganizationsSentInvitations() *schema.Resource {
 						"created_at": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the date and time when an invitation (handshake) request was made.`,
+							Description: `The date and time when an invitation (handshake) request was made.`,
 						},
 						"updated_at": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the date and time when an invitation (handshake) request was updated.`,
+							Description: `The date and time when an invitation (handshake) request was updated.`,
 						},
 						"notes": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Indicates the additional information that you want to include in the email to the recipient account owner.`,
+							Description: `The additional information included in the email to the recipient account owner.`,
 						},
 					},
 				},
@@ -115,7 +115,7 @@ func newSentInvitationsDSWrapper(d *schema.ResourceData, meta interface{}) *Sent
 	}
 }
 
-func dataSourceOrganizationsSentInvitationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSentInvitationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	wrapper := newSentInvitationsDSWrapper(d, meta)
 	listHandshakesRst, err := wrapper.ListHandshakes()
 	if err != nil {

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite.go
@@ -1,8 +1,3 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product Organizations
-// ---------------------------------------------------------------
-
 package organizations
 
 import (
@@ -21,11 +16,17 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API Organizations POST /v1/organizations/accounts/{account_id}/remove
+var (
+	accountInviteNotFoundErrCodes = []string{
+		"Organizations.1401", // The invitation has been canceled.
+	}
+)
+
 // @API Organizations POST /v1/organizations/accounts/invite
-// @API Organizations GET /v1/organizations/accounts/{account_id}
 // @API Organizations GET /v1/organizations/handshakes/{handshake_id}
+// @API Organizations GET /v1/organizations/accounts/{account_id}
 // @API Organizations POST /v1/organizations/handshakes/{handshake_id}/cancel
+// @API Organizations POST /v1/organizations/accounts/{account_id}/remove
 func ResourceAccountInvite() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceAccountInviteCreate,
@@ -41,85 +42,79 @@ func ResourceAccountInvite() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: `Specifies the ID of the target account.`,
+				Description: `The ID of the target account.`,
 			},
 			"remove_account_on_destroy": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: `Specifies whether to remove the invited account when delete the invitation (handshake).`,
+				Description: `Whether to remove the invited account when delete the invitation (handshake).`,
 			},
 			"urn": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the uniform resource name of the invitation`,
+				Description: `The uniform resource name of the invitation`,
 			},
 			"master_account_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the unique ID of the organization's management account.`,
+				Description: `The unique ID of the organization's management account.`,
 			},
 			"master_account_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the name of the organization's management account.`,
+				Description: `The name of the organization's management account.`,
 			},
 			"organization_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the ID of the organization.`,
+				Description: `The ID of the organization.`,
 			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the date and time when an invitation (handshake) request was made.`,
+				Description: `The date and time when an invitation (handshake) request was made.`,
 			},
 			"updated_at": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Description: `Indicates the date and time when an invitation (handshake) request was accepted,
+				Description: `The date and time when an invitation (handshake) request was accepted,
 canceled, declined, or expired.`,
 			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the current state of the invitation (handshake).`,
+				Description: `The current state of the invitation (handshake).`,
 			},
 		},
 	}
 }
 
 func resourceAccountInviteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// createAccountInvite: create Organizations account invite
 	var (
-		createAccountInviteHttpUrl = "v1/organizations/accounts/invite"
-		createAccountInviteProduct = "organizations"
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1/organizations/accounts/invite"
 	)
-	createAccountInviteClient, err := cfg.NewServiceClient(createAccountInviteProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	createAccountInvitePath := createAccountInviteClient.Endpoint + createAccountInviteHttpUrl
-
-	createAccountInviteOpt := golangsdk.RequestOpts{
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		JSONBody:         buildCreateAccountInviteBodyParams(d),
 	}
-	createAccountInviteOpt.JSONBody = buildCreateAccountInviteBodyParams(d)
-	createAccountInviteResp, err := createAccountInviteClient.Request("POST", createAccountInvitePath,
-		&createAccountInviteOpt)
+	resp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
-		return diag.Errorf("error creating AccountInvite: %s", err)
+		return diag.Errorf("error inviting the account (%s) to join the organization: %s", d.Get("account_id").(string), err)
 	}
 
-	createAccountInviteRespBody, err := utils.FlattenResponse(createAccountInviteResp)
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	handshakeId := utils.PathSearch("handshake.id", createAccountInviteRespBody, "").(string)
+	handshakeId := utils.PathSearch("handshake.id", respBody, "").(string)
 	if handshakeId == "" {
 		return diag.Errorf("unable to find the Organizations account invite ID from the API response")
 	}
@@ -146,85 +141,111 @@ func buildCreateAccountInviteTargetChildBody(d *schema.ResourceData) map[string]
 
 func resourceAccountInviteRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	var mErr *multierror.Error
-
-	// getAccountInvite: Query Organizations account invite
-	getAccountInviteProduct := "organizations"
-	getAccountInviteClient, err := cfg.NewServiceClient(getAccountInviteProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	getAccountInviteRespBody, err := getAccountInvite(getAccountInviteClient, d.Id())
+	handshake, err := GetAccountInvite(client, d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving AccountInvite")
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+			"error retrieving account invitation",
+		)
 	}
 
-	handshake := utils.PathSearch("handshake", getAccountInviteRespBody, nil)
-	if handshake == nil {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
-	}
-
-	status := utils.PathSearch("status", handshake, "")
-	if status == "cancelled" || status == "expired" {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
-	}
-
-	accountID := utils.PathSearch("target.entity", handshake, "").(string)
-
-	// the handshake will always exist, so it is necessary to check whether the account can be obtained if the
-	// status is accepted
-	if status == "accepted" {
-		getAccountHttpUrl := "v1/organizations/accounts/{account_id}"
-		getAccountPath := getAccountInviteClient.Endpoint + getAccountHttpUrl
-		getAccountPath = strings.ReplaceAll(getAccountPath, "{account_id}", accountID)
-
-		getAccountOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-		}
-		_, err = getAccountInviteClient.Request("GET", getAccountPath, &getAccountOpt)
-
-		if err != nil {
-			return common.CheckDeletedDiag(d, err, "error retrieving AccountInvite")
-		}
-	}
-
-	mErr = multierror.Append(
-		mErr,
+	mErr := multierror.Append(
 		d.Set("urn", utils.PathSearch("urn", handshake, nil)),
-		d.Set("account_id", accountID),
+		d.Set("account_id", utils.PathSearch("target.entity", handshake, "").(string)),
 		d.Set("master_account_id", utils.PathSearch("management_account_id", handshake, nil)),
 		d.Set("master_account_name", utils.PathSearch("management_account_name", handshake, nil)),
 		d.Set("organization_id", utils.PathSearch("organization_id", handshake, nil)),
 		d.Set("created_at", utils.PathSearch("created_at", handshake, nil)),
 		d.Set("updated_at", utils.PathSearch("updated_at", handshake, nil)),
-		d.Set("status", status),
+		d.Set("status", utils.PathSearch("status", handshake, "").(string)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func getAccountInvite(client *golangsdk.ServiceClient, handshakeId string) (interface{}, error) {
-	// getAccountInvite: Query Organizations account invite
-	var (
-		getAccountInviteHttpUrl = "v1/organizations/handshakes/{handshake_id}"
-	)
-
-	getAccountInvitePath := client.Endpoint + getAccountInviteHttpUrl
-	getAccountInvitePath = strings.ReplaceAll(getAccountInvitePath, "{handshake_id}", handshakeId)
-
-	getAccountInviteOpt := golangsdk.RequestOpts{
+func GetAccountInviteById(client *golangsdk.ServiceClient, handshakeId string) (interface{}, error) {
+	httpUrl := "v1/organizations/handshakes/{handshake_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{handshake_id}", handshakeId)
+	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
-	getAccountInviteResp, err := client.Request("GET", getAccountInvitePath, &getAccountInviteOpt)
-
+	resp, err := client.Request("GET", getPath, &opt)
 	if err != nil {
 		return nil, err
 	}
 
-	return utils.FlattenResponse(getAccountInviteResp)
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	handshake := utils.PathSearch("handshake", respBody, nil)
+	if handshake == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/organizations/handshakes/{handshake_id}",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the invitation (%s) does not exist", handshakeId)),
+			},
+		}
+	}
+
+	return handshake, nil
+}
+
+func GetAccountInvite(client *golangsdk.ServiceClient, handshakeId string) (interface{}, error) {
+	handshake, err := GetAccountInviteById(client, handshakeId)
+	if err != nil {
+		return nil, err
+	}
+
+	status := utils.PathSearch("status", handshake, "").(string)
+	if status == "cancelled" || status == "expired" {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/organizations/handshakes/{handshake_id}",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the invitation (%s) has been cancelled or expired", handshakeId)),
+			},
+		}
+	}
+
+	// the handshake will always exist, so it is necessary to check whether the account can be obtained if the
+	// status is accepted.
+	if status == "accepted" {
+		_, err = getAccountById(client, utils.PathSearch("target.entity", handshake, "").(string))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return handshake, nil
+}
+
+func getAccountById(client *golangsdk.ServiceClient, accountId string) (interface{}, error) {
+	httpUrl := "v1/organizations/accounts/{account_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{account_id}", accountId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	resp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
 }
 
 func resourceAccountInviteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
@@ -233,65 +254,56 @@ func resourceAccountInviteUpdate(_ context.Context, _ *schema.ResourceData, _ in
 
 func resourceAccountInviteDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// deleteAccountInvite: Delete Organizations account invite
-	var (
-		deleteAccountInviteProduct = "organizations"
-	)
-	deleteAccountInviteClient, err := cfg.NewServiceClient(deleteAccountInviteProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
 	status := d.Get("status")
 	if status == "pending" {
-		err = cancelAccountInvite(deleteAccountInviteClient, d.Id())
-		if err != nil {
-			return diag.FromErr(err)
+		invitationId := d.Id()
+		if err = cancelAccountInvite(client, invitationId); err != nil {
+			return common.CheckDeletedDiag(
+				d,
+				common.ConvertExpected400ErrInto404Err(
+					common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+					"error_code",
+					accountInviteNotFoundErrCodes...,
+				),
+				fmt.Sprintf("error canceling account invitation (%s)", invitationId),
+			)
 		}
 	} else if status == "accepted" && d.Get("remove_account_on_destroy").(bool) {
-		err = removeAccountInvite(deleteAccountInviteClient, d.Get("account_id").(string))
-		if err != nil {
-			return diag.FromErr(err)
+		accountId := d.Get("account_id").(string)
+		if err = removeAccountInvite(client, accountId); err != nil {
+			return common.CheckDeletedDiag(d,
+				common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+				fmt.Sprintf("error removing account (%s) from the organization", accountId))
 		}
 	}
+
 	return nil
 }
 
 func cancelAccountInvite(client *golangsdk.ServiceClient, handshakeId string) error {
-	// cancelAccountInvite: cancel Organizations account invite
-	var (
-		cancelAccountInviteHttpUrl = "v1/organizations/handshakes/{handshake_id}/cancel"
-	)
-	cancelAccountInvitePath := client.Endpoint + cancelAccountInviteHttpUrl
-	cancelAccountInvitePath = strings.ReplaceAll(cancelAccountInvitePath, "{handshake_id}", handshakeId)
+	httpUrl := "v1/organizations/handshakes/{handshake_id}/cancel"
+	cancelPath := client.Endpoint + httpUrl
+	cancelPath = strings.ReplaceAll(cancelPath, "{handshake_id}", handshakeId)
 
-	cancelAccountInviteOpt := golangsdk.RequestOpts{
+	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
-	_, err := client.Request("POST", cancelAccountInvitePath, &cancelAccountInviteOpt)
-	if err != nil {
-		return fmt.Errorf("error canceling AccountInvite: %s", err)
-	}
-	return nil
+	_, err := client.Request("POST", cancelPath, &opt)
+	return err
 }
 
 func removeAccountInvite(client *golangsdk.ServiceClient, accountId string) error {
-	// removeAccount: Remove Organizations account
-	var (
-		removeAccountHttpUrl = "v1/organizations/accounts/{account_id}/remove"
-	)
-
-	removeAccountPath := client.Endpoint + removeAccountHttpUrl
-	removeAccountPath = strings.ReplaceAll(removeAccountPath, "{account_id}", accountId)
-
-	removeAccountOpt := golangsdk.RequestOpts{
+	httpUrl := "v1/organizations/accounts/{account_id}/remove"
+	removePath := client.Endpoint + httpUrl
+	removePath = strings.ReplaceAll(removePath, "{account_id}", accountId)
+	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
-	_, err := client.Request("POST", removeAccountPath, &removeAccountOpt)
-	if err != nil {
-		return fmt.Errorf("error removing Account: %s", err)
-	}
-	return nil
+	_, err := client.Request("POST", removePath, &opt)
+	return err
 }

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_accepter.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_accepter.go
@@ -1,13 +1,7 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product Organizations
-// ---------------------------------------------------------------
-
 package organizations
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -21,9 +15,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+// @API Organizations POST /v1/received-handshakes/{handshake_id}/accept
 // @API Organizations GET /v1/organizations/handshakes/{handshake_id}
 // @API Organizations POST /v1/organizations/leave
-// @API Organizations POST /v1/received-handshakes/{handshake_id}/accept
 func ResourceAccountInviteAccepter() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceAccountInviteAccepterCreate,
@@ -39,92 +33,85 @@ func ResourceAccountInviteAccepter() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: `Specifies the unique ID of an invitation (handshake).`,
+				Description: `The unique ID of an invitation (handshake).`,
 			},
 			"leave_organization_on_destroy": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: `Specifies whether to leave the organization when delete the invitation (handshake).`,
+				Description: `Whether to leave the organization when delete the invitation (handshake).`,
 			},
 			"urn": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the uniform resource name of the invitation`,
+				Description: `The uniform resource name of the invitation`,
 			},
 			"account_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the ID of the target account.`,
+				Description: `The ID of the target account.`,
 			},
 			"master_account_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the unique ID of the organization's management account.`,
+				Description: `The unique ID of the organization's management account.`,
 			},
 			"master_account_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the name of the organization's management account.`,
+				Description: `The name of the organization's management account.`,
 			},
 			"organization_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the ID of the organization.`,
+				Description: `The ID of the organization.`,
 			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the date and time when an invitation (handshake) request was made.`,
+				Description: `The date and time when an invitation (handshake) request was made.`,
 			},
 			"updated_at": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Description: `Indicates the date and time when an invitation (handshake) request was accepted,
+				Description: `The date and time when an invitation (handshake) request was accepted,
 cancelled, declined, or expired.`,
 			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the current state of the invitation (handshake).`,
+				Description: `The current state of the invitation (handshake).`,
 			},
 		},
 	}
 }
 
 func resourceAccountInviteAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// createAccountInviteAccepter: create Organizations account invite accepter
 	var (
-		createAccountInviteAccepterHttpUrl = "v1/received-handshakes/{handshake_id}/accept"
-		createAccountInviteAccepterProduct = "organizations"
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1/received-handshakes/{handshake_id}/accept"
 	)
-	createAccountInviteAccepterClient, err := cfg.NewServiceClient(createAccountInviteAccepterProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	createAccountInviteAccepterPath := createAccountInviteAccepterClient.Endpoint + createAccountInviteAccepterHttpUrl
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{handshake_id}", d.Get("invitation_id").(string))
 
-	createAccountInviteAccepterPath = strings.ReplaceAll(createAccountInviteAccepterPath, "{handshake_id}",
-		fmt.Sprintf("%v", d.Get("invitation_id")))
-
-	createAccountInviteAccepterOpt := golangsdk.RequestOpts{
+	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
-	createAccountInviteAccepterResp, err := createAccountInviteAccepterClient.Request("POST",
-		createAccountInviteAccepterPath, &createAccountInviteAccepterOpt)
+	resp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
-		return diag.Errorf("error creating AccountInviteAccepter: %s", err)
+		return diag.Errorf("error accepting the received account invitation: %s", err)
 	}
 
-	createAccountInviteAccepterRespBody, err := utils.FlattenResponse(createAccountInviteAccepterResp)
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	handshakeId := utils.PathSearch("handshake.id", createAccountInviteAccepterRespBody, "").(string)
+	handshakeId := utils.PathSearch("handshake.id", respBody, "").(string)
 	if handshakeId == "" {
 		return diag.Errorf("unable to find the handshake ID of the Organizations account invite accepter from the API response")
 	}
@@ -135,32 +122,24 @@ func resourceAccountInviteAccepterCreate(ctx context.Context, d *schema.Resource
 
 func resourceAccountInviteAccepterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	var mErr *multierror.Error
-
-	// getAccountInviteAccepter: Query Organizations account invite accepter
-	var (
-		getAccountInviteAccepterProduct = "organizations"
-	)
-	getAccountInviteAccepterClient, err := cfg.NewServiceClient(getAccountInviteAccepterProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	getAccountInviteAccepterRespBody, err := getAccountInvite(getAccountInviteAccepterClient, d.Id())
+	invitationId := d.Id()
+	handshake, err := GetAccountInviteById(client, invitationId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving AccountInvite")
+		return common.CheckDeletedDiag(
+			d,
+			// After accepting the invitation, leave the organization.
+			common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+			"error retrieving received account invitation",
+		)
 	}
 
-	handshake := utils.PathSearch("handshake", getAccountInviteAccepterRespBody, nil)
-	if handshake == nil {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
-	}
-
-	mErr = multierror.Append(
-		mErr,
-		d.Set("invitation_id", d.Id()),
+	mErr := multierror.Append(
+		d.Set("invitation_id", invitationId),
 		d.Set("urn", utils.PathSearch("urn", handshake, nil)),
 		d.Set("account_id", utils.PathSearch("target.entity", handshake, nil)),
 		d.Set("master_account_id", utils.PathSearch("management_account_id", handshake, nil)),
@@ -179,38 +158,30 @@ func resourceAccountInviteAccepterUpdate(_ context.Context, _ *schema.ResourceDa
 }
 
 func resourceAccountInviteAccepterDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
 	if !d.Get("leave_organization_on_destroy").(bool) {
 		return nil
 	}
 
-	// deleteAccountInviteAccepter: Delete Organizations account invite accepter
-	var (
-		deleteAccountInviteAccepterHttpUrl = "v1/organizations/leave"
-		deleteAccountInviteAccepterProduct = "organizations"
-	)
-	deleteAccountInviteAccepterClient, err := cfg.NewServiceClient(deleteAccountInviteAccepterProduct, region)
+	cfg := meta.(*config.Config)
+	httpUrl := "v1/organizations/leave"
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
 	// if the value of accept is false(decline the invite), it can not be removed
-	_, err = getAccountInvite(deleteAccountInviteAccepterClient, d.Id())
+	_, err = GetAccountInviteById(client, d.Id())
 	if err != nil {
 		return nil
 	}
 
-	deleteAccountInviteAccepterPath := deleteAccountInviteAccepterClient.Endpoint + deleteAccountInviteAccepterHttpUrl
-
-	deleteAccountInviteAccepterOpt := golangsdk.RequestOpts{
+	deletePath := client.Endpoint + httpUrl
+	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
-	_, err = deleteAccountInviteAccepterClient.Request("POST", deleteAccountInviteAccepterPath,
-		&deleteAccountInviteAccepterOpt)
+	_, err = client.Request("POST", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting AccountInviteAccepter: %s", err)
+		return common.CheckDeletedDiag(d, err, "error leaving the organization")
 	}
 
 	return nil

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_decliner.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_decliner.go
@@ -25,34 +25,30 @@ func ResourceAccountInviteDecliner() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: `Specifies the unique ID of an invitation (handshake).`,
+				Description: `The unique ID of an invitation (handshake).`,
 			},
 		},
 	}
 }
 
 func resourceAccountInviteDeclinerCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
 	var (
+		cfg     = meta.(*config.Config)
 		httpUrl = "v1/received-handshakes/{handshake_id}/decline"
-		product = "organizations"
 	)
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
 	createPath := client.Endpoint + httpUrl
 	createPath = strings.ReplaceAll(createPath, "{handshake_id}", d.Get("invitation_id").(string))
-
 	createOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
 	createResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
-		return diag.Errorf("error creating Organizations account invite decliner: %s", err)
+		return diag.Errorf("error declining the received account invitation: %s", err)
 	}
 
 	createRespBody, err := utils.FlattenResponse(createResp)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The current code has the following issues and needs optimization:

- Redundant methods and variables naming
- Some error messages are inaccurate
- Some content in the documentation is inaccurately described
- Some code is not standardized
- CheckDeleted does not cover scenarios where the organization does not exist
- Some meaningless comments


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. optimize codes and documentations of the resource and data source.
2. sorting API comments according to the order of API calls in CRUD operations.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o organizations -f TestAccDataReceivedInvitations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDataReceivedInvitations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataReceivedInvitations_basic
=== PAUSE TestAccDataReceivedInvitations_basic
=== CONT  TestAccDataReceivedInvitations_basic
--- PASS: TestAccDataReceivedInvitations_basic (17.79s)
PASS
coverage: 5.4% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     17.897s coverage: 5.4% of statements in ./huaweicloud/services/organizations
```

```
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations/data_source_huaweicloud_organizations_received_invitations.go (83.3%)
```
```
./scripts/coverage.sh -o organizations -f TestAccDataSentInvitations_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDataSentInvitations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSentInvitations_basic
=== PAUSE TestAccDataSentInvitations_basic
=== CONT  TestAccDataSentInvitations_basic
--- PASS: TestAccDataSentInvitations_basic (17.85s)
PASS
coverage: 8.0% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     17.959s coverage: 8.0% of statements in ./huaweicloud/services/organizations
```

```
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations/data_source_huaweicloud_organizations_sent_invitations.go (83.3%)
```

```
 ./scripts/coverage.sh -o organizations -f TestAccAccountInvite_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccAccountInvite_basic -timeout 360m -parallel 10
=== RUN   TestAccAccountInvite_basic
=== PAUSE TestAccAccountInvite_basic
=== CONT  TestAccAccountInvite_basic
--- PASS: TestAccAccountInvite_basic (20.02s)
PASS
coverage: 6.8% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     20.125s coverage: 6.8% of statements in ./huaweicloud/services/organizations
```

```
./scripts/coverage.sh -o organizations -f TestAccAccountInviteAccepter_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccAccountInviteAccepter_basic -timeout 360m -parallel 10
=== RUN   TestAccAccountInviteAccepter_basic
=== PAUSE TestAccAccountInviteAccepter_basic
=== CONT  TestAccAccountInviteAccepter_basic
--- PASS: TestAccAccountInviteAccepter_basic (20.68s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     20.782s coverage: 6.1% of statements in ./huaweicloud/services/organizations
```
```
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_accepter.go (76.1%)
```

```
./scripts/coverage.sh -o organizations -f TestAccAccountInviteDecliner_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccAccountInviteDecliner_basic -timeout 360m -parallel 10
=== RUN   TestAccAccountInviteDecliner_basic
=== PAUSE TestAccAccountInviteDecliner_basic
=== CONT  TestAccAccountInviteDecliner_basic
--- PASS: TestAccAccountInviteDecliner_basic (16.71s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     16.812s coverage: 4.1% of statements in ./huaweicloud/services/organizations
```
```
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_decliner.go (81.8%)
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
