### PR TITLE
refactor(organizations): optimize codes and docs for account

### DIFF
--- a/docs/data-sources/organizations_accounts.md
+++ b/docs/data-sources/organizations_accounts.md
@@ -3,14 +3,22 @@ subcategory: "Organizations"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_organizations_accounts"
 description: |-
-  Use this data source to get the list of accounts in an organization.
+  Use this data source to get the list of accounts in an organization within HuaweiCloud.
 ---
 
 # huaweicloud_organizations_accounts
 
-Use this data source to get the list of accounts in an organization.
+Use this data source to get the list of accounts in an organization within HuaweiCloud.
 
 ## Example Usage
+
+### Query all accounts
+
+```hcl
+data "huaweicloud_organizations_accounts" "test" {}
+```
+
+### Query accounts by parent ID
 
 ```hcl
 variable "parent_id" {}
@@ -28,8 +36,9 @@ The following arguments are supported:
 
 * `name` - (Optional, String) Specifies the name of the account.
 
-* `with_register_contact_info` - (Optional, Bool) Whether to return email addresses and mobile
-  numbers associated with the account.
+* `with_register_contact_info` - (Optional, Bool) Specifies whether to return email addresses and mobile
+  numbers associated with the account.  
+  Default to **false**.
 
 ## Attribute Reference
 
@@ -37,7 +46,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `accounts` - The list of accounts in an organization.
+* `accounts` - The list of accounts that match the filter parameters.
   The [accounts](#Organizations_Accounts) structure is documented below.
 
 <a name="Organizations_Accounts"></a>

--- a/docs/resources/organizations_account.md
+++ b/docs/resources/organizations_account.md
@@ -10,7 +10,7 @@ description: |-
 
 Manages an Organizations account resource within HuaweiCloud.
 
--> **NOTE:** Deleting Organizations account is not support. If you destroy a resource of Organizations account,
+-> Deleting Organizations account is not support. If you destroy a resource of Organizations account,
 the Organizations account is only removed from the state, but it remains in the cloud.
 
 ## Example Usage
@@ -45,10 +45,10 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the account.
 
-* `parent_id` - (Optional, String) Specifies the ID of the root or organization unit in which you want to create a new
-  account. The default is root ID.
+* `parent_id` - (Optional, String) Specifies the ID of the root or organizational unit to which the account belongs.
+  The default is the root ID.
 
-* `tags` - (Optional, Map) Specifies the key/value to attach to the account.
+* `tags` - (Optional, Map) Specifies the key/value pairs to be associated with the account.
 
 * `email` - (Optional, String, ForceNew) Specifies the email address of the account.  
   Changing this parameter will create a new resource.

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_test.go
@@ -2,52 +2,23 @@ package organizations
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations"
 )
 
 func getAccountResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	// getAccount: Query Organizations account
-	var (
-		region            = acceptance.HW_REGION_NAME
-		getAccountHttpUrl = "v1/organizations/accounts/{account_id}"
-		getAccountProduct = "organizations"
-	)
-	getAccountClient, err := cfg.NewServiceClient(getAccountProduct, region)
+	client, err := cfg.NewServiceClient("organizations", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Organizations client: %s", err)
 	}
 
-	getAccountPath := getAccountClient.Endpoint + getAccountHttpUrl
-	getAccountPath = strings.ReplaceAll(getAccountPath, "{account_id}", state.Primary.ID)
-
-	getAccountOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	getAccountResp, err := getAccountClient.Request("GET", getAccountPath, &getAccountOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving Account: %s", err)
-	}
-
-	getAccountRespBody, err := utils.FlattenResponse(getAccountResp)
-	if err != nil {
-		return nil, err
-	}
-
-	status := utils.PathSearch("account.status", getAccountRespBody, "").(string)
-	if status == "" || status == "pending_closure" || status == "suspended" {
-		return nil, golangsdk.ErrDefault404{}
-	}
-	return getAccountRespBody, nil
+	return organizations.GetAccountInfoById(client, state.Primary.ID)
 }
 
 func TestAccAccount_basic(t *testing.T) {

--- a/huaweicloud/services/organizations/data_source_huaweicloud_organizations_accounts.go
+++ b/huaweicloud/services/organizations/data_source_huaweicloud_organizations_accounts.go
@@ -1,22 +1,15 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product Organizations
-// ---------------------------------------------------------------
-
 package organizations
 
 import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -29,12 +22,12 @@ func DataSourceAccounts() *schema.Resource {
 			"parent_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: `Specifies the ID of root or organizational unit.`,
+				Description: `The ID of root or organizational unit.`,
 			},
 			"name": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: `Specifies the name of the account.`,
+				Description: `The name of the account.`,
 			},
 			"with_register_contact_info": {
 				Type:        schema.TypeBool,
@@ -45,7 +38,7 @@ func DataSourceAccounts() *schema.Resource {
 				Type:        schema.TypeList,
 				Elem:        organizationsAccountSchema(),
 				Computed:    true,
-				Description: `List of accounts in an organization.`,
+				Description: `The list of accounts that match the filter parameters.`,
 			},
 		},
 	}
@@ -57,97 +50,109 @@ func organizationsAccountSchema() *schema.Resource {
 			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Unique ID of an account.`,
