### PR TITLE
refactor(cse): optimize the microservice instances datasource codes

### DIFF
--- a/docs/data-sources/cse_microservice_instances.md
+++ b/docs/data-sources/cse_microservice_instances.md
@@ -3,17 +3,20 @@ subcategory: "Cloud Service Engine (CSE)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_cse_microservice_instances"
 description: |-
-  Use this data source to get the list of the instances under dedicated microservice within HuaweiCloud.
+  Use this data source to get the list of the microservice instances under specified microservice within HuaweiCloud.
 ---
 
 # huaweicloud_cse_microservice_instances
 
-Use this data source to get the list of the instances under dedicated microservice within HuaweiCloud.
+Use this data source to get the list of the microservice instances under specified microservice within HuaweiCloud.
+
+-> Before creating a microservice, make sure that the engine is bound to the EIP and that the rules shown in the
+   appendix [table](#microservice_instances_default_engine_access_rules) are enabled in the corresponding security group.
 
 ## Example Usage
 
 ```hcl
-variable "microservice_engine_id" {} // Ensure EIP access is enabled.
+variable "microservice_engine_id" {} // Enable the EIP access
 variable "admin_user" {}
 variable "admin_password" {}
 variable "microservice_id" {}
@@ -40,13 +43,14 @@ The following arguments are supported:
 
 * `auth_address` - (Required, String) Specifies the address that used to request the access token.
 
-* `connect_address` - (Required, String) Specifies the address that used to send requests and manage configuration.
+* `connect_address` - (Required, String) Specifies the address that used to access engine and query microservice
+  instances.
 
 -> We are only support IPv4 addresses yet (for `auth_address` and `connect_address`).
 
-* `admin_pass` - (Optional, String) Specifies the user password that used to pass the **RBAC** control.
-
 * `admin_user` - (Optional, String) Specifies the user name that used to pass the **RBAC** control.
+
+* `admin_pass` - (Optional, String) Specifies the user password that used to pass the **RBAC** control.  
   The password format must meet the following conditions:
   + Must be `8` to `32` characters long.
   + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
@@ -56,7 +60,11 @@ The following arguments are supported:
 
 -> Both `admin_user` and `admin_pass` are required if **RBAC** is enabled for the microservice engine.
 
-* `microservice_id` - (Required, String) Specifies the ID of the dedicated microservice to which the instances belong.
+~> Please make sure that all the above parameter values ​​are correct; otherwise, **Terraform** will report a connection
+   error.
+
+* `microservice_id` - (Required, String) Specifies the ID of the microservice to which the microservice instances
+  belong.
 
 ## Attribute Reference
 
@@ -96,15 +104,6 @@ The `instances` block supports:
 
 * `updated_at` - The latest update time of the microservice instance, in RFC3339 format.
 
-<a name="microservice_instances_data_center"></a>
-The `data_center` block supports:
-
-* `region` - The custom region name of the data center.
-
-* `name` - The name of the data center.
-
-* `availability_zone` - The custom availability zone of the data center.
-
 <a name="microservice_instances_health_check"></a>
 The `health_check` block supports:
 
@@ -115,3 +114,29 @@ The `health_check` block supports:
 * `max_retries` - The maximum retry number of the health check.
 
 * `port` - The port of the health check.
+
+<a name="microservice_instances_data_center"></a>
+The `data_center` block supports:
+
+* `name` - The name of the data center.
+
+* `region` - The custom region name of the data center.
+
+* `availability_zone` - The custom availability zone of the data center.
+
+## Appendix
+
+<a name="microservice_instances_default_engine_access_rules"></a>
+Security group rules required to access the engine:
+(Remote is not the minimum range and can be adjusted according to business needs)
+
+| Direction | Priority | Action | Protocol | Ports         | Ethertype | Remote                |
+| --------- | -------- | ------ | -------- | ------------- | --------- | --------------------- |
+| Ingress   | 1        | Allow  | ICMP     | All           | Ipv6      | ::/0                  |
+| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv6      | ::/0                  |
+| Ingress   | 1        | Allow  | All      | All           | Ipv6      | cse-engine-default-sg |
+| Ingress   | 1        | Allow  | ICMP     | All           | Ipv4      | A CIDR containing the public IP address of the machine from which you executed this terraform script, such as **0.0.0.0/0** |
+| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv4      | A CIDR containing the public IP address of the machine from which you executed this terraform script, such as **0.0.0.0/0** |
+| Ingress   | 1        | Allow  | All      | All           | Ipv4      | cse-engine-default-sg |
+| Egress    | 100      | Allow  | All      | All           | Ipv6      | ::/0                  |
+| Egress    | 100      | Allow  | All      | All           | Ipv4      | 0.0.0.0/0             |

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_instances.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_instances.go
@@ -17,27 +17,35 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+// @API CSE POST /v4/token
 // @API CSE GET /v4/{project_id}/registry/microservices/{service_id}/instances
 func DataSourceMicroserviceInstances() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceMicroserviceInstancesRead,
 
 		Schema: map[string]*schema.Schema{
+			// Special parameters.
+			// These parameters are used to specify the address that used to request the access token and access the
+			// microservice engine.
 			"auth_address": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: `The address that used to request the access token.`,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The address that used to request the access token.`,
+					utils.SchemaDescInput{
+						Required: true,
+					}),
 			},
 			"connect_address": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `The address that used to send requests and manage configuration.`,
