### PR TITLE
refactor(organizations): optimize codes and docs for account associate resource

### DIFF
--- a/docs/resources/organizations_account_associate.md
+++ b/docs/resources/organizations_account_associate.md
@@ -2,18 +2,21 @@
 subcategory: "Organizations"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_organizations_account_associate"
-description: ""
+description: |-
+  Manages an Organizations account associate resource within HuaweiCloud.
 ---
 
 # huaweicloud_organizations_account_associate
 
 Manages an Organizations account associate resource within HuaweiCloud.
 
+-> Deleting this resource will move the account to the root organization unit.
+
 ## Example Usage
 
 ```hcl
-variable account_id {}
-variable parent_id {}
+variable "account_id" {}
+variable "parent_id" {}
 
 resource "huaweicloud_organizations_account_associate" "test"{
   account_id = var.account_id

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_associate_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_associate_test.go
@@ -2,42 +2,23 @@ package organizations
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations"
 )
 
 func getAccountAssociateResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	region := acceptance.HW_REGION_NAME
-	// getAccount: Query Organizations account
-	var (
-		getAccountHttpUrl = "v1/organizations/accounts/{account_id}"
-		getAccountProduct = "organizations"
-	)
-	getAccountClient, err := cfg.NewServiceClient(getAccountProduct, region)
+	getAccountClient, err := cfg.NewServiceClient("organizations", acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Organizations Client: %s", err)
+		return nil, fmt.Errorf("error creating Organizations client: %s", err)
 	}
 
-	getAccountPath := getAccountClient.Endpoint + getAccountHttpUrl
-	getAccountPath = strings.ReplaceAll(getAccountPath, "{account_id}", state.Primary.ID)
-
-	getAccountOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	getAccountResp, err := getAccountClient.Request("GET", getAccountPath, &getAccountOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving AccountAssociate: %s", err)
-	}
-	return utils.FlattenResponse(getAccountResp)
+	return organizations.GetAccountById(getAccountClient, state.Primary.ID)
 }
 
 // Before running the test, please provide an account ID under the root organization.

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_associate.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_associate.go
@@ -1,19 +1,12 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product Organizations
-// ---------------------------------------------------------------
-
 package organizations
 
 import (
 	"context"
-	"strings"
+	"fmt"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -39,32 +32,32 @@ func ResourceAccountAssociate() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: `Specifies the ID of the account.`,
+				Description: `The ID of the account.`,
 			},
 			"parent_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `Specifies the ID of root or organizational unit in which you want to move the account.`,
+				Description: `The ID of root or organizational unit in which you want to move the account.`,
 			},
 			"name": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the name of the account.`,
+				Description: `The name of the account.`,
 			},
 			"urn": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the uniform resource name of the account.`,
+				Description: `The uniform resource name of the account.`,
 			},
 			"joined_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the time when the account was created.`,
