### PR TITLE
refactor(cse): optimize the microservice engine resource codes

### DIFF
--- a/docs/resources/cse_microservice_engine.md
+++ b/docs/resources/cse_microservice_engine.md
@@ -7,7 +7,7 @@ description: ""
 
 # huaweicloud_cse_microservice_engine
 
-Manages a dedicated microservice engine (2.0+) resource within HuaweiCloud.
+Manages a microservice engine (2.0+) resource within HuaweiCloud.
 
 ## Example Usage
 
@@ -52,45 +52,45 @@ resource "huaweicloud_cse_microservice_engine" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the dedicated microservice engine.
+* `region` - (Optional, String, ForceNew) Specifies the region where the microservice engine is located.
   If omitted, the provider-level region will be used. Changing this will create a new engine.
 
-* `name` - (Required, String, ForceNew) Specifies the name of the dedicated microservice engine.
+* `name` - (Required, String, NonUpdatable) Specifies the name of the microservice engine.
  The name can contain `3` to `24` characters, only letters, digits and hyphens (-) are allowed.
   The name must start with a letter and cannot end with a hyphen (-).
-  Changing this will create a new engine.
 
-* `flavor` - (Required, String, ForceNew) Specifies the flavor of the dedicated microservice engine.
-  Changing this will create a new engine.
+* `flavor` - (Required, String, NonUpdatable) Specifies the flavor of the microservice engine.
 
-* `availability_zones` - (Optional, List, ForceNew) Specifies the list of availability zones.  
-  Required if the `version` is **CSE2**.  
-  Changing this will create a new engine.
+* `network_id` - (Required, String, NonUpdatable) Specifies the network ID of the subnet to which the microservice
+  engine belongs.
 
-* `network_id` - (Required, String, ForceNew) Specifies the network ID of the subnet to which the dedicated microservice
-  engine belongs. Changing this will create a new engine.
-
-* `auth_type` - (Required, String, ForceNew) Specifies the authentication method for the dedicated microservice engine.
-  Changing this will create a new engine.
-  + **RBAC**: Enable security authentication.
+* `auth_type` - (Required, String, NonUpdatable) Specifies the authentication type for the microservice engine.  
+  The valid values are as follows:
+  + **RBAC**: Enable security authentication.  
     Security authentication applies to the scenario where multiple users use the same engine.
     After security authentication is enabled, all users who use the engine can log in using the account and password.
     You can assign the account and role in the System Management.
-  + **NONE**: Disable security authentication.
+  + **NONE**: Disable security authentication.  
     After security authentication is disabled, all users who use the engine can use the engine without using the account
     and password, and have the same operation permissions on all services.
 
   -> **NONE** is required for the nacos engine.
 
-* `version` - (Optional, String, ForceNew) Specifies the version of the dedicated microservice engine.  
+* `availability_zones` - (Optional, List, NonUpdatable) Specifies the availability zones where the microservice engine
+  is deployed.  
+  Required if the `version` is **CSE2**.
+
+* `version` - (Optional, String, NonUpdatable) Specifies the version of the microservice engine.  
   The valid values are as follows:
   + **CSE2**
   + **Nacos2**
 
-  Defaults to **CSE2**. Changing this will create a new engine.
+  Defaults to **CSE2**.
 
-* `admin_pass` - (Optional, String, ForceNew) Specifies the account password. The corresponding account name is **root**.
-  Required if `auth_type` is **RBAC**. Changing this will create a new engine.
+* `admin_pass` - (Optional, String, NonUpdatable) Specifies the administrator account password of the microservice
+  engine.  
+  The corresponding account name is **root**.
+  Required if `auth_type` is **RBAC**.  
   The password format must meet the following conditions:
   + Must be `8` to `32` characters long.
   + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
@@ -98,28 +98,21 @@ The following arguments are supported:
   + Cannot be the account name or account name spelled backwards.
   + The password can only start with a letter.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID.  
