### PR TITLE
fix(RDS): rds mysql database privilege add content type

### DIFF
--- a/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_database_privilege.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_mysql_database_privilege.go
@@ -197,6 +197,7 @@ func deleteMysqlDatabasePrivilege(ctx context.Context, client *golangsdk.Service
 	for start < end {
 		opt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
+			MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 			JSONBody:         utils.RemoveNil(buildDeleteUserPrivilegesFromDatabaseBodyParams(dbName, users[start:end])),
 		}
 
@@ -280,6 +281,7 @@ func addPrivilegesToDatabase(ctx context.Context, client *golangsdk.ServiceClien
 	for start < end {
 		opt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
+			MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 			JSONBody:         utils.RemoveNil(buildAddUserPrivilegesToDatabaseBodyParams(dbName, users[start:end])),
 		}
 
@@ -396,6 +398,7 @@ func ListMysqlDatabasePrivileges(client *golangsdk.ServiceClient, instanceId, db
 	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
 	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
 
 	result := make([]interface{}, 0)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds mysql database privilege add content type
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds mysql database privilege add content type
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccMysqlDatabasePrivilege_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccMysqlDatabasePrivilege_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlDatabasePrivilege_basic
=== PAUSE TestAccMysqlDatabasePrivilege_basic
=== CONT  TestAccMysqlDatabasePrivilege_basic
--- PASS: TestAccMysqlDatabasePrivilege_basic (953.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       953.643s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