+				Description: `The unique ID of an account.`,
 			},
 			"name": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Name of the account.`,
+				Description: `The name of the account.`,
 			},
 			"urn": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Uniform resource name of the account.`,
+				Description: `The uniform resource name of the account.`,
 			},
 			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Description of the account.`,
+				Description: `The description of the account.`,
 			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Status of the account.`,
+				Description: `The status of the account.`,
 			},
 			"join_method": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `How an account joined an organization.`,
+				Description: `How the account joined the organization.`,
 			},
 			"joined_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Time when an account joined an organization.`,
+				Description: `The time when the account joined the organization.`,
 			},
 			"mobile_phone": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Mobile phone number.`,
+				Description: `The mobile phone number.`,
 			},
 			"intl_number_prefix": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Prefix of a mobile phone number.`,
+				Description: `The prefix of a mobile phone number.`,
 			},
 			"email": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Email address associated with the account.`,
+				Description: `The email address associated with the account.`,
 			},
 		},
 	}
 	return &sc
 }
 
+func listAccounts(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/organizations/accounts"
+		marker  = ""
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	listPath += buildListAccountsQueryParams(d)
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker += fmt.Sprintf("&marker=%v", marker)
+		}
+
+		resp, err := client.Request("GET", listPathWithMarker, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		accounts := utils.PathSearch("accounts", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, accounts...)
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return result, nil
+}
+
 func dataSourceAccountsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	listAccountsHttpUrl := "v1/organizations/accounts"
-	listAccountsProduct := "organizations"
-	listAccountsClient, err := cfg.NewServiceClient(listAccountsProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	listAccountsPath := listAccountsClient.Endpoint + listAccountsHttpUrl
-	listAccountsOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-
-	filterName := d.Get("name").(string)
-	var orgAccounts []interface{}
-	var marker string
-	var queryPath string
-
-	for {
-		queryPath = listAccountsPath + buildListAccountsQueryParams(d, marker)
-		listAccountsResp, err := listAccountsClient.Request("GET", queryPath, &listAccountsOpt)
-		if err != nil {
-			return common.CheckDeletedDiag(d, err, "error retrieving Organizations accounts")
-		}
-
-		listAccountsRespBody, err := utils.FlattenResponse(listAccountsResp)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
-		onePageAccounts := flattenAccountsResp(listAccountsRespBody, filterName)
-		orgAccounts = append(orgAccounts, onePageAccounts...)
-		marker = utils.PathSearch("page_info.next_marker", listAccountsRespBody, "").(string)
-		if marker == "" {
-			break
-		}
+	accounts, err := listAccounts(client, d)
+	if err != nil {
+		return diag.Errorf("error retrieving accounts: %s", err)
 	}
 
 	uuid, err := uuid.GenerateUUID()
@@ -156,26 +161,16 @@ func dataSourceAccountsRead(_ context.Context, d *schema.ResourceData, meta inte
 	}
 	d.SetId(uuid)
 
-	mErr := multierror.Append(nil,
-		d.Set("accounts", orgAccounts),
-	)
-
-	return diag.FromErr(mErr.ErrorOrNil())
+	return diag.FromErr(d.Set("accounts", flattenAccounts(accounts, d.Get("name").(string))))
 }
 
-func flattenAccountsResp(resp interface{}, name string) []interface{} {
-	if resp == nil {
+func flattenAccounts(accounts []interface{}, name string) []interface{} {
+	if len(accounts) == 0 {
 		return nil
 	}
 
-	jsonPath := "accounts"
-	if name != "" {
-		jsonPath += fmt.Sprintf("[?name=='%s']", name)
-	}
-	curJson := utils.PathSearch(jsonPath, resp, make([]interface{}, 0))
-	curArray := curJson.([]interface{})
-	rst := make([]interface{}, 0, len(curArray))
-	for _, v := range curArray {
+	rst := make([]interface{}, 0, len(accounts))
+	for _, v := range accounts {
 		rst = append(rst, map[string]interface{}{
 			"id":                 utils.PathSearch("id", v, nil),
 			"name":               utils.PathSearch("name", v, nil),
@@ -189,18 +184,17 @@ func flattenAccountsResp(resp interface{}, name string) []interface{} {
 			"email":              utils.PathSearch("email", v, nil),
 		})
 	}
+
+	if name != "" {
+		return utils.PathSearch(fmt.Sprintf("[?name=='%s']", name), rst, make([]interface{}, 0)).([]interface{})
+	}
+
 	return rst
 }
 
-func buildListAccountsQueryParams(d *schema.ResourceData, marker string) string {
+func buildListAccountsQueryParams(d *schema.ResourceData) string {
 	// the default value of limit is 200
-	res := "?limit=200"
-
-	res = fmt.Sprintf("%s&with_register_contact_info=%v", res, d.Get("with_register_contact_info"))
-
-	if marker != "" {
-		res = fmt.Sprintf("%s&marker=%v", res, marker)
-	}
+	res := fmt.Sprintf("?limit=200&with_register_contact_info=%v", d.Get("with_register_contact_info"))
 
 	if v, ok := d.GetOk("parent_id"); ok {
 		res = fmt.Sprintf("%s&parent_id=%v", res, v)

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account.go
@@ -1,8 +1,3 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product Organizations
-// ---------------------------------------------------------------
-
 package organizations
 
 import (
@@ -24,14 +19,18 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var accountNotFoundErrCodes = []string{
+	"Organizations.1325", // The account is being closed, cannot be closed repeatedly.
+}
+
 // @API Organizations POST /v2/organizations/accounts
 // @API Organizations POST /v1/organizations/accounts
+// @API Organizations GET /v1/organizations/create-account-status/{create_account_status_id}
+// @API Organizations GET /v1/organizations/entities
 // @API Organizations GET /v1/organizations/accounts/{account_id}
 // @API Organizations GET /v1/organizations/{resource_type}/{resource_id}/tags
 // @API Organizations POST /v1/organizations/accounts/{account_id}/move
 // @API Organizations PATCH /v1/organizations/accounts/{account_id}
-// @API Organizations GET /v1/organizations/entities
-// @API Organizations GET /v1/organizations/create-account-status/{create_account_status_id}
 // @API Organizations POST /v1/organizations/{resource_type}/{resource_id}/tags/delete
 // @API Organizations POST /v1/organizations/{resource_type}/{resource_id}/tags/create
 // @API Organizations POST /v1/organizations/accounts/{account_id}/close
@@ -56,50 +55,59 @@ func ResourceAccount() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: `Specifies the name of the account.`,
+				Description: `The name of the account.`,
 			},
 			"agency_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The agency name of the account.`,
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the account.`,
 			},
 			"parent_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The ID of the organizational unit or root to which the account belongs.`,
 			},
