### PR TITLE
refactor(cse): using new code style to optimize the resources

### DIFF
--- a/docs/resources/cse_microservice.md
+++ b/docs/resources/cse_microservice.md
@@ -2,16 +2,17 @@
 subcategory: "Cloud Service Engine (CSE)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_cse_microservice"
-description: ""
+description: |-
+  Manages a microservice resource under a specified microservice engine within HuaweiCloud.
 ---
 
 # huaweicloud_cse_microservice
 
-Manages a dedicated microservice resource within HuaweiCloud.
+Manages a microservice resource under a specified microservice engine within HuaweiCloud.
 
--> 1. Before creating a configuration, make sure the engine has enabled the rules shown in the appendix
-   [table](#microservice_default_engine_access_rules).
-   <br/> 2. When deleting a microservice, all instances under it will also be deleted together.
+-> 1. Before creating a microservice, make sure that the engine is bound to the EIP and that the rules shown in the
+   appendix [table](#microservice_default_engine_access_rules) are enabled in the corresponding security group.
+   <br/>2. When deleting a microservice, all instances under it will also be deleted together.
 
 ## Example Usage
 
@@ -70,21 +71,18 @@ resource "huaweicloud_cse_microservice" "test" {
 
 The following arguments are supported:
 
-* `auth_address` - (Required, String, ForceNew) Specifies the address that used to request the access token.  
-  Usually is the connection address of service center.  
-  Changing this will create a new resource.
+* `auth_address` - (Required, String, NonUpdatable) Specifies the address that used to request the access token.  
+  Usually is the connection address of service center.
 
-* `connect_address` - (Required, String, ForceNew) Specifies the address that used to access engine and manages
+* `connect_address` - (Required, String, NonUpdatable) Specifies the address that used to access engine and manages
   microservice.  
-  Usually is the connection address of service center.  
-  Changing this will create a new resource.
+  Usually is the connection address of service center.
 
 -> We are only support IPv4 addresses yet (for `auth_address` and `connect_address`).
 
-* `admin_user` - (Optional, String, ForceNew) Specifies the account name for **RBAC** login.
-  Changing this will create a new resource.
+* `admin_user` - (Optional, String, NonUpdatable) Specifies the user name that used to pass the **RBAC** control.
 
-* `admin_pass` - (Optional, String, ForceNew) Specifies the account password for **RBAC** login.
+* `admin_pass` - (Optional, String, NonUpdatable) Specifies the user password that used to pass the **RBAC** control.
   The password format must meet the following conditions:
   + Must be `8` to `32` characters long.
   + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
@@ -92,39 +90,44 @@ The following arguments are supported:
   + Cannot be the account name or account name spelled backwards.
   + The password can only start with a letter.
 
-  Changing this will create a new resource.
-
 -> Both `admin_user` and `admin_pass` are required if **RBAC** is enabled for the microservice engine.
 
-* `name` - (Required, String, ForceNew) Specifies the name of the dedicated microservice.
-  The name can contain `1` to `128` characters, only letters, digits, underscore (_), hyphens (-) and dots (.) are
-  allowed. The name must start and end with a letter or digit. Changing this will create a new microservice.
+~> Please make sure that all the above parameter values ​​are correct; otherwise, **Terraform** will assume the resource
+   does not exist and remove it from the local `.tfstate` file, after which it can only be managed by importing it.
 
-* `app_name` - (Required, String, ForceNew) Specifies the name of the dedicated microservice application.
-  Changing this will create a new microservice.
+* `name` - (Required, String, NonUpdatable) Specifies the name of the microservice.  
+  The valid value is limited from `1` to `128` characters, only letters, digits, underscore (_), hyphens (-) and
+  dots (.) are allowed. The name must start and end with a letter or digit.
 
-* `version` - (Required, String, ForceNew) Specifies the version of the dedicated microservice.
-  Changing this will create a new microservice.
+* `app_name` - (Required, String, NonUpdatable) Specifies the name of the microservice application.
 
-* `environment` - (Optional, String, ForceNew) Specifies the environment (stage) type.
-  The valid values are **development**, **testing**, **acceptance** and **production**.
+* `version` - (Required, String, NonUpdatable) Specifies the version of the microservice.
+
+* `environment` - (Optional, String, NonUpdatable) Specifies the environment (stage) type of the microservice.  
+  The valid values are as follows:
+  + **development**
+  + **testing**
+  + **acceptance**
+  + **production**
+
   If omitted, the microservice will be deployed in an empty environment.
-  Changing this will create a new microservice.
 
-* `level` - (Optional, String, ForceNew) Specifies the microservice level.
-  The valid values are **FRONT**, **MIDDLE**, and **BACK**. Changing this will create a new microservice.
+* `level` - (Optional, String, NonUpdatable) Specifies the level of the microservice.  
+  The valid values are as follows:
+  + **FRONT**
+  + **MIDDLE**
+  + **BACK**
 
-* `description` - (Optional, String, ForceNew) Specifies the description of the dedicated microservice.
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the microservice.  
   The description can contain a maximum of `256` characters.
-  Changing this will create a new microservice.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The microservice ID.
+* `id` - The ID of the microservice.
 
-* `status` - The microservice status. The values supports **UP** and **DOWN**.
+* `status` - The status of the microservice.
 
 ## Import
 
@@ -163,8 +166,8 @@ Security group rules required to access the engine:
 | Ingress   | 1        | Allow  | ICMP     | All           | Ipv6      | ::/0                  |
 | Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv6      | ::/0                  |
 | Ingress   | 1        | Allow  | All      | All           | Ipv6      | cse-engine-default-sg |
-| Ingress   | 1        | Allow  | ICMP     | All           | Ipv4      | 0.0.0.0/0             |
-| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv4      | 0.0.0.0/0             |
+| Ingress   | 1        | Allow  | ICMP     | All           | Ipv4      | A CIDR containing the public IP address of the machine from which you executed this terraform script, such as **0.0.0.0/0** |
+| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv4      | A CIDR containing the public IP address of the machine from which you executed this terraform script, such as **0.0.0.0/0** |
 | Ingress   | 1        | Allow  | All      | All           | Ipv4      | cse-engine-default-sg |
 | Egress    | 100      | Allow  | All      | All           | Ipv6      | ::/0                  |
 | Egress    | 100      | Allow  | All      | All           | Ipv4      | 0.0.0.0/0             |

--- a/docs/resources/cse_microservice_instance.md
+++ b/docs/resources/cse_microservice_instance.md
@@ -2,15 +2,16 @@
 subcategory: "Cloud Service Engine (CSE)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_cse_microservice_instance"
-description: ""
+description: |-
+  Manages a microservice instance resource under a specified microservice engine within HuaweiCloud.
 ---
 
 # huaweicloud_cse_microservice_instance
 
-Manages a dedicated microservice instance resource within HuaweiCloud.
+Manages a microservice instance resource under a specified microservice engine within HuaweiCloud.
 
--> Before creating a configuration, make sure the engine has enabled the rules shown in the appendix
-   [table](#microservice_instance_default_engine_access_rules).
+-> Before creating a microservice, make sure that the engine is bound to the EIP and that the rules shown in the
+   appendix [table](#microservice_instance_default_engine_access_rules) are enabled in the corresponding security group.
 
 ## Example Usage
 
@@ -107,103 +108,87 @@ resource "huaweicloud_cse_microservice_instance" "test" {
 
 The following arguments are supported:
 
-* `auth_address` - (Required, String, ForceNew) Specifies the address that used to request the access token.  
-  Usually is the connection address of service center.  
-  Changing this will create a new resource.
+* `auth_address` - (Required, String, NonUpdatable) Specifies the address that used to request the access token.  
+  Usually is the connection address of service center.
 
-* `connect_address` - (Required, String, ForceNew) Specifies the address that used to access engine and manages
+* `connect_address` - (Required, String, NonUpdatable) Specifies the address that used to access engine and manages
   microservice instance.  
-  Usually is the connection address of service center.  
-  Changing this will create a new resource.
+  Usually is the connection address of service center.
 
 -> We are only support IPv4 addresses yet (for `auth_address` and `connect_address`).
 
-* `admin_user` - (Optional, String, ForceNew) Specifies the account name for **RBAC** login.
-  Changing this will create a new resource.
+* `admin_user` - (Optional, String, NonUpdatable) Specifies the user name that used to pass the **RBAC** control.
 
-* `admin_pass` - (Optional, String, ForceNew) Specifies the account password for **RBAC** login.
+* `admin_pass` - (Optional, String, NonUpdatable) Specifies the user password that used to pass the **RBAC** control.  
   The password format must meet the following conditions:
   + Must be `8` to `32` characters long.
   + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
     (-~!@#%^*_=+?$&()|<>{}[]).
   + Cannot be the account name or account name spelled backwards.
   + The password can only start with a letter.
-
-  Changing this will create a new resource.
 
 -> Both `admin_user` and `admin_pass` are required if **RBAC** is enabled for the microservice engine.
 
-* `microservice_id` - (Required, String, ForceNew) Specifies the ID of the dedicated microservice to which the instance
-  belongs. Changing this will create a new microservice instance.
+~> Please make sure that all the above parameter values ​​are correct; otherwise, **Terraform** will assume the resource
+   does not exist and remove it from the local `.tfstate` file, after which it can only be managed by importing it.
 
-* `host_name` - (Required, String, ForceNew) Specifies the host name, such as `localhost`.
-  Changing this will create a new microservice instance.
+* `microservice_id` - (Required, String, NonUpdatable) Specifies the ID of the microservice to which the microservice
+  instance belongs.
 
-* `endpoints` - (Required, List, ForceNew) Specifies the access addresses information.
-  Changing this will create a new microservice instance.
+* `host_name` - (Required, String, NonUpdatable) Specifies the host name of the microservice instance.
 
-* `version` - (Optional, String, ForceNew) Specifies the version of the dedicated microservice instance.
-  Changing this will create a new microservice instance.
+* `endpoints` - (Required, List, NonUpdatable) Specifies the list of access addresses of the microservice instance.
 
-* `properties` - (Optional, Map, ForceNew) Specifies the extended attributes.
-  Changing this will create a new microservice instance.
+* `version` - (Optional, String, NonUpdatable) Specifies the version of the microservice instance.
+
+* `properties` - (Optional, Map, NonUpdatable) Specifies the extended attributes of the microservice instance,
+  in key/value format.
 
   -> The internal key-value pair cannot be configured or overwritten, such as **engineID** and **engineName**.
 
-* `health_check` - (Optional, List, ForceNew) Specifies the health check configuration.
-  The [object](#microservice_instance_health_check) structure is documented below.
-  Changing this will create a new microservice instance.
+* `health_check` - (Optional, List, NonUpdatable) Specifies the health check configuration of the microservice
+  instance.  
+  The [health_check](#cse_microservice_instance_health_check) structure is documented below.
 
-* `data_center` - (Optional, List, ForceNew) Specifies the data center configuration.
-  The [object](#microservice_instance_data_center) structure is documented below.
-  Changing this will create a new microservice instance.
+* `data_center` - (Optional, List, NonUpdatable) Specifies the data center configuration of the microservice instance.  
+  The [data_center](#cse_microservice_instance_data_center) structure is documented below.
 
-* `admin_user` - (Optional, String, ForceNew) Specifies the account name. The initial account name is **root**.
-  Required if the `auth_type` of engine is **RBAC**. Changing this will create a new microservice instance.
-
-* `admin_pass` - (Optional, String, ForceNew) Specifies the account password.
-  Required if the `auth_type` of engine is **RBAC**. Changing this will create a new microservice instance.
-  The password format must meet the following conditions:
-  + Must be `8` to `32` characters long.
-  + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
-    (-~!@#%^*_=+?$&()|<>{}[]).
-  + Cannot be the account name or account name spelled backwards.
-  + The password can only start with a letter.
-
-<a name="microservice_instance_health_check"></a>
+<a name="cse_microservice_instance_health_check"></a>
 The `health_check` block supports:
 
-* `mode` - (Required, String, ForceNew) Specifies the heartbeat mode. The valid values are **push** and **pull**.
-  Changing this will create a new microservice instance.
+* `mode` - (Required, String, NonUpdatable) Specifies the heartbeat mode of the health check.  
+  The valid values are as follows:
+  + **push**
+  + **pull**
 
-* `interval` - (Required, Int, ForceNew) Specifies the heartbeat interval. The unit is **s** (second).
-  Changing this will create a new microservice instance.
+* `interval` - (Required, Int, NonUpdatable) Specifies the heartbeat interval of the health check, in seconds.
 
-* `max_retries` - (Required, Int, ForceNew) Specifies the maximum retries.
-  Changing this will create a new microservice instance.
+* `max_retries` - (Required, Int, NonUpdatable) Specifies the maximum retry number of the health check.
 
-* `port` - (Optional, Int, ForceNew) Specifies the port number.
-  Changing this will create a new microservice instance.
+* `port` - (Optional, Int, NonUpdatable) Specifies the port of the health check.
 
-<a name="microservice_instance_data_center"></a>
+<a name="cse_microservice_instance_data_center"></a>
 The `data_center` block supports:
 
-* `name` - (Required, String, ForceNew) Specifies the data center name.
-  Changing this will create a new microservice instance.
+* `name` - (Required, String, NonUpdatable) Specifies the name of the data center.
 
-* `region` - (Required, String, ForceNew) Specifies the custom region name of the data center.
-  Changing this will create a new microservice instance.
+* `region` - (Required, String, NonUpdatable) Specifies the custom region name of the data center.
 
-* `availability_zone` - (Required, String, ForceNew) Specifies the custom availability zone name of the data center.
-  Changing this will create a new microservice instance.
+* `availability_zone` - (Required, String, NonUpdatable) Specifies the custom availability zone name of the data center.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The microservice instance ID.
+* `id` - The ID of the microservice instance.
 
-* `status` - The microservice instance status. The values supports **UP**, **DOWN**, **STARTING** and **OUTOFSERVICE**.
+* `status` - The status of the microservice instance.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `delete` - Default is 3 minutes.
 
 ## Import
 
@@ -243,8 +228,8 @@ Security group rules required to access the engine:
 | Ingress   | 1        | Allow  | ICMP     | All           | Ipv6      | ::/0                  |
 | Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv6      | ::/0                  |
 | Ingress   | 1        | Allow  | All      | All           | Ipv6      | cse-engine-default-sg |
-| Ingress   | 1        | Allow  | ICMP     | All           | Ipv4      | 0.0.0.0/0             |
-| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv4      | 0.0.0.0/0             |
+| Ingress   | 1        | Allow  | ICMP     | All           | Ipv4      | A CIDR containing the public IP address of the machine from which you executed this terraform script, such as **0.0.0.0/0** |
+| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv4      | A CIDR containing the public IP address of the machine from which you executed this terraform script, such as **0.0.0.0/0** |
 | Ingress   | 1        | Allow  | All      | All           | Ipv4      | cse-engine-default-sg |
 | Egress    | 100      | Allow  | All      | All           | Ipv6      | ::/0                  |
 | Egress    | 100      | Allow  | All      | All           | Ipv4      | 0.0.0.0/0             |

--- a/huaweicloud/common/config.go
+++ b/huaweicloud/common/config.go
@@ -32,8 +32,16 @@ func NewCustomClient(insecure bool, endpoints ...string) *golangsdk.ServiceClien
 		Timeout: 30 * time.Minute,
 	}
 
-	return &golangsdk.ServiceClient{
+	client := &golangsdk.ServiceClient{
 		ProviderClient: p,
-		ResourceBase:   strings.Join(endpoints, "/") + "/",
+		ResourceBase:   "",
+		Endpoint:       "",
 	}
+
+	if len(endpoints) > 0 {
+		client.Endpoint = strings.TrimSuffix(endpoints[0], "/") + "/"
+		client.ResourceBase = strings.Join(endpoints, "/") + "/"
+	}
+
+	return client
 }

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/instances"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -16,27 +14,30 @@ import (
 )
 
 func getMicroserviceInstanceFunc(_ *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	token, err := cse.GetAuthorizationToken(getAuthAddress(state.Primary.Attributes),
-		state.Primary.Attributes["admin_user"], state.Primary.Attributes["admin_pass"])
-	if err != nil {
-		return nil, err
-	}
+	var (
+		authAddress    = getAuthAddress(state.Primary.Attributes)
+		adminUser      = state.Primary.Attributes["admin_user"]
+		adminPass      = state.Primary.Attributes["admin_pass"]
+		microserviceId = state.Primary.Attributes["microservice_id"]
+		instanceId     = state.Primary.ID
+		client         = common.NewCustomClient(true, state.Primary.Attributes["connect_address"])
+	)
 
-	client := common.NewCustomClient(true, state.Primary.Attributes["connect_address"], "v4", "default")
-	return instances.Get(client, state.Primary.Attributes["microservice_id"], state.Primary.ID, token)
+	return cse.GetInstance(client, authAddress, adminUser, adminPass, microserviceId, instanceId)
 }
 
 // Beforce testing, please bind the EIP and open the access rules according to the resource ducoment appendix.
 func TestAccMicroserviceInstance_basic(t *testing.T) {
 	var (
-		instance instances.Instance
-		randName = acceptance.RandomAccResourceName()
+		obj interface{}
 
 		withAuthAddress   = "huaweicloud_cse_microservice_instance.with_auth_address"
-		rcWithAuthAddress = acceptance.InitResourceCheck(withAuthAddress, &instance, getMicroserviceInstanceFunc)
+		rcWithAuthAddress = acceptance.InitResourceCheck(withAuthAddress, &obj, getMicroserviceInstanceFunc)
 
 		withoutAuthAddress   = "huaweicloud_cse_microservice_instance.without_auth_address"
-		rcWithoutAuthAddress = acceptance.InitResourceCheck(withoutAuthAddress, &instance, getMicroserviceInstanceFunc)
+		rcWithoutAuthAddress = acceptance.InitResourceCheck(withoutAuthAddress, &obj, getMicroserviceInstanceFunc)
+
+		randName = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/services"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -25,27 +23,29 @@ func getAuthAddress(attributes map[string]string) string {
 }
 
 func getMicroserviceFunc(_ *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	token, err := cse.GetAuthorizationToken(getAuthAddress(state.Primary.Attributes),
-		state.Primary.Attributes["admin_user"], state.Primary.Attributes["admin_pass"])
-	if err != nil {
-		return nil, err
-	}
+	var (
+		authAddress    = getAuthAddress(state.Primary.Attributes)
+		adminUser      = state.Primary.Attributes["admin_user"]
+		adminPass      = state.Primary.Attributes["admin_pass"]
+		microserviceId = state.Primary.ID
+		client         = common.NewCustomClient(true, state.Primary.Attributes["connect_address"])
+	)
 
-	client := common.NewCustomClient(true, state.Primary.Attributes["connect_address"], "v4", "default")
-	return services.Get(client, state.Primary.ID, token)
+	return cse.GetMicroservice(client, authAddress, adminUser, adminPass, microserviceId)
 }
 
 // Beforce testing, please bind the EIP and open the access rules according to the resource ducoment appendix.
 func TestAccMicroservice_basic(t *testing.T) {
 	var (
-		service  services.Service
-		randName = acceptance.RandomAccResourceName()
+		obj interface{}
 
 		withAuthAddress   = "huaweicloud_cse_microservice.with_auth_address"
-		rcWithAuthAddress = acceptance.InitResourceCheck(withAuthAddress, &service, getMicroserviceFunc)
+		rcWithAuthAddress = acceptance.InitResourceCheck(withAuthAddress, &obj, getMicroserviceFunc)
 
 		withoutAuthAddress   = "huaweicloud_cse_microservice.without_auth_address"
-		rcWithoutAuthAddress = acceptance.InitResourceCheck(withoutAuthAddress, &service, getMicroserviceFunc)
+		rcWithoutAuthAddress = acceptance.InitResourceCheck(withoutAuthAddress, &obj, getMicroserviceFunc)
+
+		randName = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/huaweicloud/services/cse/config.go
+++ b/huaweicloud/services/cse/config.go
@@ -3,23 +3,48 @@ package cse
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/auth"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+const connectAddressRegex = `https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}`
+
+var connectAddressRegexPattern = regexp.MustCompile(fmt.Sprintf(`^(%[1]s)?/?(%[1]s)/(.*)$`, connectAddressRegex))
+
+func buildRequestMoreHeaders(enterpriseProjectId string) map[string]string {
+	moreHeaders := map[string]string{
+		"Content-Type": "application/json;charset=UTF-8",
+		"Accept":       "application/json",
+	}
+
+	if enterpriseProjectId != "" {
+		moreHeaders["X-Enterprise-Project-ID"] = enterpriseProjectId
+	}
+	return moreHeaders
+}
 
 // getToken is a method to request the CSE API and get the authorization token.
 // The format of is "Bearer {token}".
-func getToken(c *golangsdk.ServiceClient, username, password string) (string, error) {
-	tokenOpts := auth.CreateOpts{
-		Name:     username,
-		Password: password,
+func getToken(client *golangsdk.ServiceClient, username, password string) (string, error) {
+	httpUrl := "v4/token"
+
+	getPath := client.Endpoint + httpUrl
+
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+		JSONBody: map[string]interface{}{
+			"name":     username,
+			"password": password,
+		},
 	}
 
-	resp, err := auth.Create(c, tokenOpts)
+	requestResp, err := client.Request("POST", getPath, &requestOpts)
 	if err != nil {
 		// When a microservice engine with an EIP is deleted, attempting to obtain a token via the engine's connection
 		// address will result in an error (connection error). This needs to be handled specially to return a 404 error.
@@ -33,30 +58,22 @@ func getToken(c *golangsdk.ServiceClient, username, password string) (string, er
 				},
 			}
 		}
-		return "", fmt.Errorf("unable to create the authorization token: %v", err)
+		return "", err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return "", err
 	}
 
-	return fmt.Sprintf("Bearer %s", resp.Token), nil
+	return fmt.Sprintf("Bearer %s", utils.PathSearch("token", respBody, "").(string)), nil
 }
 
-// GetAuthorizationToken is a method for creating an authorization information for a CSE microservice to connect to the
-// specified dedicated engine.
+// GetAuthorizationToken is a method for creating an authorization information when the microservice engine's RBAC
+// authentication is enabled.
 func GetAuthorizationToken(connAddr, username, password string) (string, error) {
 	if username == "" {
 		return "", nil
 	}
-	client := common.NewCustomClient(true, connAddr, "v4")
-	return getToken(client, username, password)
-}
 
-func buildRequestMoreHeaders(enterpriseProjectId string) map[string]string {
-	moreHeaders := map[string]string{
-		"Content-Type": "application/json;charset=UTF-8",
-		"Accept":       "application/json",
-	}
-
-	if enterpriseProjectId != "" {
-		moreHeaders["X-Enterprise-Project-ID"] = enterpriseProjectId
-	}
-	return moreHeaders
+	return getToken(common.NewCustomClient(true, connAddr), username, password)
 }

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
@@ -3,8 +3,6 @@ package cse
 import (
 	"context"
 	"fmt"
-	"log"
-	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -12,36 +10,59 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/services"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var microserviceNotFoundCodes = []string{
-	"400012",
-}
+var (
+	microserviceNonUpdatableParams = []string{
+		"auth_address",
+		"connect_address",
+		"admin_user",
+		"admin_pass",
+		"name",
+		"app_name",
+		"version",
+		"environment",
+		"level",
+		"description",
+	}
+	// The project ID of the microservice instance is the fixed value "default".
+	// No region parameter needs to be defined because this resource does not use IAM authentication.
+	microserviceDefaultProjectId = "default"
+	microserviceNotFoundCodes    = []string{
+		"400012",
+	}
+)
 
-// @API CSE DELETE /v2/{project_id}/registry/microservices/{serviceId}
-// @API CSE GET /v2/{project_id}/registry/microservices/{serviceId}
-// @API CSE POST /v2/{project_id}/registry/microservices
+// @API CSE GET /v4/token
+// @API CSE POST /v4/{project_id}/registry/microservices
+// @API CSE GET /v4/{project_id}/registry/microservices/{service_id}
+// @API CSE DELETE /v4/{project_id}/registry/microservices/{service_id}
 func ResourceMicroservice() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceMicroserviceCreate,
 		ReadContext:   resourceMicroserviceRead,
+		UpdateContext: resourceMicroserviceUpdate,
 		DeleteContext: resourceMicroserviceDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceMicroserviceImportState,
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(microserviceNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
-			// Authentication and request parameters.
+			// Special parameters.
+			// These parameters are used to specify the address that used to request the access token and access the
+			// microservice engine.
 			"auth_address": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 				Description: utils.SchemaDesc(
 					`The address that used to request the access token.`,
 					utils.SchemaDescInput{
@@ -51,63 +72,72 @@ func ResourceMicroservice() *schema.Resource {
 			"connect_address": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: `The address that used to send requests and manage configuration.`,
+				Description: `The address that used to access engine and manages microservice.`,
 			},
 			"admin_user": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "The user name that used to pass the RBAC control.",
 			},
 			"admin_pass": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Sensitive:    true,
-				ForceNew:     true,
 				RequiredWith: []string{"admin_user"},
 				Description:  "The user password that used to pass the RBAC control.",
 			},
-			// Resource parameters.
+
+			// Required parameters.
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the microservice.",
 			},
 			"app_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the microservice application.",
 			},
 			"version": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The version of the microservice.",
 			},
+
+			// Optional parameters.
 			"environment": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"development", "testing", "acceptance", "production",
-				}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The environment (stage) type of the microservice.",
 			},
 			"level": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"FRONT", "MIDDLE", "BACK",
-				}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The level of the microservice.",
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the microservice.",
 			},
+
+			// Attributes.
 			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status of the microservice.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
 			},
 		},
 	}
@@ -122,89 +152,194 @@ func getAuthAddress(d *schema.ResourceData) string {
 	return d.Get("connect_address").(string)
 }
 
-func buildMicroserviceCreateOpts(d *schema.ResourceData) services.CreateOpts {
-	env := d.Get("environment").(string)
-	return services.CreateOpts{
-		Services: services.Service{
-			Name:        d.Get("name").(string),
-			AppId:       d.Get("app_name").(string),
-			Environment: &env,
-			Version:     d.Get("version").(string),
-			Level:       d.Get("level").(string),
-			Description: d.Get("description").(string),
+func buildMicroserviceCreateOpts(d *schema.ResourceData) map[string]interface{} {
+	return utils.RemoveNil(map[string]interface{}{
+		"service": map[string]interface{}{
+			// Required parameters.
+			"serviceName": d.Get("name").(string),
+			"appId":       d.Get("app_name").(string),
+			"version":     d.Get("version").(string),
+			// Optional parameters.
+			"environment": utils.ValueIgnoreEmpty(d.Get("environment").(string)),
+			"level":       utils.ValueIgnoreEmpty(d.Get("level").(string)),
+			"description": utils.ValueIgnoreEmpty(d.Get("description").(string)),
 		},
+	})
+}
+
+func createMicroservice(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	httpUrl := "v4/{project_id}/registry/microservices"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", microserviceDefaultProjectId)
+
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+		JSONBody:         buildMicroserviceCreateOpts(d),
 	}
+
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `GET /v4/token` interface.
+	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string), d.Get("admin_pass").(string))
+	if err != nil {
+		return nil, err
+	}
+	// If the microservice has RBAC authentication enabled, the Authorization header will use a special token provided
+	// by the CSE service to replace the original IAM authentication information (AKSK authentication) in the request
+	// header.
+	if token != "" {
+		createOpts.MoreHeaders["Authorization"] = token
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
 }
 
 func resourceMicroserviceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
-		d.Get("admin_pass").(string))
+	client := common.NewCustomClient(true, d.Get("connect_address").(string))
+
+	resp, err := createMicroservice(client, d)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("error creating microservice: %s", err)
 	}
 
-	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
-	createOpts := buildMicroserviceCreateOpts(d)
-	log.Printf("[DEBUG] The createOpts of the Microservice is: %v", createOpts)
-	resp, err := services.Create(client, createOpts, token)
-	if err != nil {
-		return diag.Errorf("error creating dedicated microservice: %s", err)
+	microserviceId := utils.PathSearch("serviceId", resp, "").(string)
+	if microserviceId == "" {
+		return diag.Errorf("unable to find the microservice ID from the API response")
 	}
-	d.SetId(resp.ID)
+	d.SetId(microserviceId)
 
 	return resourceMicroserviceRead(ctx, d, meta)
 }
 
-func resourceMicroserviceRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
-		d.Get("admin_pass").(string))
-	if err != nil {
-		// When the engine does not exist, obtaining a token will cause a request connection exception.
-		// To ensure that the resource is available on RFS platform, this situation is specially handled as a 404 error.
-		log.Printf("[ERROR] %s", err)
-		return common.CheckDeletedDiag(d, err, "error retrieving the authorization token")
+func GetMicroservice(client *golangsdk.ServiceClient, authAddress, adminUser, adminPass, microserviceId string) (interface{}, error) {
+	httpUrl := "v4/{project_id}/registry/microservices/{service_id}"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", microserviceDefaultProjectId)
+	getPath = strings.ReplaceAll(getPath, "{service_id}", microserviceId)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
 	}
 
-	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
-	resp, err := services.Get(client, d.Id(), token)
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `GET /v4/token` interface.
+	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
 	if err != nil {
+		return nil, err
+	}
+	// If the microservice has RBAC authentication enabled, the Authorization header will use a special token provided
+	// by the CSE service to replace the original IAM authentication information (AKSK authentication) in the request
+	// header.
+	if token != "" {
+		getOpts.MoreHeaders["Authorization"] = token
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceMicroserviceRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	var (
+		client         = common.NewCustomClient(true, d.Get("connect_address").(string))
+		authAddress    = getAuthAddress(d)
+		adminUser      = d.Get("admin_user").(string)
+		adminPass      = d.Get("admin_pass").(string)
+		microserviceId = d.Id()
+	)
+
+	respBody, err := GetMicroservice(client, authAddress, adminUser, adminPass, microserviceId)
+	if err != nil {
+		// When the microservice does not exist, the error code returned is 400, and the error information is:
+		// {"errorCode": "400012", "errorMessage": "Micro-service does not exist", "detail": "Service does not exist."}
+		// So, we need to convert the error code to 404 error and specify the key of the error code to be "errorCode".
 		return common.CheckDeletedDiag(d,
 			common.ConvertExpected400ErrInto404Err(err, "errorCode", microserviceNotFoundCodes...),
-			"CSE Microservice")
+			fmt.Sprintf("error retrieving microservice (%s)", microserviceId))
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("name", resp.Name),
-		d.Set("app_name", resp.AppId),
-		d.Set("environment", resp.Environment),
-		d.Set("version", resp.Version),
-		d.Set("level", resp.Level),
-		d.Set("description", resp.Description),
-		d.Set("status", resp.Status),
+		// Required parameters.
+		d.Set("name", utils.PathSearch("service.serviceName", respBody, "").(string)),
+		d.Set("app_name", utils.PathSearch("service.appId", respBody, "").(string)),
+		d.Set("version", utils.PathSearch("service.version", respBody, "").(string)),
+		// Optional parameters.
+		d.Set("environment", utils.PathSearch("service.environment", respBody, "").(string)),
+		d.Set("level", utils.PathSearch("service.level", respBody, "").(string)),
+		d.Set("description", utils.PathSearch("service.description", respBody, "").(string)),
+		// Attributes.
+		d.Set("status", utils.PathSearch("service.status", respBody, "").(string)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceMicroserviceDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
-		d.Get("admin_pass").(string))
-	if err != nil {
-		return diag.FromErr(err)
+func resourceMicroserviceUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func deleteMicroservice(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl        = "v4/{project_id}/registry/microservices/{service_id}"
+		microserviceId = d.Id()
+	)
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", microserviceDefaultProjectId)
+	deletePath = strings.ReplaceAll(deletePath, "{service_id}", microserviceId)
+
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
 	}
+
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `GET /v4/token` interface.
+	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string), d.Get("admin_pass").(string))
+	if err != nil {
+		return err
+	}
+	// If the microservice has RBAC authentication enabled, the Authorization header will use a special token provided
+	// by the CSE service to replace the original IAM authentication information (AKSK authentication) in the request
+	// header.
+	if token != "" {
+		deleteOpts.MoreHeaders["Authorization"] = token
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceMicroserviceDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	client := common.NewCustomClient(true, d.Get("connect_address").(string))
 
 	// The current configuration is force deletion that delete microservices and related configuration and binding
 	// instances
-	deleteOpts := services.DeleteOpts{
-		Force: true,
-	}
-	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
-	err = services.Delete(client, deleteOpts, d.Id(), token)
+	err := deleteMicroservice(client, d)
 	if err != nil {
-		return diag.Errorf("error deleting dedicated microservice (%s): %s", d.Id(), err)
+		// When the microservice does not exist, the error code returned is 400, and the error information is:
+		// {"errorCode": "400012", "errorMessage": "Micro-service does not exist", "detail": "Service does not exist."}
+		// So, we need to convert the error code to 404 error and specify the key of the error code to be "errorCode".
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "errorCode", microserviceNotFoundCodes...),
+			fmt.Sprintf("error deleting microservice (%s)", d.Id()))
 	}
 
