### PR TITLE
feat(cfw): support `cfw_export_logs` resource

### DIFF
--- a/docs/resources/cfw_export_logs.md
+++ b/docs/resources/cfw_export_logs.md
@@ -1,0 +1,90 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_export_logs"
+description: |-
+  Manages a resource to export firewall logs within HuaweiCloud.
+---
+
+# huaweicloud_cfw_export_logs
+
+Manages a resource to export firewall logs within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource used to export firewall logs. Deleting this resource will
+  not clear the corresponding request record, but will only remove the resource information from the tf state file.
+  <br/>2. Executing this resource will generate a log file with the suffix **.csv** in the current working directory.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+variable "start_time" {}
+variable "end_time" {}
+variable "log_type" {}
+variable "type" {}
+
+resource "huaweicloud_cfw_export_logs" "test" {
+  fw_instance_id = var.fw_instance_id
+  start_time     = var.start_time
+  end_time       = var.end_time
+  log_type       = var.log_type
+  type           = var.type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `fw_instance_id` - (Required, String, NonUpdatable) Specifies the firewall instance ID.
+
+* `start_time` - (Required, Int, NonUpdatable) Specifies the start time. Millisecond level timestamp.
+
+* `end_time` - (Required, Int, NonUpdatable) Specifies the end time. Millisecond level timestamp.
+
+* `log_type` - (Required, String, NonUpdatable) Specifies the log type.  
+  The valid values are as follows:
+  + **internet**: North-south (internet) logs.
+  + **nat**: NAT scenario logs.
+  + **vpc**: East-west (VPC) logs.
+  + **vgw**: VGW scenario logs.
+
+* `type` - (Required, String, NonUpdatable) Specifies the type.  
+  The valid values are as follows:
+  + **attack**: Attack logs.
+  + **acl**: Access control logs.
+  + **flow**: Flow logs.
+  + **url**: URL logs.
+
+* `filters` - (Optional, List, NonUpdatable) Specifies the filter conditions.
+
+  The [filters](#filters_struct) structure is documented below.
+
+* `time_zone` - (Optional, String, NonUpdatable) Specifies the time zone. The valid value is **GMT+08:00**.
+
+* `export_file_name` - (Optional, String, NonUpdatable) Specifies the name of the exported firewall logs file.
+  If omitted, the default file name `cfw-{log_type}-{type}-log-{start_time}.csv` will be used.
+  If the file name does not end in **.csv**, **.csv** will be automatically appended.
+
+<a name="filters_struct"></a>
+The `filters` block supports:
+
+* `field` - (Required, String, NonUpdatable) Specifies the log field, such as **src_ip**.
+
+* `operator` - (Required, String, NonUpdatable) Specifies the operator.  
+  The valid values are as follows:
+  + **equal**: Equal.
+  + **not_equal**: Not equal.
+  + **contain**: Contain.
+  + **starts_with**: Starts with.
+
+* `values` - (Optional, List, NonUpdatable) Specifies the filter values.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `fw_instance_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2893,6 +2893,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_dns_resolution":                cfw.ResourceDNSResolution(),
 			"huaweicloud_cfw_capture_task":                  cfw.ResourceCaptureTask(),
 			"huaweicloud_cfw_ips_rule_mode_change":          cfw.ResourceCfwIpsRuleModeChange(),
+			"huaweicloud_cfw_export_logs":                   cfw.ResourceExportLogs(),
 			"huaweicloud_cfw_delete_ip_blacklist":           cfw.ResourceDeleteIpBlacklist(),
 
 			"huaweicloud_cloudtable_cluster": cloudtable.ResourceCloudTableCluster(),

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_export_logs_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_export_logs_test.go
@@ -1,0 +1,48 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccExportLogs_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+			acceptance.TestAccPreCheckCfwTimeRange(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testExportLogs_basic(),
+			},
+		},
+	})
+}
+
+func testExportLogs_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cfw_export_logs" "test" {
+  fw_instance_id = "%[1]s"
+  start_time     = %[2]s
+  end_time       = %[3]s
+  log_type       = "internet"
+  type           = "flow"
+  time_zone      = "GMT+08:00"
+
+  filters {
+    field    = "src_ip"
+    operator = "contain"
+    values   = ["ANY", "TCP"]
+  }
+
+  export_file_name = "cfw-tf-test-log"
+}
+`, acceptance.HW_CFW_INSTANCE_ID, acceptance.HW_CFW_START_TIME, acceptance.HW_CFW_END_TIME)
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_export_logs.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_export_logs.go
@@ -1,0 +1,213 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var exportLogsNonUpdatableParams = []string{"fw_instance_id", "start_time", "end_time", "log_type", "type",
+	"filters", "filters.*.field", "filters.*.operator", "filters.*.values", "time_zone", "export_file_name"}
+
+// @API CFW POST /v1/{project_id}/cfw/{fw_instance_id}/logs/export
+func ResourceExportLogs() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceExportLogsCreate,
+		ReadContext:   resourceExportLogsRead,
+		UpdateContext: resourceExportLogsUpdate,
+		DeleteContext: resourceExportLogsDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(exportLogsNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"start_time": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"end_time": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"log_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"filters": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"operator": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"time_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"export_file_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildExportLogsFiltersBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	rawFilters, ok := d.Get("filters").([]interface{})
+	if !ok || len(rawFilters) == 0 {
+		return nil
+	}
+
+	filters := make([]map[string]interface{}, 0, len(rawFilters))
+	for _, raw := range rawFilters {
+		m, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		var values []string
+		if v, ok := m["values"].([]interface{}); ok {
+			values = utils.ExpandToStringList(v)
+		}
+
+		filters = append(filters, map[string]interface{}{
+			"field":    m["field"],
+			"operator": m["operator"],
+			"values":   utils.ValueIgnoreEmpty(values),
+		})
+	}
+
+	return filters
+}
+
+func buildExportLogsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	body := map[string]interface{}{
+		"start_time": d.Get("start_time"),
+		"end_time":   d.Get("end_time"),
+		"log_type":   d.Get("log_type"),
+		"type":       d.Get("type"),
+		"time_zone":  utils.ValueIgnoreEmpty(d.Get("time_zone")),
+		"filters":    buildExportLogsFiltersBodyParams(d),
+	}
+
+	return body
+}
+
+func resourceExportLogsCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v1/{project_id}/cfw/{fw_instance_id}/logs/export"
+		fwInstanceID = d.Get("fw_instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{fw_instance_id}", fwInstanceID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildExportLogsBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error exporting CFW logs: %s", err)
+	}
+
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return diag.Errorf("error reading response body: %s", err)
+	}
+
+	var outputFile string
+	if v, ok := d.GetOk("export_file_name"); ok {
+		outputFile = v.(string)
+		if !strings.HasSuffix(outputFile, ".csv") {
+			outputFile += ".csv"
+		}
+	} else {
+		outputFile = fmt.Sprintf("cfw-%s-%s-log-%d.csv",
+			d.Get("log_type").(string), d.Get("type").(string), d.Get("start_time").(int))
+	}
+
+	if err := os.WriteFile(outputFile, bodyBytes, 0600); err != nil {
+		return diag.Errorf("failed to write firewall logs to (%s): %s", outputFile, err)
+	}
+
+	d.SetId(fwInstanceID)
+
+	return nil
+}
+
+func resourceExportLogsRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceExportLogsUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceExportLogsDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to export firewall logs. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_export_logs` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_export_logs` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccExportLogs_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccExportLogs_basic -timeout 360m -parallel 4
=== RUN   TestAccExportLogs_basic
=== PAUSE TestAccExportLogs_basic
=== CONT  TestAccExportLogs_basic
--- PASS: TestAccExportLogs_basic (14.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       14.416s
```
<img width="827" height="34" alt="image" src="https://github.com/user-attachments/assets/48443e90-f74e-4ccf-9e4e-cbd6909d9672" />

<img width="613" height="89" alt="image" src="https://github.com/user-attachments/assets/cd1e0e01-1e04-4235-990d-5a75ef5da140" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