-  If omitted and the version is **Nacos2**, the default enterprise project will be used.  
-  Changing this will create a new engine.
-
-* `description` - (Optional, String, ForceNew) Specifies the description of the dedicated microservice engine.
-  The description can contain a maximum of `255` characters.
-  Changing this will create a new engine.
-
-* `eip_id` - (Optional, String, ForceNew) Specifies the EIP ID to which the dedicated microservice engine assocated.
-  Changing this will create a new engine.
-
-* `extend_params` - (Optional, Map, ForceNew) Specifies the additional parameters for the dedicated microservice engine.
-  Changing this will create a new engine.
-
--> After the engine is created, the system will automatically add a series of additional parameters to it.
-  The specific parameters are subject to the state of the dedicated microservice engine.
-  This parameter will be affected by these parameters and will appear when `terraform plan` or `terraform apply`.
-  If it is inconsistent with the script configuration, it can be ignored by `ignore_changes` in non-change scenarios.
-
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the dedicated
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID to which the
   microservice engine belongs.  
-  Changing this will create a new engine.
+  If omitted and the version is **Nacos2**, the default enterprise project will be used.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the microservice engine.
+  The description can contain a maximum of `255` characters.
+
+* `eip_id` - (Optional, String, NonUpdatable) Specifies the EIP ID bound to the microservice engine.
+
+* `extend_params` - (Optional, Map, NonUpdatable) Specifies the extended parameters of the microservice engine.
+
+-> After the engine is created, the system will automatically add a series of additional parameters to it.  
+  The specific parameters are subject to the state of the microservice engine.  
+  This parameter will be affected by these parameters and will appear when `terraform plan` or `terraform apply`.  
+  If it is inconsistent with the script configuration, it can be ignored by `ignore_changes` in non-change scenarios.
 
 ## Attribute Reference
 
@@ -131,18 +124,27 @@ In addition to all arguments above, the following attributes are exported:
 
 * `instance_limit` - The maximum number of the microservice instance resources.
 
