### PR TITLE
fix(dds): fix the error issue when deleting DDS instances

### DIFF
--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
@@ -138,7 +138,7 @@ func TestAccDDSV3Instance_withEpsId(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheckMigrateEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -148,7 +148,7 @@ func TestAccDDSV3Instance_withEpsId(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 			{
@@ -156,7 +156,7 @@ func TestAccDDSV3Instance_withEpsId(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
 				),
 			},
 		},
@@ -829,7 +829,7 @@ resource "huaweicloud_dds_instance" "instance" {
     foo   = "bar"
     owner = "terraform"
   }
-}`, common.TestBaseNetwork(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}`, common.TestBaseNetwork(rName), rName, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
 }
 
 func testAccDDSInstanceV3Config_baseEpsId(rName string) string {
@@ -846,7 +846,7 @@ resource "huaweicloud_dds_instance" "instance" {
   security_group_id     = huaweicloud_networking_secgroup.test.id
   password              = "Terraform@123"
   mode                  = "Sharding"
-  enterprise_project_id = "0"
+  enterprise_project_id = "%s"
 
   datastore {
     type           = "DDS-Community"
@@ -884,7 +884,7 @@ resource "huaweicloud_dds_instance" "instance" {
     foo   = "bar"
     owner = "terraform"
   }
-}`, common.TestBaseNetwork(rName), rName)
+}`, common.TestBaseNetwork(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
 func testAccDDSInstanceV3Config_prePaid(rName string) string {

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_instance_v3.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_instance_v3.go
@@ -479,6 +479,11 @@ func ddsInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID str
 		}
 		allPages, err := instances.List(client, &opts).AllPages()
 		if err != nil {
+			err = common.ConvertExpected400ErrInto404Err(err, "error_code", instanceNotFoundCodes...)
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				var instance instances.InstanceResponse
+				return instance, "deleted", nil
+			}
 			return nil, "", err
 		}
 		instancesList, err := instances.ExtractInstances(allPages)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix the error issue when deleting DDS instances.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
 the dds query API exist differences in different region when the instance is not exist.
in some regions, the response code is 200, such as cn-north-4; in other regions, the response code is 400, such as cn-south-4
<img width="1474" height="184" alt="south-0" src="https://github.com/user-attachments/assets/7773e425-50ae-4073-8460-bda4c179aacf" />

**Special notes for your reviewer**:
The fixed result:
1.cn-north-4
<img width="780" height="889" alt="north-1" src="https://github.com/user-attachments/assets/88a8fba3-cc74-42eb-8239-ee002ab3ebb2" />
<img width="603" height="887" alt="north-2" src="https://github.com/user-attachments/assets/0434b785-9c00-4d6e-b541-3e8bdb21c704" />
<img width="749" height="667" alt="north-3" src="https://github.com/user-attachments/assets/1f5deed0-ca3b-4a37-ae16-ea702309592d" />
<img width="618" height="164" alt="north-4" src="https://github.com/user-attachments/assets/e92f587d-096c-43bd-92af-0e641ce3c14f" />
2.cn-south-4
<img width="792" height="886" alt="south-1" src="https://github.com/user-attachments/assets/a9a911ea-4ef9-448c-a021-63c4bff0bebb" />
<img width="761" height="682" alt="south-2" src="https://github.com/user-attachments/assets/74e6065e-27f5-43e1-b7c4-af8e2ed756c2" />
<img width="759" height="531" alt="south-3" src="https://github.com/user-attachments/assets/4fe81cfb-8305-4bc1-aaa7-bfed4af662fe" />
<img width="597" height="152" alt="south-4" src="https://github.com/user-attachments/assets/972401a2-dc98-4a25-8994-d50ac54d7858" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
cn-south-4
$ make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3Instance_withEpsId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_withEpsId
=== PAUSE TestAccDDSV3Instance_withEpsId
=== CONT  TestAccDDSV3Instance_withEpsId
--- PASS: TestAccDDSV3Instance_withEpsId (1210.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       1210.524s
```
```
cn-north-4
$ make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3Instance_withEpsId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_withEpsId
=== PAUSE TestAccDDSV3Instance_withEpsId
=== CONT  TestAccDDSV3Instance_withEpsId
--- PASS: TestAccDDSV3Instance_withEpsId (953.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       953.740s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
