### PR TITLE
feat(dws): add a new datasource for query the list of disk details

### DIFF
--- a/docs/data-sources/dws_disk_details.md
+++ b/docs/data-sources/dws_disk_details.md
@@ -1,0 +1,74 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_disk_details"
+description: |-
+  Use this data source to query DWS disk details within HuaweiCloud.
+---
+
+# huaweicloud_dws_disk_details
+
+Use this data source to query DWS disk details within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_dws_disk_details" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the disk details are located.  
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Optional, String) Specifies the cluster ID.
+
+* `instance_id` - (Optional, String) Specifies the instance ID.
+
+* `instance_name` - (Optional, String) Specifies the instance name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `disk_details` - The list of disk details that matched filter parameters.  
+  The [disk_details](#dws_disk_details_struct) structure is documented below.
+
+<a name="dws_disk_details_struct"></a>
+The `disk_details` block supports:
+
+* `instance_name` - The instance name.
+
+* `instance_id` - The instance ID.
+
+* `host_name` - The host name.
+
+* `disk_name` - The disk name.
+
+* `disk_type` - The disk type.
+
+* `total` - The total disk capacity in GB.
+
+* `used` - The used disk capacity in GB.
+
+* `available` - The available disk capacity in GB.
+
+* `used_percentage` - The disk usage percentage.
+
+* `await` - The I/O wait time in milliseconds.
+
+* `svctm` - The I/O service time in milliseconds.
+
+* `util` - The I/O usage percentage.
+
+* `read_rate` - The disk read rate in KB/s.
+
+* `write_rate` - The disk write rate in KB/s.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2428,6 +2428,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_cluster_user_authorities":        dws.DataSourceClusterUserAuthorities(),
 			"huaweicloud_dws_clusters":                        dws.DataSourceDwsClusters(),
 			"huaweicloud_dws_disaster_recovery_tasks":         dws.DataSourceDisasterRecoveryTasks(),
+			"huaweicloud_dws_disk_details":                    dws.DataSourceDiskDetails(),
 			"huaweicloud_dws_event_subscriptions":             dws.DataSourceEventSubscriptions(),
 			"huaweicloud_dws_flavors":                         dws.DataSourceDwsFlavors(),
 			"huaweicloud_dws_logical_cluster_rings":           dws.DataSourceLogicalClusterRings(),

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_disk_details_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_disk_details_test.go
@@ -1,0 +1,100 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataDiskDetails_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dws_disk_details.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byInstanceId   = "data.huaweicloud_dws_disk_details.filter_by_instance_id"
+		dcByInstanceId = acceptance.InitDataSourceCheck(byInstanceId)
+
+		byInstanceName   = "data.huaweicloud_dws_disk_details.filter_by_instance_name"
+		dcByInstanceName = acceptance.InitDataSourceCheck(byInstanceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataDiskDetails_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "disk_details.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "disk_details.0.instance_name"),
+					resource.TestCheckResourceAttrSet(all, "disk_details.0.instance_id"),
+					resource.TestCheckResourceAttrSet(all, "disk_details.0.host_name"),
+					resource.TestCheckResourceAttrSet(all, "disk_details.0.disk_name"),
+					resource.TestCheckResourceAttrSet(all, "disk_details.0.disk_type"),
+					dcByInstanceId.CheckResourceExists(),
+					resource.TestCheckOutput("is_instance_id_filter_useful", "true"),
+					dcByInstanceName.CheckResourceExists(),
+					resource.TestCheckOutput("is_instance_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataDiskDetails_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dws_disk_details" "test" {
+  cluster_id = "%[1]s"
+}
+
+# Filter by instance id.
+locals {
+  first_instance_id = data.huaweicloud_dws_disk_details.test.disk_details[0].instance_id
+}
+
+data "huaweicloud_dws_disk_details" "filter_by_instance_id" {
+  cluster_id  = "%[1]s"
+  instance_id = local.first_instance_id
+}
+
+locals {
+  instance_id_filter_result = [
+    for v in data.huaweicloud_dws_disk_details.filter_by_instance_id.disk_details[*].instance_id
+    : v == local.first_instance_id
+  ]
+}
+
+output "is_instance_id_filter_useful" {
+  value = length(local.instance_id_filter_result) > 0 && alltrue(local.instance_id_filter_result)
+}
+
+# Filter by instance name.
+locals {
+  first_instance_name = data.huaweicloud_dws_disk_details.test.disk_details[0].instance_name
+}
+
+data "huaweicloud_dws_disk_details" "filter_by_instance_name" {
+  cluster_id     = "%[1]s"
+  instance_name  = local.first_instance_name
+}
+
+locals {
+  instance_name_filter_result = [
+    for v in data.huaweicloud_dws_disk_details.filter_by_instance_name.disk_details[*].instance_name
+    : v == local.first_instance_name
+  ]
+}
+
+output "is_instance_name_filter_useful" {
+  value = length(local.instance_name_filter_result) > 0 && alltrue(local.instance_name_filter_result)
+}
+`, acceptance.HW_DWS_CLUSTER_ID)
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_disk_details.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_disk_details.go
@@ -1,0 +1,253 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v1.0/{project_id}/dms/disk
+func DataSourceDiskDetails() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDiskDetailsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the disk details are located.`,
+			},
+
+			// Optional parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The cluster ID.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The instance ID.`,
+			},
+			"instance_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The instance name.`,
+			},
+
+			// Attributes.
+			"disk_details": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        diskDetailSchema(),
+				Description: `The list of disk details that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func diskDetailSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"instance_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The instance name.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The instance ID.`,
+			},
+			"host_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The host name.`,
+			},
+			"disk_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The disk name.`,
+			},
+			"disk_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The disk type.`,
+			},
+			"total": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The total disk capacity in GB.`,
+			},
+			"used": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The used disk capacity in GB.`,
+			},
+			"available": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The available disk capacity in GB.`,
+			},
+			"used_percentage": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The disk usage percentage.`,
+			},
+			"await": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The I/O wait time in milliseconds.`,
+			},
+			"svctm": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The I/O service time in milliseconds.`,
+			},
+			"util": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The I/O usage percentage.`,
+			},
+			"read_rate": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The disk read rate in KB/s.`,
+			},
+			"write_rate": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The disk write rate in KB/s.`,
+			},
+		},
+	}
+}
+
+func buildDiskDetailsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("cluster_id"); ok {
+		res = fmt.Sprintf("%s&cluster_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("instance_id"); ok {
+		res = fmt.Sprintf("%s&instance_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("instance_name"); ok {
+		res = fmt.Sprintf("%s&instance_name=%v", res, v)
+	}
+
+	return res
+}
+
+func listDiskDetails(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1.0/{project_id}/dms/disk?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+	listPathWithLimit += buildDiskDetailsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPathWithLimit + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		diskDetails := utils.PathSearch("[]", respBody, make([]interface{}, 0)).([]interface{})
+
+		result = append(result, diskDetails...)
+		if len(diskDetails) < limit {
+			break
+		}
+		offset += len(diskDetails)
+	}
+
+	return result, nil
+}
+
+func flattenDiskDetails(all []interface{}) []map[string]interface{} {
+	if len(all) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(all))
+	for _, item := range all {
+		result = append(result, map[string]interface{}{
+			"instance_name":   utils.PathSearch("instance_name", item, nil),
+			"instance_id":     utils.PathSearch("instance_id", item, nil),
+			"host_name":       utils.PathSearch("host_name", item, nil),
+			"disk_name":       utils.PathSearch("disk_name", item, nil),
+			"disk_type":       utils.PathSearch("disk_type", item, nil),
+			"total":           utils.PathSearch("total", item, nil),
+			"used":            utils.PathSearch("used", item, nil),
+			"available":       utils.PathSearch("available", item, nil),
+			"used_percentage": utils.PathSearch("used_percentage", item, nil),
+			"await":           utils.PathSearch("await", item, nil),
+			"svctm":           utils.PathSearch("svctm", item, nil),
+			"util":            utils.PathSearch("util", item, nil),
+			"read_rate":       utils.PathSearch("read_rate", item, nil),
+			"write_rate":      utils.PathSearch("write_rate", item, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceDiskDetailsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	diskDetails, err := listDiskDetails(client, d)
+	if err != nil {
+		return diag.Errorf("error retrieving disk details: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("disk_details", flattenDiskDetails(diskDetails)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new datasource for query the list of disk details

**Which issue this PR fixes**:

**Special notes for your reviewer**:
The DWS cluster provisioning process takes too long during acceptance tests. Therefore, we have pre-provisioned a cluster via the console and configured the test cases to run against this existing environment.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccDataDiskDetails_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDiskDetails_basic
=== PAUSE TestAccDataDiskDetails_basic
=== CONT  TestAccDataDiskDetails_basic
--- PASS: TestAccDataDiskDetails_basic (28.54s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       28.661s coverage: 3.7% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.