### PR TITLE
feat(cfw): new datasource to query schedules

### DIFF
--- a/docs/data-sources/cfw_schedules.md
+++ b/docs/data-sources/cfw_schedules.md
@@ -1,0 +1,90 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_schedules"
+description: |-
+  Use this data source to get the list of CFW schedules.
+---
+
+# huaweicloud_cfw_schedules
+
+Use this data source to get the list of CFW schedules.
+
+## Example Usage
+
+```hcl
+variable object_id {}
+
+data "huaweicloud_cfw_schedules" "test" {
+  object_id = var.object_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `object_id` - (Required, String) Specifies the protected object ID. This ID is used to distinguish
+  between Internet boundary protection and VPC boundary protection after the cloud firewall is created.
+  You can get this value from data source `huaweicloud_cfw_firewalls`.
+
+* `name` - (Optional, String) Specifies the schedule name.
+
+* `description` - (Optional, String) Specifies the schedule description.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The schedule records.
+
+  The [records](#data_records_struct) structure is documented below.
+
+<a name="data_records_struct"></a>
+The `records` block supports:
+
+* `schedule_id` - The schedule ID.
+
+* `name` - The schedule name.
+
+* `description` - The schedule description.
+
+* `ref_count` - The number of citations.
+
+* `periodic` - The periodic planning.
+
+  The [periodic](#records_periodic_struct) structure is documented below.
+
+* `absolute` - The absolute time planning.
+
+  The [absolute](#records_absolute_struct) structure is documented below.
+
+<a name="records_periodic_struct"></a>
+The `periodic` block supports:
+
+* `type` - The periodic type. Valid values are:
+  + `0`: each day
+  + `1`: some day of each week
+  + `2`: a period time of each week
+
+* `start_time` - The start time of the periodic plan.
+
+* `end_time` - The end time of the periodic plan.
+
+* `week_mask` - The days of each week.
+
+* `start_week` - The start date of the weekly periodic plan.
+
+* `end_week` - The end date of the weekly periodic plan.
+
+<a name="records_absolute_struct"></a>
+The `absolute` block supports:
+
+* `start_time` - The absolute start time of the plan, in milliseconds (timestamps).
+
+* `end_time` - The absolute ent time of the plan, in milliseconds (timestamps).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -847,6 +847,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_ips_custom_rules":              cfw.DataSourceCfwIpsCustomRules(),
 			"huaweicloud_cfw_ips_rule_details":              cfw.DataSourceCfwIpsRuleDetails(),
 			"huaweicloud_cfw_resource_tags":                 cfw.DataSourceCfwResourceTags(),
+			"huaweicloud_cfw_schedules":                     cfw.DataSourceSchedules(),
 			"huaweicloud_cfw_tags":                          cfw.DataSourceCfwTags(),
 			"huaweicloud_cfw_acl_rule_export_status":        cfw.DataSourceAclRuleExportStatus(),
 			"huaweicloud_cfw_ip_blacklist":                  cfw.DataSourceIpBlacklist(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_schedules_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_schedules_test.go
@@ -1,0 +1,67 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSchedules_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cfw_schedules.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare the test data in advance under the CFW firewall.
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSchedules_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.schedule_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.ref_count"),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSchedules_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cfw_schedules" "test" {
+  object_id = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+}
+
+# Filter by name
+locals {
+  name = data.huaweicloud_cfw_schedules.test.records[0].name
+}
+
+data "huaweicloud_cfw_schedules" "filter_by_name" {
+  object_id = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+  name      = local.name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_cfw_schedules.filter_by_name.records[*].name :
+    v == local.name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+`, testAccDatasourceFirewalls_basic())
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_schedules.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_schedules.go
@@ -1,0 +1,249 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/schedules
+func DataSourceSchedules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSchedulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"object_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"schedule_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ref_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"periodic": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     dataRecordsPeriodicElem(),
+						},
+						"absolute": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     dataRecordsAbsoluteElem(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataRecordsAbsoluteElem() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"start_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataRecordsPeriodicElem() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"week_mask": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"start_week": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"end_week": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildQuerySchedulesQueryParams(d *schema.ResourceData) string {
+	queryParam := fmt.Sprintf("?object_id=%s&limit=1024", d.Get("object_id").(string))
+	if v, ok := d.GetOk("name"); ok {
+		queryParam += fmt.Sprintf("&name=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		queryParam += fmt.Sprintf("&desc=%s", v.(string))
+	}
+
+	return queryParam
+}
+
+func dataSourceSchedulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "cfw"
+		httpUrl    = "v1/{project_id}/schedules"
+		offset     = 0
+		allResults = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildQuerySchedulesQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%d", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving CFW schedules: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		records := utils.PathSearch("data.records", respBody, make([]interface{}, 0)).([]interface{})
+		if len(records) == 0 {
+			break
+		}
+
+		allResults = append(allResults, records...)
+		offset += len(records)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("records", flattenSchedulesResponse(allResults)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSchedulesResponse(respArray []interface{}) []map[string]interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"schedule_id": utils.PathSearch("schedule_id", v, nil),
+			"name":        utils.PathSearch("name", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+			"ref_count":   utils.PathSearch("ref_count", v, nil),
+			"periodic":    flattenPeriodicResponse(utils.PathSearch("periodic", v, make([]interface{}, 0)).([]interface{})),
+			"absolute":    flattenAbsoluteResponse(utils.PathSearch("absolute", v, nil)),
+		})
+	}
+
+	return rst
+}
+
+func flattenAbsoluteResponse(respMap interface{}) []map[string]interface{} {
+	if respMap == nil {
+		return nil
+	}
+
+	rstMap := map[string]interface{}{
+		"start_time": utils.PathSearch("start_time", respMap, nil),
+		"end_time":   utils.PathSearch("end_time", respMap, nil),
+	}
+
+	return []map[string]interface{}{rstMap}
+}
+
+func flattenPeriodicResponse(respArray []interface{}) []map[string]interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"type":       utils.PathSearch("type", v, nil),
+			"start_time": utils.PathSearch("start_time", v, nil),
+			"end_time":   utils.PathSearch("end_time", v, nil),
+			"week_mask":  utils.PathSearch("week_mask", v, nil),
+			"start_week": utils.PathSearch("start_week", v, nil),
+			"end_week":   utils.PathSearch("end_week", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query schedules

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccDataSourceSchedules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccDataSourceSchedules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSchedules_basic
=== PAUSE TestAccDataSourceSchedules_basic
=== CONT  TestAccDataSourceSchedules_basic
--- PASS: TestAccDataSourceSchedules_basic (15.26s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       15.360s coverage: 5.1% of statements in ./huaweicloud/services/cfw
```
<img width="1333" height="90" alt="image" src="https://github.com/user-attachments/assets/c724e85a-82e9-4a86-92fc-3f3979ffb171" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
