### PR TITLE
feat(cfw): support `cfw_delete_ip_blacklist` resource

### DIFF
--- a/docs/resources/cfw_delete_ip_blacklist.md
+++ b/docs/resources/cfw_delete_ip_blacklist.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_delete_ip_blacklist"
+description: |-
+  Manages a resource to delete the imported IP blacklist within HuaweiCloud.
+---
+
+# huaweicloud_cfw_delete_ip_blacklist
+
+Manages a resource to delete the imported IP blacklist within HuaweiCloud.
+
+-> This resource is a one-time action resource used to delete the imported IP blacklist. Deleting this resource will
+  not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+variable "effect_scope" {
+  type = list(int)
+}
+
+resource "huaweicloud_cfw_delete_ip_blacklist" "test" {
+  fw_instance_id = var.fw_instance_id
+  effect_scope   = var.effect_scope
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `fw_instance_id` - (Required, String, NonUpdatable) Specifies the firewall instance ID.
+
+* `effect_scope` - (Optional, List, NonUpdatable) Specifies the effect scope.  
+  The valid values are as follows:
+  + **1**: Specify the effective scope as EIP for deletion.
+  + **2**: Specify the effective range as NAT for deletion.
+  + **1,2**: Effective scope for deleting EIP and NAT.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `fw_instance_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2893,6 +2893,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_dns_resolution":                cfw.ResourceDNSResolution(),
 			"huaweicloud_cfw_capture_task":                  cfw.ResourceCaptureTask(),
 			"huaweicloud_cfw_ips_rule_mode_change":          cfw.ResourceCfwIpsRuleModeChange(),
+			"huaweicloud_cfw_delete_ip_blacklist":           cfw.ResourceDeleteIpBlacklist(),
 
 			"huaweicloud_cloudtable_cluster": cloudtable.ResourceCloudTableCluster(),
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_delete_ip_blacklist_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_delete_ip_blacklist_test.go
@@ -1,0 +1,35 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDeleteIpBlacklist_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDeleteIpBlacklist_basic(),
+			},
+		},
+	})
+}
+
+func testDeleteIpBlacklist_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cfw_delete_ip_blacklist" "test" {
+  fw_instance_id = "%s"
+  effect_scope   = [1, 2]
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_delete_ip_blacklist.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_delete_ip_blacklist.go
@@ -1,0 +1,122 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var deleteIpBlacklistNonUpdatableParams = []string{"fw_instance_id", "effect_scope"}
+
+// @API CFW DELETE /v1/{project_id}/ptf/ip-blacklist
+func ResourceDeleteIpBlacklist() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDeleteIpBlacklistCreate,
+		ReadContext:   resourceDeleteIpBlacklistRead,
+		UpdateContext: resourceDeleteIpBlacklistUpdate,
+		DeleteContext: resourceDeleteIpBlacklistDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(deleteIpBlacklistNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"effect_scope": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildDeleteIpBlacklistQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?fw_instance_id=%s", d.Get("fw_instance_id"))
+}
+
+func buildDeleteIpBlacklistBodyParams(d *schema.ResourceData) map[string]interface{} {
+	effectScopeInput := d.Get("effect_scope").([]interface{})
+	if len(effectScopeInput) == 0 {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"effect_scope": utils.ExpandToIntList(effectScopeInput),
+	}
+}
+
+func resourceDeleteIpBlacklistCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/ptf/ip-blacklist"
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildDeleteIpBlacklistQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildDeleteIpBlacklistBodyParams(d),
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CFW imported IP blacklist: %s", err)
+	}
+
+	d.SetId(d.Get("fw_instance_id").(string))
+
+	return nil
+}
+
+func resourceDeleteIpBlacklistRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDeleteIpBlacklistUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDeleteIpBlacklistDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to delete the imported IP blacklist. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_delete_ip_blacklist` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_delete_ip_blacklist` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDeleteIpBlacklist_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccDeleteIpBlacklist_basic -timeout 360m -parallel 4
=== RUN   TestAccDeleteIpBlacklist_basic
=== PAUSE TestAccDeleteIpBlacklist_basic
=== CONT  TestAccDeleteIpBlacklist_basic
--- PASS: TestAccDeleteIpBlacklist_basic (12.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       12.700s
```
<img width="855" height="41" alt="image" src="https://github.com/user-attachments/assets/46ea23dc-3025-4adc-8e9c-1f95c4f1179c" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
