### PR TITLE
feat(dws): add new datasource for query the list of users of the cluster database

### DIFF
--- a/docs/data-sources/dws_cluster_database_users.md
+++ b/docs/data-sources/dws_cluster_database_users.md
@@ -1,0 +1,59 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_database_users"
+description: |-
+  Use this data source to query database users or roles in a DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_database_users
+
+Use this data source to query database users or roles in a DWS cluster within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_dws_cluster_database_users" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the database users are located.  
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of the cluster to be queried.
+
+* `type` - (Optional, String) Specifies the object type to be queried.  
+  The valid values are as follows:
+  + **USER** - Indicates a database user.
+  + **ROLE** - Indicates a database role.
+
+* `user_type` - (Optional, String) Specifies the user type to be queried.  
+  The valid values are as follows:
+  + **COMMON** - Indicates a common database user.
+  + **IAM** - Indicates a database user created by IAM.
+  + **OneAccess** - Indicates a database user created by OneAccess.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `users` - The list of database users or roles that matched filter parameters.  
+  The [users](#dws_users_struct) structure is documented below.
+
+<a name="dws_users_struct"></a>
+The `users` block supports:
+
+* `name` - The name of the database user or role.
+
+* `login` - Whether the database user can login.
+
+* `user_type` - The type of the database user.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2418,6 +2418,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_cluster_cns":                     dws.DataSourceDwsClusterCns(),
 			"huaweicloud_dws_cluster_database_objects":        dws.DataSourceClusterDatabaseObjects(),
 			"huaweicloud_dws_cluster_database_schemas":        dws.DataSourceClusterDatabaseSchemas(),
+			"huaweicloud_dws_cluster_database_users":          dws.DataSourceClusterDatabaseUsers(),
 			"huaweicloud_dws_cluster_logs":                    dws.DataSourceDwsClusterLogs(),
 			"huaweicloud_dws_cluster_nodes":                   dws.DataSourceDwsClusterNodes(),
 			"huaweicloud_dws_cluster_parameters":              dws.DataSourceClusterParameters(),

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_database_users_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_database_users_test.go
@@ -1,0 +1,103 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataClusterDatabaseUsers_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dws_cluster_database_users.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byType   = "data.huaweicloud_dws_cluster_database_users.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byUserType   = "data.huaweicloud_dws_cluster_database_users.filter_by_user_type"
+		dcByUserType = acceptance.InitDataSourceCheck(byUserType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataClusterDatabaseUsers_clusterNotFound(),
+				ExpectError: regexp.MustCompile("Cluster does not exist or has been deleted"),
+			},
+			{
+				Config: testAccDataClusterDatabaseUsers_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "users.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "users.0.name"),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					dcByUserType.CheckResourceExists(),
+					resource.TestCheckOutput("user_type_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataClusterDatabaseUsers_clusterNotFound() string {
+	clusterId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_database_users" "all" {
+  cluster_id = "%s"
+}
+`, clusterId)
+}
+
+func testAccDataClusterDatabaseUsers_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_database_users" "all" {
+  cluster_id = "%[1]s"
+}
+
+# Filter by type
+locals {
+  type = "USER"
+}
+
+data "huaweicloud_dws_cluster_database_users" "filter_by_type" {
+  cluster_id = "%[1]s"
+  type       = local.type
+}
+
+output "type_filter_is_useful" {
+  value = length(data.huaweicloud_dws_cluster_database_users.filter_by_type.users) > 0
+}
+
+# Filter by user type
+locals {
+  user_type = "COMMON"
+}
+
+data "huaweicloud_dws_cluster_database_users" "filter_by_user_type" {
+  cluster_id = "%[1]s"
+  type       = "USER"
+  user_type  = local.user_type
+}
+
+locals {
+  user_type_filter_result = [
+    for v in data.huaweicloud_dws_cluster_database_users.filter_by_user_type.users[*].user_type : v == local.user_type
+  ]
+}
+
+output "user_type_filter_is_useful" {
+  value = length(local.user_type_filter_result) > 0 && alltrue(local.user_type_filter_result)
+}
+`, acceptance.HW_DWS_CLUSTER_ID)
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_database_users.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_database_users.go
@@ -1,0 +1,188 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v1/{project_id}/clusters/{cluster_id}/db-manager/users
+func DataSourceClusterDatabaseUsers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterDatabaseUsersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the database users are located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster to be queried.`,
+			},
+
+			// Optional parameters.
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The object type to be queried.`,
+			},
+			"user_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The user type to be queried.`,
+			},
+
+			// Attributes.
+			"users": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        clusterDatabaseUserSchema(),
+				Description: `The list of the database users that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func clusterDatabaseUserSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the database user or role.`,
+			},
+			"login": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the database user can login.`,
+			},
+			"user_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the database user.`,
+			},
+		},
+	}
+}
+
+func buildClusterDatabaseUsersQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("type"); ok {
+		res = fmt.Sprintf("%s&type=%v", res, v)
+	}
+	if v, ok := d.GetOk("user_type"); ok {
+		res = fmt.Sprintf("%s&user_type=%v", res, v)
+	}
+
+	return res
+}
+
+func listClusterDatabaseUsers(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl   = "v1/{project_id}/clusters/{cluster_id}/db-manager/users?limit={limit}"
+		clusterId = d.Get("cluster_id").(string)
+		limit     = 1000
+		offset    = 0
+		result    = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{cluster_id}", clusterId)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+	listPathWithLimit += buildClusterDatabaseUsersQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPathWithLimit, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		users := utils.PathSearch("users", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, users...)
+		if len(users) < limit {
+			break
+		}
+		offset += len(users)
+	}
+
+	return result, nil
+}
+
+func flattenClusterDatabaseUsers(users []interface{}) []map[string]interface{} {
+	if len(users) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(users))
+	for _, user := range users {
+		result = append(result, map[string]interface{}{
+			"name":      utils.PathSearch("name", user, nil),
+			"login":     utils.PathSearch("login", user, nil),
+			"user_type": utils.PathSearch("user_type", user, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceClusterDatabaseUsersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	users, err := listClusterDatabaseUsers(client, d)
+	if err != nil {
+		return diag.Errorf("error querying cluster database users: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("users", flattenClusterDatabaseUsers(users)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add new datasource for query the list of users of the cluster database.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
The DWS cluster provisioning process takes too long during acceptance tests. Therefore, we have pre-provisioned a cluster via the console and configured the test cases to run against this existing environment.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccDataClusterDatabaseUsers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataClusterDatabaseUsers_basic
=== PAUSE TestAccDataClusterDatabaseUsers_basic
=== CONT  TestAccDataClusterDatabaseUsers_basic
--- PASS: TestAccDataClusterDatabaseUsers_basic (49.16s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       49.280s coverage: 3.7% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.