### PR TITLE
feat(mrs): add new data source to query AZ list

### DIFF
--- a/docs/data-sources/mapreduce_availability_zones.md
+++ b/docs/data-sources/mapreduce_availability_zones.md
@@ -1,0 +1,104 @@
+---
+subcategory: "MapReduce Service (MRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_mapreduce_availability_zones"
+description: |-
+  Use this data source to query the availability zones of MRS within HuaweiCloud.
+---
+
+# huaweicloud_mapreduce_availability_zones
+
+Use this data source to query the availability zones of MRS within HuaweiCloud.
+
+## Example Usage
+
+### Query all availability zones
+
+```hcl
+data "huaweicloud_mapreduce_availability_zones" "test" {}
+```
+
+### Query availability zones by scope
+
+```hcl
+data "huaweicloud_mapreduce_availability_zones" "test" {
+  scope = "Center"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the availability zones are located.
+  If omitted, the provider-level region will be used.
+
+* `scope` - (Optional, String) Specifies the availability zone scope.  
+  The valid values are as follows:
+  + **Center**
+  + **Edge**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `default_az_code` - The default availability zone code.
+
+* `support_physical_az_group` - Whether the physical availability zone grouping is supported.
+
+* `available_zones` - The availability zone list that matched the filter parameters.  
+  The [available_zones](#mapreduce_availability_zones_available_zones) structure is documented below.
+
+<a name="mapreduce_availability_zones_available_zones"></a>
+The `available_zones` block supports:
+
+* `id` - The availability zone code.
+
+* `az_id` - The availability zone ID.
+
+* `az_code` - The availability zone code.
+
+* `az_name` - The availability zone name.
+
+* `status` - The availability zone status.
+
+* `region_id` - The region ID.
+
+* `az_group_id` - The availability zone group ID.
+
+* `az_type` - The availability zone type.  
+  The valid values are as follows:
+  + **Core**
+  + **Satellite**
+  + **Dedicated**
+  + **Virtual**
+  + **Edge**
+  + **EdgeCentral**
+
+* `az_category` - The availability zone category.  
+  The valid values are as follows:
+  + **0**: Large cloud primary AZ.
+  + **21**: Local AZ.
+  + **41**: Edge AZ.
+
+* `charge_policy` - The charge policy of the availability zone.  
+  The valid values are as follows:
+  + **charge**
+  + **notCharge**
+
+* `az_tags` - The availability zone tags.  
+  The [az_tags](#mapreduce_availability_zones_az_tags) structure is documented below.
+
+<a name="mapreduce_availability_zones_az_tags"></a>
+The `az_tags` block supports:
+
+* `mode` - The availability zone mode.  
+  The valid values are as follows:
+  + **dedicated**
+  + **shared**
+
+* `alias` - The alias of the availability zone.
+
+* `public_border_group` - The public border group to which the availability zone belongs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1863,8 +1863,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_networking_secgroup_rules":    vpc.DataSourceNetworkingSecGroupRules(),
 			"huaweicloud_networking_secgroup_tags":     vpc.DataSourceVpcNetworkingSecgroupTags(),
 
-			"huaweicloud_mapreduce_versions": mrs.DataSourceMrsVersions(),
-
 			"huaweicloud_modelarts_datasets":         modelarts.DataSourceDatasets(),
 			"huaweicloud_modelarts_dataset_versions": modelarts.DataSourceDatasetVerions(),
 			"huaweicloud_modelarts_notebook_images":  modelarts.DataSourceNotebookImages(),
@@ -1880,7 +1878,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelartsv2_resource_pool_nodes": modelarts.DataSourceV2ResourcePoolNodes(),
 			"huaweicloud_modelartsv2_resource_pools":      modelarts.DataSourceV2ResourcePools(),
 
-			"huaweicloud_mapreduce_clusters": mrs.DataSourceMrsClusters(),
+			"huaweicloud_mapreduce_availability_zones": mrs.DataSourceAvailabilityZones(),
+			"huaweicloud_mapreduce_clusters":           mrs.DataSourceMrsClusters(),
+			"huaweicloud_mapreduce_versions":           mrs.DataSourceMrsVersions(),
 
 			"huaweicloud_obs_buckets":       obs.DataSourceObsBuckets(),
 			"huaweicloud_obs_bucket_object": obs.DataSourceObsBucketObject(),

--- a/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_availability_zones_test.go
+++ b/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_availability_zones_test.go
@@ -1,0 +1,62 @@
+package mrs
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataAvailabilityZones_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_mapreduce_availability_zones.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byScope   = "data.huaweicloud_mapreduce_availability_zones.filter_by_scope"
+		dcByScope = acceptance.InitDataSourceCheck(byScope)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAvailabilityZones_basic,
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(all, "default_az_code"),
+					resource.TestCheckResourceAttrSet(all, "support_physical_az_group"),
+					resource.TestMatchResourceAttr(all, "available_zones.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "available_zones.0.id"),
+					resource.TestCheckResourceAttrSet(all, "available_zones.0.az_id"),
+					resource.TestCheckResourceAttrSet(all, "available_zones.0.az_code"),
+					resource.TestCheckResourceAttrSet(all, "available_zones.0.az_name"),
+					resource.TestCheckResourceAttrSet(all, "available_zones.0.status"),
+					resource.TestCheckResourceAttrSet(all, "available_zones.0.region_id"),
+					resource.TestCheckResourceAttrSet(all, "available_zones.0.az_type"),
+					resource.TestCheckResourceAttrSet(all, "available_zones.0.az_category"),
+					resource.TestCheckResourceAttrSet(all, "available_zones.0.charge_policy"),
+					resource.TestCheckResourceAttr(all, "available_zones.0.az_tags.#", "1"),
+					resource.TestCheckResourceAttrSet(all, "available_zones.0.az_tags.0.public_border_group"),
+					// az_group_id, az_tags.mode, az_tags.alias currently are empty, not checked.
+					// Filter by 'scope' parameter.
+					dcByScope.CheckResourceExists(),
+					resource.TestMatchResourceAttr(byScope, "available_zones.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataAvailabilityZones_basic = `
+#Without any filter parameters.
+data "huaweicloud_mapreduce_availability_zones" "test" {}
+
+# Filter by 'scope' parameter.
+data "huaweicloud_mapreduce_availability_zones" "filter_by_scope" {
+  scope = "Center"
+}
+`

--- a/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_availability_zones.go
+++ b/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_availability_zones.go
@@ -1,0 +1,226 @@
+package mrs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API MRS GET /v1.1/{region_id}/available-zones
+func DataSourceAvailabilityZones() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAvailabilityZonesRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the availability zones are located.`,
+			},
+			// Optional parameters.
+			"scope": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The scope of the availability zone.`,
+			},
+			// Attributes.
+			"default_az_code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The default availability zone code.`,
+			},
+			"support_physical_az_group": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the physical availability zone grouping is supported.`,
+			},
+			"available_zones": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The availability zone code.`,
+						},
+						"az_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The availability zone ID.`,
+						},
+						"az_code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The availability zone code.`,
+						},
+						"az_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The availability zone name.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The availability zone status.`,
+						},
+						"region_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The region ID.`,
+						},
+						"az_group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The availability zone group ID.`,
+						},
+						"az_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The availability zone type.`,
+						},
+						"az_category": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The availability zone category.`,
+						},
+						"charge_policy": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The charge policy of the availability zone.`,
+						},
+						"az_tags": {
+							Type:        schema.TypeList,
+							Elem:        availabilityZoneTagsSchema(),
+							Computed:    true,
+							Description: `The availability zone tags.`,
+						},
+					},
+				},
+				Description: `The availability zone list that matched the filter parameters.`,
+			},
+		},
+	}
+}
+
+func availabilityZoneTagsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The mode of the availability zone.`,
+			},
+			"alias": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The alias of the availability zone.`,
+			},
+			"public_border_group": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The public border group to which the availability zone belongs.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceAvailabilityZonesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("mrs", region)
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	respBody, err := listAvailabilityZones(client, d, region)
+	if err != nil {
+		return diag.Errorf("error retrieving availability zones: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("default_az_code", utils.PathSearch("default_az_code", respBody, nil)),
+		d.Set("support_physical_az_group", utils.PathSearch("support_physical_az_group", respBody, nil)),
+		d.Set("available_zones", flattenAvailabilityZones(utils.PathSearch("available_zones",
+			respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func listAvailabilityZones(client *golangsdk.ServiceClient, d *schema.ResourceData, region string) (interface{}, error) {
+	httpUrl := "v1.1/{region_id}/available-zones"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{region_id}", region)
+
+	if scope, ok := d.GetOk("scope"); ok {
+		listPath += fmt.Sprintf("?scope=%v", scope)
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func flattenAvailabilityZones(availabilityZones []interface{}) []map[string]interface{} {
+	if len(availabilityZones) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(availabilityZones))
+	for _, v := range availabilityZones {
+		result = append(result, map[string]interface{}{
+			"id":            utils.PathSearch("id", v, nil),
+			"az_code":       utils.PathSearch("az_code", v, nil),
+			"az_name":       utils.PathSearch("az_name", v, nil),
+			"az_id":         utils.PathSearch("az_id", v, nil),
+			"status":        utils.PathSearch("status", v, nil),
+			"region_id":     utils.PathSearch("region_id", v, nil),
+			"az_group_id":   utils.PathSearch("az_group_id", v, nil),
+			"az_type":       utils.PathSearch("az_type", v, nil),
+			"az_category":   utils.PathSearch("az_category", v, nil),
+			"charge_policy": utils.PathSearch("charge_policy", v, nil),
+			"az_tags":       flattenAvailabilityZoneTags(utils.PathSearch("az_tags", v, nil)),
+		})
+	}
+	return result
+}
+
+func flattenAvailabilityZoneTags(tag interface{}) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"mode":                utils.PathSearch("mode", tag, nil),
+			"alias":               utils.PathSearch("alias", tag, nil),
+			"public_border_group": utils.PathSearch("public_border_group", tag, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source to query the availability zone list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source
2. add corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o mrs -f TestAccDataAvailabilityZones_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccDataAvailabilityZones_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAvailabilityZones_basic
=== PAUSE TestAccDataAvailabilityZones_basic
=== CONT  TestAccDataAvailabilityZones_basic
--- PASS: TestAccDataAvailabilityZones_basic (20.96s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       21.069s coverage: 5.2% of statements in ./huaweicloud/services/mrs
```
<img width="1025" height="91" alt="image" src="https://github.com/user-attachments/assets/75a451f2-5850-4668-ae1f-6f3241138411" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
