### PR TITLE
feat(dws): add a new datasource to query DWS indicators

### DIFF
--- a/docs/data-sources/dws_monitor_indicators.md
+++ b/docs/data-sources/dws_monitor_indicators.md
@@ -1,0 +1,44 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_monitor_indicators"
+description: |-
+  Use this data source to query monitor indicators of DWS within HuaweiCloud.
+---
+
+# huaweicloud_dws_monitor_indicators
+
+Use this data source to query monitor indicators of DWS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dws_monitor_indicators" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the monitor indicators are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `indicators` - The list of monitor indicators.  
+  The [indicators](#dws_indicators_struct) structure is documented below.
+
+<a name="dws_indicators_struct"></a>
+The `indicators` block supports:
+
+* `indicator_name` - The monitor indicator name.
+
+* `plugin_name` - The collection plugin name.
+
+* `default_collect_rate` - The default collection rate.
+
+* `support_datastore_version` - The supported datastore version.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2416,6 +2416,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_logical_cluster_rings":           dws.DataSourceLogicalClusterRings(),
 			"huaweicloud_dws_logical_cluster_volumes":         dws.DataSourceDwsLogicalClusterVolumes(),
 			"huaweicloud_dws_logical_clusters":                dws.DataSourceDwsLogicalClusters(),
+			"huaweicloud_dws_monitor_indicators":              dws.DataSourceMonitorIndicators(),
 			"huaweicloud_dws_om_account_configuration":        dws.DataSourceOmAccountConfiguration(),
 			"huaweicloud_dws_quotas":                          dws.DataSourceDwsQuotas(),
 			"huaweicloud_dws_snapshot_policies":               dws.DataSourceDwsSnapshotPolicies(),

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_monitor_indicators_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_monitor_indicators_test.go
@@ -1,0 +1,41 @@
+package dws
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataMonitorIndicators_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dws_monitor_indicators.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataMonitorIndicators_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "indicators.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "indicators.0.indicator_name"),
+					resource.TestCheckResourceAttrSet(all, "indicators.0.plugin_name"),
+					resource.TestCheckResourceAttrSet(all, "indicators.0.default_collect_rate"),
+					resource.TestCheckResourceAttrSet(all, "indicators.0.support_datastore_version"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataMonitorIndicators_basic = `
+data "huaweicloud_dws_monitor_indicators" "test" {}
+`

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_monitor_indicators.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_monitor_indicators.go
@@ -1,0 +1,146 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v1.0/{project_id}/dms/metric-data/indicators
+func DataSourceMonitorIndicators() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMonitorIndicatorsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the monitor indicators are located.`,
+			},
+
+			// Attributes.
+			"indicators": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        monitorIndicatorsSchema(),
+				Description: `The list of monitor indicators.`,
+			},
+		},
+	}
+}
+
+func monitorIndicatorsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"indicator_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The monitor indicator name.`,
+			},
+			"plugin_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The collection plugin name.`,
+			},
+			"default_collect_rate": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The default collection rate.`,
+			},
+			"support_datastore_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The supported datastore version.`,
+			},
+		},
+	}
+}
+
+func listMonitorIndicators(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	httpUrl := "v1.0/{project_id}/dms/metric-data/indicators"
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	listOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	indicators, ok := respBody.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected response format, expected list but got %T", respBody)
+	}
+
+	return indicators, nil
+}
+
+func flattenMonitorIndicators(indicators []interface{}) []map[string]interface{} {
+	if len(indicators) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(indicators))
+	for _, indicator := range indicators {
+		result = append(result, map[string]interface{}{
+			"indicator_name":            utils.PathSearch("indicator_name", indicator, nil),
+			"plugin_name":               utils.PathSearch("plugin_name", indicator, nil),
+			"default_collect_rate":      utils.PathSearch("default_collect_rate", indicator, nil),
+			"support_datastore_version": utils.PathSearch("support_datastore_version", indicator, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceMonitorIndicatorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	indicators, err := listMonitorIndicators(client)
+	if err != nil {
+		return diag.Errorf("error retrieving monitor indicators: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("indicators", flattenMonitorIndicators(indicators)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new datasource to query DWS indicators.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
The DWS cluster provisioning process takes too long during acceptance tests. Therefore, we have pre-provisioned a cluster via the console and configured the test cases to run against this existing environment.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccDataMonitorIndicators_basic -timeout 360m -parallel 10
=== RUN   TestAccDataMonitorIndicators_basic
=== PAUSE TestAccDataMonitorIndicators_basic
=== CONT  TestAccDataMonitorIndicators_basic
--- PASS: TestAccDataMonitorIndicators_basic (13.80s)
PASS
coverage: 3.3% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       13.922s coverage: 3.3% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.