### PR TITLE
feat(cfw): support `cfw_ip_blacklist_retry` resource

### DIFF
--- a/docs/resources/cfw_ip_blacklist_retry.md
+++ b/docs/resources/cfw_ip_blacklist_retry.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_ip_blacklist_retry"
+description: |-
+  Manages a resource to retry the failed IP blacklist import within HuaweiCloud.
+---
+
+# huaweicloud_cfw_ip_blacklist_retry
+
+Manages a resource to retry the failed IP blacklist import within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource used to retry the failed IP blacklist import. Deleting this resource
+  will not clear the corresponding request record, but will only remove the resource information from the tf state file.
+  <br/>2. When importing the IP blacklist fails, you can use this resource to retry the failed IP blacklist import.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+variable "name" {}
+
+resource "huaweicloud_cfw_ip_blacklist_retry" "test" {
+  fw_instance_id = var.fw_instance_id
+  name           = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `fw_instance_id` - (Required, String, NonUpdatable) Specifies the firewall instance ID.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the failed IP blacklist to retry.  
+  The value can be obtained using the `data_stource_huaweicloud_cfw_ic_blacklist` data source.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `fw_instance_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2916,6 +2916,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_export_logs":                   cfw.ResourceExportLogs(),
 			"huaweicloud_cfw_delete_ip_blacklist":           cfw.ResourceDeleteIpBlacklist(),
 			"huaweicloud_cfw_export_ip_blacklist":           cfw.ResourceExportIpBlacklist(),
+			"huaweicloud_cfw_ip_blacklist_retry":            cfw.ResourceIpBlacklistRetry(),
 
 			"huaweicloud_cloudtable_cluster": cloudtable.ResourceCloudTableCluster(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -458,6 +458,7 @@ var (
 	HW_CFW_PREDEFINED_ADDRESS_GROUP2 = os.Getenv("HW_CFW_PREDEFINED_ADDRESS_GROUP2")
 	HW_CFW_IPS_CUSTOM_RULE           = os.Getenv("HW_CFW_IPS_CUSTOM_RULE")
 	HW_CFW_ACL_RULE_ID               = os.Getenv("HW_CFW_ACL_RULE_ID")
+	HW_CFW_IP_BLACKLIST_NAME         = os.Getenv("HW_CFW_IP_BLACKLIST_NAME")
 
 	HW_CTS_START_TIME = os.Getenv("HW_CTS_START_TIME")
 	HW_CTS_END_TIME   = os.Getenv("HW_CTS_END_TIME")
@@ -2811,6 +2812,13 @@ func TestAccPreCheckCfwIpsCustomRule(t *testing.T) {
 func TestAccPreCheckCfwAclRuleId(t *testing.T) {
 	if HW_CFW_ACL_RULE_ID == "" {
 		t.Skip("HW_CFW_ACL_RULE_ID must be set for CFW acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCfwIpBlacklistName(t *testing.T) {
+	if HW_CFW_IP_BLACKLIST_NAME == "" {
+		t.Skip("HW_CFW_IP_BLACKLIST_NAME must be set for CFW acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_ip_blacklist_retry_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_ip_blacklist_retry_test.go
@@ -1,0 +1,36 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccIpBlacklistRetry_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+			acceptance.TestAccPreCheckCfwIpBlacklistName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testIpBlacklistRetry_basic(),
+			},
+		},
+	})
+}
+
+func testIpBlacklistRetry_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cfw_ip_blacklist_retry" "test" {
+  fw_instance_id = "%[1]s"
+  name           = "%[2]s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID, acceptance.HW_CFW_IP_BLACKLIST_NAME)
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_ip_blacklist_retry.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_ip_blacklist_retry.go
@@ -1,0 +1,101 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+var ipBlacklistRetryNonUpdatableParams = []string{"fw_instance_id", "name"}
+
+// @API CFW POST /v1/{project_id}/ptf/ip-blacklist/retry
+func ResourceIpBlacklistRetry() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIpBlacklistRetryCreate,
+		ReadContext:   resourceIpBlacklistRetryRead,
+		UpdateContext: resourceIpBlacklistRetryUpdate,
+		DeleteContext: resourceIpBlacklistRetryDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(ipBlacklistRetryNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// The parameter `name` is optional in the API documentation, but it is actually required.
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func buildIpBlacklistRetryQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?fw_instance_id=%s&name=%s", d.Get("fw_instance_id"), d.Get("name"))
+}
+
+func resourceIpBlacklistRetryCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/ptf/ip-blacklist/retry"
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildIpBlacklistRetryQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrying CFW IP blacklist import: %s", err)
+	}
+
+	d.SetId(d.Get("fw_instance_id").(string))
+
+	return nil
+}
+
+func resourceIpBlacklistRetryRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceIpBlacklistRetryUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceIpBlacklistRetryDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to retry the failed IP blacklist import. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_ip_blacklist_retry` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_ip_blacklist_retry` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccIpBlacklistRetry_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccIpBlacklistRetry_basic -timeout 360m -parallel 4
=== RUN   TestAccIpBlacklistRetry_basic
=== PAUSE TestAccIpBlacklistRetry_basic
=== CONT  TestAccIpBlacklistRetry_basic
--- PASS: TestAccIpBlacklistRetry_basic (13.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       13.516s
```
<img width="864" height="38" alt="image" src="https://github.com/user-attachments/assets/1bbc3de9-4b00-47f8-8d0a-72a7e727df9a" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
