### PR TITLE
feat(dws): add new datasource for query cluster database schemas

### DIFF
--- a/docs/data-sources/dws_cluster_database_schemas.md
+++ b/docs/data-sources/dws_cluster_database_schemas.md
@@ -1,0 +1,79 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_database_schemas"
+description: |-
+  Use this data source to query the list of schemas in a specified database of a DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_database_schemas
+
+Use this data source to query the list of schemas in a specified database of a DWS cluster within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_dws_cluster_database_schemas" "test" {
+  cluster_id    = var.cluster_id
+  database_name = "gaussdb"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the database schemas are located.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of the cluster to be queried.
+
+* `database_name` - (Required, String) Specifies the name of the database to be queried.
+
+* `sort_key` - (Optional, String) Specifies the field used to sort query results.
+  The valid value is **schemaName**.
+
+* `sort_dir` - (Optional, String) Specifies the direction of sorting query results.
+  The valid values are as follows:
+  + **ASC**: Sorts query results in ascending order.
+  + **DESC**: Sorts query results in descending order.
+
+-> If the sort_key and sort_dir parameters are not specified, the results will be sorted according to
+   the default system behavior.  
+   Typically, data is sorted by creation time.
+
+* `keywords` - (Optional, String) Specifies the keywords used for fuzzy query.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `schemas` - The list of the database schemas that matched filter parameters.  
+  The [schemas](#dws_schemas_struct) structure is documented below.
+
+<a name="dws_schemas_struct"></a>
+The `schemas` block supports:
+
+* `schema_name` - The name of the schema.
+
+* `database_name` - The name of the database to which the schema belongs.
+
+* `total_value` - The total used space value of the schema.
+
+* `perm_space` - The space threshold of the schema.
+
+* `skew_percent` - The skew percentage of the schema.
+
+* `min_value` - The minimum value.
+
+* `max_value` - The maximum value.
+
+* `min_dn` - The minimum DN node.
+
+* `max_dn` - The maximum DN node.
+
+* `dn_num` - The number of DN nodes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2416,6 +2416,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_availability_zones":              dws.DataSourceDwsAvailabilityZones(),
 			"huaweicloud_dws_cluster_cns":                     dws.DataSourceDwsClusterCns(),
 			"huaweicloud_dws_cluster_database_objects":        dws.DataSourceClusterDatabaseObjects(),
+			"huaweicloud_dws_cluster_database_schemas":        dws.DataSourceClusterDatabaseSchemas(),
 			"huaweicloud_dws_cluster_logs":                    dws.DataSourceDwsClusterLogs(),
 			"huaweicloud_dws_cluster_nodes":                   dws.DataSourceDwsClusterNodes(),
 			"huaweicloud_dws_cluster_parameters":              dws.DataSourceClusterParameters(),

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_database_schemas_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_database_schemas_test.go
@@ -1,0 +1,110 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataClusterDatabaseSchemas_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dws_cluster_database_schemas.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byKeywords   = "data.huaweicloud_dws_cluster_database_schemas.filter_by_keywords"
+		dcByKeywords = acceptance.InitDataSourceCheck(byKeywords)
+
+		emptyResult = "data.huaweicloud_dws_cluster_database_schemas.not_found_database"
+		dcEmpty     = acceptance.InitDataSourceCheck(emptyResult)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataClusterDatabaseSchemas_clusterNotFound(),
+				ExpectError: regexp.MustCompile("Cluster does not exist or has been deleted"),
+			},
+			{
+				Config: testAccDataClusterDatabaseSchemas_databaseNotFound(),
+				Check: resource.ComposeTestCheckFunc(
+					dcEmpty.CheckResourceExists(),
+					resource.TestCheckResourceAttr(emptyResult, "schemas.#", "0"),
+				),
+			},
+			{
+				Config: testAccDataClusterDatabaseSchemas_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "schemas.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "schemas.0.schema_name"),
+					resource.TestCheckResourceAttrSet(all, "schemas.0.database_name"),
+					resource.TestCheckResourceAttrSet(all, "schemas.0.total_value"),
+					resource.TestCheckResourceAttrSet(all, "schemas.0.perm_space"),
+					resource.TestCheckResourceAttrSet(all, "schemas.0.skew_percent"),
+					resource.TestCheckResourceAttrSet(all, "schemas.0.min_value"),
+					resource.TestCheckResourceAttrSet(all, "schemas.0.max_value"),
+					resource.TestCheckResourceAttrSet(all, "schemas.0.min_dn"),
+					resource.TestCheckResourceAttrSet(all, "schemas.0.dn_num"),
+					dcByKeywords.CheckResourceExists(),
+					resource.TestCheckOutput("keywords_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataClusterDatabaseSchemas_clusterNotFound() string {
+	randomUUID, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_database_schemas" "test" {
+  cluster_id    = "%[1]s"
+  database_name = "gaussdb"
+}
+`, randomUUID)
+}
+
+func testAccDataClusterDatabaseSchemas_databaseNotFound() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_database_schemas" "not_found_database" {
+  cluster_id    = "%[1]s"
+  database_name = "database_name_not_exist_for_acc_test"
+}
+`, acceptance.HW_DWS_CLUSTER_ID)
+}
+
+func testAccDataClusterDatabaseSchemas_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_database_schemas" "test" {
+  cluster_id    = "%[1]s"
+  database_name = "gaussdb"
+}
+
+locals {
+  schema_name = data.huaweicloud_dws_cluster_database_schemas.test.schemas[0].schema_name
+}
+
+data "huaweicloud_dws_cluster_database_schemas" "filter_by_keywords" {
+  cluster_id    = "%[1]s"
+  database_name = "gaussdb"
+  keywords      = local.schema_name
+}
+
+locals {
+  schema_names = data.huaweicloud_dws_cluster_database_schemas.filter_by_keywords.schemas[*].schema_name
+}
+
+output "keywords_filter_is_useful" {
+  value = length(local.schema_names) > 0 && contains(local.schema_names, local.schema_name)
+}
+`, acceptance.HW_DWS_CLUSTER_ID)
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_database_schemas.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_database_schemas.go
@@ -1,0 +1,246 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v2/{project_id}/clusters/{cluster_id}/databases/{database_name}/schemas
+func DataSourceClusterDatabaseSchemas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterDatabaseSchemasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the database schemas are located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster to be queried.`,
+			},
+			"database_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the database to be queried.`,
+			},
+
+			// Optional parameters.
+			"sort_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The field used to sort query results.`,
+			},
+			"sort_dir": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The direction of sorting query results.`,
+			},
+			"keywords": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The keywords used for fuzzy query.`,
+			},
+
+			// Attributes.
+			"schemas": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        clusterDatabaseSchemasSchema(),
+				Description: `The list of the database schemas that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func clusterDatabaseSchemasSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"schema_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the schema.`,
+			},
+			"database_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the database to which the schema belongs.`,
+			},
+			"total_value": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The total used space value of the schema.`,
+			},
+			"perm_space": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The space threshold of the schema.`,
+			},
+			"skew_percent": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The skew percentage of the schema.`,
+			},
+			"min_value": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The minimum value.`,
+			},
+			"max_value": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The maximum value.`,
+			},
+			"min_dn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The minimum DN node.`,
+			},
+			"max_dn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The maximum DN node.`,
+			},
+			"dn_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of DN nodes.`,
+			},
+		},
+	}
+}
+
+func buildClusterDatabaseSchemasQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		res = fmt.Sprintf("%s&sort_key=%v", res, v)
+	}
+	if v, ok := d.GetOk("sort_dir"); ok {
+		res = fmt.Sprintf("%s&sort_dir=%v", res, v)
+	}
+	if v, ok := d.GetOk("keywords"); ok {
+		res = fmt.Sprintf("%s&keywords=%v", res, v)
+	}
+
+	return res
+}
+
+func listClusterDatabaseSchemas(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl      = "v2/{project_id}/clusters/{cluster_id}/databases/{database_name}/schemas?limit={limit}"
+		clusterID    = d.Get("cluster_id").(string)
+		databaseName = d.Get("database_name").(string)
+		limit        = 100
+		offset       = 0
+		result       = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{cluster_id}", clusterID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{database_name}", databaseName)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+	listPathWithLimit += buildClusterDatabaseSchemasQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPathWithLimit + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		schemas := utils.PathSearch("schemas", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, schemas...)
+		if len(schemas) < limit {
+			break
+		}
+
+		offset += len(schemas)
+	}
+
+	return result, nil
+}
+
+func flattenClusterDatabaseSchemas(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"schema_name":   utils.PathSearch("schema_name", item, nil),
+			"database_name": utils.PathSearch("database_name", item, nil),
+			"total_value":   utils.PathSearch("total_value", item, nil),
+			"perm_space":    utils.PathSearch("perm_space", item, nil),
+			"skew_percent":  utils.PathSearch("skew_percent", item, nil),
+			"min_value":     utils.PathSearch("min_value", item, nil),
+			"max_value":     utils.PathSearch("max_value", item, nil),
+			"min_dn":        utils.PathSearch("min_dn", item, nil),
+			"max_dn":        utils.PathSearch("max_dn", item, nil),
+			"dn_num":        utils.PathSearch("dn_num", item, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceClusterDatabaseSchemasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	schemas, err := listClusterDatabaseSchemas(client, d)
+	if err != nil {
+		return diag.Errorf("error querying cluster database schemas: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("schemas", flattenClusterDatabaseSchemas(schemas)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add new datasource for query cluster database schemas.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
The DWS cluster provisioning process takes too long during acceptance tests. Therefore, we have pre-provisioned a cluster via the console and configured the test cases to run against this existing environment.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccDataClusterDatabaseSchemas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataClusterDatabaseSchemas_basic
=== PAUSE TestAccDataClusterDatabaseSchemas_basic
=== CONT  TestAccDataClusterDatabaseSchemas_basic
--- PASS: TestAccDataClusterDatabaseSchemas_basic (57.45s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       57.576s coverage: 3.8% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.