### PR TITLE
feat(ECS): ecs instance add params

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -278,6 +278,11 @@ The following arguments are supported:
 * `system_disk_dss_pool_id` - (Optional, String, ForceNew) Specifies the system disk DSS pool ID. This field is used
   only for dedicated storage. Changing this parameter will create a new resource.
 
+* `system_pass_through` - (Optional, String, ForceNew) Specifies the device type of the EVS disks to be created.
+  Changing this parameter will create a new resource. Value options:
+  + **true**: SCSI disks are created.
+  + **false(default)**: VBD disks are created.
+
 * `data_disks` - (Optional, List, ForceNew) Specifies an array of one or more data disks to attach to the instance.
   The data_disks object structure is documented below. Changing this creates a new instance.
 
@@ -426,8 +431,16 @@ The `data_disks` block supports:
 * `size` - (Required, Int, ForceNew) Specifies the data disk size, in GB. The value ranges form 10 to 32768.
   Changing this creates a new instance.
 
+* `data_image_id` - (Optional, String, ForceNew) Specifies the ID of the data image. If data disks are created using a
+  data disk image, this parameter is mandatory, and it does not support `kms_key_id`. Changing this creates a new instance.
+
 * `snapshot_id` - (Optional, String, ForceNew) Specifies the EVS snapshot ID or ID of the original data disk contained
   in the full-ECS image. Changing this creates a new instance.
+
+* `delete_on_termination` - (Optional, String, ForceNew) Specifies the policy of releasing data disks when the ECS is
+  deleted. Changing this creates a new instance. Value options:
+  + **true**: The data disk is released when the ECS is deleted.
+  + **false**: The data disk is not released when the ECS is deleted.
 
 * `kms_key_id` - (Optional, String, ForceNew) Specifies the ID of a KMS key. This is used to encrypt the disk.
   Changing this creates a new instance.
@@ -453,6 +466,11 @@ The `data_disks` block supports:
 
 * `dss_pool_id` - (Optional, String, ForceNew) Specifies the data disk DSS pool ID. This field is used
   only for dedicated storage. Changing this parameter will create a new resource.
+
+* `pass_through` - (Optional, String, ForceNew) Specifies the device type of the EVS disks to be created. Changing this
+  parameter will create a new resource. Value options:
+  + **true**: SCSI disks are created.
+  + **false(default)**: VBD disks are created.
 
 The `bandwidth` block supports:
 
@@ -560,6 +578,9 @@ The `volume_attached` block supports:
 * `size` - The volume size on that attachment.
 * `type` - The volume type on that attachment.
 * `pci_address` - The volume pci address on that attachment.