+				Description: `The time when the account was created.`,
 			},
 			"joined_method": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates how an account joined an organization.`,
+				Description: `How an account joined an organization.`,
 			},
 		},
 	}
@@ -72,85 +65,59 @@ func ResourceAccountAssociate() *schema.Resource {
 
 func resourceAccountAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// createAccountAssociate: create Organizations account associate
-	var (
-		createAccountAssociateProduct = "organizations"
-	)
-	createAccountAssociateClient, err := cfg.NewServiceClient(createAccountAssociateProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	accountID := d.Get("account_id").(string)
-	oParentID, err := getParentIdByAccountId(createAccountAssociateClient, accountID)
+	accountId := d.Get("account_id").(string)
+	oParentId, err := getParentIdByAccountId(client, accountId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	nParentID := d.Get("parent_id").(string)
-	if oParentID != nParentID {
-		err = moveAccount(createAccountAssociateClient, accountID, oParentID, nParentID)
+
+	nParentId := d.Get("parent_id").(string)
+	if oParentId != nParentId {
+		err = moveAccount(client, accountId, oParentId, nParentId)
 		if err != nil {
-			return diag.Errorf("error updating Account: %s", err)
+			return diag.Errorf("error moving account (%s) to organization unit (%v): %s", accountId, nParentId, err)
 		}
 	}
 
-	d.SetId(accountID)
+	d.SetId(accountId)
 
 	return resourceAccountAssociateRead(ctx, d, meta)
 }
 
 func resourceAccountAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	var mErr *multierror.Error
-
-	// getAccountAssociate: Query Organizations account associate
-	var (
-		getAccountAssociateHttpUrl = "v1/organizations/accounts/{account_id}"
-		getAccountAssociateProduct = "organizations"
-	)
-	getAccountAssociateClient, err := cfg.NewServiceClient(getAccountAssociateProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	getAccountAssociatePath := getAccountAssociateClient.Endpoint + getAccountAssociateHttpUrl
-	getAccountAssociatePath = strings.ReplaceAll(getAccountAssociatePath, "{account_id}", d.Id())
-
-	getAccountAssociateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-
-	getAccountAssociateResp, err := getAccountAssociateClient.Request("GET", getAccountAssociatePath,
-		&getAccountAssociateOpt)
-
+	accountId := d.Id()
+	account, err := GetAccountById(client, accountId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving AccountAssociate")
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+			"error retrieving account associate",
+		)
 	}
 
-	getAccountAssociateRespBody, err := utils.FlattenResponse(getAccountAssociateResp)
+	parentId, err := getParentIdByAccountId(client, accountId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	parentID, err := getParentIdByAccountId(getAccountAssociateClient, d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	mErr = multierror.Append(
-		mErr,
-		d.Set("account_id", d.Id()),
-		d.Set("parent_id", parentID),
-		d.Set("name", utils.PathSearch("account.name", getAccountAssociateRespBody, nil)),
-		d.Set("urn", utils.PathSearch("account.urn", getAccountAssociateRespBody, nil)),
-		d.Set("joined_at", utils.PathSearch("account.joined_at", getAccountAssociateRespBody,
-			nil)),
-		d.Set("joined_method", utils.PathSearch("account.join_method", getAccountAssociateRespBody,
-			nil)),
+	mErr := multierror.Append(
+		d.Set("account_id", accountId),
+		d.Set("parent_id", parentId),
+		d.Set("name", utils.PathSearch("account.name", account, nil)),
+		d.Set("urn", utils.PathSearch("account.urn", account, nil)),
+		d.Set("joined_at", utils.PathSearch("account.joined_at", account, nil)),
+		d.Set("joined_method", utils.PathSearch("account.join_method", account, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -158,26 +125,21 @@ func resourceAccountAssociateRead(_ context.Context, d *schema.ResourceData, met
 
 func resourceAccountAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// updateAccountAssociate: update Organizations account associate
-	var (
-		updateAccountAssociateProduct = "organizations"
-	)
-	updateAccountAssociateClient, err := cfg.NewServiceClient(updateAccountAssociateProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	oParentID, err := getParentIdByAccountId(updateAccountAssociateClient, d.Id())
+	accountId := d.Id()
+	oParentId, err := getParentIdByAccountId(client, accountId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	nParentID := d.Get("parent_id").(string)
 
-	err = moveAccount(updateAccountAssociateClient, d.Id(), oParentID, nParentID)
+	nParentId := d.Get("parent_id").(string)
+	err = moveAccount(client, accountId, oParentId, nParentId)
 	if err != nil {
-		return diag.Errorf("error updating Account: %s", err)
+		return diag.Errorf("error moving account (%s) to organization unit (%v): %s", accountId, nParentId, err)
 	}
 
 	return resourceAccountAssociateRead(ctx, d, meta)
@@ -185,26 +147,24 @@ func resourceAccountAssociateUpdate(ctx context.Context, d *schema.ResourceData,
 
 func resourceAccountAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// deleteAccountAssociate: Delete Organizations account associate
-	var (
-		deleteAccountAssociateProduct = "organizations"
-	)
-	deleteAccountAssociateClient, err := cfg.NewServiceClient(deleteAccountAssociateProduct, region)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating Organizations Client: %s", err)
+		return diag.Errorf("error creating Organizations client: %s", err)
 	}
 
-	getRootRespBody, err := getRoot(deleteAccountAssociateClient)
+	getRootRespBody, err := getRoot(client)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	rootId := utils.PathSearch("roots|[0].id", getRootRespBody, "").(string)
-	parentID := d.Get("parent_id").(string)
-	err = moveAccount(deleteAccountAssociateClient, d.Id(), parentID, rootId)
+
+	accountId := d.Id()
+	parentId := d.Get("parent_id").(string)
+	err = moveAccount(client, accountId, parentId, utils.PathSearch("roots|[0].id", getRootRespBody, "").(string))
 	if err != nil {
-		return diag.Errorf("error updating Account: %s", err)
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+			fmt.Sprintf("error moving account (%s) to root", accountId))
 	}
 
 	return nil

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite.go
@@ -223,7 +223,7 @@ func GetAccountInvite(client *golangsdk.ServiceClient, handshakeId string) (inte
 	// the handshake will always exist, so it is necessary to check whether the account can be obtained if the
 	// status is accepted.
 	if status == "accepted" {
-		_, err = getAccountById(client, utils.PathSearch("target.entity", handshake, "").(string))
+		_, err = GetAccountById(client, utils.PathSearch("target.entity", handshake, "").(string))
 		if err != nil {
 			return nil, err
 		}
@@ -232,7 +232,7 @@ func GetAccountInvite(client *golangsdk.ServiceClient, handshakeId string) (inte
 	return handshake, nil
 }
 
-func getAccountById(client *golangsdk.ServiceClient, accountId string) (interface{}, error) {
+func GetAccountById(client *golangsdk.ServiceClient, accountId string) (interface{}, error) {
 	httpUrl := "v1/organizations/accounts/{account_id}"
 	getPath := client.Endpoint + httpUrl
 	getPath = strings.ReplaceAll(getPath, "{account_id}", accountId)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The current code has the following issues and needs optimization:

- Redundant methods and variables naming
- Some code is not standardized
- CheckDeleted does not cover scenarios where the organization does not exist
- Some meaningless comments

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
optimize codes and documentations for resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o organizations -f TestAccAccountAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccAccountAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccAccountAssociate_basic
=== PAUSE TestAccAccountAssociate_basic
=== CONT  TestAccAccountAssociate_basic
--- PASS: TestAccAccountAssociate_basic (33.92s)
PASS
coverage: 14.0% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     34.046s coverage: 14.0% of statements in ./huaweicloud/services/organizations
```

```
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_associate.go (78.2%)
```

```
 ./scripts/coverage.sh -o organizations -f TestAccAccountInvite_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccAccountInvite_basic -timeout 360m -parallel 10
=== RUN   TestAccAccountInvite_basic
=== PAUSE TestAccAccountInvite_basic
=== CONT  TestAccAccountInvite_basic
--- PASS: TestAccAccountInvite_basic (18.16s)
PASS
coverage: 6.9% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     18.256s coverage: 6.9% of statements in ./huaweicloud/services/organizations
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