-	d.SetId("")
 	return nil
 }
 
@@ -214,26 +349,31 @@ func resourceMicroserviceImportState(_ context.Context, d *schema.ResourceData,
 		authAddr, connectAddr, importedIdWithoutAddrs, microserviceId, adminUser, adminPwd string
 		mErr                                                                               *multierror.Error
 
-		importedId   = d.Id()
-		addressRegex = `https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}`
-		re           = regexp.MustCompile(fmt.Sprintf(`^(%[1]s)?/?(%[1]s)/(.*)$`, addressRegex))
-		formatErr    = fmt.Errorf("the imported microservice ID specifies an invalid format, want "+
+		importedId = d.Id()
+		formatErr  = fmt.Errorf("the imported microservice ID specifies an invalid format, want "+
 			"'<auth_address>/<connect_address>/<id>' or '<auth_address>/<connect_address>/<id>/<admin_user>/<admin_pass>', but got '%s'",
 			importedId)
 	)
 
-	if !re.MatchString(importedId) {
+	if !connectAddressRegexPattern.MatchString(importedId) {
 		return nil, formatErr
 	}
-	resp := re.FindAllStringSubmatch(importedId, -1)
-	// If the imported ID matches the address regular expression, the length of the response result must be greater than 1.
+	resp := connectAddressRegexPattern.FindAllStringSubmatch(importedId, -1)
+	// To prevent panics caused by null resp values ​​due to differences in regular expression implementation, defensive
+	// checks are added.
+	if len(resp) == 0 {
+		return nil, formatErr
+	}
+	// If the imported ID matches the address regular expression, the length of the response result must be greater
+	// than 1.
 	switch len(resp[0]) {
 	case 4:
 		authAddr = resp[0][1]
 		connectAddr = resp[0][2]
 		importedIdWithoutAddrs = resp[0][3]
 		if authAddr == "" {
-			authAddr = connectAddr // Using the connect address as the auth address if the auth address input is omitted.
+			// Using the connect address as the auth address if the auth address input is omitted.
+			authAddr = connectAddr
 		}
 	default:
 		return nil, formatErr

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
@@ -3,48 +3,81 @@ package cse
 import (
 	"context"
 	"fmt"
-	"log"
-	"reflect"
-	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/instances"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 var (
-	internalPropertyKeys  = []string{"engineID", "engineName"}
-	instanceNotFoundCodes = []string{
+	microserviceInstanceNonUpdatableParams = []string{
+		"auth_address",
+		"connect_address",
+		"admin_user",
+		"admin_pass",
+		"microservice_id",
+		"host_name",
+		"endpoints",
+		"version",
+		"properties",
+		"health_check",
+		"health_check.*.mode",
+		"health_check.*.interval",
+		"health_check.*.max_retries",
+		"health_check.*.port",
+		"data_center",
+		"data_center.*.name",
+		"data_center.*.region",
+		"data_center.*.availability_zone",
+	}
+	// The project ID of the microservice instance is the fixed value "default".
+	// No region parameter needs to be defined because this resource does not use IAM authentication.
+	microserviceInstanceProjectId     = "default"
+	internalPropertyKeys              = []string{"engineID", "engineName"}
+	microserviceInstanceNotFoundCodes = []string{
 		"400017",
 	}
 )
 
-// @API CSE GET /v2/{project_id}/registry/microservices/{serviceId}/instances/{instanceId}
-// @API CSE DELETE /v2/{project_id}/registry/microservices/{serviceId}/instances/{instanceId}
-// @API CSE POST /v2/{project_id}/registry/microservices/{serviceId}/instances
+// @API CSE GET /v4/token
+// @API CSE POST /v4/{project_id}/registry/microservices/{service_id}/instances
+// @API CSE GET /v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}
+// @API CSE DELETE /v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}
 func ResourceMicroserviceInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceMicroserviceInstanceCreate,
 		ReadContext:   resourceMicroserviceInstanceRead,
+		UpdateContext: resourceMicroserviceInstanceUpdate,
 		DeleteContext: resourceMicroserviceInstanceDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceMicroserviceInstanceImportState,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(microserviceInstanceNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
-			// Authentication and request parameters.
+			// Special parameters.
+			// These parameters are used to specify the address that used to request the access token and access the
+			// microservice engine.
 			"auth_address": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 				Description: utils.SchemaDesc(
 					`The address that used to request the access token.`,
 					utils.SchemaDescInput{
@@ -54,149 +87,164 @@ func ResourceMicroserviceInstance() *schema.Resource {
 			"connect_address": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: `The address that used to send requests and manage configuration.`,
+				Description: `The address that used to access engine and manages microservice instance.`,
 			},
 			"admin_user": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "The user name that used to pass the RBAC control.",
 			},
 			"admin_pass": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Sensitive:    true,
-				ForceNew:     true,
 				RequiredWith: []string{"admin_user"},
-				Description:  "The user password that used to pass the RBAC control.",
+				Description:  `The user password that used to pass the RBAC control.`,
 			},
-			// Resource parameters.
+
+			// Required parameters.
 			"microservice_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the microservice to which the microservice instance belongs.`,
 			},
 			"host_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The host name of the microservice instance.`,
 			},
 			"endpoints": {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of access addresses of the microservice instance.`,
 			},
+			// Optional parameters.
 			"version": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The version of the microservice instance.`,
 			},
 			"properties": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The extended attributes of the microservice instance, in key/value format.`,
 			},
 			"health_check": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"mode": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The heartbeat mode of the health check.`,
 						},
 						"interval": {
-							Type:     schema.TypeInt,
-							Required: true,
-							ForceNew: true,
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: `The heartbeat interval of the health check, in seconds.`,
 						},
 						"max_retries": {
-							Type:     schema.TypeInt,
-							Required: true,
-							ForceNew: true,
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: `The maximum retry number of the health check.`,
 						},
 						"port": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `The port of the health check.`,
 						},
 					},
 				},