-			"tags": common.TagsSchema(),
+			"tags": common.TagsSchema(`The key/value pairs to be associated with the account`),
 			"email": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The email address of the account.`,
 			},
 			"phone": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The mobile number of the account.`,
 			},
 			"intl_number_prefix": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The prefix of a mobile number.`,
 			},
 			"urn": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The uniform resource name of the account.`,
 			},
 			"joined_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the account was created.`,
 			},
 			"joined_method": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `How the account joined the organization.`,
 			},
 		},
 	}
@@ -143,25 +151,23 @@ func resourceAccountCreate(ctx context.Context, d *schema.ResourceData, meta int
 	// we cannot get the account ID in API response, retrieve it from ShowCreateAccountStatus API
 	statusID := utils.PathSearch("create_account_status.id", respBody, "").(string)
 	if statusID == "" {
-		return diag.Errorf("error creating Account: state is not found in API response")
+		return diag.Errorf("unable to find the account creation status ID from the API response")
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"in_progress"},
-		Target:       []string{"succeeded"},
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
 		Refresh:      accountStateRefreshFunc(client, statusID),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
 	}
 
-	accountName := d.Get("name").(string)
 	accountStatusRespBody, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("error waiting for Organizations account (%s) to create: %s", accountName, err)
+		return diag.Errorf("error waiting for account (%v) to be created: %s", d.Get("name"), err)
 	}
 
