### PR TITLE
feat(mrs): add a new resource to manage auto scaling policy that use the v2 API

### DIFF
--- a/docs/resources/mapreduce_scaling_policy.md
+++ b/docs/resources/mapreduce_scaling_policy.md
@@ -150,7 +150,7 @@ The `trigger` block supports:
 * `metric_name` - (Required, String) Metric name.  
   This triggering condition makes a judgment according to the value of the metric.  
   A metric name contains a maximum of 64 characters.  
-  For details about metric names, see [Configuring Auto Scaling for an MRS Cluster](https://support.huaweicloud.com/intl/en-us/qs-mrs/mrs_09_0005.html).
+  For details about metric names, see [Configuring Auto Scaling for an MRS Cluster](https://support.huaweicloud.com/intl/en-us/bestpractice-mrs/mrs_05_0132.html#mrs_05_0132__en-us_topic_0000001168444324_table15133845184415).
 
 * `metric_value` - (Required, String) Metric threshold to trigger a rule.  
   The parameter value can only be an integer or number with two decimal places.

--- a/docs/resources/mapreduce_scaling_policy_v2.md
+++ b/docs/resources/mapreduce_scaling_policy_v2.md
@@ -1,0 +1,191 @@
+---
+subcategory: "MapReduce Service (MRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_mapreduce_scaling_policy_v2"
+description: |-
+  Manages an auto scaling policy of an MRS cluster within HuaweiCloud.
+---
+
+# huaweicloud_mapreduce_scaling_policy_v2
+
+Manages an auto scaling policy of an MRS cluster within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "node_group_name" {}
+
+resource "huaweicloud_mapreduce_scaling_policy_v2" "test" {
+  cluster_id         = var.cluster_id
+  node_group_name    = var.node_group_name
+  resource_pool_name = "default"
+
+  auto_scaling_policy {
+    auto_scaling_enable = true
+    min_capacity        = 0
+    max_capacity        = 5
+
+    resources_plans {
+      period_type    = "daily"
+      start_time     = "06:00"
+      end_time       = "20:00"
+      min_capacity   = 0
+      max_capacity   = 2
+      effective_days = ["MONDAY"]
+    }
+
+    rules {
+      name               = "default-expand-1"
+      adjustment_type    = "scale_out"
+      cool_down_minutes  = 20
+      scaling_adjustment = 1
+
+      trigger {
+        metric_name         = "YARNAppRunning"
+        metric_value        = "75"
+        comparison_operator = "GT"
+        evaluation_periods  = 1
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the scaling policy is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster.
+
+* `node_group_name` - (Required, String, NonUpdatable) Specifies the name of the node group.
+
+* `resource_pool_name` - (Required, String, NonUpdatable) Specifies the name of the resource pool.  
+  When the cluster version does not support elastic scaling by the specified resource pool, this parameter
+  must be set to **default**.
+
+* `auto_scaling_policy` - (Required, List) Specifies the configurations of the auto scaling policy.  
+  The [auto_scaling_policy](#scaling_policy_v2_auto_scaling_policy) structure is documented below.
+
+<a name="scaling_policy_v2_auto_scaling_policy"></a>
+The `auto_scaling_policy` block supports:
+
+* `auto_scaling_enable` - (Optional, Bool) Specifies whether to enable the auto scaling policy.  
+  Defaults to **false**.
+
+* `min_capacity` - (Optional, Int) Specifies the minimum number of nodes in the node group.  
+  Defaults to `0`.  
+  The valid value ranges from `0` to `500`.
+
+* `max_capacity` - (Optional, Int) Specifies the maximum number of nodes in the node group.  
+  Defaults to `0`.  
+  The valid value ranges from `0` to `500`.
+
+* `resources_plans` - (Optional, List) Specifies the list of resource plans.  
+  The [resources_plans](#scaling_policy_v2_resources_plans) structure is documented below.
+
+* `rules` - (Optional, List) Specifies the list of auto scaling rules.  
+  The [rules](#scaling_policy_v2_rule) structure is documented below.
+
+-> At least one of the `resources_plans` and `rules` parameters must be specified.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs associated with auto scaling policy.  
+  The maximum number of tags is `20`.
+
+<a name="scaling_policy_v2_resources_plans"></a>
+The `resources_plans` block supports:
+
+* `period_type` - (Required, String) Specifies the period type of the resource plan.  
+  The valid values are as follows:
+  + **daily**
+
+* `start_time` - (Required, String) Specifies the start time of the resource plan, in `HH:mm` format.
+
+* `end_time` - (Required, String) Specifies the end time of the resource plan, in `HH:mm` format.  
+  The interval between `start_time` and `end_time` must be greater than or equal to `30` minutes.
+
+* `min_capacity` - (Optional, Int) Specifies the minimum number of retained nodes for the node group in the
+  resource plan.  
+  Defaults to `0`.  
+  The valid value ranges from `0` to `500`.
+
+* `max_capacity` - (Optional, Int) Specifies the maximum number of retained nodes for the node group in the
+  resource plan.
+  Defaults to `0`.  
+  The valid value ranges from `0` to `500`.
+
+* `effective_days` - (Optional, List) Specifies the effective day list of the resource plan.  
+  The valid values are as follows:
+  + **MONDAY**
+  + **TUESDAY**
+  + **WEDNESDAY**
+  + **THURSDAY**
+  + **FRIDAY**
+  + **SATURDAY**
+  + **SUNDAY**
+
+  If not specified, it means the resource plan will take effect on all days.
+
+<a name="scaling_policy_v2_rule"></a>
+The `rules` block supports:
+
+* `name` - (Required, String) Specifies the name of the rule.  
+  The maximum length is `64` characters.  
+  Only letters, digits, hyphens (-), and underscores (_) are allowed.  
+  The rule name must be unique in the same node group.
+
+* `adjustment_type` - (Required, String) Specifies the adjustment type of the rule.  
+  The valid values are as follows:
+  + **scale_out**
+  + **scale_in**
+
+* `cool_down_minutes` - (Required, Int) Specifies the cool down time of the cluster after the scaling rule
+  is triggered, in minutes.  
+  The valid value ranges from `5` to `10,080`.
+
+* `scaling_adjustment` - (Required, Int) Specifies the number of adjusted nodes in one scaling action.  
+  The valid value ranges from `1` to `100`.
+
+* `trigger` - (Required, List) Specifies the trigger condition list of the rule.  
+  The [trigger](#scaling_policy_v2_rule_trigger) structure is documented below.
+
+* `description` - (Optional, String) Specifies the description of the rule.  
+  Only letters, digits, hyphens (-), and underscores (_) are allowed.  
+
+<a name="scaling_policy_v2_rule_trigger"></a>
+The `trigger` block supports:
+
+* `metric_name` - (Required, String) Specifies the name of the metric.  
+  For details about metric names, see [documentation](https://support.huaweicloud.com/intl/en-us/bestpractice-mrs/mrs_05_0132.html#mrs_05_0132__en-us_topic_0000001168444324_table15133845184415).
+
+* `metric_value` - (Required, String) Specifies the threshold value of the metric.  
+  The parameter value can only be an integer or number with two decimal places.
+
+* `evaluation_periods` - (Required, Int) Specifies the number of consecutive periods that meet the metric threshold.  
+  The interval between the consecutive periods is `5` minutes.
+  The valid value ranges from `1` to `200`.
+
+* `comparison_operator` - (Optional, String) Specifies the comparison operator of the metric judgment logic.  
+  The valid values are as follows:
+  + **LT**
+  + **GT**
+  + **LTOE**
+  + **GTOE**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The resource can be imported using the `cluster_id`, `node_group_name` and `resource_pool_name`, separated by
+slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_mapreduce_scaling_policy_v2.test <cluster_id>/<node_group_name>/<resource_pool_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3632,6 +3632,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_mapreduce_job":                         mrs.ResourceMRSJobV2(),
 			"huaweicloud_mapreduce_data_connection":             mrs.ResourceDataConnection(),
 			"huaweicloud_mapreduce_scaling_policy":              mrs.ResourceScalingPolicy(),
+			"huaweicloud_mapreduce_scaling_policy_v2":           mrs.ResourceScalingPolicyV2(),
 
 			"huaweicloud_meeting_admin_assignment": meeting.ResourceAdminAssignment(),
 			"huaweicloud_meeting_conference":       meeting.ResourceConference(),

--- a/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_scaling_policy_v2_test.go
+++ b/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_scaling_policy_v2_test.go
@@ -1,0 +1,263 @@
+package mrs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/mrs"
+)
+
+func getScalingPolicyV2ResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("mrs", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating MRS client: %s", err)
+	}
+
+	return mrs.GetScalingPolicyV2(client, state.Primary.Attributes["cluster_id"],
+		state.Primary.Attributes["node_group_name"], state.Primary.Attributes["resource_pool_name"])
+}
+
+// Before running acceptance test, please ensure that the node name provided is that of the task node.
+func TestAccScalingPolicyV2_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_mapreduce_scaling_policy_v2.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getScalingPolicyV2ResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMrsClusterID(t)
+			acceptance.TestAccPreCheckMrsClusterNodeGroupName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testScalingPolicyV2_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_MRS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "node_group_name", acceptance.HW_MRS_CLUSTER_NODE_GROUP_NAME),
+					resource.TestCheckResourceAttr(rName, "resource_pool_name", "default"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.auto_scaling_enable", "false"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.min_capacity", "1"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.max_capacity", "10"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.#", "2"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.1.period_type", "daily"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.1.start_time", "05:00"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.1.end_time", "06:00"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.1.min_capacity", "0"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.1.max_capacity", "1"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.1.effective_days.#", "2"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.1.effective_days.1", "SATURDAY"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.#", "2"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.0.name", "default-expand-1"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.0.adjustment_type", "scale_out"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.0.description", "Created_by_TF_script"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.1.name", "default-shrink-1"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.1.adjustment_type", "scale_in"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.1.cool_down_minutes", "30"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.1.scaling_adjustment", "2"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.1.trigger.0.metric_name", "YARNAppRunning"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.1.trigger.0.metric_value", "25"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.1.trigger.0.comparison_operator", "LT"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.1.trigger.0.evaluation_periods", "2"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.tags.%", "1"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.tags.foo", "bar"),
+				),
+			},
+			{
+				Config: testScalingPolicyV2_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.auto_scaling_enable", "false"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.min_capacity", "0"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.max_capacity", "0"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.#", "0"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.#", "1"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.0.name", "default-shrink"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.0.adjustment_type", "scale_out"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.0.cool_down_minutes", "10"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.0.scaling_adjustment", "2"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.0.description", ""),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.0.trigger.0.metric_name", "YARNAppPending"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.0.trigger.0.metric_value", "80"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.0.trigger.0.comparison_operator", "LTOE"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.0.trigger.0.evaluation_periods", "5"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.tags.%", "0"),
+				),
+			},
+			{
+				Config: testScalingPolicyV2_basic_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.auto_scaling_enable", "true"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.min_capacity", "2"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.max_capacity", "3"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.#", "1"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.0.period_type", "daily"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.0.start_time", "03:00"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.0.end_time", "03:30"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.0.effective_days.#", "1"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.resources_plans.0.effective_days.0", "MONDAY"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.rules.#", "0"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.tags.%", "2"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(rName, "auto_scaling_policy.0.tags.foo", "barr"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testScalingPolicyV2ImportState(rName),
+			},
+		},
+	})
+}
+
+func testScalingPolicyV2_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_mapreduce_scaling_policy_v2" "test" {
+  cluster_id         = "%[1]s"
+  node_group_name    = "%[2]s"
+  resource_pool_name = "default"
+
+  auto_scaling_policy {
+    min_capacity = 1
+    max_capacity = 10
+
+    resources_plans {
+      period_type  = "daily"
+      start_time   = "01:00"
+      end_time     = "03:00"
+      min_capacity = 1
+      max_capacity = 2
+    }
+    resources_plans {
+      period_type    = "daily"
+      start_time     = "05:00"
+      end_time       = "06:00"
+      min_capacity   = 0
+      max_capacity   = 1
+      effective_days = ["SUNDAY", "SATURDAY"]
+    }
+
+    rules {
+      name               = "default-expand-1"
+      adjustment_type    = "scale_out"
+      cool_down_minutes  = 20
+      scaling_adjustment = 1
+      # Only letters, digits, underscores (_), and hyphens (-) are allowed.
+      description        = "Created_by_TF_script"
+
+      trigger {
+        metric_name         = "YARNAppRunning"
+        metric_value        = "75"
+        comparison_operator = "GT"
+        evaluation_periods  = 2
+      }
+    }
+    rules {
+      name               = "default-shrink-1"
+      adjustment_type    = "scale_in"
+      cool_down_minutes  = 30
+      scaling_adjustment = 2
+
+      trigger {
+        metric_name         = "YARNAppRunning"
+        metric_value        = "25"
+        comparison_operator = "LT"
+        evaluation_periods  = 2
+      }
+    }
+
+    tags = {
+      foo = "bar"
+    }
+  }
+}
+`, acceptance.HW_MRS_CLUSTER_ID, acceptance.HW_MRS_CLUSTER_NODE_GROUP_NAME, name)
+}
+
+func testScalingPolicyV2_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_mapreduce_scaling_policy_v2" "test" {
+  cluster_id         = "%[1]s"
+  node_group_name    = "%[2]s"
+  resource_pool_name = "default"
+
+  auto_scaling_policy {
+    rules {
+      name               = "default-shrink"
+      adjustment_type    = "scale_out"
+      cool_down_minutes  = 10
+      scaling_adjustment = 2
+
+      trigger {
+        metric_name         = "YARNAppPending"
+        metric_value        = "80"
+        comparison_operator = "LTOE"
+        evaluation_periods  = 5
+      }
+    }
+  }
+}
+`, acceptance.HW_MRS_CLUSTER_ID, acceptance.HW_MRS_CLUSTER_NODE_GROUP_NAME, name)
+}
+
+func testScalingPolicyV2_basic_step3(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_mapreduce_scaling_policy_v2" "test" {
+  cluster_id         = "%[1]s"
+  node_group_name    = "%[2]s"
+  resource_pool_name = "default"
+
+  auto_scaling_policy {
+    min_capacity        = 2
+    max_capacity        = 3
+    auto_scaling_enable = true
+
+    resources_plans {
+      period_type    = "daily"
+      start_time     = "03:00"
+      end_time       = "03:30"
+      effective_days = ["MONDAY"]
+    }
+
+    tags = {
+      owner = "terraform"
+      foo   = "barr"
+    }
+  }
+}
+`, acceptance.HW_MRS_CLUSTER_ID, acceptance.HW_MRS_CLUSTER_NODE_GROUP_NAME, name)
+}
+
+func testScalingPolicyV2ImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		clusterId := rs.Primary.Attributes["cluster_id"]
+		nodeGroupName := rs.Primary.Attributes["node_group_name"]
+		resourcePoolName := rs.Primary.Attributes["resource_pool_name"]
+		if clusterId == "" || nodeGroupName == "" || resourcePoolName == "" {
+			return "", fmt.Errorf("some import IDs is valid, want `<cluster_id>/<node_group_name>/<resource_pool_name>`, "+
+				"but got '%s/%s/%s'", clusterId, nodeGroupName, resourcePoolName)
+		}
+
+		return fmt.Sprintf("%s/%s/%s", clusterId, nodeGroupName, resourcePoolName), nil
+	}
+}

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_scaling_policy_v2.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_scaling_policy_v2.go
@@ -1,0 +1,539 @@
+package mrs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	scalingPolicyV2NonUpdatableParams = []string{
+		"cluster_id",
+		"node_group_name",
+		"resource_pool_name",
+	}
+
+	scalingPolicyV2NotFoundCodes = []string{
+		"MRS.00005016", // The scaling policy does not exist.
+	}
+)
+
+// @API MRS POST /v2/{project_id}/autoscaling-policy/{cluster_id}
+// @API MRS GET /v2/{project_id}/autoscaling-policy/{cluster_id}
+// @API MRS PUT /v2/{project_id}/autoscaling-policy/{cluster_id}
+// @API MRS DELETE /v2/{project_id}/autoscaling-policy/{cluster_id}
+func ResourceScalingPolicyV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceScalingPolicyV2Create,
+		ReadContext:   resourceScalingPolicyV2Read,
+		UpdateContext: resourceScalingPolicyV2Update,
+		DeleteContext: resourceScalingPolicyV2Delete,
+
+		CustomizeDiff: config.FlexibleForceNew(scalingPolicyV2NonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceScalingPolicyV2ImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the scaling policy is located.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster.`,
+			},
+			"node_group_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the node group.`,
+			},
+			"resource_pool_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the resource pool.`,
+			},
+			"auto_scaling_policy": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auto_scaling_enable": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: `Whether to enable the auto scaling policy.`,
+						},
+						"min_capacity": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `The minimum number of nodes in the node group.`,
+						},
+						"max_capacity": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `The maximum number of nodes in the node group.`,
+						},
+						"resources_plans": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"period_type": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `The period type of the resource plan.`,
+									},
+									"start_time": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `The start time of the resource plan, in 'HH:mm' format.`,
+									},
+									"end_time": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `The end time of the resource plan, in 'HH:mm' format.`,
+									},
+									"min_capacity": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: `The minimum number of retained nodes for the node group in the resource plan.`,
+									},
+									"max_capacity": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: `The maximum number of retained nodes for the node group in the resource plan.`,
+									},
+									"effective_days": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `The effective day list of the resource plan.`,
+									},
+								},
+							},
+							Description: `The list of resource plans.`,
+						},
+						"rules": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `The name of the rule.`,
+									},
+									"adjustment_type": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `The adjustment type of the rule.`,
+									},
+									"cool_down_minutes": {
+										Type:        schema.TypeInt,
+										Required:    true,
+										Description: `The cool down time of the cluster after the scaling rule is triggered, in minutes.`,
+									},
+									"scaling_adjustment": {
+										Type:        schema.TypeInt,
+										Required:    true,
+										Description: `The number of adjusted nodes in one scaling action.`,
+									},
+									"trigger": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"metric_name": {
+													Type:        schema.TypeString,
+													Required:    true,
+													Description: `The name of the metric.`,
+												},
+												"metric_value": {
+													Type:        schema.TypeString,
+													Required:    true,
+													Description: `The threshold value of the metric.`,
+												},
+												"evaluation_periods": {
+													Type:        schema.TypeInt,
+													Required:    true,
+													Description: `The number of consecutive periods that meet the metric threshold.`,
+												},
+												"comparison_operator": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    true,
+													Description: `The comparison operator of the metric judgment logic.`,
+												},
+											},
+										},
+										Description: `The trigger condition list of the rule.`,
+									},
+									"description": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: `The description of the rule.`,
+									},
+								},
+							},
+							Description: `The list of auto scaling rules.`,
+						},
+						"tags": {
+							Type:        schema.TypeMap,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The key/value pairs associated with auto scaling policy.`,
+						},
+					},
+				},
+				Description: `The configurations of the auto scaling policy.`,
+			},
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildScalingPolicyV2Params(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"node_group_name":     d.Get("node_group_name"),
+		"resource_pool_name":  d.Get("resource_pool_name"),
+		"auto_scaling_policy": buildScalingPolicyV2AutoScalingPolicy(d.Get("auto_scaling_policy").([]interface{})),
+	}
+}
+
+func buildScalingPolicyV2AutoScalingPolicy(policies []interface{}) map[string]interface{} {
+	if len(policies) < 1 {
+		return nil
+	}
+
+	policy := policies[0]
+	return map[string]interface{}{
+		"auto_scaling_enable": utils.PathSearch("auto_scaling_enable", policy, nil),
+		"min_capacity":        utils.ValueIgnoreEmpty(utils.PathSearch("min_capacity", policy, nil)),
+		"max_capacity":        utils.ValueIgnoreEmpty(utils.PathSearch("max_capacity", policy, nil)),
+		"resources_plans": buildScalingPolicyV2ResourcesPlans(utils.PathSearch("resources_plans",
+			policy, make([]interface{}, 0)).([]interface{})),
+		"rules": buildScalingPolicyV2Rules(utils.PathSearch("rules",
+			policy, make([]interface{}, 0)).([]interface{})),
+		"tags": utils.ValueIgnoreEmpty(utils.ExpandResourceTags(utils.PathSearch("tags",
+			policy, make(map[string]interface{})).(map[string]interface{}))),
+	}
+}
+
+func buildScalingPolicyV2ResourcesPlans(plans []interface{}) []map[string]interface{} {
+	if len(plans) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(plans))
+	for _, v := range plans {
+		result = append(result, map[string]interface{}{
+			"period_type":    utils.PathSearch("period_type", v, nil),
+			"start_time":     utils.PathSearch("start_time", v, nil),
+			"end_time":       utils.PathSearch("end_time", v, nil),
+			"min_capacity":   utils.ValueIgnoreEmpty(utils.PathSearch("min_capacity", v, nil)),
+			"max_capacity":   utils.ValueIgnoreEmpty(utils.PathSearch("max_capacity", v, nil)),
+			"effective_days": utils.ValueIgnoreEmpty(utils.PathSearch("effective_days", v, nil)),
+		})
+	}
+
+	return result
+}
+
+func buildScalingPolicyV2Rules(rules []interface{}) []map[string]interface{} {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(rules))
+	for _, v := range rules {
+		result = append(result, map[string]interface{}{
+			"name":               utils.PathSearch("name", v, nil),
+			"adjustment_type":    utils.PathSearch("adjustment_type", v, nil),
+			"cool_down_minutes":  utils.PathSearch("cool_down_minutes", v, nil),
+			"scaling_adjustment": utils.PathSearch("scaling_adjustment", v, nil),
+			"trigger":            buildScalingPolicyV2RuleTrigger(utils.PathSearch("trigger", v, make([]interface{}, 0)).([]interface{})),
+			"description":        utils.ValueIgnoreEmpty(utils.PathSearch("description", v, nil)),
+		})
+	}
+
+	return result
+}
+
+func buildScalingPolicyV2RuleTrigger(triggers []interface{}) map[string]interface{} {
+	if len(triggers) == 0 {
+		return nil
+	}
+
+	trigger := triggers[0]
+	return map[string]interface{}{
+		"metric_name":         utils.PathSearch("metric_name", trigger, nil),
+		"metric_value":        utils.PathSearch("metric_value", trigger, nil),
+		"evaluation_periods":  utils.PathSearch("evaluation_periods", trigger, nil),
+		"comparison_operator": utils.ValueIgnoreEmpty(utils.PathSearch("comparison_operator", trigger, nil)),
+	}
+}
+
+func resourceScalingPolicyV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("mrs", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	createPath := client.Endpoint + "v2/{project_id}/autoscaling-policy/{cluster_id}"
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{cluster_id}", d.Get("cluster_id").(string))
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildScalingPolicyV2Params(d)),
+	}
+
+	clusterId := d.Get("cluster_id").(string)
+	_, err = client.Request("POST", createPath, &opts)
+	if err != nil {
+		return diag.Errorf("error creating scaling policy for the cluster (%s): %s", clusterId, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s/%s", clusterId, d.Get("node_group_name").(string), d.Get("resource_pool_name").(string)))
+
+	return resourceScalingPolicyV2Read(ctx, d, meta)
+}
+
+// There are no paging parameters, query all data.
+func listScalingPolicyV2(client *golangsdk.ServiceClient, clusterId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/autoscaling-policy/{cluster_id}"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{cluster_id}", clusterId)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", listPath, &opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func GetScalingPolicyV2(client *golangsdk.ServiceClient, clusterId, nodeGroupName, resourcePoolName string) (interface{}, error) {
+	policies, err := listScalingPolicyV2(client, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	policy := utils.PathSearch(fmt.Sprintf("[?node_group_name=='%s'&&resource_pool_name=='%s']|[0]", nodeGroupName, resourcePoolName),
+		policies, nil)
+	if policy == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/autoscaling-policy/{cluster_id}",
+				RequestId: "NONE",
+				Body:      []byte("the scaling policy does not exist"),
+			},
+		}
+	}
+
+	return policy, nil
+}
+
+func resourceScalingPolicyV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("mrs", region)
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	clusterId := d.Get("cluster_id").(string)
+	policy, err := GetScalingPolicyV2(client, clusterId, d.Get("node_group_name").(string), d.Get("resource_pool_name").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", clusterNotFoundCodes...),
+			"error retrieving scaling policy",
+		)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("cluster_id", clusterId),
+		d.Set("node_group_name", utils.PathSearch("node_group_name", policy, nil)),
+		d.Set("resource_pool_name", utils.PathSearch("resource_pool_name", policy, nil)),
+		d.Set("auto_scaling_policy", flattenScalingPolicyV2AutoScalingPolicy(utils.PathSearch("auto_scaling_policy", policy, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenScalingPolicyV2AutoScalingPolicy(policy interface{}) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"auto_scaling_enable": utils.PathSearch("auto_scaling_enable", policy, nil),
+			"min_capacity":        utils.PathSearch("min_capacity", policy, nil),
+			"max_capacity":        utils.PathSearch("max_capacity", policy, nil),
+			"resources_plans": flattenScalingPolicyV2ResourcesPlans(utils.PathSearch("resources_plans",
+				policy, make([]interface{}, 0)).([]interface{})),
+			"rules": flattenScalingPolicyV2Rules(utils.PathSearch("rules",
+				policy, make([]interface{}, 0)).([]interface{})),
+			"tags": utils.FlattenTagsToMap(utils.PathSearch("tags", policy, make([]interface{}, 0))),
+		},
+	}
+}
+
+func flattenScalingPolicyV2ResourcesPlans(plans []interface{}) []interface{} {
+	if len(plans) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(plans))
+	for _, v := range plans {
+		result = append(result, map[string]interface{}{
+			"period_type":    utils.PathSearch("period_type", v, nil),
+			"start_time":     utils.PathSearch("start_time", v, nil),
+			"end_time":       utils.PathSearch("end_time", v, nil),
+			"min_capacity":   utils.PathSearch("min_capacity", v, nil),
+			"max_capacity":   utils.PathSearch("max_capacity", v, nil),
+			"effective_days": utils.PathSearch("effective_days", v, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenScalingPolicyV2Rules(rules []interface{}) []interface{} {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(rules))
+	for _, v := range rules {
+		result = append(result, map[string]interface{}{
+			"name":               utils.PathSearch("name", v, nil),
+			"adjustment_type":    utils.PathSearch("adjustment_type", v, nil),
+			"cool_down_minutes":  utils.PathSearch("cool_down_minutes", v, nil),
+			"scaling_adjustment": utils.PathSearch("scaling_adjustment", v, nil),
+			"trigger":            flattenScalingPolicyV2RuleTrigger(utils.PathSearch("trigger", v, nil)),
+			"description":        utils.PathSearch("description", v, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenScalingPolicyV2RuleTrigger(trigger interface{}) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"metric_name":         utils.PathSearch("metric_name", trigger, nil),
+			"metric_value":        utils.PathSearch("metric_value", trigger, nil),
+			"evaluation_periods":  utils.PathSearch("evaluation_periods", trigger, nil),
+			"comparison_operator": utils.PathSearch("comparison_operator", trigger, nil),
+		},
+	}
+}
+
+func resourceScalingPolicyV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("mrs", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	updatePath := client.Endpoint + "v2/{project_id}/autoscaling-policy/{cluster_id}"
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", d.Get("cluster_id").(string))
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildScalingPolicyV2Params(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating scaling policy: %s", err)
+	}
+
+	return resourceScalingPolicyV2Read(ctx, d, meta)
+}
+
+func resourceScalingPolicyV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("mrs", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	deletePath := client.Endpoint + "v2/{project_id}/autoscaling-policy/{cluster_id}"
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", d.Get("cluster_id").(string))
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"node_group_name":    d.Get("node_group_name"),
+			"resource_pool_name": d.Get("resource_pool_name"),
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", append(clusterNotFoundCodes, scalingPolicyV2NotFoundCodes...)...),
+			"error deleting scaling policy",
+		)
+	}
+
+	return nil
+}
+
+func resourceScalingPolicyV2ImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid format specified for import ID, must be `<cluster_id>/<node_group_name>/<resource_pool_name>`, "+
+			"but got '%s'", d.Id())
+	}
+
+	mErr := multierror.Append(
+		d.Set("cluster_id", parts[0]),
+		d.Set("node_group_name", parts[1]),
+		d.Set("resource_pool_name", parts[2]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a new resources to manage auto scaling policy, all APIs use version v2.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new resource.
2. add corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o mrs -f TestAccScalingPolicyV2_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccScalingPolicyV2_basic -timeout 360m -parallel 10
=== RUN   TestAccScalingPolicyV2_basic
=== PAUSE TestAccScalingPolicyV2_basic
=== CONT  TestAccScalingPolicyV2_basic
--- PASS: TestAccScalingPolicyV2_basic (42.58s)
PASS
coverage: 10.4% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       42.661s coverage: 10.4% of statements in ./huaweicloud/services/mrs
```
<img width="993" height="311" alt="image" src="https://github.com/user-attachments/assets/1a17f70f-b064-4a4e-9b71-ba8ccd76e431" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found   
    <img width="1438" height="766" alt="image" src="https://github.com/user-attachments/assets/fa5bae68-30d5-476c-b5aa-c9f76f2dd61f" />

    ab. Related resources (parent resources) not found
    <img width="1245" height="829" alt="image" src="https://github.com/user-attachments/assets/8a53b176-523c-4d97-8276-aa23bf037003" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
      <img width="1325" height="857" alt="image" src="https://github.com/user-attachments/assets/a00ef349-7311-4ce5-b387-2b42e674da1e" />

    bb. Related resources (parent resources) not found  
    <img width="1416" height="863" alt="image" src="https://github.com/user-attachments/assets/786a7d3d-a555-4824-acba-9969ceb509a8" />