-* `service_registry_addresses` - The connection address of service center.
-  The [object](#engine_center_addresses) structure is documented below.
+* `service_registry_addresses` - The service registry addresses of the microservice engine.  
+  The [service_registry_addresses](#cse_microservice_engine_service_registry_addresses) structure is documented below.
 
-* `config_center_addresses` - The address of config center.
-  The [object](#engine_center_addresses) structure is documented below.
+* `config_center_addresses` - The config center addresses of the microservice engine.  
+  The [config_center_addresses](#cse_microservice_engine_config_center_addresses) structure is documented below.
 
-<a name="engine_center_addresses"></a>
-The `service_registry_addresses` and `config_center_addresses` block supports:
+<a name="cse_microservice_engine_service_registry_addresses"></a>
+The `service_registry_addresses` block supports:
 
-* `private` - The internal access address.
+* `private` - The private address of the service registry.
 
-* `public` - The public access address. This address is only set when EIP is bound.
+* `public` - The public address of the service registry.  
+  This address is only set when EIP is bound.
+
+<a name="cse_microservice_engine_config_center_addresses"></a>
+The `config_center_addresses` block supports:
+
+* `private` - The private address of the config center.
+
+* `public` - The public address of the config center.  
+  This address is only set when EIP is bound.
 
 ## Timeouts
 
@@ -156,7 +158,7 @@ This resource provides the following timeouts configuration options:
 Engines can be imported using their `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_cse_microservice_engine.test eddc5d42-f9d5-4f8e-984b-d6f3e088561c
+$ terraform import huaweicloud_cse_microservice_engine.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
@@ -168,6 +170,7 @@ align with the instance. Also you can ignore changes as below.
 ```hcl
 resource "huaweicloud_cse_microservice_engine" "test" {
   ...
+
   lifecycle {
     ignore_changes = [
       admin_pass,
@@ -181,5 +184,5 @@ For the engine created with the `enterprise_project_id`, its enterprise project 
 when importing, the format is `<id>/<enterprise_project_id>`, e.g.
 
 ```bash
-$ terraform import huaweicloud_cse_microservice_engine.test eddc5d42-f9d5-4f8e-984b-d6f3e088561c/ef101e1a-990c-42cd-bb99-a4474e41e461
+$ terraform import huaweicloud_cse_microservice_engine.test <id>/<enterprise_project_id>
 ```

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
@@ -148,7 +148,7 @@ resource "huaweicloud_cse_microservice_engine" "test" {
   description           = "Created by terraform test"
   flavor                = data.huaweicloud_cse_microservice_engine_flavors.test.flavors[0].id
   network_id            = huaweicloud_vpc_subnet.test.id
-  eip_id                = huaweicloud_vpc_eip.test.id
+  # eip_id                = huaweicloud_vpc_eip.test.id
   availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
   enterprise_project_id = huaweicloud_vpc.test.enterprise_project_id != "" ? huaweicloud_vpc.test.enterprise_project_id : null
 

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
@@ -21,9 +21,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var (
-	DefaultVersion = "CSE2"
+const DefaultVersion = "CSE2"
 
+var (
 	microserviceEngineNotFoundCodes = []string{
 		"SVCSTG.00501116",
 		"SVCSTG.00501125",
@@ -91,7 +91,7 @@ func ResourceMicroserviceEngine() *schema.Resource {
 			"network_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `The network ID of the microservice engine.`,
+				Description: `The network ID of the subnet to which the microservice engine belongs.`,
 			},
 			"auth_type": {
 				Type:        schema.TypeString,
@@ -117,7 +117,7 @@ func ResourceMicroserviceEngine() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
-				Description: `The administrator password of the microservice engine.`,
+				Description: `The administrator account password of the microservice engine.`,
 			},
 			"enterprise_project_id": {
 				Type:        schema.TypeString,
@@ -147,17 +147,16 @@ func ResourceMicroserviceEngine() *schema.Resource {
 			"service_limit": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: `The service limit of the microservice engine.`,
+				Description: `The maximum number of the microservice resources.`,
 			},
 			"instance_limit": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: `The instance limit of the microservice engine.`,
+				Description: `The maximum number of the microservice instance resources.`,
 			},
 			"service_registry_addresses": {
-				Type:        schema.TypeList,
-				Computed:    true,
-				Description: `The service registry addresses of the microservice engine.`,
+				Type:     schema.TypeList,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"private": {
@@ -172,11 +171,11 @@ func ResourceMicroserviceEngine() *schema.Resource {
 						},
 					},
 				},
+				Description: `The service registry addresses of the microservice engine.`,
 			},
 			"config_center_addresses": {
-				Type:        schema.TypeList,
-				Computed:    true,
-				Description: `The config center addresses of the microservice engine.`,
+				Type:     schema.TypeList,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"private": {
@@ -191,6 +190,7 @@ func ResourceMicroserviceEngine() *schema.Resource {
 						},
 					},
 				},
+				Description: `The config center addresses of the microservice engine.`,
 			},
 
 			// Internal parameters.
@@ -198,7 +198,11 @@ func ResourceMicroserviceEngine() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
-				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
 			},
 		},
 	}
@@ -253,26 +257,28 @@ func buildAuthCred(authType, adminPass string) interface{} {
 	return nil
 }
 
-// buildMicroserviceEngineCreateOpts builds the request body for creating a microservice engine.
+// buildMicroserviceEngineBodyParams builds the request body for creating a microservice engine.
 // It extracts data from the schema, VPC info, and subnet info, then constructs the API request parameters.
 // The function handles field mapping, type conversion, and optional field processing (using utils.ValueIgnoreEmpty).
-func buildMicroserviceEngineCreateOpts(d *schema.ResourceData, vpcInfo, subnetInfo interface{}) map[string]interface{} {
+func buildMicroserviceEngineBodyParams(d *schema.ResourceData, vpcInfo, subnetInfo interface{}) map[string]interface{} {
 	authType := d.Get("auth_type").(string)
 	return map[string]interface{}{
-		"name":        d.Get("name").(string),
+		"payment": "1", // PostPaid
+		// Required parameters.
+		"name":       d.Get("name").(string),
+		"flavor":     d.Get("flavor").(string),
+		"networkId":  d.Get("network_id").(string),
+		"authType":   authType,
+		"vpc":        utils.PathSearch("vpc.name", vpcInfo, ""),
+		"vpcId":      utils.PathSearch("subnet.vpc_id", subnetInfo, ""),
+		"subnetCidr": utils.PathSearch("subnet.cidr", subnetInfo, ""),
+		// Optional parameters.
 		"description": utils.ValueIgnoreEmpty(d.Get("description").(string)),
-		"payment":     "1", // PostPaid
-		"flavor":      d.Get("flavor").(string),
-		"azList":      utils.ExpandToStringListBySet(d.Get("availability_zones").(*schema.Set)),
-		"authType":    authType,
-		"vpc":         utils.PathSearch("vpc.name", vpcInfo, ""),
-		"vpcId":       utils.PathSearch("subnet.vpc_id", subnetInfo, ""),
-		"networkId":   d.Get("network_id").(string),
-		"subnetCidr":  utils.PathSearch("subnet.cidr", subnetInfo, ""),
+		"azList":      utils.ValueIgnoreEmpty(utils.ExpandToStringListBySet(d.Get("availability_zones").(*schema.Set))),
 		"publicIpId":  utils.ValueIgnoreEmpty(d.Get("eip_id").(string)),
-		"auth_cred":   buildAuthCred(authType, d.Get("admin_pass").(string)),
-		"specType":    d.Get("version").(string),
-		"inputs":      d.Get("extend_params").(map[string]interface{}),
+		"auth_cred":   utils.ValueIgnoreEmpty(buildAuthCred(authType, d.Get("admin_pass").(string))),
+		"specType":    utils.ValueIgnoreEmpty(d.Get("version").(string)),
+		"inputs":      utils.ValueIgnoreEmpty(d.Get("extend_params").(map[string]interface{})),
 	}
 }
 
@@ -295,7 +301,7 @@ func createMicroserviceEngine(cseClient, vpcClient *golangsdk.ServiceClient, d *
 	createOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      buildRequestMoreHeaders(enterpriseProjectId),
-		JSONBody:         utils.RemoveNil(buildMicroserviceEngineCreateOpts(d, vpcInfo, subnetInfo)),
+		JSONBody:         utils.RemoveNil(buildMicroserviceEngineBodyParams(d, vpcInfo, subnetInfo)),
 	}
 
 	requestResp, err := cseClient.Request("POST", createPath, &createOpts)
@@ -344,7 +350,7 @@ func refreshMicroserviceEngineJobFunc(client *golangsdk.ServiceClient, engineId,
 			if _, ok := parsedErr.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
 				return "RESOURCE_NOT_FOUND", "COMPLETED", nil
 			}
-			return nil, "ERROR", parsedErr
+			return resp, "ERROR", parsedErr
 		}
 
 		status := utils.PathSearch("status", resp, "").(string)
@@ -393,7 +399,7 @@ func resourceMicroserviceEngineCreate(ctx context.Context, d *schema.ResourceDat
 		Refresh: refreshMicroserviceEngineJobFunc(cseClient, engineId,
 			strconv.Itoa(int(utils.PathSearch("jobId", createOpts, float64(0)).(float64))), enterpriseProjectId, []string{"Finished"}),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
-		Delay:        180 * time.Second,
+		Delay:        3 * time.Minute,
 		PollInterval: 15 * time.Second,
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
@@ -456,6 +462,9 @@ func resourceMicroserviceEngineRead(_ context.Context, d *schema.ResourceData, m
 
 	respBody, err := GetMicroserviceEngineById(client, engineId, enterpriseProjectId)
 	if err != nil {
+		// When the microservice engine does not exist, the error code returned is 400/401, and the error information
+		// contains "SVCSTG.00501116" or "SVCSTG.00501125". So, we need to convert the error to 404 and specify
+		// the key of the error code to be "error_code".
 		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(
 			common.ConvertExpected401ErrInto404Err(err, "error_code", microserviceEngineNotFoundCodes...),
 			"error_code",
@@ -465,16 +474,19 @@ func resourceMicroserviceEngineRead(_ context.Context, d *schema.ResourceData, m
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
+		// Required parameters.
 		d.Set("name", utils.PathSearch("name", respBody, "").(string)),
 		d.Set("flavor", utils.PathSearch("flavor", respBody, "").(string)),
-		d.Set("availability_zones", utils.PathSearch("reference.azList", respBody, make([]interface{}, 0)).([]interface{})),
+		d.Set("network_id", utils.PathSearch("reference.networkId", respBody, "").(string)),
 		d.Set("auth_type", utils.PathSearch("authType", respBody, "").(string)),
+		// Optional parameters.
+		d.Set("availability_zones", utils.PathSearch("reference.azList", respBody, make([]interface{}, 0)).([]interface{})),
 		d.Set("version", utils.PathSearch("specType", respBody, "").(string)),
 		d.Set("enterprise_project_id", utils.PathSearch("enterpriseProjectId", respBody, "").(string)),
-		d.Set("network_id", utils.PathSearch("reference.networkId", respBody, "").(string)),
 		d.Set("description", utils.PathSearch("description", respBody, "").(string)),
 		d.Set("eip_id", utils.PathSearch("reference.publicIpId", respBody, "").(string)),
 		d.Set("extend_params", utils.PathSearch("reference.inputs", respBody, map[string]interface{}{}).(map[string]interface{})),
+		// Attributes.
 		d.Set("service_registry_addresses", flattenServiceRegistryAddresses(utils.PathSearch("externalEntrypoint",
 			respBody, make(map[string]interface{})).(map[string]interface{}))),
 		d.Set("config_center_addresses", flattenConfigAddresses(utils.PathSearch("externalEntrypoint",
@@ -482,7 +494,7 @@ func resourceMicroserviceEngineRead(_ context.Context, d *schema.ResourceData, m
 	)
 
 	diagErr := make([]diag.Diagnostic, 0, 3)
-	// Attributes
+	// Attributes (service_limit, instance_limit with special parsing).
 	if serviceLimit := utils.PathSearch("reference.serviceLimit", respBody, "").(string); serviceLimit != "" {
 		limit, err := strconv.Atoi(serviceLimit)
 		if err != nil {
@@ -552,6 +564,9 @@ func resourceMicroserviceEngineDelete(ctx context.Context, d *schema.ResourceDat
 
 	resp, err := deleteMicroserviceEngine(client, engineId, enterpriseProjectId)
 	if err != nil {
+		// When the microservice engine does not exist, the error code returned is 400/401, and the error information
+		// contains "SVCSTG.00501116" or "SVCSTG.00501125". So, we need to convert the error to 404 and specify
+		// the key of the error code to be "error_code".
 		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(
 			common.ConvertExpected401ErrInto404Err(err, "error_code", microserviceEngineNotFoundCodes...),
 			"error_code",
@@ -566,7 +581,7 @@ func resourceMicroserviceEngineDelete(ctx context.Context, d *schema.ResourceDat
 		Refresh: refreshMicroserviceEngineJobFunc(client, engineId,
 			strconv.Itoa(int(utils.PathSearch("jobId", resp, float64(0)).(float64))), enterpriseProjectId, nil),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
-		Delay:        120 * time.Second,
+		Delay:        2 * time.Minute,
 		PollInterval: 15 * time.Second,
 	}
 	_, err = stateConf.WaitForStateContext(ctx)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Optimize some microservice engine resource codes
- Using constant value to define the string value if we would not change it.
- Format the name of the request body build function
- Using `time.Minute` as the interval/delay unit if its times of 60 seconds
- Adjust some description of resource parameters

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. optimize the microservice engine resource codes
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccMicroserviceEngine_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccMicroserviceEngine_basic -timeout 360m -parallel 10
=== RUN   TestAccMicroserviceEngine_basic
=== PAUSE TestAccMicroserviceEngine_basic
=== CONT  TestAccMicroserviceEngine_basic
--- PASS: TestAccMicroserviceEngine_basic (918.97s)
PASS
coverage: 21.8% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       919.048s        coverage: 21.8% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