-	// set the account ID
 	accountId := utils.PathSearch("create_account_status.account_id", accountStatusRespBody, "").(string)
 	if accountId == "" {
 		return diag.Errorf("unable to find the account ID from the API response")
@@ -173,10 +179,11 @@ func resourceAccountCreate(ctx context.Context, d *schema.ResourceData, meta int
 		if err != nil {
 			return diag.FromErr(err)
 		}
+
 		if v.(string) != parentID {
-			err = moveAccount(client, d.Id(), parentID, v.(string))
+			err = moveAccount(client, accountId, parentID, v.(string))
 			if err != nil {
-				return diag.Errorf("error moving Account %s to organization unit %s: %s", d.Id(), v.(string), err)
+				return diag.Errorf("error moving account (%s) to organization unit (%v): %s", accountId, v, err)
 			}
 		}
 	}
@@ -186,31 +193,35 @@ func resourceAccountCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 func accountStateRefreshFunc(client *golangsdk.ServiceClient, accountStatusId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		getAccountStatusHttpUrl := "v1/organizations/create-account-status/{create_account_status_id}"
-		getAccountStatusPath := client.Endpoint + getAccountStatusHttpUrl
-		getAccountStatusPath = strings.ReplaceAll(getAccountStatusPath, "{create_account_status_id}", accountStatusId)
+		httpUrl := "v1/organizations/create-account-status/{create_account_status_id}"
+		getPath := client.Endpoint + httpUrl
+		getPath = strings.ReplaceAll(getPath, "{create_account_status_id}", accountStatusId)
 
-		getAccountStatusOpt := golangsdk.RequestOpts{
+		getOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
+			MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 		}
-		getAccountStatusResp, err := client.Request("GET", getAccountStatusPath, &getAccountStatusOpt)
+		resp, err := client.Request("GET", getPath, &getOpt)
 		if err != nil {
-			return nil, "", err
+			return nil, "failed", err
 		}
 
-		getAccountStatusRespBody, err := utils.FlattenResponse(getAccountStatusResp)
+		respBody, err := utils.FlattenResponse(resp)
 		if err != nil {
-			return nil, "", err
+			return nil, "failed", err
 		}
 
-		state := utils.PathSearch("create_account_status.state", getAccountStatusRespBody, "").(string)
-
-		reason := utils.PathSearch("create_account_status.failure_reason", getAccountStatusRespBody, "").(string)
-		if reason != "" {
-			return getAccountStatusRespBody, state, fmt.Errorf("state: %s; failure_reason: %s", state, reason)
+		state := utils.PathSearch("create_account_status.state", respBody, "").(string)
+		if state == "succeeded" {
+			return respBody, "COMPLETED", nil
 		}
 
-		return getAccountStatusRespBody, state, nil
+		if state == "failed" {
+			return respBody, state, fmt.Errorf("state: %s; failure_reason: %v", state,
+				utils.PathSearch("create_account_status.failure_reason", respBody, ""))
+		}
+
+		return respBody, state, nil
 	}
 }
 
@@ -221,70 +232,79 @@ func buildCreateAccountBodyParams(d *schema.ResourceData) map[string]interface{}
 		"phone":       utils.ValueIgnoreEmpty(d.Get("phone")),
 		"agency_name": utils.ValueIgnoreEmpty(d.Get("agency_name")),
 		"description": utils.ValueIgnoreEmpty(d.Get("description")),
-		"tags":        utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
+		"tags":        utils.ValueIgnoreEmpty(utils.ExpandResourceTags(d.Get("tags").(map[string]interface{}))),
 	}
 	return bodyParams
 }
 
