### PR TITLE
feat(cfw): the `cfw_firewall` resource support update name

### DIFF
--- a/docs/resources/cfw_firewall.md
+++ b/docs/resources/cfw_firewall.md
@@ -102,9 +102,7 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `name` - (Required, String, ForceNew) Specifies the firewall name.
-
-  Changing this parameter will create a new resource.
+* `name` - (Required, String) Specifies the firewall name.
 
 * `flavor` - (Required, List, ForceNew) Specifies the flavor of the firewall.
   Changing this parameter will create a new resource.

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_firewall_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_firewall_test.go
@@ -113,6 +113,7 @@ func TestAccFirewall_prePaid(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckChargingMode(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -123,7 +124,7 @@ func TestAccFirewall_prePaid(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "charging_mode", "prePaid"),
-					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttrSet(rName, "engine_type"),
@@ -138,7 +139,7 @@ func TestAccFirewall_prePaid(t *testing.T) {
 				Config: testFirewall_prePaid_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
 					resource.TestCheckResourceAttr(rName, "tags.k1", "v1"),
 					resource.TestCheckResourceAttr(rName, "tags.k2", "v2"),
 				),
@@ -461,7 +462,7 @@ resource "huaweicloud_cfw_firewall" "test" {
 func testFirewall_prePaid(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cfw_firewall" "test" {
-  name = "%s"
+  name = "%[1]s"
 
   flavor {
     version = "Professional"
@@ -472,18 +473,19 @@ resource "huaweicloud_cfw_firewall" "test" {
     foo = "bar"
   }
 
-  charging_mode = "prePaid"
-  period_unit   = "month"
-  period        = 1
-  auto_renew    = false
+  charging_mode         = "prePaid"
+  period_unit           = "month"
+  period                = 1
+  auto_renew            = false
+  enterprise_project_id = "%[2]s"
 }
-`, name)
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
 func testFirewall_prePaid_update(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_cfw_firewall" "test" {
-  name = "%s"
+  name = "%[1]s_update"
 
   flavor {
     version = "Professional"
@@ -494,12 +496,13 @@ resource "huaweicloud_cfw_firewall" "test" {
     k2 = "v2"
   }
 
-  charging_mode = "prePaid"
-  period_unit   = "month"
-  period        = 1
-  auto_renew    = false
+  charging_mode         = "prePaid"
+  period_unit           = "month"
+  period                = 1
+  auto_renew            = false
+  enterprise_project_id = "%[2]s"
 }
-`, name)
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
 func testFirewall_eastWestBase(name string, bgpAsNum int) string {

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_firewall.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_firewall.go
@@ -43,7 +43,7 @@ const (
 // @API CFW GET /v1/{project_id}/ips/protect
 // @API CFW POST /v2/{project_id}/cfw-cfw/{fw_instance_id}/tags/create
 // @API CFW DELETE /v2/{project_id}/cfw-cfw/{fw_instance_id}/tags/delete
-
+// @API CFW PUT /v1/{project_id}/firewall/name
 func ResourceFirewall() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceFirewallCreate,
@@ -93,7 +93,6 @@ func ResourceFirewall() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `Specifies the firewall name.`,
 			},
 			"flavor": {
@@ -934,6 +933,13 @@ func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
+	if !d.IsNewResource() && d.HasChange("name") {
+		err := updateFirewallName(d, meta)
+		if err != nil {
+			return diag.Errorf("error updating firewall name: %s", err)
+		}
+	}
+
 	if !d.IsNewResource() && d.HasChange("tags") {
 		err := updateTags(d, meta)
 		if err != nil {
@@ -942,6 +948,34 @@ func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	return resourceFirewallRead(ctx, d, meta)
+}
+
+func updateFirewallName(d *schema.ResourceData, meta interface{}) error {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/firewall/name"
+		product = "cfw"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?fw_instance_id=%s", d.Id())
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"fw_instance_name": d.Get("name").(string),
+		},
+	}
+
+	_, err = client.Request("PUT", requestPath, &requestOpts)
+
+	return err
 }
 
 func updateEastWestFirewallStatus(d *schema.ResourceData, meta interface{}, objectID string) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

the `cfw_firewall` resource support update name

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

the `cfw_firewall` resource support update name

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccFirewall_prePaid"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccFirewall_prePaid -timeout 360m -parallel 4
=== RUN   TestAccFirewall_prePaid
=== PAUSE TestAccFirewall_prePaid
=== CONT  TestAccFirewall_prePaid
--- PASS: TestAccFirewall_prePaid (592.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       592.261s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
