### PR TITLE
feat(dws): add a new datasource to query cluster host nets

### DIFF
--- a/docs/data-sources/dws_host_nets.md
+++ b/docs/data-sources/dws_host_nets.md
@@ -1,0 +1,72 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_host_nets"
+description: |-
+  Use this data source to get the list of host network metrics in DWS within HuaweiCloud.
+---
+
+# huaweicloud_dws_host_nets
+
+Use this data source to get the list of host network metrics in DWS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_dws_host_nets" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the host nets are located.  
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Optional, String) Specifies the cluster ID to be queried.
+
+* `instance_name` - (Optional, String) Specifies the instance name to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `host_nets` - The list of the host nets that matched filter parameters.  
+  The [host_nets](#dws_host_nets_struct) structure is documented below.
+
+<a name="dws_host_nets_struct"></a>
+The `host_nets` block supports:
+
+* `virtual_cluster_id` - The virtual cluster ID.
+
+* `ctime` - The query timestamp in Unix milliseconds.
+
+* `host_id` - The host ID.
+
+* `host_name` - The host name.
+
+* `instance_name` - The instance name.
+
+* `interface_name` - The network interface name.
+
+* `up` - Whether the network interface is up.
+
+* `speed` - The network interface speed in Mbps.
+
+* `recv_packets` - The received packets.
+
+* `send_packets` - The sent packets.
+
+* `recv_drop` - The dropped packets on receiving.
+
+* `recv_rate` - The receiving rate in KB/s.
+
+* `send_rate` - The sending rate in KB/s.
+
+* `io_rate` - The network IO rate in KB/s.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2413,6 +2413,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_disaster_recovery_tasks":         dws.DataSourceDisasterRecoveryTasks(),
 			"huaweicloud_dws_event_subscriptions":             dws.DataSourceEventSubscriptions(),
 			"huaweicloud_dws_flavors":                         dws.DataSourceDwsFlavors(),
+			"huaweicloud_dws_host_nets":                       dws.DataSourceHostNets(),
 			"huaweicloud_dws_logical_cluster_rings":           dws.DataSourceLogicalClusterRings(),
 			"huaweicloud_dws_logical_cluster_volumes":         dws.DataSourceDwsLogicalClusterVolumes(),
 			"huaweicloud_dws_logical_clusters":                dws.DataSourceDwsLogicalClusters(),

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_host_nets_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_host_nets_test.go
@@ -1,0 +1,83 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataHostNets_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dws_host_nets.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byInstanceName   = "data.huaweicloud_dws_host_nets.filter_by_instance_name"
+		dcByInstanceName = acceptance.InitDataSourceCheck(byInstanceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataHostNets_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "host_nets.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.virtual_cluster_id"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.ctime"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.host_id"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.host_name"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.instance_name"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.interface_name"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.up"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.speed"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.recv_packets"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.send_packets"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.recv_drop"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.recv_rate"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.send_rate"),
+					resource.TestCheckResourceAttrSet(all, "host_nets.0.io_rate"),
+					dcByInstanceName.CheckResourceExists(),
+					resource.TestCheckOutput("instance_name_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataHostNets_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dws_host_nets" "test" {
+  cluster_id = "%[1]s"
+}
+
+locals {
+  instance_name = data.huaweicloud_dws_host_nets.test.host_nets[0].instance_name
+}
+
+data "huaweicloud_dws_host_nets" "filter_by_instance_name" {
+  cluster_id    = "%[1]s"
+  instance_name = local.instance_name
+}
+
+locals {
+  instance_names = [
+    for v in data.huaweicloud_dws_host_nets.filter_by_instance_name.host_nets[*].instance_name : v
+  ]
+}
+
+output "instance_name_filter_is_useful" {
+  value = length(local.instance_names) > 0 && alltrue([
+    for v in local.instance_names : v == local.instance_name
+  ])
+}
+`, acceptance.HW_DWS_CLUSTER_ID)
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_host_nets.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_host_nets.go
@@ -1,0 +1,249 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v1.0/{project_id}/dms/net
+func DataSourceHostNets() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceHostNetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the host nets are located.`,
+			},
+
+			// Optional parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The cluster ID to be queried.`,
+			},
+			"instance_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The instance name to be queried.`,
+			},
+
+			// Attributes.
+			"host_nets": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        hostNetSchema(),
+				Description: `The list of the host nets that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func hostNetSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"virtual_cluster_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The virtual cluster ID.`,
+			},
+			"ctime": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The query timestamp in Unix milliseconds.`,
+			},
+			"host_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The host ID.`,
+			},
+			"host_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The host name.`,
+			},
+			"instance_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The instance name.`,
+			},
+			"interface_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The network interface name.`,
+			},
+			"up": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the network interface is up.`,
+			},
+			"speed": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The network interface speed in Mbps.`,
+			},
+			"recv_packets": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The received packets.`,
+			},
+			"send_packets": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The sent packets.`,
+			},
+			"recv_drop": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The dropped packets on receiving.`,
+			},
+			"recv_rate": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The receiving rate in KB/s.`,
+			},
+			"send_rate": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The sending rate in KB/s.`,
+			},
+			"io_rate": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The network IO rate in KB/s.`,
+			},
+		},
+	}
+}
+
+func buildHostNetsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("cluster_id"); ok {
+		res = fmt.Sprintf("%s&cluster_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("instance_name"); ok {
+		res = fmt.Sprintf("%s&instance_name=%v", res, v)
+	}
+
+	return res
+}
+
+func listHostNets(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1.0/{project_id}/dms/net?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+	listPathWithLimit += buildHostNetsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPathWithLimit, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		// The API returns a JSON array at the root; PathSearch("[]", ...) is invalid JMESPath for this shape.
+		hostNets, ok := respBody.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("unexpected response type for DWS host nets list, want JSON array, got %T", respBody)
+		}
+
+		result = append(result, hostNets...)
+		if len(hostNets) < limit {
+			break
+		}
+		offset += len(hostNets)
+	}
+
+	return result, nil
+}
+
+func flattenHostNets(hostNets []interface{}) []map[string]interface{} {
+	if len(hostNets) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(hostNets))
+	for _, item := range hostNets {
+		result = append(result, map[string]interface{}{
+			"virtual_cluster_id": utils.PathSearch("virtual_cluster_id", item, nil),
+			"ctime":              utils.PathSearch("ctime", item, nil),
+			"host_id":            utils.PathSearch("host_id", item, nil),
+			"host_name":          utils.PathSearch("host_name", item, nil),
+			"instance_name":      utils.PathSearch("instance_name", item, nil),
+			"interface_name":     utils.PathSearch("interface_name", item, nil),
+			"up":                 utils.PathSearch("up", item, nil),
+			"speed":              utils.PathSearch("speed", item, nil),
+			"recv_packets":       utils.PathSearch("recv_packets", item, nil),
+			"send_packets":       utils.PathSearch("send_packets", item, nil),
+			"recv_drop":          utils.PathSearch("recv_drop", item, nil),
+			"recv_rate":          utils.PathSearch("recv_rate", item, float64(0)),
+			"send_rate":          utils.PathSearch("send_rate", item, float64(0)),
+			"io_rate":            utils.PathSearch("io_rate", item, float64(0)),
+		})
+	}
+
+	return result
+}
+
+func dataSourceHostNetsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	hostNets, err := listHostNets(client, d)
+	if err != nil {
+		return diag.Errorf("error querying host nets: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("host_nets", flattenHostNets(hostNets)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new datasource to query cluster host nets.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
The DWS cluster provisioning process takes too long during acceptance tests. Therefore, we have pre-provisioned a cluster via the console and configured the test cases to run against this existing environment.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccDataHostNets_basic -timeout 360m -parallel 10
=== RUN   TestAccDataHostNets_basic
=== PAUSE TestAccDataHostNets_basic
=== CONT  TestAccDataHostNets_basic
--- PASS: TestAccDataHostNets_basic (17.98s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       18.093s coverage: 3.7% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.