### PR TITLE
feat(cfw): support `cfw_acl_rule_export_status` data source

### DIFF
--- a/docs/data-sources/cfw_acl_rule_export_status.md
+++ b/docs/data-sources/cfw_acl_rule_export_status.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_acl_rule_export_status"
+description: |-
+  Use this data source to get the ACL rule export status within HuaweiCloud.
+---
+
+# huaweicloud_cfw_acl_rule_export_status
+
+Use this data source to get the ACL rule export status within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "object_id" {}
+
+data "huaweicloud_cfw_acl_rule_export_status" "test" {
+  object_id = var.object_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `object_id` - (Required, String) Specifies the protected object ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data` - The ACL rule export status data.
+
+  The [data](#cfw_acl_rule_export_status_data) structure is documented below.
+
+<a name="cfw_acl_rule_export_status_data"></a>
+The `data` block supports:
+
+* `id` - The protected object ID.
+
+* `status` - The export status.  
+  The valid values are as follows:
+  + **0**: No task.
+  + **1**: Task waiting.
+  + **2**: Task executing.
+  + **3**: Task success.
+  + **4**: Task failed.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -847,6 +847,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_ips_rule_details":          cfw.DataSourceCfwIpsRuleDetails(),
 			"huaweicloud_cfw_resource_tags":             cfw.DataSourceCfwResourceTags(),
 			"huaweicloud_cfw_tags":                      cfw.DataSourceCfwTags(),
+			"huaweicloud_cfw_acl_rule_export_status":    cfw.DataSourceAclRuleExportStatus(),
 			"huaweicloud_cfw_ip_blacklist":              cfw.DataSourceIpBlacklist(),
 
 			"huaweicloud_cnad_advanced_instances":           cnad.DataSourceInstances(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_acl_rule_export_status_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_acl_rule_export_status_test.go
@@ -1,0 +1,54 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAclRuleExportStatus_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cfw_acl_rule_export_status.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAclRuleExportStatus_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.status"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAclRuleExportStatus_base() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_firewalls" "test" {
+  fw_instance_id = "%s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}
+
+func testDataSourceAclRuleExportStatus_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cfw_acl_rule_export_status" "test" {
+  object_id = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+}
+`, testDataSourceAclRuleExportStatus_base())
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_acl_rule_export_status.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_acl_rule_export_status.go
@@ -1,0 +1,114 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/acl-rule/export-status
+func DataSourceAclRuleExportStatus() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAclRuleExportStatusRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"object_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAclRuleExportStatusQueryParams(objectID string) string {
+	return fmt.Sprintf("?object_id=%s", objectID)
+}
+
+func dataSourceAclRuleExportStatusRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		objectID = d.Get("object_id").(string)
+		httpUrl  = "v1/{project_id}/acl-rule/export-status"
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAclRuleExportStatusQueryParams(objectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW ACL rule export status: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenAclRuleExportStatusData(utils.PathSearch("data", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAclRuleExportStatusData(data interface{}) []interface{} {
+	if data == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"id":     utils.PathSearch("id", data, nil),
+			"status": utils.PathSearch("status", data, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_acl_rule_export_status` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_acl_rule_export_status` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceAclRuleExportStatus_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccDataSourceAclRuleExportStatus_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAclRuleExportStatus_basic
--- PASS: TestAccDataSourceAclRuleExportStatus_basic (13.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       14.018s
```
<img width="915" height="35" alt="image" src="https://github.com/user-attachments/assets/833f9ecf-12b8-4ad3-bf9c-78bb83064bda" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