+				Description: `The health check configuration of the microservice instance.`,
 			},
 			"data_center": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the data center.`,
 						},
 						"region": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The custom region name of the data center.`,
 						},
 						"availability_zone": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The custom availability zone of the data center.`,
 						},
 					},
 				},
+				Description: `The data center configuration of the microservice instance.`,
 			},
+
+			// Attributes.
 			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the microservice instance.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
 			},
 		},
 	}
 }
 
-func buildHealthCheckStructure(healthChecks []interface{}) *instances.HealthCheck {
+func buildInstanceHealthCheck(healthChecks []interface{}) map[string]interface{} {
 	if len(healthChecks) < 1 {
 		return nil
 	}
 
 	healthCheck := healthChecks[0].(map[string]interface{})
 
-	return &instances.HealthCheck{
-		Mode:     healthCheck["mode"].(string),
-		Interval: healthCheck["interval"].(int),
-		Times:    healthCheck["max_retries"].(int),
-		Port:     healthCheck["port"].(int),
+	return map[string]interface{}{
+		"mode":     utils.PathSearch("mode", healthCheck, nil),
+		"interval": utils.PathSearch("interval", healthCheck, nil),
+		"times":    utils.PathSearch("max_retries", healthCheck, nil),
+		"port":     utils.ValueIgnoreEmpty(utils.PathSearch("port", healthCheck, nil)),
 	}
 }
 
-func buildDataCenterStructure(dataCenters []interface{}) *instances.DataCenter {
+func buildInstanceDataCenter(dataCenters []interface{}) map[string]interface{} {
 	if len(dataCenters) < 1 {
 		return nil
 	}
 
 	dataCenter := dataCenters[0].(map[string]interface{})
 
-	return &instances.DataCenter{
-		Name:          dataCenter["name"].(string),
-		Region:        dataCenter["region"].(string),
-		AvailableZone: dataCenter["availability_zone"].(string),
+	return map[string]interface{}{
+		"name":          utils.PathSearch("name", dataCenter, nil),
+		"region":        utils.PathSearch("region", dataCenter, nil),
+		"availableZone": utils.PathSearch("availability_zone", dataCenter, nil),
 	}
 }
 
-func buildCustomProperties(properties map[string]interface{}) map[string]interface{} {
+// buildCustomProperties filters out internal property keys (engineID, engineName) from the properties map.
+func buildInstanceProperties(properties map[string]interface{}) map[string]interface{} {
 	if len(properties) < 1 {
 		return nil
 	}
@@ -211,138 +259,302 @@ func buildCustomProperties(properties map[string]interface{}) map[string]interfa
 	return result
 }
 
-func buildInstanceCreateOpts(d *schema.ResourceData) instances.CreateOpts {
-	return instances.CreateOpts{
-		HostName:       d.Get("host_name").(string),
-		Endpoints:      utils.ExpandToStringList(d.Get("endpoints").([]interface{})),
-		Version:        d.Get("version").(string),
-		Status:         d.Get("status").(string),
-		Properties:     buildCustomProperties(d.Get("properties").(map[string]interface{})),
-		HealthCheck:    buildHealthCheckStructure(d.Get("health_check").([]interface{})),
-		DataCenterInfo: buildDataCenterStructure(d.Get("data_center").([]interface{})),
+func buildInstanceCreateOpts(d *schema.ResourceData) map[string]interface{} {
+	return utils.RemoveNil(map[string]interface{}{
+		"instance": map[string]interface{}{
+			// Required parameters.
+			"hostName":  d.Get("host_name").(string),
+			"endpoints": d.Get("endpoints").([]interface{}),
+			// Optional parameters.
+			"version":        utils.ValueIgnoreEmpty(d.Get("version").(string)),
+			"properties":     buildInstanceProperties(d.Get("properties").(map[string]interface{})),
+			"healthCheck":    buildInstanceHealthCheck(d.Get("health_check").([]interface{})),
+			"dataCenterInfo": buildInstanceDataCenter(d.Get("data_center").([]interface{})),
+		},
+	})
+}
+
+func createInstance(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl        = "v4/{project_id}/registry/microservices/{service_id}/instances"
+		microserviceId = d.Get("microservice_id").(string)
+	)
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", microserviceInstanceProjectId)
+	createPath = strings.ReplaceAll(createPath, "{service_id}", microserviceId)
+
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+		JSONBody:         buildInstanceCreateOpts(d),
 	}
+
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `GET /v4/token` interface.
+	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string), d.Get("admin_pass").(string))
+	if err != nil {
+		return nil, err
+	}
+	// If the microservice instance has RBAC authentication enabled, the Authorization header will use a special token
+	// provided by the CSE service to replace the original IAM authentication information (AKSK authentication) in the
+	// request header.
+	if token != "" {
+		createOpts.MoreHeaders["Authorization"] = token
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
 }
 
 func resourceMicroserviceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
-		d.Get("admin_pass").(string))
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	// Creating a microservice instance in the microservice engine requires building a client based on the microservice
+	// engine's connection address, which does not use IAM authentication.
+	client := common.NewCustomClient(true, d.Get("connect_address").(string))
 
-	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
-	createOpts := buildInstanceCreateOpts(d)
-	log.Printf("[DEBUG] The createOpts of the Microservice instance is: %v", createOpts)
-	resp, err := instances.Create(client, createOpts, d.Get("microservice_id").(string), token)
+	resp, err := createInstance(client, d)
 	if err != nil {
 		return diag.Errorf("error creating microservice instance: %s", err)
 	}
-	d.SetId(resp.ID)
+
+	instanceId := utils.PathSearch("instanceId", resp, "").(string)
+	if instanceId == "" {
+		return diag.Errorf("unable to find the instance ID from the API response")
+	}
+	d.SetId(instanceId)
 
 	return resourceMicroserviceInstanceRead(ctx, d, meta)
 }
 
-func flattenHealthCheck(healthCheck instances.HealthCheck) (result []map[string]interface{}) {
-	if reflect.DeepEqual(healthCheck, instances.HealthCheck{}) {
-		return nil
+// GetInstance retrieves the microservice instance details by authorization parameters, microservice ID, and instance ID.
+func GetInstance(client *golangsdk.ServiceClient, authAddress, adminUser, adminPass, microserviceId, instanceId string) (interface{}, error) {
+	httpUrl := "v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", microserviceInstanceProjectId)
+	getPath = strings.ReplaceAll(getPath, "{service_id}", microserviceId)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
 	}
 
-	result = append(result, map[string]interface{}{
-		"mode":        healthCheck.Mode,
-		"interval":    healthCheck.Interval,
-		"max_retries": healthCheck.Times,
-		"port":        healthCheck.Port,
-	})
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `GET /v4/token` interface.
+	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
+	if err != nil {
+		return nil, err
+	}
+	// If the microservice instance has RBAC authentication enabled, the Authorization header will use a special token
+	// provided by the CSE service to replace the original IAM authentication information (AKSK authentication) in the
+	// request header.
+	if token != "" {
+		getOpts.MoreHeaders["Authorization"] = token
+	}
 
-	log.Printf("[DEBUG] The health check result is %#v", result)
-	return
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
 }
 
-func flattenDataCenter(dataCenter instances.DataCenter) (result []map[string]interface{}) {
-	if reflect.DeepEqual(dataCenter, instances.DataCenter{}) {
+func flattenHealthCheck(healthCheck interface{}) []map[string]interface{} {
+	if healthCheck == nil {
 		return nil
 	}
 
-	result = append(result, map[string]interface{}{
-		"name":              dataCenter.Name,
-		"region":            dataCenter.Region,
-		"availability_zone": dataCenter.AvailableZone,
-	})
+	return []map[string]interface{}{
+		{
+			"mode":        utils.PathSearch("mode", healthCheck, nil),
+			"interval":    utils.PathSearch("interval", healthCheck, nil),
+			"max_retries": utils.PathSearch("times", healthCheck, nil),
+			"port":        utils.PathSearch("port", healthCheck, nil),
+		},
+	}
+}
 
-	log.Printf("[DEBUG] The data center result is %#v", result)
-	return
+func flattenDataCenter(dataCenter interface{}) []map[string]interface{} {
+	if dataCenter == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"name":              utils.PathSearch("name", dataCenter, nil),
+			"region":            utils.PathSearch("region", dataCenter, nil),
+			"availability_zone": utils.PathSearch("availableZone", dataCenter, nil),
+		},
+	}
 }
 
 func resourceMicroserviceInstanceRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
-		d.Get("admin_pass").(string))
-	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving the authorization token")
-	}
+	var (
+		// Creating a microservice instance in the microservice engine requires building a client based on the
+		// microservice engine's connection address, which does not use IAM authentication.
+		client         = common.NewCustomClient(true, d.Get("connect_address").(string))
+		authAddress    = getAuthAddress(d)
+		adminUser      = d.Get("admin_user").(string)
+		adminPass      = d.Get("admin_pass").(string)
+		microserviceId = d.Get("microservice_id").(string)
+		instanceId     = d.Id()
+	)
 
-	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
-	resp, err := instances.Get(client, d.Get("microservice_id").(string), d.Id(), token)
+	respBody, err := GetInstance(client, authAddress, adminUser, adminPass, microserviceId, instanceId)
 	if err != nil {
+		// When the microservice instance does not exist, the error code returned is 400, and the error information is:
+		// {"errorCode": "400017", "errorMessage": "Instance does not exist", "detail": "... instance does not exist"}
+		// So, we need to convert the error code to 404 error and specify the key of the error code to be "errorCode".
 		return common.CheckDeletedDiag(d,
-			common.ConvertExpected400ErrInto404Err(err, "errorCode", instanceNotFoundCodes...),
-			"error retrieving Microservice instance")
+			common.ConvertExpected400ErrInto404Err(err, "errorCode", microserviceInstanceNotFoundCodes...),
+			fmt.Sprintf("error retrieving microservice instance (%s)", instanceId))
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("host_name", resp.HostName),
-		d.Set("endpoints", resp.Endpoints),
-		d.Set("version", resp.Version),
-		d.Set("properties", buildCustomProperties(resp.Properties)),
-		d.Set("health_check", flattenHealthCheck(resp.HealthCheck)),
-		d.Set("data_center", flattenDataCenter(resp.DataCenterInfo)),
-		d.Set("status", resp.Status),
+		d.Set("host_name", utils.PathSearch("instance.hostName", respBody, nil)),
+		d.Set("endpoints", utils.PathSearch("instance.endpoints", respBody, nil)),
+		d.Set("version", utils.PathSearch("instance.version", respBody, nil)),
+		d.Set("properties", buildInstanceProperties(utils.PathSearch("instance.properties", respBody,
+			make(map[string]interface{})).(map[string]interface{}))),
+		d.Set("health_check", flattenHealthCheck(utils.PathSearch("instance.healthCheck", respBody, nil))),
+		d.Set("data_center", flattenDataCenter(utils.PathSearch("instance.dataCenterInfo", respBody, nil))),
+		d.Set("status", utils.PathSearch("instance.status", respBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceMicroserviceInstanceDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
-		d.Get("admin_pass").(string))
-	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving the authorization token")
+func resourceMicroserviceInstanceUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func deleteInstance(client *golangsdk.ServiceClient, authAddress, adminUser, adminPass, microserviceId, instanceId string) error {
+	httpUrl := "v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}"
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", microserviceInstanceProjectId)
+	deletePath = strings.ReplaceAll(deletePath, "{service_id}", microserviceId)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
 	}
 
-	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
-	err = instances.Delete(client, d.Get("microservice_id").(string), d.Id(), token)
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `GET /v4/token` interface.
+	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
 	if err != nil {
-		return diag.Errorf("error deleting dedicated microservice instance (%s): %s", d.Id(), err)
+		return err
+	}
+	// If the microservice instance has RBAC authentication enabled, the Authorization header will use a special token
+	// provided by the CSE service to replace the original IAM authentication information (AKSK authentication) in the
+	// request header.
+	if token != "" {
+		deleteOpts.MoreHeaders["Authorization"] = token
 	}
 
-	d.SetId("")
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func instanceStatusRefreshFunc(client *golangsdk.ServiceClient, authAddress, adminUser, adminPass,
+	microserviceId, instanceId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetInstance(client, authAddress, adminUser, adminPass, microserviceId, instanceId)
+		if err != nil {
+			// Convert 400 error to 404 error if it matches instance not found codes.
+			convertedErr := common.ConvertExpected400ErrInto404Err(err, "errorCode", microserviceInstanceNotFoundCodes...)
+			if _, ok := convertedErr.(golangsdk.ErrDefault404); ok {
+				// When the error code is 404 (or converted to 404), the instance has been deleted.
+				return "Resource Not Found", "COMPLETED", nil
+			}
+			return nil, "ERROR", err
+		}
+
+		// Instance still exists, continue polling.
+		return respBody, "PENDING", nil
+	}
+}
+
+func resourceMicroserviceInstanceDelete(ctx context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	var (
+		// Creating a microservice instance in the microservice engine requires building a client based on the
+		// microservice engine's connection address, which does not use IAM authentication.
+		client         = common.NewCustomClient(true, d.Get("connect_address").(string))
+		authAddress    = getAuthAddress(d)
+		adminUser      = d.Get("admin_user").(string)
+		adminPass      = d.Get("admin_pass").(string)
+		microserviceId = d.Get("microservice_id").(string)
+		instanceId     = d.Id()
+	)
+
+	err := deleteInstance(client, authAddress, adminUser, adminPass, microserviceId, instanceId)
+	if err != nil {
+		// When the microservice instance does not exist, the error code returned is 400, and the error information is:
+		// {"errorCode": "400017", "errorMessage": "Instance does not exist", "detail": "... instance does not exist"}
+		// So, we need to convert the error code to 404 error and specify the key of the error code to be "errorCode".
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "errorCode", microserviceInstanceNotFoundCodes...),
+			fmt.Sprintf("error deleting microservice instance (%s)", instanceId))
+	}
+
+	// Wait for the instance to be deleted.
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      instanceStatusRefreshFunc(client, authAddress, adminUser, adminPass, microserviceId, instanceId),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the microservice instance (%s) to be deleted: %s", instanceId, err)
+	}
+
 	return nil
 }
 
 func resourceMicroserviceInstanceImportState(_ context.Context, d *schema.ResourceData,
 	_ interface{}) ([]*schema.ResourceData, error) {
 	var (
-		authAddr, connectAddr, importedIdWithoutAddrs, microserviceId, instanceId, adminUser, adminPwd string
-		mErr                                                                                           *multierror.Error
+		authAddr, connectAddr, idWithoutAddrs, microserviceId, instanceId, adminUser, adminPwd string
+		mErr                                                                                   *multierror.Error
 
-		importedId   = d.Id()
-		addressRegex = `https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}`
-		re           = regexp.MustCompile(fmt.Sprintf(`^(%[1]s)?/?(%[1]s)/(.*)$`, addressRegex))
-		formatErr    = fmt.Errorf("the imported microservice ID specifies an invalid format, want "+
+		importedId = d.Id()
+		formatErr  = fmt.Errorf("the imported microservice ID specifies an invalid format, want "+
 			"'<auth_address>/<connect_address>/<microservice_id>/<id>' or "+
 			"'<auth_address>/<connect_address>/<microservice_id>/<id>/<admin_user>/<admin_pass>', but got '%s'",
 			importedId)
 	)
 
-	if !re.MatchString(importedId) {
+	if !connectAddressRegexPattern.MatchString(importedId) {
 		return nil, formatErr
 	}
-	resp := re.FindAllStringSubmatch(importedId, -1)
+	resp := connectAddressRegexPattern.FindAllStringSubmatch(importedId, -1)
+	// To prevent panics caused by null resp values ​​due to differences in regular expression implementation, defensive
+	// checks are added.
+	if len(resp) == 0 {
+		return nil, formatErr
+	}
 	// If the imported ID matches the address regular expression, the length of the response result must be greater than 1.
 	switch len(resp[0]) {
 	case 4:
 		authAddr = resp[0][1]
 		connectAddr = resp[0][2]
-		importedIdWithoutAddrs = resp[0][3]
+		idWithoutAddrs = resp[0][3]
 		if authAddr == "" {
 			authAddr = connectAddr // Using the connect address as the auth address if the auth address input is omitted.
 		}
@@ -355,7 +567,7 @@ func resourceMicroserviceInstanceImportState(_ context.Context, d *schema.Resour
 		d.Set("connect_address", connectAddr),
 	)
 
-	parts := strings.Split(importedIdWithoutAddrs, "/")
+	parts := strings.Split(idWithoutAddrs, "/")
 	switch len(parts) {
 	case 2:
 		microserviceId = parts[0]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactors CSE microservice resources to comply with code quality standards:
(huaweicloud_cse_microservice + huaweicloud_cse_microservice_instance)
- Migrated from `ForceNew: true` to `CustomizeDiff: config.FlexibleForceNew()`
- Standardized error handling (formatting in parent methods, not sub-methods)
- Optimized request body construction with `utils.ValueIgnoreEmpty()` and `utils.RemoveNil()`
- Extracted API logic into reusable helper methods
- Added required `UpdateContext` methods and `enable_force_new` parameters

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using new code style to optimize the resources
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccMicroservice_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccMicroservice_ -timeout 360m -parallel 10
=== RUN   TestAccMicroservice_basic
=== PAUSE TestAccMicroservice_basic
=== CONT  TestAccMicroservice_basic
--- PASS: TestAccMicroservice_basic (18.27s)
PASS
coverage: 18.1% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       18.342s coverage: 18.1% of statements in ./huaweicloud/services/cse
```
```
./scripts/coverage.sh -o cse -f TestAccMicroserviceInstance_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccMicroserviceInstance_ -timeout 360m -parallel 10
=== RUN   TestAccMicroserviceInstance_basic
=== PAUSE TestAccMicroserviceInstance_basic
=== CONT  TestAccMicroserviceInstance_basic
--- PASS: TestAccMicroserviceInstance_basic (28.57s)
PASS
coverage: 29.3% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       28.644s coverage: 29.3% of statements in ./huaweicloud/services/cse
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