+				Description: `The address that used to access engine and query microservice instances.`,
 			},
 			"admin_user": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"admin_pass"},
-				Description:  `The user name that used to pass the RBAC control.`,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The user name that used to pass the RBAC control.`,
 			},
 			"admin_pass": {
 				Type:         schema.TypeString,
@@ -46,11 +54,15 @@ func DataSourceMicroserviceInstances() *schema.Resource {
 				RequiredWith: []string{"admin_user"},
 				Description:  `The user password that used to pass the RBAC control.`,
 			},
+
+			// Required parameters.
 			"microservice_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `The ID of the dedicated microservice to which the instances belong.`,
+				Description: `The ID of the microservice to which the microservice instances belong.`,
 			},
+
+			// Attributes.
 			"instances": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -64,7 +76,7 @@ func DataSourceMicroserviceInstances() *schema.Resource {
 						"host_name": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `The host name ID of the microservice instance.`,
+							Description: `The host name of the microservice instance.`,
 						},
 						"endpoints": {
 							Type:        schema.TypeList,
@@ -117,15 +129,15 @@ func DataSourceMicroserviceInstances() *schema.Resource {
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"region": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: `The custom region name of the data center.`,
-									},
 									"name": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: `The name of the data center.`,
+									},
+									"region": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The custom region name of the data center.`,
 									},
 									"availability_zone": {
 										Type:        schema.TypeString,
@@ -159,25 +171,36 @@ func DataSourceMicroserviceInstances() *schema.Resource {
 	}
 }
 
