### PR TITLE
feat(dws): add new datasource for query cluster user authorities

### DIFF
--- a/docs/data-sources/dws_cluster_user_authorities.md
+++ b/docs/data-sources/dws_cluster_user_authorities.md
@@ -1,0 +1,72 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_user_authorities"
+description: |-
+  Use this data source to query user or role authorities in a specified DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_user_authorities
+
+Use this data source to query user or role authorities in a specified DWS cluster within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "user_name" {}
+
+data "huaweicloud_dws_cluster_user_authorities" "test" {
+  cluster_id = var.cluster_id
+  name       = var.user_name # Also can be queried by role name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the cluster user authorities are located.  
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of the DWS cluster to be queried.
+
+* `name` - (Required, String) Specifies the user name or role name to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `authorities` - The list of user or role authorities.  
+  The [authorities](#dws_authorities_struct) structure is documented below.
+
+<a name="dws_authorities_struct"></a>
+The `authorities` block supports:
+
+* `type` - The authority type.
+
+* `database` - The database name.
+
+* `schema_name` - The schema name.
+
+* `object_name` - The object name.
+
+* `all_object` - Whether all objects are effective.
+
+* `future` - Whether future objects are effective.
+
+* `future_object_owners` - The owners of future objects.
+
+* `column_names` - The list of column names.
+
+* `privileges` - The privilege list under this authority record.  
+  The [privileges](#authorities_privileges_struct) structure is documented below.
+
+<a name="authorities_privileges_struct"></a>
+The `privileges` block supports:
+
+* `permission` - The privilege name.
+
+* `grant_with` - Whether the grant option is included.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2409,6 +2409,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_cluster_parameters":              dws.DataSourceClusterParameters(),
 			"huaweicloud_dws_cluster_snapshot_statistics":     dws.DataSourceDwsClusterSnapshotStatistics(),
 			"huaweicloud_dws_cluster_topo_rings":              dws.DataSourceDwsClusterTopoRings(),
+			"huaweicloud_dws_cluster_user_authorities":        dws.DataSourceClusterUserAuthorities(),
 			"huaweicloud_dws_clusters":                        dws.DataSourceDwsClusters(),
 			"huaweicloud_dws_disaster_recovery_tasks":         dws.DataSourceDisasterRecoveryTasks(),
 			"huaweicloud_dws_event_subscriptions":             dws.DataSourceEventSubscriptions(),

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_user_authorities_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_user_authorities_test.go
@@ -1,0 +1,68 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataClusterUserAuthorities_basic(t *testing.T) {
+	dcName := "data.huaweicloud_dws_cluster_user_authorities.test"
+	dc := acceptance.InitDataSourceCheck(dcName)
+	userName := strings.Split(acceptance.HW_DWS_ASSOCIATE_USER_NAMES, ",")[0]
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+			acceptance.TestAccPreCheckDwsClusterUserNames(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataClusterUserAuthorities_clusterNotFound(userName),
+				ExpectError: regexp.MustCompile("Cluster does not exist or has been deleted"),
+			},
+			{
+				Config: testAccDataClusterUserAuthorities_basic(userName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dcName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(dcName, "name", userName),
+					resource.TestMatchResourceAttr(dcName, "authorities.#", regexp.MustCompile(`^([0-9]|[1-9][0-9]*)$`)),
+					resource.TestCheckResourceAttrSet(dcName, "authorities.0.database"),
+					resource.TestCheckResourceAttrSet(dcName, "authorities.0.all_object"),
+					resource.TestCheckResourceAttrSet(dcName, "authorities.0.future"),
+					resource.TestMatchResourceAttr(dcName, "authorities.0.privileges.#", regexp.MustCompile(`^([0-9]|[1-9][0-9]*)$`)),
+					resource.TestCheckResourceAttrSet(dcName, "authorities.0.privileges.0.permission"),
+					resource.TestCheckResourceAttrSet(dcName, "authorities.0.privileges.0.grant_with"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataClusterUserAuthorities_clusterNotFound(userName string) string {
+	randUUID, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_user_authorities" "test" {
+  cluster_id = "%s"
+  name       = "%s"
+}
+`, randUUID, userName)
+}
+
+func testAccDataClusterUserAuthorities_basic(userName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_user_authorities" "test" {
+  cluster_id = "%s"
+  name       = "%s"
+}
+`, acceptance.HW_DWS_CLUSTER_ID, userName)
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_user_authorities.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_user_authorities.go
@@ -1,0 +1,237 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}/authority
+func DataSourceClusterUserAuthorities() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterUserAuthoritiesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the cluster user authorities are located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the DWS cluster to be queried.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The user name or role name to be queried.`,
+			},
+
+			// Attributes.
+			"authorities": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of user or role authorities.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The authority type.`,
+						},
+						"database": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The database name.`,
+						},
+						"schema_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The schema name.`,
+						},
+						"object_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The object name.`,
+						},
+						"all_object": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether all objects are effective.`,
+						},
+						"future": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether future objects are effective.`,
+						},
+						"future_object_owners": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The owners of future objects.`,
+						},
+						"column_names": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of column names.`,
+						},
+						"privileges": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        clusterUserAuthorityPrivilegeSchema(),
+							Description: `The privilege list under this authority record.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func clusterUserAuthorityPrivilegeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"permission": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The privilege name.`,
+			},
+			"grant_with": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the grant option is included.`,
+			},
+		},
+	}
+}
+
+func listClusterUserAuthorities(client *golangsdk.ServiceClient, clusterId, name string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}/authority?limit={limit}"
+		limit   = 1000
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{cluster_id}", clusterId)
+	listPath = strings.ReplaceAll(listPath, "{name}", name)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		authorities := utils.PathSearch("authority_list", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, authorities...)
+		if len(authorities) < limit {
+			break
+		}
+		offset += len(authorities)
+	}
+
+	return result, nil
+}
+
+func flattenClusterUserAuthorityPrivileges(privileges []interface{}) []map[string]interface{} {
+	if len(privileges) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(privileges))
+	for _, privilege := range privileges {
+		result = append(result, map[string]interface{}{
+			"permission": utils.PathSearch("permission", privilege, nil),
+			"grant_with": utils.PathSearch("grant_with", privilege, false),
+		})
+	}
+
+	return result
+}
+
+func flattenClusterUserAuthorities(authorities []interface{}) []map[string]interface{} {
+	if len(authorities) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(authorities))
+	for _, authority := range authorities {
+		result = append(result, map[string]interface{}{
+			"type":                 utils.PathSearch("type", authority, nil),
+			"database":             utils.PathSearch("database", authority, nil),
+			"schema_name":          utils.PathSearch("schema", authority, nil),
+			"object_name":          utils.PathSearch("obj_name", authority, nil),
+			"all_object":           utils.PathSearch("all_object", authority, false),
+			"future":               utils.PathSearch("future", authority, false),
+			"future_object_owners": utils.PathSearch("future_object_owners", authority, nil),
+			"column_names":         utils.PathSearch("column_name", authority, make([]interface{}, 0)),
+			"privileges": flattenClusterUserAuthorityPrivileges(utils.PathSearch("privileges", authority,
+				make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func dataSourceClusterUserAuthoritiesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+		name      = d.Get("name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	authorities, err := listClusterUserAuthorities(client, clusterId, name)
+	if err != nil {
+		return diag.Errorf("error querying cluster user authorities: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("authorities", flattenClusterUserAuthorities(authorities)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new datasource for query cluster user authorities

**Which issue this PR fixes**:
nothing

**Special notes for your reviewer**:
The DWS cluster provisioning process takes too long during acceptance tests. Therefore, we have pre-provisioned a cluster via the console and configured the test cases to run against this existing environment.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccDataClusterUserAuthorities_basic -timeout 360m -parallel 10
=== RUN   TestAccDataClusterUserAuthorities_basic
=== PAUSE TestAccDataClusterUserAuthorities_basic
=== CONT  TestAccDataClusterUserAuthorities_basic
--- PASS: TestAccDataClusterUserAuthorities_basic (52.06s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/dws
ok   github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws  52.175s coverage: 3.7% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.