### PR TITLE
chore(cse): trigger deleted check when engine is not found

### DIFF
--- a/huaweicloud/services/cse/config.go
+++ b/huaweicloud/services/cse/config.go
@@ -2,6 +2,8 @@ package cse
 
 import (
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/auth"
@@ -16,8 +18,21 @@ func getToken(c *golangsdk.ServiceClient, username, password string) (string, er
 		Name:     username,
 		Password: password,
 	}
+
 	resp, err := auth.Create(c, tokenOpts)
 	if err != nil {
+		// When a microservice engine with an EIP is deleted, attempting to obtain a token via the engine's connection
+		// address will result in an error (connection error). This needs to be handled specially to return a 404 error.
+		if err == io.EOF || strings.Contains(err.Error(), "connection error") {
+			return "", golangsdk.ErrDefault404{
+				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+					Method:    "POST",
+					URL:       "/v4/token",
+					RequestId: "NONE",
+					Body:      []byte(`unable to connect the microservice engine`),
+				},
+			}
+		}
 		return "", fmt.Errorf("unable to create the authorization token: %v", err)
 	}
 

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/services"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -163,7 +162,7 @@ func resourceMicroserviceRead(_ context.Context, d *schema.ResourceData, _ inter
 		// When the engine does not exist, obtaining a token will cause a request connection exception.
 		// To ensure that the resource is available on RFS platform, this situation is specially handled as a 404 error.
 		log.Printf("[ERROR] %s", err)
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+		return common.CheckDeletedDiag(d, err, "error retrieving the authorization token")
 	}
 
 	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine_configuration.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine_configuration.go
@@ -277,7 +277,7 @@ func resourceMicroserviceEngineConfigurationDelete(_ context.Context, d *schema.
 	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
 		d.Get("admin_pass").(string))
 	if err != nil {
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d, err, "error retrieving the authorization token")
 	}
 	deleteOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
@@ -277,7 +277,7 @@ func resourceMicroserviceInstanceRead(_ context.Context, d *schema.ResourceData,
 	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
 		d.Get("admin_pass").(string))
 	if err != nil {
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d, err, "error retrieving the authorization token")
 	}
 
 	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
@@ -305,7 +305,7 @@ func resourceMicroserviceInstanceDelete(_ context.Context, d *schema.ResourceDat
 	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
 		d.Get("admin_pass").(string))
 	if err != nil {
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d, err, "error retrieving the authorization token")
 	}
 
 	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

If the engine (with the RBAC authorization) is not exist, the API which query the RBAC token will be failed and report the connection error.

So we need to exchange the connection error to the 404 error that we can trigger the deleted logic using CheckDeletedDiag method.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. return 404 error if the getToken function request is connect error.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

Before:
<img width="1248" height="630" alt="image" src="https://github.com/user-attachments/assets/4ef99d63-e8b6-44c7-afb6-1ab5a817b20a" />

After:
<img width="920" height="637" alt="image" src="https://github.com/user-attachments/assets/84df4237-7675-4881-b277-bd689d111568" />

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
