### PR TITLE
feat(dws): add new datasource for query the list of upgrade records of the cluster

### DIFF
--- a/docs/data-sources/dws_cluster_upgrade_records.md
+++ b/docs/data-sources/dws_cluster_upgrade_records.md
@@ -1,0 +1,60 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_upgrade_records"
+description: |-
+  Use this data source to get the list of DWS cluster upgrade records within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_upgrade_records
+
+Use this data source to get the list of DWS cluster upgrade records within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_dws_cluster_upgrade_records" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the cluster upgrade records are located.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of the cluster to which the upgrade records belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The list of cluster upgrade records that matched filter parameters.  
+  The [records](#dws_records_struct) structure is documented below.
+
+<a name="dws_records_struct"></a>
+The `records` block supports:
+
+* `id` - The ID of the upgrade record.
+
+* `status` - The status of the upgrade record.
+
+* `record_type` - The type of the upgrade record.
+
+* `from_version` - The source version before the upgrade.
+
+* `to_version` - The target version after the upgrade.
+
+* `start_time` - The start time of the upgrade task, in RFC3339 format.
+
+* `end_time` - The end time of the upgrade task, in RFC3339 format.
+
+* `job_id` - The ID of the upgrade job.
+
+* `failed_reason` - The reason why the upgrade failed.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2420,6 +2420,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_cluster_parameters":              dws.DataSourceClusterParameters(),
 			"huaweicloud_dws_cluster_snapshot_statistics":     dws.DataSourceDwsClusterSnapshotStatistics(),
 			"huaweicloud_dws_cluster_topo_rings":              dws.DataSourceDwsClusterTopoRings(),
+			"huaweicloud_dws_cluster_upgrade_records":         dws.DataSourceClusterUpgradeRecords(),
 			"huaweicloud_dws_cluster_user_authorities":        dws.DataSourceClusterUserAuthorities(),
 			"huaweicloud_dws_clusters":                        dws.DataSourceDwsClusters(),
 			"huaweicloud_dws_disaster_recovery_tasks":         dws.DataSourceDisasterRecoveryTasks(),

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_upgrade_records_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_upgrade_records_test.go
@@ -1,0 +1,48 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataClusterUpgradeRecords_basic(t *testing.T) {
+	all := "data.huaweicloud_dws_cluster_upgrade_records.test"
+	dc := acceptance.InitDataSourceCheck(all)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataClusterUpgradeRecords_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "records.#", regexp.MustCompile(`^[0-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "records.0.id"),
+					resource.TestCheckResourceAttrSet(all, "records.0.status"),
+					resource.TestCheckResourceAttrSet(all, "records.0.record_type"),
+					resource.TestCheckResourceAttrSet(all, "records.0.from_version"),
+					resource.TestCheckResourceAttrSet(all, "records.0.to_version"),
+					resource.TestCheckResourceAttrSet(all, "records.0.start_time"),
+					resource.TestCheckResourceAttrSet(all, "records.0.job_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataClusterUpgradeRecords_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_upgrade_records" "test" {
+  cluster_id = "%[1]s"
+}
+`, acceptance.HW_DWS_CLUSTER_ID)
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_upgrade_records.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_upgrade_records.go
@@ -1,0 +1,198 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v1/{project_id}/clusters/{cluster_id}/upgrade-management/records
+func DataSourceClusterUpgradeRecords() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterUpgradeRecordsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the cluster upgrade records are located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster to which the upgrade records belong.`,
+			},
+
+			// Attributes.
+			"records": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        clusterUpgradeRecordSchema(),
+				Description: `The list of cluster upgrade records that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func clusterUpgradeRecordSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the upgrade record.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the upgrade record.`,
+			},
+			"record_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the upgrade record.`,
+			},
+			"from_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The source version before the upgrade.`,
+			},
+			"to_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The target version after the upgrade.`,
+			},
+			"start_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The start time of the upgrade task, in RFC3339 format.`,
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The end time of the upgrade task, in RFC3339 format.`,
+			},
+			"job_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the upgrade job.`,
+			},
+			"failed_reason": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The reason why the upgrade failed.`,
+			},
+		},
+	}
+}
+
+func listClusterUpgradeRecords(client *golangsdk.ServiceClient, clusterId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/clusters/{cluster_id}/upgrade-management/records?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{cluster_id}", clusterId)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPathWithLimit, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		records := utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, records...)
+		if len(records) < limit {
+			break
+		}
+		offset += len(records)
+	}
+
+	return result, nil
+}
+
+func flattenClusterUpgradeRecords(records []interface{}) []map[string]interface{} {
+	if len(records) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(records))
+	for _, record := range records {
+		result = append(result, map[string]interface{}{
+			"id":            utils.PathSearch("item_id", record, nil),
+			"status":        utils.PathSearch("status", record, nil),
+			"record_type":   utils.PathSearch("record_type", record, nil),
+			"from_version":  utils.PathSearch("from_version", record, nil),
+			"to_version":    utils.PathSearch("to_version", record, nil),
+			"start_time":    utils.PathSearch("start_time", record, nil),
+			"end_time":      utils.PathSearch("end_time", record, nil),
+			"job_id":        utils.PathSearch("job_id", record, nil),
+			"failed_reason": utils.PathSearch("failed_reason", record, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceClusterUpgradeRecordsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	records, err := listClusterUpgradeRecords(client, clusterId)
+	if err != nil {
+		return diag.Errorf("error querying cluster upgrade records: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("records", flattenClusterUpgradeRecords(records)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add new datasource for query the list of upgrade records of the cluster.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
The DWS cluster provisioning process takes too long during acceptance tests. Therefore, we have pre-provisioned a cluster via the console and configured the test cases to run against this existing environment.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccDataClusterUpgradeRecords_basic -timeout 360m -parallel 10
=== RUN   TestAccDataClusterUpgradeRecords_basic
=== PAUSE TestAccDataClusterUpgradeRecords_basic
=== CONT  TestAccDataClusterUpgradeRecords_basic
--- PASS: TestAccDataClusterUpgradeRecords_basic (13.50s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       13.608s coverage: 3.4% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.