-func queryMicroserviceInstances(client *golangsdk.ServiceClient, token, microserviceId string) ([]interface{}, error) {
-	var (
-		httpUrl = "registry/microservices/{service_id}/instances"
-		listOpt = golangsdk.RequestOpts{
-			KeepResponseBody: true,
-		}
-	)
+func listMicroserviceInstances(client *golangsdk.ServiceClient, authAddress, adminUser, adminPass,
+	microserviceId string) ([]interface{}, error) {
+	httpUrl := "v4/{project_id}/registry/microservices/{service_id}/instances"
 
-	if token != "" {
-		listOpt.MoreHeaders = map[string]string{
-			"Authorization": token,
-		}
-	}
-
-	listPath := client.ResourceBase + httpUrl
-	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath := client.Endpoint + httpUrl
+	// The project ID of the microservice instance is the fixed value "default".
+	// No region parameter needs to be defined because this data source does not use IAM authentication.
+	listPath = strings.ReplaceAll(listPath, "{project_id}", microserviceInstanceProjectId)
 	listPath = strings.ReplaceAll(listPath, "{service_id}", microserviceId)
 
-	requestResp, err := client.Request("GET", listPath, &listOpt)
+	listOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+	}
+
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `POST /v4/token` interface.
+	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
+	if err != nil {
+		return nil, err
+	}
+	// If the microservice instance has RBAC authentication enabled, the Authorization header will use a special token
+	// provided by the CSE service to replace the original IAM authentication information (AKSK authentication) in the
+	// request header.
+	if token != "" {
+		listOpts.MoreHeaders["Authorization"] = token
+	}
+
+	requestResp, err := client.Request("GET", listPath, &listOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -189,88 +212,78 @@ func queryMicroserviceInstances(client *golangsdk.ServiceClient, token, microser
 	return utils.PathSearch("instances", respBody, make([]interface{}, 0)).([]interface{}), nil
 }
 
-func flattenMicroserviceInstances(instances []interface{}) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(instances))
+// parseMicroserviceInstanceTimestamp converts the timestamp from API response (string, float64, or int) to RFC3339 format.
+func parseMicroserviceInstanceTimestamp(val interface{}) string {
+	if val == nil {
+		return ""
+	}
+	switch v := val.(type) {
+	case string:
+		if v == "" {
+			return ""
+		}
+		r, err := strconv.Atoi(v)
+		if err != nil {
+			log.Printf("[ERROR] unable to convert the string (%s) to int: %v", v, err)
+			return ""
+		}
+		return utils.FormatTimeStampRFC3339(int64(r), false)
+	case float64:
+		return utils.FormatTimeStampRFC3339(int64(v), false)
+	case int:
+		return utils.FormatTimeStampRFC3339(int64(v), false)
+	default:
+		return ""
+	}
+}
 
+func flattenMicroserviceInstances(instances []interface{}) []map[string]interface{} {
+	if len(instances) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(instances))
 	for _, instance := range instances {
 		result = append(result, map[string]interface{}{
 			"id":           utils.PathSearch("instanceId", instance, nil),
 			"host_name":    utils.PathSearch("hostName", instance, nil),
 			"endpoints":    utils.PathSearch("endpoints", instance, nil),
 			"version":      utils.PathSearch("version", instance, nil),
-			"properties":   utils.PathSearch("properties", instance, nil),
-			"health_check": flattenMicroserviceInstancesHealthCheck(utils.PathSearch("healthCheck", instance, nil)),
-			"data_center":  flattenMicroserviceInstancesDataCenter(utils.PathSearch("dataCenterInfo", instance, nil)),
+			"properties":   buildInstanceProperties(utils.PathSearch("properties", instance, make(map[string]interface{})).(map[string]interface{})),
+			"health_check": flattenHealthCheck(utils.PathSearch("healthCheck", instance, nil)),
+			"data_center":  flattenDataCenter(utils.PathSearch("dataCenterInfo", instance, nil)),
 			"status":       utils.PathSearch("status", instance, nil),
-			"created_at":   parseMicroserviceInstancesTime(utils.PathSearch("timestamp", instance, "").(string)),
-			"updated_at":   parseMicroserviceInstancesTime(utils.PathSearch("modTimestamp", instance, "").(string)),
+			"created_at":   parseMicroserviceInstanceTimestamp(utils.PathSearch("timestamp", instance, nil)),
+			"updated_at":   parseMicroserviceInstanceTimestamp(utils.PathSearch("modTimestamp", instance, nil)),
 		})
 	}
-
 	return result
 }
 
-func flattenMicroserviceInstancesHealthCheck(healthCheck interface{}) []map[string]interface{} {
-	if healthCheck == nil {
-		return nil
-	}
-
-	return []map[string]interface{}{
-		{
-			"mode":        utils.PathSearch("mode", healthCheck, nil),
-			"interval":    utils.PathSearch("interval", healthCheck, nil),
-			"max_retries": utils.PathSearch("times", healthCheck, nil),
-			"port":        utils.PathSearch("port", healthCheck, nil),
-		},
-	}
-}
-
-func flattenMicroserviceInstancesDataCenter(dataCenter interface{}) []map[string]interface{} {
-	if dataCenter == nil {
-		return nil
-	}
-
-	return []map[string]interface{}{
-		{
-			"region":            utils.PathSearch("region", dataCenter, nil),
-			"name":              utils.PathSearch("name", dataCenter, nil),
-			"availability_zone": utils.PathSearch("availableZone", dataCenter, nil),
-		},
-	}
-}
-
-func parseMicroserviceInstancesTime(timeStampStr string) string {
-	r, err := strconv.Atoi(timeStampStr)
-	if err != nil {
-		log.Printf("[ERROR] unable to convert the string (%s) to int", timeStampStr)
-		return ""
-	}
-
-	return utils.FormatTimeStampRFC3339(int64(r), false)
-}
-
 func dataSourceMicroserviceInstancesRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