+func GetAccountInfoById(client *golangsdk.ServiceClient, accountId string) (interface{}, error) {
+	getHttpUrl := "v1/organizations/accounts/{account_id}?with_register_contact_info=true"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{account_id}", accountId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	status := utils.PathSearch("account.status", respBody, "").(string)
+	if status == "" || status == "pending_closure" || status == "suspended" {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/organizations/accounts/{account_id}",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the account (%s) does not exist", accountId)),
+			},
+		}
+	}
+
+	return utils.PathSearch("account", respBody, nil), nil
+}
+
 func resourceAccountRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	var mErr *multierror.Error
-
-	// getAccount: Query Organizations account
-	var (
-		getAccountProduct = "organizations"
-	)
-	getAccountClient, err := cfg.NewServiceClient(getAccountProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	getAccountHttpUrl := "v1/organizations/accounts/{account_id}?with_register_contact_info=true"
-	getAccountPath := getAccountClient.Endpoint + getAccountHttpUrl
-	getAccountPath = strings.ReplaceAll(getAccountPath, "{account_id}", d.Id())
-
-	getAccountOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	getAccountResp, err := getAccountClient.Request("GET", getAccountPath, &getAccountOpt)
-
+	accountId := d.Id()
+	account, err := GetAccountInfoById(client, accountId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving Account")
+		return common.CheckDeletedDiag(d, common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+			"error retrieving account")
 	}
 
-	getAccountRespBody, err := utils.FlattenResponse(getAccountResp)
+	parentID, err := getParentIdByAccountId(client, accountId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	status := utils.PathSearch("account.status", getAccountRespBody, "").(string)
-	if status == "" || status == "pending_closure" || status == "suspended" {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
-	}
-
-	parentID, err := getParentIdByAccountId(getAccountClient, d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	mErr = multierror.Append(
-		mErr,
+	mErr := multierror.Append(
 		d.Set("parent_id", parentID),
-		d.Set("name", utils.PathSearch("account.name", getAccountRespBody, nil)),
-		d.Set("email", utils.PathSearch("account.email", getAccountRespBody, nil)),
-		d.Set("phone", utils.PathSearch("account.mobile_phone", getAccountRespBody, nil)),
-		d.Set("description", utils.PathSearch("account.description", getAccountRespBody, nil)),
-		d.Set("intl_number_prefix", utils.PathSearch("account.intl_number_prefix", getAccountRespBody, nil)),
-		d.Set("urn", utils.PathSearch("account.urn", getAccountRespBody, nil)),
-		d.Set("joined_at", utils.PathSearch("account.joined_at", getAccountRespBody, nil)),
-		d.Set("joined_method", utils.PathSearch("account.join_method", getAccountRespBody, nil)),
+		d.Set("name", utils.PathSearch("name", account, nil)),
+		d.Set("email", utils.PathSearch("email", account, nil)),
+		d.Set("phone", utils.PathSearch("mobile_phone", account, nil)),
+		d.Set("description", utils.PathSearch("description", account, nil)),
+		d.Set("intl_number_prefix", utils.PathSearch("intl_number_prefix", account, nil)),
+		d.Set("urn", utils.PathSearch("urn", account, nil)),
+		d.Set("joined_at", utils.PathSearch("joined_at", account, nil)),
+		d.Set("joined_method", utils.PathSearch("join_method", account, nil)),
 	)
 
-	tagMap, err := getTags(getAccountClient, accountsType, d.Id())
+	tagMap, err := getTags(client, accountsType, accountId)
 	if err != nil {
-		log.Printf("[WARN] error fetching tags of Organizations account (%s): %s", d.Id(), err)
+		log.Printf("[WARN] error fetching tags of Organizations account (%s): %s", accountId, err)
 	} else {
 		mErr = multierror.Append(mErr, d.Set("tags", tagMap))
 	}
@@ -294,34 +314,29 @@ func resourceAccountRead(_ context.Context, d *schema.ResourceData, meta interfa
 
 func resourceAccountUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// updateAccount: update Organizations account
-	var (
-		updateAccountProduct = "organizations"
-	)
-	updateAccountClient, err := cfg.NewServiceClient(updateAccountProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
+	accountId := d.Id()
 	if d.HasChange("parent_id") {
 		oldVal, newVal := d.GetChange("parent_id")
-		err = moveAccount(updateAccountClient, d.Id(), oldVal.(string), newVal.(string))
+		err = moveAccount(client, accountId, oldVal.(string), newVal.(string))
 		if err != nil {
-			return diag.Errorf("error moving account: %s", err)
+			return diag.Errorf("error moving account (%s) to organizational unit (%v): %s", accountId, newVal, err)
 		}
 	}
 
 	if d.HasChange("description") {
-		err = updateAccount(updateAccountClient, d)
+		err = updateAccount(client, d)
 		if err != nil {
-			return diag.Errorf("error updating account: %s", err)
+			return diag.Errorf("error updating account (%s): %s", accountId, err)
 		}
 	}
 
 	if d.HasChange("tags") {
-		err = updateTags(d, updateAccountClient, accountsType, d.Id(), "tags")
+		err = updateTags(d, client, accountsType, accountId, "tags")
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -337,17 +352,15 @@ func buildUpdateAccountBodyParams(d *schema.ResourceData) map[string]interface{}
 }
 
 func updateAccount(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
-	var (
-		updateAccountHttpUrl = "v1/organizations/accounts/{account_id}"
-	)
-	updateAccountPath := client.Endpoint + updateAccountHttpUrl
-	updateAccountPath = strings.ReplaceAll(updateAccountPath, "{account_id}", d.Id())
+	updateHttpUrl := "v1/organizations/accounts/{account_id}"
+	updatePath := client.Endpoint + updateHttpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{account_id}", d.Id())
 
-	updateAccountOpt := golangsdk.RequestOpts{
+	updateOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		JSONBody:         buildUpdateAccountBodyParams(d),
 	}
-	updateAccountOpt.JSONBody = utils.RemoveNil(buildUpdateAccountBodyParams(d))
-	_, err := client.Request("PATCH", updateAccountPath, &updateAccountOpt)
+	_, err := client.Request("PATCH", updatePath, &updateOpt)
 	return err
 }
 
@@ -360,44 +373,44 @@ func buildMoveAccountBodyParams(oldOrganizationsUnitId, newOrganizationsUnitId s
 }
 
 func moveAccount(client *golangsdk.ServiceClient, accountId, sourceParentID, destinationParentID string) error {
-	// moveAccount: update Organizations account
-	var (
-		moveAccountHttpUrl = "v1/organizations/accounts/{account_id}/move"
-	)
-	moveAccountPath := client.Endpoint + moveAccountHttpUrl
-	moveAccountPath = strings.ReplaceAll(moveAccountPath, "{account_id}", accountId)
+	moveHttpUrl := "v1/organizations/accounts/{account_id}/move"
+	movePath := client.Endpoint + moveHttpUrl
+	movePath = strings.ReplaceAll(movePath, "{account_id}", accountId)
 
-	moveAccountOpt := golangsdk.RequestOpts{
+	moveOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		JSONBody:         buildMoveAccountBodyParams(sourceParentID, destinationParentID),
 	}
-	moveAccountOpt.JSONBody = utils.RemoveNil(buildMoveAccountBodyParams(sourceParentID, destinationParentID))
-	_, err := client.Request("POST", moveAccountPath, &moveAccountOpt)
+	_, err := client.Request("POST", movePath, &moveOpt)
 	return err
 }
 
 func resourceAccountDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// deleteAccount: close Organizations account
 	var (
-		deleteAccountHttpUrl = "v1/organizations/accounts/{account_id}/close"
-		deleteAccountProduct = "organizations"
+		cfg     = meta.(*config.Config)
+		httpUrl = "v1/organizations/accounts/{account_id}/close"
 	)
-	deleteAccountClient, err := cfg.NewServiceClient(deleteAccountProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	deleteAccountPath := deleteAccountClient.Endpoint + deleteAccountHttpUrl
-	deleteAccountPath = strings.ReplaceAll(deleteAccountPath, "{account_id}", d.Id())
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{account_id}", d.Id())
 
-	deleteAccountOpt := golangsdk.RequestOpts{
+	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
-	_, err = deleteAccountClient.Request("POST", deleteAccountPath, &deleteAccountOpt)
+	_, err = client.Request("POST", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting account: %s", err)
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected401ErrInto404Err(
+				common.ConvertExpected400ErrInto404Err(err, "error_code", accountNotFoundErrCodes...),
+				"error_code", organizationNotFoundErrCodes...,
+			),
+			"error deleting account",
+		)
 	}
 
 	return nil
@@ -410,17 +423,16 @@ func getParentIdByAccountId(client *golangsdk.ServiceClient, accountID string) (
 
 	getParentOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
 	getAccountResp, err := client.Request("GET", getParentPath, &getParentOpt)
 	if err != nil {
-		return "", fmt.Errorf("error retrieving parent by account_id: %s", accountID)
+		return "", fmt.Errorf("error retrieving parent by account ID: %s", accountID)
 	}
-	getAccountRespBody, err := utils.FlattenResponse(getAccountResp)
+	respBody, err := utils.FlattenResponse(getAccountResp)
 	if err != nil {
 		return "", err
 	}
 
-	id := utils.PathSearch("entities|[0].id", getAccountRespBody, "").(string)
-
-	return id, nil
+	return utils.PathSearch("entities|[0].id", respBody, "").(string), nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The current code has the following issues and needs optimization:

- Redundant methods and variables naming
- Some error messages are inaccurate
- Some content in the documentation is inaccurately described
- Some code is not standardized
- CheckDeleted does not cover scenarios where the organization does not exist
- Some meaningless comments

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. optimize codes and documentations of the resource and data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o organizations -f TestAccDataAccounts_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDataAccounts_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAccounts_basic
=== PAUSE TestAccDataAccounts_basic
=== CONT  TestAccDataAccounts_basic
--- PASS: TestAccDataAccounts_basic (48.65s)
PASS
coverage: 14.5% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     48.758s coverage: 14.5% of statements in ./huaweicloud/services/organizations
```
```
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations/data_source_huaweicloud_organizations_accounts.go (85.4%)
```
```
./scripts/coverage.sh -o organizations -f TestAccAccount_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccAccount_basic -timeout 360m -parallel 10
=== RUN   TestAccAccount_basic
=== PAUSE TestAccAccount_basic
=== CONT  TestAccAccount_basic
--- PASS: TestAccAccount_basic (55.17s)
PASS
coverage: 19.4% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     55.272s coverage: 19.4% of statements in ./huaweicloud/services/organizations
```
```
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations/resource_huaweicloud_organizations_account.go (81.2%)
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
