### PR TITLE
feat(dws): add new datasource for query cluster database objects

### DIFF
--- a/docs/data-sources/dws_cluster_database_objects.md
+++ b/docs/data-sources/dws_cluster_database_objects.md
@@ -1,0 +1,73 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_database_objects"
+description: |-
+  Use this data source to query database objects in a specified DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_database_objects
+
+Use this data source to query database objects in a specified DWS cluster within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_dws_cluster_database_objects" "test" {
+  cluster_id = var.cluster_id
+  type       = "DATABASE"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the database objects are located.  
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of the cluster.
+
+* `type` - (Required, String) Specifies the type of the database object.  
+  The valid values are as follows:
+  + **DATABASE**
+  + **SCHEMA**
+  + **TABLE**
+  + **VIEW**
+  + **COLUMN**
+  + **FUNCTION**
+  + **SEQUENCE**
+  + **NODEGROUP**
+
+* `name` - (Optional, String) Specifies the name of the database object.
+
+* `database` - (Optional, String) Specifies the name of the database.
+
+* `schema` - (Optional, String) Specifies the name of the schema.  
+  Required if the `type` is set to **TABLE**, **VIEW**, **COLUMN**, **FUNCTION**
+  or **SEQUENCE**.
+
+* `table` - (Optional, String) Specifies the name of the table.  
+  Required if the `type` is set to **COLUMN**.
+
+* `is_fine_grained_disaster` - (Optional, String) Specifies whether fine-grained disaster recovery
+  is enabled.  
+  The valid values are as follows:
+  + **true**: fine-grained disaster recovery is enabled.
+  + **false**: fine-grained disaster recovery is disabled.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `objects` - The list of the database objects that matched filter parameters.  
+  The [objects](#dws_objects_struct) structure is documented below.
+
+<a name="dws_objects_struct"></a>
+The `objects` block supports:
+
+* `name` - The name of the database object.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2415,6 +2415,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_alarm_subscriptions":             dws.DataSourceAlarmSubscriptions(),
 			"huaweicloud_dws_availability_zones":              dws.DataSourceDwsAvailabilityZones(),
 			"huaweicloud_dws_cluster_cns":                     dws.DataSourceDwsClusterCns(),
+			"huaweicloud_dws_cluster_database_objects":        dws.DataSourceClusterDatabaseObjects(),
 			"huaweicloud_dws_cluster_logs":                    dws.DataSourceDwsClusterLogs(),
 			"huaweicloud_dws_cluster_nodes":                   dws.DataSourceDwsClusterNodes(),
 			"huaweicloud_dws_cluster_parameters":              dws.DataSourceClusterParameters(),

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_database_objects_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_database_objects_test.go
@@ -1,0 +1,71 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataClusterDatabaseObjects_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dws_cluster_database_objects.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_dws_cluster_database_objects.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataClusterDatabaseObjects_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "objects.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "objects.0.name"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataClusterDatabaseObjects_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_database_objects" "test" {
+  cluster_id = "%[1]s"
+  type       = "DATABASE"
+}
+
+locals {
+  first_object_name = data.huaweicloud_dws_cluster_database_objects.test.objects[0].name
+}
+
+data "huaweicloud_dws_cluster_database_objects" "filter_by_name" {
+  cluster_id = "%[1]s"
+  type       = "DATABASE"
+  name       = local.first_object_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dws_cluster_database_objects.filter_by_name.objects[*].name :
+    v == local.first_object_name
+  ]
+}
+
+output "name_filter_is_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+`, acceptance.HW_DWS_CLUSTER_ID)
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_database_objects.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_database_objects.go
@@ -1,0 +1,199 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v1/{project_id}/clusters/{cluster_id}/db-manager/objects
+func DataSourceClusterDatabaseObjects() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterDatabaseObjectsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the database objects are located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the database object.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the database object.`,
+			},
+			"database": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the database.`,
+			},
+			"schema": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the schema.`,
+			},
+			"table": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the table.`,
+			},
+			"is_fine_grained_disaster": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Whether fine-grained disaster recovery is enabled.`,
+			},
+
+			// Attributes.
+			"objects": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the database object.`,
+						},
+					},
+				},
+				Description: `The list of the database objects that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildClusterDatabaseObjectsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	res = fmt.Sprintf("%s&type=%v", res, d.Get("type"))
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("database"); ok {
+		res = fmt.Sprintf("%s&database=%v", res, v)
+	}
+	if v, ok := d.GetOk("schema"); ok {
+		res = fmt.Sprintf("%s&schema=%v", res, v)
+	}
+	if v, ok := d.GetOk("table"); ok {
+		res = fmt.Sprintf("%s&table=%v", res, v)
+	}
+	if v, ok := d.GetOk("is_fine_grained_disaster"); ok {
+		res = fmt.Sprintf("%s&is_fine_grained_disaster=%v", res, v)
+	}
+
+	return res
+}
+
+func listClusterDatabaseObjects(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl   = "v1/{project_id}/clusters/{cluster_id}/db-manager/objects?limit={limit}"
+		clusterId = d.Get("cluster_id").(string)
+		limit     = 1000
+		offset    = 0
+		result    = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{cluster_id}", clusterId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildClusterDatabaseObjectsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		objects := utils.PathSearch("object_list", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, objects...)
+		if len(objects) < limit {
+			break
+		}
+		offset += len(objects)
+	}
+
+	return result, nil
+}
+
+func flattenClusterDatabaseObjects(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"name": utils.PathSearch("obj_name", item, nil),
+		})
+	}
+	return result
+}
+
+func dataSourceClusterDatabaseObjectsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	objects, err := listClusterDatabaseObjects(client, d)
+	if err != nil {
+		return diag.Errorf("error querying cluster database objects: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("objects", flattenClusterDatabaseObjects(objects)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new datasource for query cluster database objects

**Which issue this PR fixes**:

**Special notes for your reviewer**:
The DWS cluster provisioning process takes too long during acceptance tests. Therefore, we have pre-provisioned a cluster via the console and configured the test cases to run against this existing environment.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccDataClusterDatabaseObjects_basic -timeout 360m -parallel 10
=== RUN   TestAccDataClusterDatabaseObjects_basic
=== PAUSE TestAccDataClusterDatabaseObjects_basic
=== CONT  TestAccDataClusterDatabaseObjects_basic
--- PASS: TestAccDataClusterDatabaseObjects_basic (41.76s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/dws
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws	41.882s	coverage: 3.7% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.