### PR TITLE
feat(cfw): new resource to manage report profile

### DIFF
--- a/docs/resources/cfw_report_profile.md
+++ b/docs/resources/cfw_report_profile.md
@@ -1,0 +1,163 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_report_profile"
+description: |-
+  Manages a CFW report profile resource within HuaweiCloud.
+---
+
+# huaweicloud_cfw_report_profile
+
+Manages a CFW report profile resource within HuaweiCloud.
+
+## Example Usage
+
+### Daily Report Profile
+
+```hcl
+variable "fw_instance_id" {}
+variable "topic_urn" {}
+
+resource "huaweicloud_cfw_report_profile" "test" {
+  fw_instance_id    = var.fw_instance_id
+  category          = "daily"
+  name              = "test-name"
+  topic_urn         = var.topic_urn
+  send_period       = "3"
+  subscription_type = "0"
+  status            = "0"
+  description       = "test description"
+}
+```
+
+### Weekly Report Profile
+
+```hcl
+variable "fw_instance_id" {}
+variable "topic_urn" {}
+
+resource "huaweicloud_cfw_report_profile" "test" {
+  fw_instance_id    = var.fw_instance_id
+  category          = "weekly"
+  name              = "test-name"
+  topic_urn         = var.topic_urn
+  send_period       = "1"
+  send_week_day     = "1"
+  subscription_type = "0"
+  status            = "1"
+  description       = "test description"
+}
+```
+
+### Custom Report Profile
+
+```hcl
+variable "fw_instance_id" {}
+variable "topic_urn" {}
+variable "start_time" {
+  type = number
+}
+variable "end_time" {
+  type = number
+}
+
+resource "huaweicloud_cfw_report_profile" "test" {
+  fw_instance_id    = var.fw_instance_id
+  category          = "custom"
+  name              = "test-name"
+  topic_urn         = var.topic_urn
+  subscription_type = "0"
+  status            = "1"
+  description       = "test description"
+
+  statistic_period {
+    start_time = var.start_time
+    end_time   = var.end_time
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `fw_instance_id` - (Required, String, NonUpdatable) Specifies the firewall ID.
+  It is a unique ID generated after a firewall instance is created. You can obtain the firewall ID by referring to
+  the data source `huaweicloud_cfw_firewalls`.
+
+* `category` - (Required, String, NonUpdatable) Specifies the report type. The value can be:
+  + **daily**: Daily report
+  + **weekly**: Weekly report
+  + **custom**: Custom report
+
+* `name` - (Required, String) Specifies the template name.
+
+* `topic_urn` - (Required, String) Specifies the topic URN.
+
+* `send_period` - (Optional, String) Specifies the sending time. Valid value must be between `0` and `23`.
+  This field is mandatory when `category` is set to **daily** or **weekly**.
+
+* `send_week_day` - (Optional, String) Specifies the days in a week when data is sent.
+  Valid value must be between `1` and `7`.
+  This field is mandatory when `category` is set to **weekly**.
+
+* `status` - (Optional, String) Specifies the enabling status. The value can be:
+  + **0**: Disabled
+  + **1**: Enabled
+
+* `subscription_type` - (Optional, String) Specifies the notification method. The value can be:
+  + **0**: SMN notification
+  + **1**: No notification
+
+* `statistic_period` - (Optional, List) Specifies the statistical period.
+  This field is mandatory when `category` is set to **custom**.
+
+  The [statistic_period](#statistic_period_struct) structure is documented below.
+
+* `description` - (Optional, String) Specifies the description.
+
+<a name="statistic_period_struct"></a>
+The `statistic_period` block supports:
+
+* `start_time` - (Optional, Int) Specifies the start time of the statistical period. Milliseconds-level timestamp.
+  The value of this field must be the start of the day at midnight. Valid format examples: `1772035200000`.
+
+* `end_time` - (Optional, Int) Specifies the end time of the statistical period. Milliseconds-level timestamp.
+  The value of this field must be the end of the day at midnight. Valid format examples: `1772726399999`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also the report profile ID).
+
+* `topic_name` - The topic name.
+
+## Import
+
+The resource can be imported using `fw_instance_id`, `id` (report profile ID), separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_cfw_report_profile.test <fw_instance_id>/<id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `description`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_cfw_report_profile" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      description,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2892,6 +2892,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_firewall":                      cfw.ResourceFirewall(),
 			"huaweicloud_cfw_domain_name_group":             cfw.ResourceDomainNameGroup(),
 			"huaweicloud_cfw_lts_log":                       cfw.ResourceLtsLog(),
+			"huaweicloud_cfw_report_profile":                cfw.ResourceReportProfile(),
 			"huaweicloud_cfw_dns_resolution":                cfw.ResourceDNSResolution(),
 			"huaweicloud_cfw_capture_task":                  cfw.ResourceCaptureTask(),
 			"huaweicloud_cfw_ips_rule_mode_change":          cfw.ResourceCfwIpsRuleModeChange(),

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_report_profile_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_report_profile_test.go
@@ -1,0 +1,403 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cfw"
+)
+
+func getReportProfileResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "cfw"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CFW client: %s", err)
+	}
+
+	return cfw.GetReportProfileDetail(client, state.Primary.ID, state.Primary.Attributes["fw_instance_id"])
+}
+
+func TestAccReportProfile_daily(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_cfw_report_profile.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getReportProfileResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testReportProfile_daily(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "category", "daily"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "fw_instance_id", acceptance.HW_CFW_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "send_period", "3"),
+					resource.TestCheckResourceAttr(rName, "status", "0"),
+					resource.TestCheckResourceAttr(rName, "subscription_type", "0"),
+					resource.TestCheckResourceAttrPair(rName, "topic_urn", "huaweicloud_smn_topic.test", "topic_urn"),
+					resource.TestCheckResourceAttrSet(rName, "topic_name"),
+				),
+			},
+			{
+				Config: testReportProfile_daily_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "category", "daily"),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "fw_instance_id", acceptance.HW_CFW_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "send_period", "4"),
+					resource.TestCheckResourceAttr(rName, "status", "1"),
+					resource.TestCheckResourceAttr(rName, "subscription_type", "1"),
+					resource.TestCheckResourceAttrPair(rName, "topic_urn", "huaweicloud_smn_topic.test_another", "topic_urn"),
+					resource.TestCheckResourceAttrSet(rName, "topic_name"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testReportProfileImportState(rName),
+				ImportStateVerifyIgnore: []string{
+					"description",
+				},
+			},
+		},
+	})
+}
+
+func testReportProfile_daily(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name         = "%[1]s"
+  display_name = "%[1]s"
+}
+
+resource "huaweicloud_cfw_report_profile" "test" {
+  fw_instance_id    = "%[2]s"
+  category          = "daily"
+  name              = "%[1]s"
+  topic_urn         = huaweicloud_smn_topic.test.topic_urn
+  send_period       = "3"
+  subscription_type = "0"
+  status            = "0"
+  description       = "test description"
+}
+`, name, acceptance.HW_CFW_INSTANCE_ID)
+}
+
+func testReportProfile_daily_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test_another" {
+  name         = "%[1]s_another"
+  display_name = "%[1]s_another"
+}
+
+resource "huaweicloud_cfw_report_profile" "test" {
+  fw_instance_id    = "%[2]s"
+  category          = "daily"
+  name              = "%[1]s_update"
+  topic_urn         = huaweicloud_smn_topic.test_another.topic_urn
+  send_period       = "4"
+  subscription_type = "1"
+  status            = "1"
+  description       = "test description update"
+}
+`, name, acceptance.HW_CFW_INSTANCE_ID)
+}
+
+func TestAccReportProfile_weekly(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_cfw_report_profile.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getReportProfileResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testReportProfile_weekly(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "category", "weekly"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "fw_instance_id", acceptance.HW_CFW_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "send_period", "1"),
+					resource.TestCheckResourceAttr(rName, "send_week_day", "1"),
+					resource.TestCheckResourceAttr(rName, "status", "1"),
+					resource.TestCheckResourceAttr(rName, "subscription_type", "0"),
+					resource.TestCheckResourceAttrPair(rName, "topic_urn", "huaweicloud_smn_topic.test", "topic_urn"),
+					resource.TestCheckResourceAttrSet(rName, "topic_name"),
+				),
+			},
+			{
+				Config: testReportProfile_weekly_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "category", "weekly"),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "fw_instance_id", acceptance.HW_CFW_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "send_period", "3"),
+					resource.TestCheckResourceAttr(rName, "send_week_day", "2"),
+					resource.TestCheckResourceAttr(rName, "status", "0"),
+					resource.TestCheckResourceAttr(rName, "subscription_type", "1"),
+					resource.TestCheckResourceAttrPair(rName, "topic_urn", "huaweicloud_smn_topic.test_another", "topic_urn"),
+					resource.TestCheckResourceAttrSet(rName, "topic_name"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testReportProfileImportState(rName),
+				ImportStateVerifyIgnore: []string{
+					"description",
+				},
+			},
+		},
+	})
+}
+
+func testReportProfile_weekly(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name         = "%[1]s"
+  display_name = "%[1]s"
+}
+
+resource "huaweicloud_cfw_report_profile" "test" {
+  fw_instance_id    = "%[2]s"
+  category          = "weekly"
+  name              = "%[1]s"
+  topic_urn         = huaweicloud_smn_topic.test.topic_urn
+  send_period       = "1"
+  send_week_day     = "1"
+  subscription_type = "0"
+  status            = "1"
+  description       = "test description"
+}
+`, name, acceptance.HW_CFW_INSTANCE_ID)
+}
+
+func testReportProfile_weekly_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test_another" {
+  name         = "%[1]s_another"
+  display_name = "%[1]s_another"
+}
+
+resource "huaweicloud_cfw_report_profile" "test" {
+  fw_instance_id    = "%[2]s"
+  category          = "weekly"
+  name              = "%[1]s_update"
+  topic_urn         = huaweicloud_smn_topic.test_another.topic_urn
+  send_period       = "3"
+  send_week_day     = "2"
+  subscription_type = "1"
+  status            = "0"
+  description       = "test description update"
+}
+`, name, acceptance.HW_CFW_INSTANCE_ID)
+}
+
+func TestAccReportProfile_custom(t *testing.T) {
+	var (
+		obj              interface{}
+		name             = acceptance.RandomAccResourceName()
+		rName            = "huaweicloud_cfw_report_profile.test"
+		twoWeeksAgoStart = getDaysAgoStart(14)
+		oneWeekAgoStart  = getDaysAgoStart(7)
+		oneWeekAgoEnd    = getDaysAgoEnd(7)
+		threeDaysAgoEnd  = getDaysAgoEnd(3)
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getReportProfileResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testReportProfile_custom(name, twoWeeksAgoStart, oneWeekAgoEnd),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "category", "custom"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "fw_instance_id", acceptance.HW_CFW_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "status", "1"),
+					resource.TestCheckResourceAttr(rName, "subscription_type", "0"),
+					resource.TestCheckResourceAttr(rName, "statistic_period.0.start_time", fmt.Sprintf("%d", twoWeeksAgoStart)),
+					resource.TestCheckResourceAttr(rName, "statistic_period.0.end_time", fmt.Sprintf("%d", oneWeekAgoEnd)),
+					resource.TestCheckResourceAttrPair(rName, "topic_urn", "huaweicloud_smn_topic.test", "topic_urn"),
+					resource.TestCheckResourceAttrSet(rName, "topic_name"),
+				),
+			},
+			{
+				Config: testReportProfile_custom_update(name, oneWeekAgoStart, threeDaysAgoEnd),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "category", "custom"),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "fw_instance_id", acceptance.HW_CFW_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "status", "0"),
+					resource.TestCheckResourceAttr(rName, "subscription_type", "1"),
+					resource.TestCheckResourceAttr(rName, "statistic_period.0.start_time", fmt.Sprintf("%d", oneWeekAgoStart)),
+					resource.TestCheckResourceAttr(rName, "statistic_period.0.end_time", fmt.Sprintf("%d", threeDaysAgoEnd)),
+					resource.TestCheckResourceAttrPair(rName, "topic_urn", "huaweicloud_smn_topic.test_another", "topic_urn"),
+					resource.TestCheckResourceAttrSet(rName, "topic_name"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testReportProfileImportState(rName),
+				ImportStateVerifyIgnore: []string{
+					"description",
+				},
+			},
+		},
+	})
+}
+
+func testReportProfile_custom(name string, startTime, endTime int64) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name         = "%[1]s"
+  display_name = "%[1]s"
+}
+
+resource "huaweicloud_cfw_report_profile" "test" {
+  fw_instance_id    = "%[2]s"
+  category          = "custom"
+  name              = "%[1]s"
+  topic_urn         = huaweicloud_smn_topic.test.topic_urn
+  subscription_type = "0"
+  status            = "1"
+  description       = "test description"
+
+  statistic_period {
+    start_time = %[3]d
+    end_time   = %[4]d
+  }
+}
+`, name, acceptance.HW_CFW_INSTANCE_ID, startTime, endTime)
+}
+
+func testReportProfile_custom_update(name string, startTime, endTime int64) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test_another" {
+  name         = "%[1]s_another"
+  display_name = "%[1]s_another"
+}
+
+resource "huaweicloud_cfw_report_profile" "test" {
+  fw_instance_id    = "%[2]s"
+  category          = "custom"
+  name              = "%[1]s_update"
+  topic_urn         = huaweicloud_smn_topic.test_another.topic_urn
+  subscription_type = "1"
+  status            = "0"
+  description       = "test description update"
+
+  statistic_period {
+    start_time = %[3]d
+    end_time   = %[4]d
+  }
+}
+`, name, acceptance.HW_CFW_INSTANCE_ID, startTime, endTime)
+}
+
+func testReportProfileImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		fwInstanceId := rs.Primary.Attributes["fw_instance_id"]
+		if fwInstanceId == "" {
+			return "", fmt.Errorf("attribute (fw_instance_id) of Resource (%s) not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return "", fmt.Errorf("attribute (ID) of Resource (%s) not found", name)
+		}
+
+		return fmt.Sprintf("%s/%s", fwInstanceId, rs.Primary.ID), nil
+	}
+}
+
+func getDaysAgoStart(days int) int64 {
+	now := time.Now()
+	targetDay := now.AddDate(0, 0, -days)
+	start := time.Date(
+		targetDay.Year(),
+		targetDay.Month(),
+		targetDay.Day(),
+		0, 0, 0, 0,
+		now.Location(),
+	)
+	return start.UnixMilli()
+}
+
+func getDaysAgoEnd(days int) int64 {
+	now := time.Now()
+	targetDay := now.AddDate(0, 0, -days)
+	end := time.Date(
+		targetDay.Year(),
+		targetDay.Month(),
+		targetDay.Day(),
+		23, 59, 59, 999999999,
+		now.Location(),
+	)
+	return end.UnixMilli()
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_report_profile.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_report_profile.go
@@ -1,0 +1,394 @@
+package cfw
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW POST /v1/{project_id}/report-profile
+// @API CFW PUT /v1/{project_id}/report-profile/{report_profile_id}
+// @API CFW GET /v1/{project_id}/report-profile/{report_profile_id}
+// @API CFW DELETE /v1/{project_id}/report-profile/{report_profile_id}
+func ResourceReportProfile() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceReportProfileCreate,
+		ReadContext:   resourceReportProfileRead,
+		UpdateContext: resourceReportProfileUpdate,
+		DeleteContext: resourceReportProfileDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceReportProfileImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"fw_instance_id",
+			"category",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			// Unable to retrieve the value of field `fw_instance_id` from the details API.
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"topic_urn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// API requires the fields `send_period`, `send_week_day`, `status` and `subscription_type` to be numeric
+			// types, but the default value of `0` has practical significance, so their types have been changed to strings.
+			"send_period": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"send_week_day": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"subscription_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"statistic_period": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem:     statisticPeriodSchema(),
+			},
+			// Unable to retrieve the value of field `description` from the details API. So no Computed attribute was added.
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"topic_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func statisticPeriodSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"start_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildCreateReportProfileStatisticPeriodBodyParam(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"start_time": rawMap["start_time"],
+		"end_time":   rawMap["end_time"],
+	}
+}
+
+func convertStringToInt(rawValue string) interface{} {
+	if rawValue == "" {
+		return nil
+	}
+
+	r, err := strconv.Atoi(rawValue)
+	if err != nil {
+		log.Printf("[ERROR] convert the string %s to int failed.", rawValue)
+		return nil
+	}
+
+	return r
+}
+
+func buildCreateReportProfileBodyParam(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"category":          d.Get("category"),
+		"name":              d.Get("name"),
+		"topic_urn":         d.Get("topic_urn"),
+		"send_period":       convertStringToInt(d.Get("send_period").(string)),
+		"send_week_day":     convertStringToInt(d.Get("send_week_day").(string)),
+		"status":            convertStringToInt(d.Get("status").(string)),
+		"subscription_type": convertStringToInt(d.Get("subscription_type").(string)),
+		"statistic_period":  buildCreateReportProfileStatisticPeriodBodyParam(d.Get("statistic_period").([]interface{})),
+		"description":       utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
+func resourceReportProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/report-profile"
+		product = "cfw"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?fw_instance_id=%s", d.Get("fw_instance_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateReportProfileBodyParam(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating CFW report profile: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("data.id", respBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating CFW report profile: ID is not found in API response")
+	}
+	d.SetId(id)
+
+	return resourceReportProfileRead(ctx, d, meta)
+}
+
+func flattenStatisticPeriodAttribute(respMap interface{}) []map[string]interface{} {
+	if respMap == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"start_time": utils.PathSearch("start_time", respMap, nil),
+			"end_time":   utils.PathSearch("end_time", respMap, nil),
+		},
+	}
+}
+
+func GetReportProfileDetail(client *golangsdk.ServiceClient, id, fwInstanceId string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/report-profile/{report_profile_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{report_profile_id}", id)
+	requestPath += fmt.Sprintf("?fw_instance_id=%s", fwInstanceId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func flattenReportProfileNumberValue(respValue interface{}) string {
+	if respValue == nil {
+		return ""
+	}
+
+	// The response value type for this field should be float64.
+	float64Value, ok := respValue.(float64)
+	if !ok {
+		log.Printf("[WARN] failed to convert %v to float64", respValue)
+		return ""
+	}
+
+	return strconv.Itoa(int(float64Value))
+}
+
+func resourceReportProfileRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cfw"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	respBody, err := GetReportProfileDetail(client, d.Id(), d.Get("fw_instance_id").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "CFW.00200005"),
+			"error retrieving CFW report profile",
+		)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("category", utils.PathSearch("data.category", respBody, nil)),
+		d.Set("name", utils.PathSearch("data.name", respBody, nil)),
+		d.Set("topic_urn", utils.PathSearch("data.topic_urn", respBody, nil)),
+		d.Set("send_period", flattenReportProfileNumberValue(utils.PathSearch("data.send_period", respBody, nil))),
+		d.Set("send_week_day", flattenReportProfileNumberValue(utils.PathSearch("data.send_week_day", respBody, nil))),
+		d.Set("status", flattenReportProfileNumberValue(utils.PathSearch("data.status", respBody, nil))),
+		d.Set("subscription_type", flattenReportProfileNumberValue(utils.PathSearch("data.subscription_type", respBody, nil))),
+		d.Set("statistic_period", flattenStatisticPeriodAttribute(utils.PathSearch("data.statistic_period", respBody, nil))),
+		d.Set("topic_name", utils.PathSearch("data.topic_name", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateReportProfileStatisticPeriodBodyParam(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"start_time": rawMap["start_time"],
+		"end_time":   rawMap["end_time"],
+	}
+}
+
+func buildUpdateReportProfileBodyParam(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":              d.Get("name"),
+		"topic_urn":         d.Get("topic_urn"),
+		"send_period":       convertStringToInt(d.Get("send_period").(string)),
+		"send_week_day":     convertStringToInt(d.Get("send_week_day").(string)),
+		"status":            convertStringToInt(d.Get("status").(string)),
+		"subscription_type": convertStringToInt(d.Get("subscription_type").(string)),
+		"statistic_period":  buildUpdateReportProfileStatisticPeriodBodyParam(d.Get("statistic_period").([]interface{})),
+		"description":       utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
+func resourceReportProfileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/report-profile/{report_profile_id}"
+		product = "cfw"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{report_profile_id}", d.Id())
+	requestPath += fmt.Sprintf("?fw_instance_id=%s", d.Get("fw_instance_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdateReportProfileBodyParam(d)),
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error updating CFW report profile: %s", err)
+	}
+
+	return resourceReportProfileRead(ctx, d, meta)
+}
+
+func resourceReportProfileDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/report-profile/{report_profile_id}"
+		product = "cfw"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{report_profile_id}", d.Id())
+	requestPath += fmt.Sprintf("?fw_instance_id=%s", d.Get("fw_instance_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CFW report profile: %s", err)
+	}
+
+	return nil
+}
+
+func resourceReportProfileImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, errors.New("invalid format specified for import ID, must be <fw_instance_id>/<id>")
+	}
+
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, d.Set("fw_instance_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to manage report profile.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccReportProfile_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccReportProfile_ -timeout 360m -parallel 10
=== RUN   TestAccReportProfile_daily
=== PAUSE TestAccReportProfile_daily
=== RUN   TestAccReportProfile_weekly
=== PAUSE TestAccReportProfile_weekly
=== RUN   TestAccReportProfile_custom
=== PAUSE TestAccReportProfile_custom
=== CONT  TestAccReportProfile_daily
=== CONT  TestAccReportProfile_custom
=== CONT  TestAccReportProfile_weekly
--- PASS: TestAccReportProfile_daily (44.10s)
--- PASS: TestAccReportProfile_weekly (44.46s)
--- PASS: TestAccReportProfile_custom (45.67s)
PASS
coverage: 5.0% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       45.761s coverage: 5.0% of statements in ./huaweicloud/services/cfw
```
<img width="1294" height="80" alt="image" src="https://github.com/user-attachments/assets/27877faa-38e0-4cd2-b0d8-44b5c1af23bf" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    - fw_instance_id not found:<img width="781" height="190" alt="image" src="https://github.com/user-attachments/assets/a255c303-32b3-4db7-a51f-13114c59fe95" />
    - id not found:<img width="736" height="184" alt="image" src="https://github.com/user-attachments/assets/3d88f0bb-5dff-4c29-b7f4-840294f6a82e" />


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
