### PR TITLE
feat(cfw): new resource to download imported acl rule

### DIFF
--- a/docs/resources/cfw_download_imported_acl_rule.md
+++ b/docs/resources/cfw_download_imported_acl_rule.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_download_imported_acl_rule"
+description: |-
+  Manages a resource to download CFW imported ACL rule within HuaweiCloud.
+---
+
+# huaweicloud_cfw_download_imported_acl_rule
+
+Manages a resource to download CFW imported ACL rule within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource used to download imported ACL rule. Deleting this resource will
+  not clear the corresponding request record, but will only remove the resource information from the tf state file.
+  <br/>2. Running this resource will generate a file with the suffix **.xlsx** in the current working directory.
+
+## Example Usage
+
+```hcl
+variable "object_id" {}
+
+resource "huaweicloud_cfw_download_imported_acl_rule" "test" {
+  object_id        = var.object_id
+  export_file_name = "temp-download-file.xlsx"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `object_id` - (Required, String, NonUpdatable) Specifies the protected object ID. This ID is used to distinguish
+  between Internet boundary protection and VPC boundary protection after the cloud firewall is created.
+  You can get this value from data source `huaweicloud_cfw_firewalls`.
+
+* `export_file_name` - (Required, String, NonUpdatable) Specifies the directory file using to store the downloaded ACL
+  rule, and requires the file ending in `.xlsx`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `object_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2904,6 +2904,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_firewall":                      cfw.ResourceFirewall(),
 			"huaweicloud_cfw_ips_custom_rule":               cfw.ResourceIpsCustomRule(),
 			"huaweicloud_cfw_domain_name_group":             cfw.ResourceDomainNameGroup(),
+			"huaweicloud_cfw_download_imported_acl_rule":    cfw.ResourceDownloadImportedAclRule(),
 			"huaweicloud_cfw_lts_log":                       cfw.ResourceLtsLog(),
 			"huaweicloud_cfw_report_profile":                cfw.ResourceReportProfile(),
 			"huaweicloud_cfw_schedule":                      cfw.ResourceSchedule(),

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_download_imported_acl_rule_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_download_imported_acl_rule_test.go
@@ -1,0 +1,46 @@
+package cfw
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDownloadImportedAclRule_basic(t *testing.T) {
+	exportFileName := fmt.Sprintf("./%s.xlsx", acceptance.RandomAccResourceName())
+	defer func() {
+		if err := os.Remove(exportFileName); err != nil {
+			log.Printf("error deleting testing file %s: %s", exportFileName, err)
+		}
+	}()
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDownloadImportedAclRule_basic(exportFileName),
+			},
+		},
+	})
+}
+
+func testDownloadImportedAclRule_basic(exportFileName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cfw_download_imported_acl_rule" "test" {
+  object_id        = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+  export_file_name = "%[2]s"
+}
+`, testAccDatasourceFirewalls_basic(), exportFileName)
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_download_imported_acl_rule.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_download_imported_acl_rule.go
@@ -1,0 +1,119 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/acl-rule/import-result
+func ResourceDownloadImportedAclRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDownloadImportedAclRuleCreate,
+		ReadContext:   resourceDownloadImportedAclRuleRead,
+		UpdateContext: resourceDownloadImportedAclRuleUpdate,
+		DeleteContext: resourceDownloadImportedAclRuleDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"object_id",
+			"export_file_name",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"object_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"export_file_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceDownloadImportedAclRuleCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		httpUrl        = "v1/{project_id}/acl-rule/import-result"
+		objectId       = d.Get("object_id").(string)
+		exportFileName = d.Get("export_file_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?object_id=%s", objectId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error downloading CFW imported ACL rule: %s", err)
+	}
+
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return diag.Errorf("error reading response body: %s", err)
+	}
+
+	if err := os.WriteFile(exportFileName, bodyBytes, 0600); err != nil {
+		return diag.Errorf("failed to write file to (%s): %s", exportFileName, err)
+	}
+
+	d.SetId(objectId)
+	return nil
+}
+
+func resourceDownloadImportedAclRuleRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDownloadImportedAclRuleUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDownloadImportedAclRuleDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to download imported acl rule. Deleting this resource
+    will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to download imported acl rule

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccDownloadImportedAclRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccDownloadImportedAclRule_basic -timeout 360m -parallel 10
=== RUN   TestAccDownloadImportedAclRule_basic
=== PAUSE TestAccDownloadImportedAclRule_basic
=== CONT  TestAccDownloadImportedAclRule_basic
--- PASS: TestAccDownloadImportedAclRule_basic (15.17s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       15.267s coverage: 4.5% of statements in ./huaweicloud/services/cfw
```
<img width="1294" height="85" alt="image" src="https://github.com/user-attachments/assets/9bad6206-3770-4cdd-8415-5bd0386e2d5f" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