+* `data_image_id` - The ID of the data image.
+* `delete_on_termination` - The policy of releasing data disks when the ECS is deleted.
+* `pass_through` - The device type of the EVS disks to be created.
 
 ## Timeouts
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20260127035608-5e70605a8cd7
+	github.com/chnsz/golangsdk v0.0.0-20260310020804-1615ffe6c577
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
@@ -62,8 +62,8 @@ require (
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.11.0 // indirect
-	go.mongodb.org/mongo-driver v1.17.6 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
+	go.mongodb.org/mongo-driver v1.17.9 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sys v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20260127035608-5e70605a8cd7 h1:VFzDto0iO8hgl8RKbBYIB1VlG1mIhC5NqHT3KtwQwQ0=
-github.com/chnsz/golangsdk v0.0.0-20260127035608-5e70605a8cd7/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
+github.com/chnsz/golangsdk v0.0.0-20260310020804-1615ffe6c577 h1:0q5L0eTnfB96fZf/JIb+TUqS/zg/vPfFGTsfQKeEMz4=
+github.com/chnsz/golangsdk v0.0.0-20260310020804-1615ffe6c577/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -242,8 +242,8 @@ github.com/zclconf/go-cty v1.11.0/go.mod h1:s9IfD1LK5ccNMSWCVFCE2rJfHiZgi7JijgeW
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 go.mongodb.org/mongo-driver v1.12.0/go.mod h1:AZkxhPnFJUoH7kZlFkVKucV20K387miPfm7oimrSmK0=
 go.mongodb.org/mongo-driver v1.17.2/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
-go.mongodb.org/mongo-driver v1.17.6 h1:87JUG1wZfWsr6rIz3ZmpH90rL5tea7O3IHuSwHUpsss=
-go.mongodb.org/mongo-driver v1.17.6/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
+go.mongodb.org/mongo-driver v1.17.9/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
@@ -270,9 +270,49 @@ func TestAccComputeInstance_diskIopsThroughput(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data_disks.0.type", "GPSSD2"),
 					resource.TestCheckResourceAttr(resourceName, "data_disks.0.iops", "4000"),
 					resource.TestCheckResourceAttr(resourceName, "data_disks.0.throughput", "200"),
+					resource.TestCheckResourceAttr(resourceName, "data_disks.0.delete_on_termination", "true"),
+					resource.TestCheckResourceAttr(resourceName, "data_disks.0.pass_through", "true"),
 					resource.TestCheckResourceAttr(resourceName, "data_disks.1.type", "GPSSD2"),
 					resource.TestCheckResourceAttr(resourceName, "data_disks.1.iops", "5000"),
 					resource.TestCheckResourceAttr(resourceName, "data_disks.1.throughput", "300"),
+					resource.TestCheckResourceAttr(resourceName, "data_disks.1.delete_on_termination", "false"),
+					resource.TestCheckResourceAttr(resourceName, "data_disks.1.pass_through", "false"),
+					resource.TestCheckResourceAttr(resourceName, "data_disks.2.type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName, "data_disks.2.iops", "5000"),
+					resource.TestCheckResourceAttr(resourceName, "data_disks.2.throughput", "300"),
+					resource.TestCheckResourceAttrPair(resourceName, "data_disks.2.data_image_id",
+						"huaweicloud_ims_evs_data_image.data_image", "id"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.0.volume_id"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.0.size", "50"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.0.type", "GPSSD2"),
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.0.boot_index"),
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.0.pci_address"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.0.delete_on_termination", "true"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.1.volume_id"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.1.size", "50"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.1.type", "GPSSD2"),
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.1.boot_index"),
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.1.pci_address"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.1.delete_on_termination", "true"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.1.pass_through", "true"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.2.volume_id"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.2.size", "50"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.2.type", "GPSSD2"),
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.2.boot_index"),
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.2.pci_address"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.2.delete_on_termination", "false"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.2.pass_through", "false"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.3.volume_id"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.3.size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "volume_attached.3.type", "GPSSD2"),
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.3.boot_index"),
+					resource.TestCheckResourceAttrSet(resourceName, "volume_attached.3.pci_address"),
+					resource.TestCheckResourceAttrPair(resourceName, "volume_attached.3.data_image_id",
+						"huaweicloud_ims_evs_data_image.data_image", "id"),
 				),
 			},
 		},
@@ -430,6 +470,7 @@ func TestAccComputeInstance_change_charging_mode_to_prepaid(t *testing.T) {
 		},
 	})
 }
