### PR TITLE
feat(cfw): support `cfw_eip_auto_protect_status` data source

### DIFF
--- a/docs/data-sources/cfw_eip_auto_protect_status.md
+++ b/docs/data-sources/cfw_eip_auto_protect_status.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_eip_auto_protect_status"
+description: |-
+  Use this data source to get the EIP auto protect status information within HuaweiCloud.
+---
+
+# huaweicloud_cfw_eip_auto_protect_status
+
+Use this data source to get the EIP auto protect status information within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "object_id" {}
+
+data "huaweicloud_cfw_eip_auto_protect_status" "test" {
+  object_id = var.object_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `object_id` - (Required, String) Specifies the protected object ID.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data` - The firewall status object.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `available_eip_count` - The number of EIPs that can be protected.
+
+* `beyond_max_count` - Whether the EIP count limit is exceeded.
+
+* `eip_protected_self` - The number of protected EIPs.
+
+* `eip_total` - The total number of EIPs.
+
+* `eip_un_protected` - The number of unprotected EIPs.
+
+* `object_id` - The protected object ID.
+
+* `status` - Whether the auto protection for new EIPs is enabled.  
+  The valid values are as follows:
+  + **1**: Yes.
+  + **0**: No.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -834,6 +834,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_capture_task_results":      cfw.DataSourceCfwCaptureTaskResults(),
 			"huaweicloud_cfw_domain_name_groups":        cfw.DataSourceCfwDomainNameGroups(),
 			"huaweicloud_cfw_domain_name_parse_ip_list": cfw.DataSourceCfwDomainNameParseIpList(),
+			"huaweicloud_cfw_eip_auto_protect_status":   cfw.DataSourceEipAutoProtectStatus(),
 			"huaweicloud_cfw_protection_rules":          cfw.DataSourceCfwProtectionRules(),
 			"huaweicloud_cfw_service_groups":            cfw.DataSourceCfwServiceGroups(),
 			"huaweicloud_cfw_service_group_members":     cfw.DataSourceCfwServiceGroupMembers(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_eip_auto_protect_status_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_eip_auto_protect_status_test.go
@@ -1,0 +1,61 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEipAutoProtectStatus_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cfw_eip_auto_protect_status.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a firewall instance ID and the enterprise project ID it belongs to.
+			acceptance.TestAccPreCheckCfw(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceEipAutoProtectStatus_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.available_eip_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.beyond_max_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.eip_protected_self"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.eip_total"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.eip_un_protected"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.status"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceEipAutoProtectStatus_base() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_firewalls" "test" {
+  fw_instance_id = "%s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}
+
+func testDataSourceEipAutoProtectStatus_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cfw_eip_auto_protect_status" "test" {
+  object_id             = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+  enterprise_project_id = "%[2]s"
+}
+`, testDataSourceEipAutoProtectStatus_base(), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_eip_auto_protect_status.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_eip_auto_protect_status.go
@@ -1,0 +1,149 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/eip/auto-protect-status/{object_id}
+func DataSourceEipAutoProtectStatus() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEipAutoProtectStatusRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"object_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"available_eip_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"beyond_max_count": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"eip_protected_self": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"eip_total": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"eip_un_protected": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"object_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildEipAutoProtectStatusQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func dataSourceEipAutoProtectStatusRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		objectID = d.Get("object_id").(string)
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		httpUrl  = "v1/{project_id}/eip/auto-protect-status/{object_id}"
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{object_id}", objectID)
+	requestPath += buildEipAutoProtectStatusQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW EIP auto protect status: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenEipAutoProtectStatusData(utils.PathSearch("data", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenEipAutoProtectStatusData(data interface{}) []interface{} {
+	if data == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"available_eip_count": utils.PathSearch("available_eip_count", data, nil),
+			"beyond_max_count":    utils.PathSearch("beyond_max_count", data, nil),
+			"eip_protected_self":  utils.PathSearch("eip_protected_self", data, nil),
+			"eip_total":           utils.PathSearch("eip_total", data, nil),
+			"eip_un_protected":    utils.PathSearch("eip_un_protected", data, nil),
+			"object_id":           utils.PathSearch("object_id", data, nil),
+			"status":              utils.PathSearch("status", data, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_eip_auto_protect_status` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_eip_auto_protect_status` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceEipAutoProtectStatus_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccDataSourceEipAutoProtectStatus_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceEipAutoProtectStatus_basic
--- PASS: TestAccDataSourceEipAutoProtectStatus_basic (20.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       20.313s
```
<img width="920" height="32" alt="image" src="https://github.com/user-attachments/assets/83a8008f-3cfc-4bac-a320-749cc8a533c4" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
