### PR TITLE
feat(cfw): new resource to manage IPS custom rule

### DIFF
--- a/docs/resources/cfw_ips_custom_rule.md
+++ b/docs/resources/cfw_ips_custom_rule.md
@@ -1,0 +1,270 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_ips_custom_rule"
+description: |-
+  Manages a CFW IPS custom rule resource within HuaweiCloud.
+---
+
+# huaweicloud_cfw_ips_custom_rule
+
+Manages a CFW IPS custom rule resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+
+resource "huaweicloud_cfw_ips_custom_rule" "test" {
+  fw_instance_id = var.fw_instance_id
+  ips_name       = "test-name"
+  action_type    = 0
+  affected_os    = 0
+  attack_type    = 3
+  direction      = 1
+  protocol       = 10
+  severity       = 1
+  software       = 3
+
+  contents {
+    content           = "vvvvvv"
+    depth             = 65535
+    is_hex            = false
+    is_ignore         = true
+    is_uri            = false
+    offset            = 50
+    relative_position = 0
+  }
+
+  contents {
+    content           = "DF"
+    depth             = 65535
+    is_hex            = true
+    is_ignore         = false
+    is_uri            = false
+    offset            = 200
+    relative_position = 0
+  }
+
+  dst_port {
+    port_type = 1
+    ports     = "9008"
+  }
+
+  src_port {
+    port_type = 0
+    ports     = "5005"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `fw_instance_id` - (Required, String, NonUpdatable) Specifies the firewall ID.
+  It is a unique ID generated after a firewall instance is created. You can obtain the firewall ID by referring to
+  the data source `huaweicloud_cfw_firewalls`.
+
+* `ips_name` - (Required, String, NonUpdatable) Specifies the IPS custom rule name.
+
+* `protocol` - (Required, Int, NonUpdatable) Specifies the protocol type. Valid values are:
+  + `1`: FTP
+  + `2`: TELNET
+  + `3`: SMTP
+  + `4`: DNS_TCP
+  + `5`: DNS_UDP
+  + `6`: DHCP
+  + `7`: TFTP
+  + `8`: FINGER
+  + `9`: HTTP
+  + `10`: POP3
+  + `11`: SUNRPC_TCP
+  + `12`: SUNRPC_UDP
+  + `13`: NNTP
+  + `14`: MSRPC_TCP
+  + `15`: MSRPC_UDP
+  + `16`: NETBIOS_NAME_TCP
+  + `17`: NETBIOS_NAME_UDP
+  + `18`: NETBIOS_SMB
+  + `19`: NETBIOS_DATAGRAM
+  + `20`: IMAP4
+  + `21`: SNMP
+  + `22`: LDAP
+  + `23`: MSSQL
+  + `24`: ORACLE
+
+* `action_type` - (Required, Int) Specifies the action type. Valid values are:
+  + `0`: Used only for logging
+  + `1`: Reset/Intercept
+
+* `affected_os` - (Required, Int) Specifies the affected operating system. Valid values are:
+  + `0`: ANY
+  + `1`: Windows
+  + `2`: Linux
+  + `3`: FreeBSD
+  + `4`: Solaris
+  + `5`: Other Unix
+  + `6`: Network equipment
+  + `7`: Mac OS
+  + `8`: IOS
+  + `9`: Android
+  + `10`: Others
+
+* `attack_type` - (Required, Int) Specifies the attack type. Valid values are:
+  + `1`: Access control
+  + `2`: Vulnerability scan
+  + `3`: Email attack
+  + `4`: Vulnerability attack
+  + `5`: Web attack
+  + `6`: Password attack
+  + `7`: Hijacking attack
+  + `8`: Protocol anomaly
+  + `9`: Trojan horse
+  + `10`: Worm
+  + `11`: Buffer overflow
+  + `12`: Hacker tool
+  + `13`: Spyware
+  + `14`: DDoS flood
+  + `15`: Application layer DDoS attack
+  + `16`: Other suspicious behavior
+  + `17`: Suspicious DNS activity
+  + `18`: Network fishing
+  + `19`: Spam email
+  + `20`: Other attack
+
+* `contents` - (Required, List) Specifies the the message content to match IPS attacks.
+
+  The [contents](#contents_struct) structure is documented below.
+
+* `direction` - (Required, Int) Specifies the direction. Valid values are:
+  + `-1`: All directions
+  + `0`: Client to server
+  + `1`: Server to client
+
+* `dst_port` - (Required, List) Specifies the destination port information.
+  A maximum of one set of elements can be configured.
+
+  The [dst_port](#port_struct) structure is documented below.
+
+* `severity` - (Required, Int) Specifies the severity. Valid value are:
+  + `0`: Critical
+  + `1`: High
+  + `2`: Medium
+  + `3`: Low
+
+* `software` - (Required, Int) Specifies the software affected. Valid value are:
+  + `0`: ANY
+  + `1`: ADOBE
+  + `2`: APACHE
+  + `3`: APPLE
+  + `4`: CA
+  + `5`: CISCO
+  + `6`: GOOGLE_CHROME
+  + `7`: HP
+  + `8`: IBM
+  + `9`: IE
+  + `10`: IIS
+  + `11`: MC_AFEE
+  + `12`: MEDIA_PLAYER
+  + `13`: MICROSOFT_NET
+  + `14`: MICROSOFT_EDGE
+  + `15`: MICROSOFT_EXCHANGE
+  + `16`: MICROSOFT_OFFICE
+  + `17`: MICROSOFT_OUTLOOK
+  + `18`: MICROSOFT_SHARE_POINT
+  + `19`: MICROSOFT_WINDOWS
+  + `20`: MOZILLA
+  + `21`: MSSQL
+  + `22`: MYSQL
+  + `23`: NOVELL
+  + `24`: ORACLE
+  + `25`: SAMBA
+  + `26`: SAMSUNG
+  + `27`: SAP
+  + `28`: SCADA
+  + `29`: SQUID
+  + `30`: SUN
+  + `31`: SYMANTEC
+  + `32`: TREND_MICRO
+  + `33`: VMWARE
+  + `34`: WORD_PRESS
+  + `35`: Others
+
+* `src_port` - (Required, List) Specifies the source port information.
+  A maximum of one set of elements can be configured.
+
+  The [src_port](#port_struct) structure is documented below.
+
+<a name="port_struct"></a>
+The `dst_port` and `src_port` block supports:
+
+* `port_type` - (Required, Int) Specifies the port type. Valid values are:
+  + `-1`: All ports
+  + `0`: Include ports
+  + `1`: Exclude ports
+
+* `ports` - (Optional, String) Specifies the port.
+
+<a name="contents_struct"></a>
+The `contents` block supports:
+
+* `content` - (Required, String) Specifies the content.
+
+* `depth` - (Required, Int) Specifies the position to end the matching when matching features. Valid values are
+  from `1` to `65535`.
+
+* `is_hex` - (Optional, Bool) Specifies whether to enable hexadecimal matching. Valid values are:
+  + **true**: Enable hexadecimal matching
+  + **false**: Disable hexadecimal matching
+
+  Defaults to **false**.
+
+* `is_ignore` - (Optional, Bool) Specifies whether to ignore case. Valid values are:
+  + **true**: Ignore case
+  + **false**: Do not ignore case
+
+  Defaults to **false**.
+
+* `is_uri` - (Optional, Bool) Specifies whether to match a field in the URL that is the same as `content`.
+  Valid values are:
+  + **true**: Match
+  + **false**: Does not match
+
+  Defaults to **false**.
+
+* `offset` - (Optional, Int) Specifies the starting position when matching features.
+  Valid values are from `0` to `65535`.
+
+* `relative_position` - (Optional, Int) Specifies the starting position. Valid values are `0` and `1`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also the IPS custom rule ID).
+
+* `config_status` - The configuration status. Valid values are:
+  + `0`: Unknown
+  + `1`: Configuring
+  + `2`: Configured
+  + `3`: Configuration failed
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The resource can be imported using `fw_instance_id`, `id` (IPS custom rule ID), separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_cfw_ips_custom_rule.test <fw_instance_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2893,6 +2893,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_service_group":                 cfw.ResourceServiceGroup(),
 			"huaweicloud_cfw_service_group_member":          cfw.ResourceServiceGroupMember(),
 			"huaweicloud_cfw_firewall":                      cfw.ResourceFirewall(),
+			"huaweicloud_cfw_ips_custom_rule":               cfw.ResourceIpsCustomRule(),
 			"huaweicloud_cfw_domain_name_group":             cfw.ResourceDomainNameGroup(),
 			"huaweicloud_cfw_lts_log":                       cfw.ResourceLtsLog(),
 			"huaweicloud_cfw_report_profile":                cfw.ResourceReportProfile(),

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_ips_custom_rule_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_ips_custom_rule_test.go
@@ -1,0 +1,215 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cfw"
+)
+
+func getIpsCustomRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region       = acceptance.HW_REGION_NAME
+		product      = "cfw"
+		fwInstanceId = state.Primary.Attributes["fw_instance_id"]
+		ipsCfwId     = state.Primary.ID
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CFW client: %s", err)
+	}
+
+	return cfw.GetIpsCustomRuleDetail(client, fwInstanceId, ipsCfwId)
+}
+
+func TestAccIpsCustomRule_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_cfw_ips_custom_rule.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getIpsCustomRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testIpsCustomRule_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "fw_instance_id", acceptance.HW_CFW_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "ips_name", name),
+					resource.TestCheckResourceAttr(rName, "action_type", "0"),
+					resource.TestCheckResourceAttr(rName, "affected_os", "0"),
+					resource.TestCheckResourceAttr(rName, "attack_type", "3"),
+					resource.TestCheckResourceAttr(rName, "direction", "1"),
+					resource.TestCheckResourceAttr(rName, "protocol", "10"),
+					resource.TestCheckResourceAttr(rName, "severity", "1"),
+					resource.TestCheckResourceAttr(rName, "software", "3"),
+					resource.TestCheckResourceAttr(rName, "contents.#", "2"),
+					resource.TestCheckResourceAttr(rName, "contents.0.content", "vvvvvv"),
+					resource.TestCheckResourceAttr(rName, "contents.0.depth", "65535"),
+					resource.TestCheckResourceAttr(rName, "contents.0.is_hex", "false"),
+					resource.TestCheckResourceAttr(rName, "contents.0.is_ignore", "true"),
+					resource.TestCheckResourceAttr(rName, "contents.0.is_uri", "false"),
+					resource.TestCheckResourceAttr(rName, "contents.0.offset", "50"),
+					resource.TestCheckResourceAttr(rName, "contents.0.relative_position", "0"),
+					resource.TestCheckResourceAttr(rName, "dst_port.0.port_type", "1"),
+					resource.TestCheckResourceAttr(rName, "dst_port.0.ports", "9008"),
+					resource.TestCheckResourceAttr(rName, "src_port.0.port_type", "0"),
+					resource.TestCheckResourceAttr(rName, "src_port.0.ports", "5005"),
+					resource.TestCheckResourceAttrSet(rName, "config_status"),
+				),
+			},
+			{
+				Config: testIpsCustomRule_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "fw_instance_id", acceptance.HW_CFW_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "ips_name", name),
+					resource.TestCheckResourceAttr(rName, "action_type", "1"),
+					resource.TestCheckResourceAttr(rName, "affected_os", "2"),
+					resource.TestCheckResourceAttr(rName, "attack_type", "12"),
+					resource.TestCheckResourceAttr(rName, "direction", "-1"),
+					resource.TestCheckResourceAttr(rName, "protocol", "10"),
+					resource.TestCheckResourceAttr(rName, "severity", "0"),
+					resource.TestCheckResourceAttr(rName, "software", "0"),
+					resource.TestCheckResourceAttr(rName, "contents.#", "1"),
+					resource.TestCheckResourceAttr(rName, "contents.0.content", "DF"),
+					resource.TestCheckResourceAttr(rName, "contents.0.depth", "65500"),
+					resource.TestCheckResourceAttr(rName, "contents.0.is_hex", "true"),
+					resource.TestCheckResourceAttr(rName, "contents.0.is_ignore", "false"),
+					resource.TestCheckResourceAttr(rName, "contents.0.is_uri", "false"),
+					resource.TestCheckResourceAttr(rName, "contents.0.offset", "100"),
+					resource.TestCheckResourceAttr(rName, "contents.0.relative_position", "1"),
+					resource.TestCheckResourceAttr(rName, "dst_port.0.port_type", "-1"),
+					resource.TestCheckResourceAttr(rName, "src_port.0.port_type", "1"),
+					resource.TestCheckResourceAttr(rName, "src_port.0.ports", "6000"),
+					resource.TestCheckResourceAttrSet(rName, "config_status"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testIpsCustomRuleImportState(rName),
+			},
+		},
+	})
+}
+
+func testIpsCustomRule_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cfw_ips_custom_rule" "test" {
+  fw_instance_id = "%[1]s"
+  ips_name       = "%[2]s"
+  action_type    = 0
+  affected_os    = 0
+  attack_type    = 3
+  direction      = 1
+  protocol       = 10
+  severity       = 1
+  software       = 3
+
+  contents {
+    content           = "vvvvvv"
+    depth             = 65535
+    is_hex            = false
+    is_ignore         = true
+    is_uri            = false
+    offset            = 50
+    relative_position = 0
+  }
+
+  contents {
+    content           = "DF"
+    depth             = 65535
+    is_hex            = true
+    is_ignore         = false
+    is_uri            = false
+    offset            = 200
+    relative_position = 0
+  }
+
+  dst_port {
+    port_type = 1
+    ports     = "9008"
+  }
+
+  src_port {
+    port_type = 0
+    ports     = "5005"
+  }
+}
+`, acceptance.HW_CFW_INSTANCE_ID, name)
+}
+
+func testIpsCustomRule_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cfw_ips_custom_rule" "test" {
+  fw_instance_id = "%[1]s"
+  ips_name       = "%[2]s"
+  action_type    = 1
+  affected_os    = 2
+  attack_type    = 12
+  direction      = -1
+  protocol       = 10
+  severity       = 0
+  software       = 0
+
+  contents {
+    content           = "DF"
+    depth             = 65500
+    is_hex            = true
+    is_ignore         = false
+    is_uri            = false
+    offset            = 100
+    relative_position = 1
+  }
+
+  dst_port {
+    port_type = -1
+  }
+
+  src_port {
+    port_type = 1
+    ports     = "6000"
+  }
+}
+`, acceptance.HW_CFW_INSTANCE_ID, name)
+}
+
+func testIpsCustomRuleImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		fwInstanceId := rs.Primary.Attributes["fw_instance_id"]
+		if fwInstanceId == "" {
+			return "", fmt.Errorf("attribute (fw_instance_id) of Resource (%s) not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return "", fmt.Errorf("attribute (ID) of Resource (%s) not found", name)
+		}
+
+		return fmt.Sprintf("%s/%s", fwInstanceId, rs.Primary.ID), nil
+	}
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_ips_custom_rule.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_ips_custom_rule.go
@@ -1,0 +1,665 @@
+package cfw
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW POST /v1/{project_id}/ips/custom-rule
+// @API CFW PUT /v1/{project_id}/ips/custom-rule/{ips_cfw_id}
+// @API CFW GET /v1/{project_id}/ips/custom-rule
+// @API CFW GET /v1/{project_id}/ips/custom-rule/{ips_cfw_id}
+// @API CFW POST /v1/{project_id}/ips/custom-rule/batch-delete
+func ResourceIpsCustomRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIpsCustomRuleCreate,
+		ReadContext:   resourceIpsCustomRuleRead,
+		UpdateContext: resourceIpsCustomRuleUpdate,
+		DeleteContext: resourceIpsCustomRuleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceIpsCustomRuleImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"fw_instance_id",
+			"ips_name",
+			"protocol",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			// Unable to retrieve the value of field `fw_instance_id` from the details API.
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ips_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"protocol": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"action_type": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"affected_os": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"attack_type": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"contents": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     contentsSchema(),
+			},
+			"direction": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"dst_port": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem:     portSchema(),
+			},
+			"severity": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"software": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"src_port": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem:     portSchema(),
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"config_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func contentsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required
+			"content": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: utils.SchemaDesc("", utils.SchemaDescInput{Required: true}),
+			},
+			// Between 1 ~ 65535  Required
+			"depth": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: utils.SchemaDesc("", utils.SchemaDescInput{Required: true}),
+			},
+			// Defaults to false.
+			"is_hex": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			// Defaults to false.
+			"is_ignore": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			// Defaults to false.
+			"is_uri": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			// Between 0 ~ 65535
+			"offset": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			// Between 0 ~ 1
+			"relative_position": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func portSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"port_type": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: utils.SchemaDesc("", utils.SchemaDescInput{Required: true}),
+			},
+			"ports": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildIpsCustomRuleContentsParam(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"content":           rawMap["content"],
+			"depth":             rawMap["depth"],
+			"is_hex":            rawMap["is_hex"],
+			"is_ignore":         rawMap["is_ignore"],
+			"is_uri":            rawMap["is_uri"],
+			"offset":            rawMap["offset"],
+			"relative_position": rawMap["relative_position"],
+		})
+	}
+
+	return rst
+}
+
+func buildIpsCustomRulePortParam(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"port_type": rawMap["port_type"],
+		"ports":     utils.ValueIgnoreEmpty(rawMap["ports"]),
+	}
+}
+
+func buildCreateIpsCustomRuleBodyParam(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"fw_instance_id": d.Get("fw_instance_id"),
+		"ips_name":       d.Get("ips_name"),
+		"protocol":       d.Get("protocol"),
+		"action_type":    d.Get("action_type"),
+		"affected_os":    d.Get("affected_os"),
+		"attack_type":    d.Get("attack_type"),
+		"contents":       buildIpsCustomRuleContentsParam(d.Get("contents").([]interface{})),
+		"direction":      d.Get("direction"),
+		"dst_port":       buildIpsCustomRulePortParam(d.Get("dst_port").([]interface{})),
+		"severity":       d.Get("severity"),
+		"software":       d.Get("software"),
+		"src_port":       buildIpsCustomRulePortParam(d.Get("src_port").([]interface{})),
+	}
+}
+
+func buildListIpsCustomRuleQueryParams(d *schema.ResourceData) string {
+	var (
+		ipsName      = d.Get("ips_name").(string)
+		fwInstanceId = d.Get("fw_instance_id").(string)
+		limit        = 1024
+	)
+
+	return fmt.Sprintf("?ips_name=%s&fw_instance_id=%s&limit=%d", ipsName, fwInstanceId, limit)
+}
+
+func getIpsCustomRuleByList(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/ips/custom-rule"
+		ipsName = d.Get("ips_name").(string)
+		offset  = 0
+	)
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildListIpsCustomRuleQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := requestPath + fmt.Sprintf("&offset=%d", offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		records := utils.PathSearch("data.records", respBody, make([]interface{}, 0)).([]interface{})
+		if len(records) == 0 {
+			break
+		}
+
+		// The `ips_name` filter parameter in the API is a fuzzy search; we need to perform a precise match afterwards.
+		targetRule := utils.PathSearch(fmt.Sprintf("[?ips_name=='%s']|[0]", ipsName), records, nil)
+		if targetRule != nil {
+			return targetRule, nil
+		}
+
+		// If the target data is not found on the current page, continue the search from the next offset.
+		offset += len(records)
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func buildIpsCustomRuleDetailQueryParams(fwInstanceId string) string {
+	return fmt.Sprintf("?fw_instance_id=%s", fwInstanceId)
+}
+
+func GetIpsCustomRuleDetail(client *golangsdk.ServiceClient, fwInstanceId, ipsCfwId string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/ips/custom-rule/{ips_cfw_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{ips_cfw_id}", ipsCfwId)
+	requestPath += buildIpsCustomRuleDetailQueryParams(fwInstanceId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	contents := utils.PathSearch("data.contents", respBody, make([]interface{}, 0)).([]interface{})
+	protocol := int(utils.PathSearch("data.protocol", respBody, float64(0)).(float64))
+	severity := int(utils.PathSearch("data.severity", respBody, float64(0)).(float64))
+
+	if len(contents) == 00 || protocol == -99 || severity == -99 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return respBody, nil
+}
+
+func refreshIpsCustomRuleConfigStatusFunc(client *golangsdk.ServiceClient, fwInstanceId, ipsCfwId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetIpsCustomRuleDetail(client, fwInstanceId, ipsCfwId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		configStatus := int(utils.PathSearch("data.config_status", respBody, float64(0)).(float64))
+		if configStatus == 2 {
+			return respBody, "COMPLETED", nil
+		}
+
+		if configStatus == 3 {
+			return respBody, "ERROR", errors.New("unexpected config status `3` detected")
+		}
+
+		return respBody, "PENDING", nil
+	}
+}
+
+func waitingForIpsCustomRuleConfigSuccess(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	fwInstanceId := d.Get("fw_instance_id").(string)
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshIpsCustomRuleConfigStatusFunc(client, fwInstanceId, d.Id()),
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceIpsCustomRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/ips/custom-rule"
+		product = "cfw"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateIpsCustomRuleBodyParam(d)),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating CFW IPS custom rule: %s", err)
+	}
+
+	customRule, err := getIpsCustomRuleByList(client, d)
+	if err != nil {
+		return diag.Errorf("error querying CFW IPS custom rule after creation: %s", err)
+	}
+
+	id := utils.PathSearch("ips_cfw_id", customRule, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating CFW IPS custom rule: ID is not found in API response")
+	}
+
+	d.SetId(id)
+
+	if err := waitingForIpsCustomRuleConfigSuccess(ctx, client, d, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for CFW IPS custom rule (%s) creation to config success: %s", d.Id(), err)
+	}
+
+	return resourceIpsCustomRuleRead(ctx, d, meta)
+}
+
+func flattenIpsCustomRuleContentsAttr(respBody interface{}) []map[string]interface{} {
+	if respBody == nil {
+		return nil
+	}
+
+	respArray, ok := respBody.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"content":           utils.PathSearch("content", v, nil),
+			"depth":             utils.PathSearch("depth", v, nil),
+			"is_hex":            utils.PathSearch("is_hex", v, nil),
+			"is_ignore":         utils.PathSearch("is_ignore", v, nil),
+			"is_uri":            utils.PathSearch("is_uri", v, nil),
+			"offset":            utils.PathSearch("offset", v, nil),
+			"relative_position": utils.PathSearch("relative_position", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenIpsCustomRuledPortAttr(respBody interface{}) []map[string]interface{} {
+	if respBody == nil {
+		return nil
+	}
+
+	portMap := map[string]interface{}{
+		"port_type": utils.PathSearch("port_type", respBody, nil),
+		"ports":     utils.PathSearch("ports", respBody, nil),
+	}
+
+	return []map[string]interface{}{portMap}
+}
+
+func resourceIpsCustomRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		product      = "cfw"
+		fwInstanceId = d.Get("fw_instance_id").(string)
+		ipsCfwId     = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	respBody, err := GetIpsCustomRuleDetail(client, fwInstanceId, ipsCfwId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CFW IPS custom rule")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("ips_name", utils.PathSearch("data.ips_name", respBody, nil)),
+		d.Set("protocol", utils.PathSearch("data.protocol", respBody, nil)),
+		d.Set("action_type", utils.PathSearch("data.action", respBody, nil)),
+		d.Set("affected_os", utils.PathSearch("data.affected_os", respBody, nil)),
+		d.Set("attack_type", utils.PathSearch("data.attack_type", respBody, nil)),
+		d.Set("contents", flattenIpsCustomRuleContentsAttr(utils.PathSearch("data.contents", respBody, nil))),
+		d.Set("direction", utils.PathSearch("data.direction", respBody, nil)),
+		d.Set("dst_port", flattenIpsCustomRuledPortAttr(utils.PathSearch("data.dst_port", respBody, nil))),
+		d.Set("severity", utils.PathSearch("data.severity", respBody, nil)),
+		d.Set("software", utils.PathSearch("data.software", respBody, nil)),
+		d.Set("src_port", flattenIpsCustomRuledPortAttr(utils.PathSearch("data.src_port", respBody, nil))),
+		d.Set("config_status", utils.PathSearch("data.config_status", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateIpsCustomRuleBodyParam(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"fw_instance_id": d.Get("fw_instance_id"),
+		"ips_name":       d.Get("ips_name"),
+		"protocol":       d.Get("protocol"),
+		"action_type":    d.Get("action_type"),
+		"affected_os":    d.Get("affected_os"),
+		"attack_type":    d.Get("attack_type"),
+		"contents":       buildIpsCustomRuleContentsParam(d.Get("contents").([]interface{})),
+		"direction":      d.Get("direction"),
+		"dst_port":       buildIpsCustomRulePortParam(d.Get("dst_port").([]interface{})),
+		"severity":       d.Get("severity"),
+		"software":       d.Get("software"),
+		"src_port":       buildIpsCustomRulePortParam(d.Get("src_port").([]interface{})),
+	}
+}
+
+func handleRetryUpdateOperationsError(err error) (bool, error) {
+	if err == nil {
+		// The operation was executed successfully and does not need to be executed again.
+		return false, nil
+	}
+	if errCode, ok := err.(golangsdk.ErrDefault400); ok {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)
+		}
+
+		errorCode := utils.PathSearch("error_code", apiError, "").(string)
+		if errorCode == "" {
+			return false, errors.New("unable to find error code from API response")
+		}
+
+		errorMsg := utils.PathSearch("error_msg", apiError, "").(string)
+		if errorMsg == "" {
+			return false, errors.New("unable to find error message from API response")
+		}
+
+		if errorCode == "CFW.00109003" {
+			return true, err
+		}
+	}
+	// Operation execution failed due to some resource or server issues, no need to try again.
+	return false, err
+}
+
+func resourceIpsCustomRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/ips/custom-rule/{ips_cfw_id}"
+		product = "cfw"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{ips_cfw_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdateIpsCustomRuleBodyParam(d)),
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		_, err = client.Request("PUT", requestPath, &requestOpt)
+		retry, err := handleRetryUpdateOperationsError(err)
+		return nil, retry, err
+	}
+
+	_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return diag.Errorf("error updating CFW IPS custom rule: %s", err)
+	}
+
+	if err := waitingForIpsCustomRuleConfigSuccess(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return diag.Errorf("error waiting for CFW IPS custom rule (%s) update to config success: %s", d.Id(), err)
+	}
+
+	return resourceIpsCustomRuleRead(ctx, d, meta)
+}
+
+func buildDeleteIpsCustomRuleBodyParam(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"fw_instance_id": d.Get("fw_instance_id"),
+		"ips_ids":        []string{d.Id()},
+	}
+}
+
+func waitingForIpsCustomRuleDeleteSuccess(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	fwInstanceId := d.Get("fw_instance_id").(string)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := GetIpsCustomRuleDetail(client, fwInstanceId, d.Id())
+			if err != nil {
+				var errCode404 golangsdk.ErrDefault404
+				if errors.As(err, &errCode404) {
+					return "deleted", "COMPLETED", nil
+				}
+
+				return nil, "ERROR", err
+			}
+
+			return respBody, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceIpsCustomRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/ips/custom-rule/batch-delete"
+		product = "cfw"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildDeleteIpsCustomRuleBodyParam(d)),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CFW IPS custom rule: %s", err)
+	}
+
+	if err := waitingForIpsCustomRuleDeleteSuccess(ctx, client, d, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for CFW IPS custom rule (%s) deletion to complete: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceIpsCustomRuleImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, errors.New("invalid format specified for import ID, must be <fw_instance_id>/<id>")
+	}
+
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, d.Set("fw_instance_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to manage IPS custom rule.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccIpsCustomRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccIpsCustomRule_basic -timeout 360m -parallel 10
=== RUN   TestAccIpsCustomRule_basic
=== PAUSE TestAccIpsCustomRule_basic
=== CONT  TestAccIpsCustomRule_basic
--- PASS: TestAccIpsCustomRule_basic (170.20s)
PASS
coverage: 6.5% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       170.322s        coverage: 6.5% of statements in ./huaweicloud/services/cfw
```
<img width="1330" height="75" alt="image" src="https://github.com/user-attachments/assets/5079d999-a7f5-4e88-b885-e64904552913" />



* [X] Documentation updated.
* [X] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    
<img width="829" height="187" alt="image" src="https://github.com/user-attachments/assets/51744a44-8b98-4b8a-b229-b2f57314b589" />


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