+
 func testAccCheckComputeInstanceDestroy(s *terraform.State) error {
 	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
 	computeClient, err := cfg.ComputeV1Client(acceptance.HW_REGION_NAME)
@@ -760,10 +801,35 @@ resource "huaweicloud_compute_instance" "test" {
 
 func testAccComputeInstance_diskIopsThroughput(rName string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
+
+resource "huaweicloud_compute_instance" "data_image" {
+  name               = "%[2]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid = data.huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_evs_volume" "data_image" {
+  name              = "%[2]s"
+  volume_type       = "GPSSD"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  server_id         = huaweicloud_compute_instance.data_image.id
+  size              = 100
+}
+
+resource "huaweicloud_ims_evs_data_image" "data_image" {
+  name      = "%[2]s"
+  volume_id = huaweicloud_evs_volume.data_image.id
+}
 
 resource "huaweicloud_compute_instance" "test" {
-  name                = "%s"
+  name                = "%[2]s"
   image_id            = data.huaweicloud_images_image.test.id
   flavor_id           = data.huaweicloud_compute_flavors.test.ids[0]
   security_group_ids  = [data.huaweicloud_networking_secgroup.test.id]
@@ -778,18 +844,30 @@ resource "huaweicloud_compute_instance" "test" {
   system_disk_size       = 50
   system_disk_iops       = 3000
   system_disk_throughput = 125
+  system_pass_through    = false
 
   data_disks {
-    type       = "GPSSD2"
-    size       = "50"
-    iops       = 4000
-    throughput = 200
+    type                  = "GPSSD2"
+    size                  = "50"
+    iops                  = 4000
+    throughput            = 200
+    delete_on_termination = true
+    pass_through          = true
   }
   data_disks {
-    type       = "GPSSD2"
-    size       = "50"
-    iops       = 5000
-    throughput = 300
+    type                  = "GPSSD2"
+    size                  = "50"
+    iops                  = 5000
+    throughput            = 300
+    delete_on_termination = false
+    pass_through          = false
+  }
+  data_disks {
+    type          = "GPSSD2"
+    size          = "200"
+    iops          = 5000
+    throughput    = 300
+    data_image_id = huaweicloud_ims_evs_data_image.data_image.id
   }
 }
 `, testAccCompute_data, rName)

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -248,6 +249,14 @@ func ResourceComputeInstance() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"system_pass_through": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"true", "false",
+				}, false),
+			},
 			"data_disks": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -265,7 +274,17 @@ func ResourceComputeInstance() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"data_image_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 						"snapshot_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"delete_on_termination": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
@@ -289,6 +308,14 @@ func ResourceComputeInstance() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
+						},
+						"pass_through": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"true", "false",
+							}, false),
 						},
 					},
 				},
@@ -543,6 +570,18 @@ func ResourceComputeInstance() *schema.Resource {
 							Computed: true,
 						},
 						"kms_key_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"data_image_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"delete_on_termination": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"pass_through": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -962,12 +1001,15 @@ func resourceComputeInstanceRead(_ context.Context, d *schema.ResourceData, meta
 			log.Printf("[DEBUG] retrieved block device %s: %#v", b.ID, va)
 
 			bds[i] = map[string]interface{}{
-				"volume_id":   b.ID,
-				"size":        volumeInfo.Size,
-				"type":        volumeInfo.VolumeType,
-				"boot_index":  va.BootIndex,
-				"pci_address": va.PciAddress,
-				"kms_key_id":  volumeInfo.Metadata.SystemCmkID,
+				"volume_id":             b.ID,
+				"size":                  volumeInfo.Size,
+				"type":                  volumeInfo.VolumeType,
+				"boot_index":            va.BootIndex,
+				"pci_address":           va.PciAddress,
+				"kms_key_id":            volumeInfo.Metadata.SystemCmkID,
+				"delete_on_termination": b.DeleteOnTermination,
+				"pass_through":          volumeInfo.Metadata.HwPassthrough,
+				"data_image_id":         volumeInfo.ImageMetadata["image_id"],
 			}
 
 			if va.BootIndex == 0 {
@@ -2159,6 +2201,11 @@ func buildInstanceRootVolume(d *schema.ResourceData) cloudservers.RootVolume {
 		volRequest.ClusterId = v.(string)
 	}
 
+	if v, ok := d.GetOk("system_pass_through"); ok {
+		systemPassThrough, _ := strconv.ParseBool(v.(string))
+		volRequest.PassThrough = &systemPassThrough
+	}
+
 	return volRequest
 }
 
@@ -2182,6 +2229,10 @@ func buildInstanceDataVolumes(d *schema.ResourceData) []cloudservers.DataVolume 
 			volRequest.Extendparam = &extendparam
 		}
 
+		if vol["data_image_id"] != "" {
+			volRequest.DataImageId = vol["data_image_id"].(string)
+		}
+
 		if vol["kms_key_id"] != "" {
 			matadata := cloudservers.VolumeMetadata{
 				SystemEncrypted: "1",
@@ -2190,9 +2241,19 @@ func buildInstanceDataVolumes(d *schema.ResourceData) []cloudservers.DataVolume 
 			volRequest.Metadata = &matadata
 		}
 
+		if vol["delete_on_termination"] != "" {
+			deleteOnTermination, _ := strconv.ParseBool(vol["delete_on_termination"].(string))
+			volRequest.DeleteOnTermination = &deleteOnTermination
+		}
+
 		if vol["dss_pool_id"] != "" {
 			volRequest.ClusterType = "DSS"
 			volRequest.ClusterId = vol["dss_pool_id"].(string)
+		}
+
+		if vol["pass_through"] != "" {
+			passThrough, _ := strconv.ParseBool(vol["pass_through"].(string))
+			volRequest.PassThrough = &passThrough
 		}
 
 		volRequests = append(volRequests, volRequest)

--- a/vendor/github.com/chnsz/golangsdk/OWNERS
+++ b/vendor/github.com/chnsz/golangsdk/OWNERS
@@ -4,7 +4,6 @@ reviewers:
 - deer-hang
 - saf3dfsa
 - houpeng80
-- jason-zhang9309
 - lance52259
 - niuzhenguo
 - zippo-wang
@@ -15,6 +14,5 @@ approvers:
 - chengxiangdong
 - deer-hang
 - houpeng80
-- jason-zhang9309
 - lance52259
 - niuzhenguo

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
@@ -148,6 +148,8 @@ type RootVolume struct {
 	ClusterId string `json:"cluster_id,omitempty"`
 	// The cluster type is default to DSS
 	ClusterType string `json:"cluster_type,omitempty"`
+
+	PassThrough *bool `json:"hw:passthrough,omitempty"`
 }
 
 type DataVolume struct {
@@ -166,7 +168,11 @@ type DataVolume struct {
 
 	Extendparam *VolumeExtendParam `json:"extendparam,omitempty"`
 
+	DataImageId string `json:"data_image_id,omitempty"`
+
 	Metadata *VolumeMetadata `json:"metadata,omitempty"`
+
+	DeleteOnTermination *bool `json:"delete_on_termination,omitempty"`
 
 	ClusterId string `json:"cluster_id,omitempty"`
 	// The cluster type is default to DSS

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20260127035608-5e70605a8cd7
+# github.com/chnsz/golangsdk v0.0.0-20260310020804-1615ffe6c577
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -650,7 +650,7 @@ github.com/zclconf/go-cty/cty/function/stdlib
 github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/json
 github.com/zclconf/go-cty/cty/set
-# go.mongodb.org/mongo-driver v1.17.6
+# go.mongodb.org/mongo-driver v1.17.9
 ## explicit; go 1.18
 go.mongodb.org/mongo-driver/bson
 go.mongodb.org/mongo-driver/bson/bsoncodec
@@ -659,7 +659,7 @@ go.mongodb.org/mongo-driver/bson/bsonrw
 go.mongodb.org/mongo-driver/bson/bsontype
 go.mongodb.org/mongo-driver/bson/primitive
 go.mongodb.org/mongo-driver/x/bsonx/bsoncore
-# golang.org/x/crypto v0.45.0 => golang.org/x/crypto v0.21.0
+# golang.org/x/crypto v0.48.0 => golang.org/x/crypto v0.21.0
 ## explicit; go 1.18
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/cast5


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1.  ecs instance add param system_pass_through
2.  ecs instance data_disks add param data_image_id, delete_on_termination and pass_through
3.  ecs instance volume_attached add attributes  data_image_id, delete_on_termination and pass_through

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  ecs instance add params
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/ecs/ TESTARGS='-run TestAccComputeInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs/ -v -run TestAccComputeInstance_ -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== RUN   TestAccComputeInstance_prePaid
=== PAUSE TestAccComputeInstance_prePaid
=== RUN   TestAccComputeInstance_spot
=== PAUSE TestAccComputeInstance_spot
=== RUN   TestAccComputeInstance_powerAction
=== PAUSE TestAccComputeInstance_powerAction
=== RUN   TestAccComputeInstance_disk_encryption
=== PAUSE TestAccComputeInstance_disk_encryption
=== RUN   TestAccComputeInstance_diskIopsThroughput
=== PAUSE TestAccComputeInstance_diskIopsThroughput
=== RUN   TestAccComputeInstance_withEPS
=== PAUSE TestAccComputeInstance_withEPS
=== RUN   TestAccComputeInstance_changeNetwork
=== PAUSE TestAccComputeInstance_changeNetwork
=== RUN   TestAccComputeInstance_with_deh
=== PAUSE TestAccComputeInstance_with_deh
=== RUN   TestAccComputeInstance_change_charging_mode_to_prepaid
=== PAUSE TestAccComputeInstance_change_charging_mode_to_prepaid
=== CONT  TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_diskIopsThroughput
=== CONT  TestAccComputeInstance_powerAction
=== CONT  TestAccComputeInstance_disk_encryption
    acceptance.go:2341: This environment does not support KMS tests
--- SKIP: TestAccComputeInstance_disk_encryption (0.01s)
=== CONT  TestAccComputeInstance_changeNetwork
--- PASS: TestAccComputeInstance_basic (421.53s)
=== CONT  TestAccComputeInstance_spot
--- PASS: TestAccComputeInstance_changeNetwork (464.98s)
=== CONT  TestAccComputeInstance_prePaid
--- PASS: TestAccComputeInstance_spot (250.84s)
=== CONT  TestAccComputeInstance_withEPS
    acceptance.go:1242: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccComputeInstance_withEPS (0.01s)
=== CONT  TestAccComputeInstance_change_charging_mode_to_prepaid
--- PASS: TestAccComputeInstance_diskIopsThroughput (734.67s)
=== CONT  TestAccComputeInstance_with_deh
    acceptance.go:4435: HW_DEDICATED_HOST_ID must be set for the acceptance test
--- SKIP: TestAccComputeInstance_with_deh (0.01s)
--- PASS: TestAccComputeInstance_prePaid (357.00s)
--- PASS: TestAccComputeInstance_powerAction (915.86s)
--- PASS: TestAccComputeInstance_change_charging_mode_to_prepaid (452.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       1125.421s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