-		d.Get("admin_pass").(string))
+	var (
+		// Querying microservice instances in the microservice engine requires building a client based on the
+		// microservice engine's connection address, which does not use IAM authentication.
+		client         = common.NewCustomClient(true, d.Get("connect_address").(string))
+		authAddress    = getAuthAddress(d)
+		adminUser      = d.Get("admin_user").(string)
+		adminPass      = d.Get("admin_pass").(string)
+		microserviceId = d.Get("microservice_id").(string)
+	)
+
+	instances, err := listMicroserviceInstances(client, authAddress, adminUser, adminPass, microserviceId)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("error querying microservice instances: %s", err)
 	}
 
-	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
-	instances, err := queryMicroserviceInstances(client, token, d.Get("microservice_id").(string))
-	if err != nil {
-		return diag.Errorf("error querying CSE microservice instances: %s", err)
-	}
-
-	uuid, err := uuid.GenerateUUID()
+	randomUUID, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
-	d.SetId(uuid)
+	d.SetId(randomUUID)
 
 	mErr := multierror.Append(nil,
 		d.Set("instances", flattenMicroserviceInstances(instances)),
 	)
-
 	return diag.FromErr(mErr.ErrorOrNil())
 }

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
@@ -38,7 +38,7 @@ var (
 	}
 )
 
-// @API CSE GET /v4/token
+// @API CSE POST /v4/token
 // @API CSE POST /v4/{project_id}/registry/microservices
 // @API CSE GET /v4/{project_id}/registry/microservices/{service_id}
 // @API CSE DELETE /v4/{project_id}/registry/microservices/{service_id}
@@ -180,7 +180,7 @@ func createMicroservice(client *golangsdk.ServiceClient, d *schema.ResourceData)
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
-	// `GET /v4/token` interface.
+	// `POST /v4/token` interface.
 	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string), d.Get("admin_pass").(string))
 	if err != nil {
 		return nil, err
@@ -230,7 +230,7 @@ func GetMicroservice(client *golangsdk.ServiceClient, authAddress, adminUser, ad
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
-	// `GET /v4/token` interface.
+	// `POST /v4/token` interface.
 	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
 	if err != nil {
 		return nil, err
@@ -306,7 +306,7 @@ func deleteMicroservice(client *golangsdk.ServiceClient, d *schema.ResourceData)
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
-	// `GET /v4/token` interface.
+	// `POST /v4/token` interface.
 	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string), d.Get("admin_pass").(string))
 	if err != nil {
 		return err

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
@@ -49,7 +49,7 @@ var (
 	}
 )
 
-// @API CSE GET /v4/token
+// @API CSE POST /v4/token
 // @API CSE POST /v4/{project_id}/registry/microservices/{service_id}/instances
 // @API CSE GET /v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}
 // @API CSE DELETE /v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}
@@ -292,7 +292,7 @@ func createInstance(client *golangsdk.ServiceClient, d *schema.ResourceData) (in
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
-	// `GET /v4/token` interface.
+	// `POST /v4/token` interface.
 	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string), d.Get("admin_pass").(string))
 	if err != nil {
 		return nil, err
@@ -346,7 +346,7 @@ func GetInstance(client *golangsdk.ServiceClient, authAddress, adminUser, adminP
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
-	// `GET /v4/token` interface.
+	// `POST /v4/token` interface.
 	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
 	if err != nil {
 		return nil, err
@@ -450,7 +450,7 @@ func deleteInstance(client *golangsdk.ServiceClient, authAddress, adminUser, adm
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
-	// `GET /v4/token` interface.
+	// `POST /v4/token` interface.
 	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactors the data source of CSE microservice instances query to comply with code quality standards:

Standardized error handling (formatting in parent methods, not sub-methods)
Extracted API logic into reusable helper methods
Supplement some comments for the complex functions and logics

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. optimize the microservice instances datasource codes
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccDataMicroserviceInstances_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccDataMicroserviceInstances_ -timeout 360m -parallel 10
=== RUN   TestAccDataMicroserviceInstances_basic
=== PAUSE TestAccDataMicroserviceInstances_basic
=== CONT  TestAccDataMicroserviceInstances_basic
--- PASS: TestAccDataMicroserviceInstances_basic (26.00s)
PASS
coverage: 30.9% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       26.082s coverage: 30.9% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
