### PR TITLE
fix(cfw): fix resource deletion failure issue

### DIFF
--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_alarm_config.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_alarm_config.go
@@ -229,12 +229,11 @@ func resourceAlarmConfigDelete(_ context.Context, d *schema.ResourceData, meta i
 	deleteAlarmConfigPath = strings.ReplaceAll(deleteAlarmConfigPath, "{project_id}", deleteAlarmConfigClient.ProjectID)
 	deleteAlarmConfigPath = strings.ReplaceAll(deleteAlarmConfigPath, "{fw_instance_id}", fwInstanceID)
 
-	alarmType := d.Get("alarm_type").(int)
 	deleteAlarmConfigOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
 
-	deleteAlarmConfigOpt.JSONBody = buildDeleteAlarmConfigBodyParams(alarmType)
+	deleteAlarmConfigOpt.JSONBody = buildDeleteAlarmConfigBodyParams(d)
 	_, err = deleteAlarmConfigClient.Request("PUT", deleteAlarmConfigPath, &deleteAlarmConfigOpt)
 	if err != nil {
 		return common.CheckDeletedDiag(d,
@@ -246,10 +245,11 @@ func resourceAlarmConfigDelete(_ context.Context, d *schema.ResourceData, meta i
 }
 
 // Restore common parameters to default values.
-func buildDeleteAlarmConfigBodyParams(alarmType int) map[string]interface{} {
+func buildDeleteAlarmConfigBodyParams(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{
 		"enable_status":     0,
-		"alarm_type":        alarmType,
+		"alarm_type":        d.Get("alarm_type").(int),
+		"severity":          d.Get("severity").(string),
 		"alarm_time_period": 0,
 		"topic_urn":         "",
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix resource deletion failure issue

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The test cases were showing errors before the fix:
```
./scripts/coverage.sh -o cfw -f TestAccResourceAlarmConfig_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccResourceAlarmConfig_basic -timeout 360m -parallel 10        
=== RUN   TestAccResourceAlarmConfig_basic
=== PAUSE TestAccResourceAlarmConfig_basic
=== CONT  TestAccResourceAlarmConfig_basic
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: error deleting CFW alarm configuration: Internal Server Error: [PUT https://cfw.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/cfw/alarm/config?fw_instance_id=35bbd419-b585-4859-be37-a636dca875e2], request_id: fcbb1803c9cc6a3bb64c7fe40 fcbb1803c9cc6a3bb64c7fe40ca13ef6, error message: {"error_code":"CFW.00000500","error_msg":"Internal Server Error"}

--- FAIL: TestAccResourceAlarmConfig_basic (35.72s)
FAIL
coverage: 4.6% of statements in ./huaweicloud/services/cfw
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       35.803s
FAIL
```

After the fix, the test cases executed normally:
```
./scripts/coverage.sh -o cfw -f TestAccResourceAlarmConfig_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccResourceAlarmConfig_basic -timeout 360m -parallel 10        
=== RUN   TestAccResourceAlarmConfig_basic
=== PAUSE TestAccResourceAlarmConfig_basic
=== CONT  TestAccResourceAlarmConfig_basic
--- PASS: TestAccResourceAlarmConfig_basic (34.63s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       34.721s coverage: 4.6% of statements in ./huaweicloud/services/cfw
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccResourceAlarmConfig_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccResourceAlarmConfig_basic -timeout 360m -parallel 10        
=== RUN   TestAccResourceAlarmConfig_basic
=== PAUSE TestAccResourceAlarmConfig_basic
=== CONT  TestAccResourceAlarmConfig_basic
--- PASS: TestAccResourceAlarmConfig_basic (34.63s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       34.721s coverage: 4.6% of statements in ./huaweicloud/services/cfw
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
