### PR TITLE
feat(mrs): add a new resource to manage cluster default tags switch

### DIFF
--- a/docs/resources/mapreduce_cluster_default_tags_switch.md
+++ b/docs/resources/mapreduce_cluster_default_tags_switch.md
@@ -1,0 +1,66 @@
+---
+subcategory: "MapReduce Service (MRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_mapreduce_cluster_default_tags_switch"
+description: |-
+  Manages an MRS cluster default tags switch resource within HuaweiCloud.
+---
+
+# huaweicloud_mapreduce_cluster_default_tags_switch
+
+Manages an MRS cluster default tags switch resource within HuaweiCloud.
+
+~> 1. Using this resource to enable the default tags switch will add default tags to the cluster and each node, and occupy
+  `2` tag quotas.
+  <br>2. Destroying this resource will remove the default tags that have been added to the cluster and each node.
+  <br>3. Using this resource will affect the `tags` parameter in the `huaweicloud_mapreduce_cluster` resource. You can use
+   `lifecycle.ignore_changes` or manually synchronize the changes of this resource.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+resource "huaweicloud_mapreduce_cluster_default_tags_switch" "test" {
+  cluster_id = var.cluster_id
+  action     = "create"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the cluster default tags switch is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster.
+
+* `action` - (Required, String, NonUpdatable) Specifies the type of the action.
+  The valid values are as follows:
+  + **create**: Enable the default tags switch, and add default tags to the cluster and each node.
+  + **delete**: Disable the default tags switch, and removes the default tags that have been added to the cluster and
+    each node.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `default_tags_enable` - Whether the default tags switch is enabled.
+
+## Timeouts
+
+This resource provides the following Timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `delete` - Default is 5 minutes.
+
+## Import
+
+The resource can be imported using the `cluster_id`, e.g.
+
+```bash
+terraform import huaweicloud_mapreduce_cluster_default_tags_switch.test <cluster_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3620,6 +3620,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_mapreduce_cluster":                     mrs.ResourceMRSClusterV2(),
 			"huaweicloud_mapreduce_cluster_component_batch_add": mrs.ResourceClusterComponentBatchAdd(),
+			"huaweicloud_mapreduce_cluster_default_tags_switch": mrs.ResourceClusterDefaultTagsSwitch(),
 			"huaweicloud_mapreduce_cluster_node_batch_expand":   mrs.ResourceClusterNodeBatchExpand(),
 			"huaweicloud_mapreduce_cluster_node_batch_shrink":   mrs.ResourceClusterNodeBatchShrink(),
 			"huaweicloud_mapreduce_job":                         mrs.ResourceMRSJobV2(),

--- a/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_cluster_default_tags_switch_test.go
+++ b/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_cluster_default_tags_switch_test.go
@@ -1,0 +1,139 @@
+package mrs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/mrs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getClusterDefaultTagsSwitchResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("mrs", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating MRS client: %s", err)
+	}
+
+	respbody, err := mrs.GetClusterDefaultTagsSwitchStatus(client, state.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if !utils.PathSearch("default_tags_enable", respbody, false).(bool) {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return respbody, nil
+}
+
+func TestAccClusterDefaultTagsSwitch_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_mapreduce_cluster_default_tags_switch.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getClusterDefaultTagsSwitchResourceFunc)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMrsClusterID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDefaultTagsSwitch_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_MRS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "action", "create"),
+					resource.TestCheckResourceAttr(rName, "default_tags_enable", "true"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccClusterDefaultTagsSwitch_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_mapreduce_cluster_default_tags_switch" "test" {
+  cluster_id = "%s"
+  action     = "create"
+}
+`, acceptance.HW_MRS_CLUSTER_ID)
+}
+
+func getClusterDeleteDefaultTagsSwitchResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("mrs", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating MRS client: %s", err)
+	}
+
+	return mrs.GetClusterDefaultTagsSwitchStatus(client, state.Primary.ID)
+}
+
+func TestAccClusterDefaultTagsSwitch_delete(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_mapreduce_cluster_default_tags_switch.delete"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getClusterDeleteDefaultTagsSwitchResourceFunc)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMrsClusterID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// When `action` parameter is `delete`, the resource does not need to be deleted.
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDefaultTagsSwitch_delete(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_MRS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "action", "delete"),
+					resource.TestCheckResourceAttr(rName, "default_tags_enable", "false"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccClusterDefaultTagsSwitch_delete() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_mapreduce_cluster_default_tags_switch" "create" {
+  cluster_id = "%[1]s"
+  action     = "create"
+
+  lifecycle {
+    ignore_changes = [action]
+  }
+}
+
+resource "huaweicloud_mapreduce_cluster_default_tags_switch" "delete" {
+  cluster_id = "%[1]s"
+  action     = "delete"
+
+  depends_on = [huaweicloud_mapreduce_cluster_default_tags_switch.create]
+}
+`, acceptance.HW_MRS_CLUSTER_ID)
+}

--- a/huaweicloud/services/mrs/common.go
+++ b/huaweicloud/services/mrs/common.go
@@ -13,6 +13,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var clusterNotFoundCodes = []string{
+	"12000003", // The MRS cluster does not exist.
+}
+
 func getClusterById(client *golangsdk.ServiceClient, clusterId string) (interface{}, error) {
 	httpUrl := "v1.1/{project_id}/cluster_infos/{cluster_id}"
 	getPath := client.Endpoint + httpUrl

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster_default_tags_switch.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster_default_tags_switch.go
@@ -1,0 +1,251 @@
+package mrs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	clusterDefaultTagsActionCreate = "create"
+	clusterDefaultTagsActionDelete = "delete"
+)
+
+var clusterDefaultTagsSwitchNonUpdatable = []string{"cluster_id"}
+
+// @API MRS POST /v2/{project_id}/clusters/{cluster_id}/tags/switch
+// @API MRS GET /v2/{project_id}/clusters/{cluster_id}/tags/status
+func ResourceClusterDefaultTagsSwitch() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceClusterDefaultTagsSwitchCreate,
+		ReadContext:   resourceClusterDefaultTagsSwitchRead,
+		UpdateContext: resourceClusterDefaultTagsSwitchUpdate,
+		DeleteContext: resourceClusterDefaultTagsSwitchDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(clusterDefaultTagsSwitchNonUpdatable),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the cluster default tags switch is located.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the action.`,
+			},
+			"default_tags_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the default tags switch is enabled.`,
+			},
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func switchClusterDefaultTags(client *golangsdk.ServiceClient, clusterId, action string) error {
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/tags/switch"
+	switchPath := client.Endpoint + httpUrl
+	switchPath = strings.ReplaceAll(switchPath, "{project_id}", client.ProjectID)
+	switchPath = strings.ReplaceAll(switchPath, "{cluster_id}", clusterId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"action": action,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err := client.Request("POST", switchPath, &opt)
+	return err
+}
+
+func GetClusterDefaultTagsSwitchStatus(client *golangsdk.ServiceClient, clusterId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/tags/status"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func waitForClusterDefaultTagsStatus(ctx context.Context, client *golangsdk.ServiceClient, clusterId string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshClusterDefaultTagsStatusFunc(client, clusterId),
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func refreshClusterDefaultTagsStatusFunc(client *golangsdk.ServiceClient, clusterID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetClusterDefaultTagsSwitchStatus(client, clusterID)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		// status options: "failed", "succeed", "processing"
+		status := utils.PathSearch("status", respBody, "").(string)
+		if status == "failed" {
+			return nil, "ERROR", fmt.Errorf("unexpected status: %s", status)
+		}
+
+		if status == "succeed" {
+			return respBody, "COMPLETED", nil
+		}
+
+		return respBody, "PENDING", nil
+	}
+}
+
+func resourceClusterDefaultTagsSwitchCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+	)
+	client, err := cfg.NewServiceClient("mrs", region)
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	action := d.Get("action").(string)
+	if err = switchClusterDefaultTags(client, clusterId, action); err != nil {
+		return diag.Errorf("unable to %s default tags of cluster (%s): %s", action, clusterId, err)
+	}
+
+	if err = waitForClusterDefaultTagsStatus(ctx, client, clusterId, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for default tags to be enabled of cluster (%s): %s", clusterId, err)
+	}
+
+	d.SetId(clusterId)
+
+	return resourceClusterDefaultTagsSwitchRead(ctx, d, meta)
+}
+
+func resourceClusterDefaultTagsSwitchRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("mrs", region)
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	respBody, err := GetClusterDefaultTagsSwitchStatus(client, clusterId)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "errorCode", clusterNotFoundCodes...),
+			"error querying cluster default tags status",
+		)
+	}
+
+	enabled := utils.PathSearch("default_tags_enable", respBody, false).(bool)
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("cluster_id", clusterId),
+		d.Set("action", parseClusterDefaultTagsSwitchAction(enabled)),
+		d.Set("default_tags_enable", enabled),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func parseClusterDefaultTagsSwitchAction(enabled bool) string {
+	if enabled {
+		return clusterDefaultTagsActionCreate
+	}
+
+	return clusterDefaultTagsActionDelete
+}
+
+func resourceClusterDefaultTagsSwitchUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceClusterDefaultTagsSwitchDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+	)
+	client, err := cfg.NewServiceClient("mrs", region)
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	// Currently, repeating the operation to disable the default tags switch will not report an error, but it may
+	// report an error in the future, so we need to check if it has already been disabled.
+	if !d.Get("default_tags_enable").(bool) {
+		return nil
+	}
+
+	if err = switchClusterDefaultTags(client, clusterId, "delete"); err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected400ErrInto404Err(err, "errorCode", clusterNotFoundCodes...),
+			"error disabling default tags for cluster",
+		)
+	}
+
+	if err = waitForClusterDefaultTagsStatus(ctx, client, clusterId, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for default tags to be disabled of cluster (%s): %s", clusterId, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource to manage the cluster's default tag switch.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new resource
2. add corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o mrs -f TestAccClusterDefaultTagsSwitch_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccClusterDefaultTagsSwitch_ -timeout 360m -parallel 10
=== RUN   TestAccClusterDefaultTagsSwitch_basic
--- PASS: TestAccClusterDefaultTagsSwitch_basic (45.94s)
=== RUN   TestAccClusterDefaultTagsSwitch_delete
--- PASS: TestAccClusterDefaultTagsSwitch_delete (52.60s)
PASS
coverage: 8.0% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       98.759s coverage: 8.0% of statements in ./huaweicloud/services/mrs
```

<img width="1038" height="168" alt="image" src="https://github.com/user-attachments/assets/b5701436-3cc8-4703-8e74-2e502c0766e5" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
        The resource does not exist and the return status code is 200.
       <img width="1622" height="635" alt="image" src="https://github.com/user-attachments/assets/c4f8669d-1885-4fbe-b9fc-ab332330cf99" />

    ab. Related resources (parent resources) not found
    <img width="1540" height="894" alt="image" src="https://github.com/user-attachments/assets/7a3a0d92-3d47-4901-970d-d8b0f054fdeb" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
     The resource does not exist and the return status code is 202.
    <img width="1613" height="712" alt="image" src="https://github.com/user-attachments/assets/3b66ef8b-3709-4916-8066-58125ddb43ca" />

     bb. Related resources (parent resources) not found
    <img width="1221" height="869" alt="image" src="https://github.com/user-attachments/assets/4b16e873-be76-47c8-b903-e099fb5a4134" />

