### PR TITLE
feat(cfw): support `cfw_export_ip_blacklist` resource

### DIFF
--- a/docs/resources/cfw_export_ip_blacklist.md
+++ b/docs/resources/cfw_export_ip_blacklist.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_export_ip_blacklist"
+description: |-
+  Manages a resource to export the IP blacklist within HuaweiCloud.
+---
+
+# huaweicloud_cfw_export_ip_blacklist
+
+Manages a resource to export the IP blacklist within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource used to export the IP blacklist. Deleting this resource will
+  not clear the corresponding request record, but will only remove the resource information from the tf state file.
+  <br/>2. Before using this resource, it is necessary to ensure that the IP blacklist has been imported into the current
+  firewall instance, otherwise executing the resource will result in an error.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+
+resource "huaweicloud_cfw_export_ip_blacklist" "test" {
+  fw_instance_id = var.fw_instance_id
+  name           = "ip-blacklist-eip.txt"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `fw_instance_id` - (Required, String, NonUpdatable) Specifies the firewall instance ID.
+
+* `name` - (Required, String, NonUpdatable) Specifies the IP blacklist name.  
+  The valid values are as follows:
+  + **ip-blacklist-eip.txt**: Export IP blacklist with effect scope EIP.
+  + **ip-blacklist-nat.txt**: Export IP blacklist with effect scope NAT.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `fw_instance_id`.
+
+* `data` - The exported IP blacklist data.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2894,6 +2894,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_capture_task":                  cfw.ResourceCaptureTask(),
 			"huaweicloud_cfw_ips_rule_mode_change":          cfw.ResourceCfwIpsRuleModeChange(),
 			"huaweicloud_cfw_delete_ip_blacklist":           cfw.ResourceDeleteIpBlacklist(),
+			"huaweicloud_cfw_export_ip_blacklist":           cfw.ResourceExportIpBlacklist(),
 
 			"huaweicloud_cloudtable_cluster": cloudtable.ResourceCloudTableCluster(),
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_export_ip_blacklist_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_export_ip_blacklist_test.go
@@ -1,0 +1,35 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccExportIpBlacklist_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testExportIpBlacklist_basic(),
+			},
+		},
+	})
+}
+
+func testExportIpBlacklist_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cfw_export_ip_blacklist" "test" {
+  fw_instance_id = "%s"
+  name           = "ip-blacklist-eip.txt"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_export_ip_blacklist.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_export_ip_blacklist.go
@@ -1,0 +1,124 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var exportIpBlacklistNonUpdatableParams = []string{"fw_instance_id", "name"}
+
+// @API CFW POST /v1/{project_id}/ptf/ip-blacklist/export
+func ResourceExportIpBlacklist() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceExportIpBlacklistCreate,
+		ReadContext:   resourceExportIpBlacklistRead,
+		UpdateContext: resourceExportIpBlacklistUpdate,
+		DeleteContext: resourceExportIpBlacklistDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(exportIpBlacklistNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildExportIpBlacklistQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?fw_instance_id=%s&name=%s", d.Get("fw_instance_id"), d.Get("name"))
+}
+
+func resourceExportIpBlacklistCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/ptf/ip-blacklist/export"
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildExportIpBlacklistQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error exporting CFW IP blacklist: %s", err)
+	}
+
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return diag.Errorf("error reading export response body: %s", err)
+	}
+
+	if err := d.Set("data", string(bodyBytes)); err != nil {
+		return diag.Errorf("error setting exported IP blacklist data field: %s", err)
+	}
+
+	d.SetId(d.Get("fw_instance_id").(string))
+
+	return nil
+}
+
+func resourceExportIpBlacklistRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceExportIpBlacklistUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceExportIpBlacklistDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to export the IP blacklist. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_export_ip_blacklist` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_export_ip_blacklist` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccExportIpBlacklist_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccExportIpBlacklist_basic -timeout 360m -parallel 4
=== RUN   TestAccExportIpBlacklist_basic
=== PAUSE TestAccExportIpBlacklist_basic
=== CONT  TestAccExportIpBlacklist_basic
--- PASS: TestAccExportIpBlacklist_basic (12.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       12.308s
```
<img width="878" height="38" alt="image" src="https://github.com/user-attachments/assets/dfc0bc2c-9082-4b27-8325-0234c5d7a73d" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
