### PR TITLE
feat(dws): add new datasource for query cluster flavor by snapshot

### DIFF
--- a/docs/data-sources/dws_cluster_snapshot_flavors.md
+++ b/docs/data-sources/dws_cluster_snapshot_flavors.md
@@ -1,0 +1,107 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_snapshot_flavors"
+description: |-
+  Use this data source to query the DWS cluster flavors by snapshot ID within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_snapshot_flavors
+
+Use this data source to query the DWS cluster flavors by snapshot ID within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "snapshot_id" {}
+data "huaweicloud_dws_cluster_snapshot_flavors" "test" {
+  snapshot_id = var.snapshot_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the cluster flavors are located.  
+  If omitted, the provider-level region will be used.
+
+* `snapshot_id` - (Required, String) Specifies the ID of the snapshot to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `flavors` - The list of cluster flavors for the snapshot.  
+  The [flavors](#dws_snapshot_flavors) structure is documented below.
+
+<a name="dws_snapshot_flavors"></a>
+The `flavors` block supports:
+
+* `id` - The flavor ID.
+
+* `code` - The flavor code.
+
+* `classify` - The flavor type.
+
+* `scenario` - The flavor scenario.
+
+* `version` - The flavor version.
+
+* `status` - The flavor status.
+
+* `default_capacity` - The default capacity of the flavor.
+
+* `duplicate` - The number of replicas used by the flavor.
+
+* `default_node` - The default number of nodes.
+
+* `min_node` - The minimum number of nodes.
+
+* `max_node` - The maximum number of nodes.
+
+* `flavor_id` - The underlying flavor ID.
+
+* `flavor_code` - The underlying flavor code.
+
+* `volume_num` - The number of disks.
+
+* `attribute` - The list of extended information.  
+  The [attribute](#dws_snapshot_flavors_attribute) structure is documented below.
+
+* `product_version_list` - The list of product versions supported by the flavor.  
+  The [product_version_list](#dws_snapshot_flavors_product_version_list) structure is documented below.
+
+* `volume_used` - The disk usage information of the snapshot source cluster.  
+  The [volume_used](#dws_snapshot_flavors_volume_used) structure is documented below.
+
+<a name="dws_snapshot_flavors_attribute"></a>
+The `attribute` block supports:
+
+* `code` - The extended information code.
+
+* `value` - The extended information value.
+
+<a name="dws_snapshot_flavors_product_version_list"></a>
+The `product_version_list` block supports:
+
+* `min_cn` - The minimum number of CN nodes supported by this version.
+
+* `max_cn` - The maximum number of CN nodes supported by this version.
+
+* `version_type` - The type of this version.
+
+* `datastore_version` - The datastore version name.
+
+<a name="dws_snapshot_flavors_volume_used"></a>
+The `volume_used` block supports:
+
+* `volume_type` - The disk type.
+
+* `volume_num` - The number of disks.
+
+* `capacity` - The available storage capacity of a single node, in GB.
+
+* `volume_size` - The physical storage capacity of a single disk, in GB.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2438,6 +2438,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_cluster_logs":                    dws.DataSourceDwsClusterLogs(),
 			"huaweicloud_dws_cluster_nodes":                   dws.DataSourceDwsClusterNodes(),
 			"huaweicloud_dws_cluster_parameters":              dws.DataSourceClusterParameters(),
+			"huaweicloud_dws_cluster_snapshot_flavors":        dws.DataSourceClusterSnapshotFlavors(),
 			"huaweicloud_dws_cluster_snapshot_statistics":     dws.DataSourceDwsClusterSnapshotStatistics(),
 			"huaweicloud_dws_cluster_topo_rings":              dws.DataSourceDwsClusterTopoRings(),
 			"huaweicloud_dws_cluster_upgrade_records":         dws.DataSourceClusterUpgradeRecords(),

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_snapshot_flavors_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_snapshot_flavors_test.go
@@ -1,0 +1,86 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataClusterSnapshotFlavors_basic(t *testing.T) {
+	var (
+		name   = acceptance.RandomAccResourceName()
+		dcName = "data.huaweicloud_dws_cluster_snapshot_flavors.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// A non-existent snapshot ID returns HTTP 200 with an empty flavors list (no API error).
+				Config: testAccDataClusterSnapshotFlavors_nonexistentSnapshot(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dcName, "flavors.#", "0"),
+				),
+			},
+			{
+				Config: testAccDataClusterSnapshotFlavors_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dcName, "flavors.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.id"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.code"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.classify"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.scenario"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.version"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.status"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.default_capacity"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.duplicate"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.default_node"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.min_node"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.max_node"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.flavor_code"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.volume_num"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.attribute.#"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.product_version_list.#"),
+					resource.TestCheckResourceAttrSet(dcName, "flavors.0.volume_used.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataClusterSnapshotFlavors_nonexistentSnapshot() string {
+	snapshotId, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_snapshot_flavors" "test" {
+  snapshot_id = "%[1]s"
+}
+`, snapshotId)
+}
+
+func testAccDataClusterSnapshotFlavors_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_snapshot" "test" {
+  cluster_id = "%[1]s"
+  name       = "%[2]s"
+}
+
+data "huaweicloud_dws_cluster_snapshot_flavors" "test" {
+  snapshot_id = huaweicloud_dws_snapshot.test.id
+
+  depends_on  = [huaweicloud_dws_snapshot.test]
+}
+`, acceptance.HW_DWS_CLUSTER_ID, name)
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_snapshot_flavors.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_snapshot_flavors.go
@@ -1,0 +1,339 @@
+package dws
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v2/{project_id}/snapshots/{snapshot_id}/flavors
+func DataSourceClusterSnapshotFlavors() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterSnapshotFlavorsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the cluster flavors are located.`,
+			},
+
+			// Required parameters.
+			"snapshot_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the snapshot to be queried.`,
+			},
+
+			// Attributes.
+			"flavors": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        snapshotFlavorSchema(),
+				Description: `The list of cluster flavors for the snapshot.`,
+			},
+		},
+	}
+}
+
+func snapshotFlavorSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor ID.`,
+			},
+			"code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor code.`,
+			},
+			"classify": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor type.`,
+			},
+			"scenario": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor scenario.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor version.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor status.`,
+			},
+			"default_capacity": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The default capacity of the flavor.`,
+			},
+			"duplicate": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of replicas used by the flavor.`,
+			},
+			"default_node": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The default number of nodes.`,
+			},
+			"min_node": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The minimum number of nodes.`,
+			},
+			"max_node": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The maximum number of nodes.`,
+			},
+			"flavor_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The underlying flavor ID.`,
+			},
+			"flavor_code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The underlying flavor code.`,
+			},
+			"volume_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of disks.`,
+			},
+			"attribute": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        snapshotFlavorAttributeSchema(),
+				Description: `The list of extended information.`,
+			},
+			"product_version_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        snapshotFlavorProductVersionSchema(),
+				Description: `The list of product versions supported by the flavor.`,
+			},
+			"volume_used": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        snapshotFlavorVolumeUsedSchema(),
+				Description: `The disk usage information of the snapshot source cluster.`,
+			},
+		},
+	}
+}
+
+func snapshotFlavorAttributeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The extended information code.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The extended information value.`,
+			},
+		},
+	}
+}
+
+func snapshotFlavorProductVersionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"min_cn": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The minimum number of CN nodes supported by this version.`,
+			},
+			"max_cn": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The maximum number of CN nodes supported by this version.`,
+			},
+			"version_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of this version.`,
+			},
+			"datastore_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The datastore version name.`,
+			},
+		},
+	}
+}
+
+func snapshotFlavorVolumeUsedSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"volume_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The disk type.`,
+			},
+			"volume_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of disks.`,
+			},
+			"capacity": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The available storage capacity of a single node, in GB.`,
+			},
+			"volume_size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The physical storage capacity of a single disk, in GB.`,
+			},
+		},
+	}
+}
+
+func flattenSnapshotFlavorAttributes(items []interface{}) []interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"code":  utils.PathSearch("code", item, nil),
+			"value": utils.PathSearch("value", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenSnapshotFlavorProductVersions(items []interface{}) []interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"min_cn":            utils.PathSearch("min_cn", item, nil),
+			"max_cn":            utils.PathSearch("max_cn", item, nil),
+			"version_type":      utils.PathSearch("version_type", item, nil),
+			"datastore_version": utils.PathSearch("datastore_version", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenSnapshotFlavorVolumeUsed(volumeUsed map[string]interface{}) []interface{} {
+	if len(volumeUsed) < 1 {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"volume_type": utils.PathSearch("volume_type", volumeUsed, nil),
+			"volume_num":  utils.PathSearch("volume_num", volumeUsed, nil),
+			"capacity":    utils.PathSearch("capacity", volumeUsed, nil),
+			"volume_size": utils.PathSearch("volume_size", volumeUsed, nil),
+		},
+	}
+}
+
+func flattenSnapshotFlavors(items []interface{}) []interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"id":               utils.PathSearch("id", item, nil),
+			"code":             utils.PathSearch("code", item, nil),
+			"classify":         utils.PathSearch("classify", item, nil),
+			"scenario":         utils.PathSearch("scenario", item, nil),
+			"version":          utils.PathSearch("version", item, nil),
+			"status":           utils.PathSearch("status", item, nil),
+			"default_capacity": utils.PathSearch("default_capacity", item, nil),
+			"duplicate":        utils.PathSearch("duplicate", item, nil),
+			"default_node":     utils.PathSearch("default_node", item, nil),
+			"min_node":         utils.PathSearch("min_node", item, nil),
+			"max_node":         utils.PathSearch("max_node", item, nil),
+			"flavor_id":        utils.PathSearch("flavor_id", item, nil),
+			"flavor_code":      utils.PathSearch("flavor_code", item, nil),
+			"volume_num":       utils.PathSearch("volume_num", item, nil),
+			"attribute": flattenSnapshotFlavorAttributes(utils.PathSearch("attribute", item,
+				make([]interface{}, 0)).([]interface{})),
+			"product_version_list": flattenSnapshotFlavorProductVersions(utils.PathSearch("product_version_list", item,
+				make([]interface{}, 0)).([]interface{})),
+			"volume_used": flattenSnapshotFlavorVolumeUsed(utils.PathSearch("volume_used", item,
+				make(map[string]interface{})).(map[string]interface{})),
+		})
+	}
+	return result
+}
+
+func dataSourceClusterSnapshotFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		snapshotId = d.Get("snapshot_id").(string)
+		httpUrl    = "v2/{project_id}/snapshots/{snapshot_id}/flavors"
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{snapshot_id}", snapshotId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	resp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return diag.Errorf("error querying the snapshot flavors by snapshot ID (%s): %s", snapshotId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error flattening response of the snapshot flavors by snapshot ID (%s): %s", snapshotId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("flavors", flattenSnapshotFlavors(
+			utils.PathSearch("flavors", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new datasource for query cluster flavor by snapshot

**Which issue this PR fixes**:

**Special notes for your reviewer**:
The DWS cluster provisioning process takes too long during acceptance tests. Therefore, we have pre-provisioned a cluster via the console and configured the test cases to run against this existing environment.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccDataClusterSnapshotFlavors_basic -timeout 360m -parallel 10
=== RUN   TestAccDataClusterSnapshotFlavors_basic
=== PAUSE TestAccDataClusterSnapshotFlavors_basic
=== CONT  TestAccDataClusterSnapshotFlavors_basic
--- PASS: TestAccDataClusterSnapshotFlavors_basic (416.77s)
PASS
coverage: 5.9% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       416.898s        coverage: 5.9% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.