### PR TITLE
feat(cse): microservice instance supports update status

### DIFF
--- a/docs/resources/cse_microservice_instance.md
+++ b/docs/resources/cse_microservice_instance.md
@@ -153,6 +153,12 @@ The following arguments are supported:
 * `data_center` - (Optional, List, NonUpdatable) Specifies the data center configuration of the microservice instance.  
   The [data_center](#cse_microservice_instance_data_center) structure is documented below.
 
+* `status` - (Optional, String) Specifies the status of the microservice instance.  
+  The valid values are as follows:
+  + **UP**
+  + **OUTOFSERVICE**
+  + **DOWN**
+
 <a name="cse_microservice_instance_health_check"></a>
 The `health_check` block supports:
 
@@ -181,8 +187,6 @@ The `data_center` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the microservice instance.
-
-* `status` - The status of the microservice instance.
 
 ## Timeouts
 

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
@@ -53,7 +53,7 @@ func TestAccMicroserviceInstance_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMicroserviceInstance_basic(randName),
+				Config: testAccMicroserviceInstance_basic_step1(randName),
 				Check: resource.ComposeTestCheckFunc(
 					// With auth_address parameter.
 					rcWithAuthAddress.CheckResourceExists(),
@@ -72,7 +72,7 @@ func TestAccMicroserviceInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withAuthAddress, "data_center.0.region", acceptance.HW_REGION_NAME),
 					resource.TestCheckResourceAttrPair(withAuthAddress, "data_center.0.availability_zone",
 						"data.huaweicloud_availability_zones.test", "names.0"),
-					resource.TestCheckResourceAttr(withAuthAddress, "status", "UP"),
+					resource.TestCheckResourceAttr(withAuthAddress, "status", "DOWN"),
 					// Without auth_address parameter.
 					rcWithoutAuthAddress.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(withAuthAddress, "microservice_id",
@@ -90,7 +90,25 @@ func TestAccMicroserviceInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(withoutAuthAddress, "data_center.0.region", acceptance.HW_REGION_NAME),
 					resource.TestCheckResourceAttrPair(withoutAuthAddress, "data_center.0.availability_zone",
 						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "status", "DOWN"),
+				),
+			},
+			{
+				Config: testAccMicroserviceInstance_basic_step2(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rcWithAuthAddress.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withAuthAddress, "status", "UP"),
+					rcWithoutAuthAddress.CheckResourceExists(),
 					resource.TestCheckResourceAttr(withoutAuthAddress, "status", "UP"),
+				),
+			},
+			{
+				Config: testAccMicroserviceInstance_basic_step3(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rcWithAuthAddress.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withAuthAddress, "status", "OUTOFSERVICE"),
+					rcWithoutAuthAddress.CheckResourceExists(),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "status", "OUTOFSERVICE"),
 				),
 			},
 			{
@@ -177,13 +195,15 @@ resource "huaweicloud_cse_microservice" "test" {
 		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD)
 }
 
-func testAccMicroserviceInstance_basic(name string) string {
+func testAccMicroserviceInstance_basic_with_status(name, status string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_cse_microservice_instance" "with_auth_address" {
   auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
   connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+  admin_user      = "root"
+  admin_pass      = "%[2]s"
 
   microservice_id = huaweicloud_cse_microservice.test.id
   host_name       = "localhost_with_auth_address"
@@ -202,12 +222,11 @@ resource "huaweicloud_cse_microservice_instance" "with_auth_address" {
 
   data_center {
     name              = "dc1"
-    region            = "%[2]s"
+    region            = "%[3]s"
     availability_zone = data.huaweicloud_availability_zones.test.names[0]
   }
 
-  admin_user = "root"
-  admin_pass = "%[3]s"
+  status = "%[4]s"
 
   lifecycle {
     ignore_changes = [
@@ -218,6 +237,8 @@ resource "huaweicloud_cse_microservice_instance" "with_auth_address" {
 
 resource "huaweicloud_cse_microservice_instance" "without_auth_address" {
   connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+  admin_user      = "root"
+  admin_pass      = "%[2]s"
 
   microservice_id = huaweicloud_cse_microservice.test.id
   host_name       = "localhost_without_auth_address"
@@ -236,12 +257,11 @@ resource "huaweicloud_cse_microservice_instance" "without_auth_address" {
 
   data_center {
     name              = "dc1"
-    region            = "%[2]s"
+    region            = "%[3]s"
     availability_zone = data.huaweicloud_availability_zones.test.names[0]
   }
 
-  admin_user = "root"
-  admin_pass = "%[3]s"
+  status = "%[4]s"
 
   lifecycle {
     ignore_changes = [
@@ -250,6 +270,19 @@ resource "huaweicloud_cse_microservice_instance" "without_auth_address" {
   }
 }
 `, testAccMicroserviceInstance_base(name),
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD,
 		acceptance.HW_REGION_NAME,
-		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD)
+		status)
+}
+
+func testAccMicroserviceInstance_basic_step1(name string) string {
+	return testAccMicroserviceInstance_basic_with_status(name, "DOWN")
+}
+
+func testAccMicroserviceInstance_basic_step2(name string) string {
+	return testAccMicroserviceInstance_basic_with_status(name, "UP")
+}
+
+func testAccMicroserviceInstance_basic_step3(name string) string {
+	return testAccMicroserviceInstance_basic_with_status(name, "OUTOFSERVICE")
 }

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
@@ -3,6 +3,7 @@ package cse
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -52,6 +53,7 @@ var (
 // @API CSE POST /v4/token
 // @API CSE POST /v4/{project_id}/registry/microservices/{service_id}/instances
 // @API CSE GET /v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}
+// @API CSE PUT /v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}/status
 // @API CSE DELETE /v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}
 func ResourceMicroserviceInstance() *schema.Resource {
 	return &schema.Resource{
@@ -65,6 +67,8 @@ func ResourceMicroserviceInstance() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(3 * time.Minute),
+			Update: schema.DefaultTimeout(3 * time.Minute),
 			Delete: schema.DefaultTimeout(3 * time.Minute),
 		},
 
@@ -191,10 +195,9 @@ func ResourceMicroserviceInstance() *schema.Resource {
 				},
 				Description: `The data center configuration of the microservice instance.`,
 			},
-
-			// Attributes.
 			"status": {
 				Type:        schema.TypeString,
+				Optional:    true,
 				Computed:    true,
 				Description: `The status of the microservice instance.`,
 			},
@@ -311,6 +314,68 @@ func createInstance(client *golangsdk.ServiceClient, d *schema.ResourceData) (in
 	return utils.FlattenResponse(requestResp)
 }
 
+func microserviceInstanceStatusRefreshFunc(client *golangsdk.ServiceClient, d *schema.ResourceData, instanceId string,
+	targets []string, allowNotFound bool) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var (
+			authAddress    = getAuthAddress(d)
+			adminUser      = d.Get("admin_user").(string)
+			adminPass      = d.Get("admin_pass").(string)
+			microserviceId = d.Get("microservice_id").(string)
+		)
+
+		respBody, err := GetInstance(client, authAddress, adminUser, adminPass, microserviceId, instanceId)
+		if err != nil {
+			convertedErr := common.ConvertExpected400ErrInto404Err(err, "errorCode", microserviceInstanceNotFoundCodes...)
+			if _, ok := convertedErr.(golangsdk.ErrDefault404); ok && allowNotFound {
+				return "continue", "PENDING", nil
+			}
+			return nil, "ERROR", convertedErr
+		}
+
+		status := utils.PathSearch("instance.status", respBody, "").(string)
+		if utils.StrSliceContains(targets, status) {
+			return respBody, "COMPLETED", nil
+		}
+		return respBody, "PENDING", nil
+	}
+}
+
+func updateMicroserviceInstanceStatus(client *golangsdk.ServiceClient, d *schema.ResourceData, instanceId, status string) error {
+	var (
+		httpUrl        = "v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}/status"
+		authAddress    = getAuthAddress(d)
+		adminUser      = d.Get("admin_user").(string)
+		adminPass      = d.Get("admin_pass").(string)
+		microserviceId = d.Get("microservice_id").(string)
+	)
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", microserviceInstanceProjectId)
+	updatePath = strings.ReplaceAll(updatePath, "{service_id}", microserviceId)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceId)
+	updatePath = fmt.Sprintf("%s?value=%s", updatePath, status)
+
+	updateOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+	}
+
+	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
+	if err != nil {
+		return err
+	}
+	if token != "" {
+		updateOpts.MoreHeaders["Authorization"] = token
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpts)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func resourceMicroserviceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Creating a microservice instance in the microservice engine requires building a client based on the microservice
 	// engine's connection address, which does not use IAM authentication.
@@ -326,6 +391,44 @@ func resourceMicroserviceInstanceCreate(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("unable to find the instance ID from the API response")
 	}
 	d.SetId(instanceId)
+
+	log.Printf("[DEBUG] Waiting for the microservice instance (%s) status to become 'UP'", instanceId)
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      microserviceInstanceStatusRefreshFunc(client, d, instanceId, []string{"UP"}, true),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	resp, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the microservice instance (%s) status to become 'UP': %s", instanceId, err)
+	}
+
+	// If the user specifies the expected initial status, it may differ from the status after registration.
+	// In this case, an additional update status request is required to keep the instance status consistent.
+	if v, ok := d.GetOk("status"); ok && utils.PathSearch("instance.status", resp, "").(string) != v.(string) {
+		instanceStatus := v.(string)
+		if err := updateMicroserviceInstanceStatus(client, d, instanceId, instanceStatus); err != nil {
+			return diag.Errorf("error updating the status of the microservice instance (%s): %s", instanceId, err)
+		}
+
+		log.Printf("[DEBUG] Waiting for the microservice instance (%s) status to become '%s'", instanceId, instanceStatus)
+		stateConf := &resource.StateChangeConf{
+			Pending:      []string{"PENDING"},
+			Target:       []string{"COMPLETED"},
+			Refresh:      microserviceInstanceStatusRefreshFunc(client, d, instanceId, []string{instanceStatus}, false),
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			Delay:        5 * time.Second,
+			PollInterval: 10 * time.Second,
+		}
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return diag.Errorf("error waiting for the microservice instance (%s) status to become '%s': %s", instanceId, instanceStatus, err)
+		}
+		return nil
+	}
 
 	return resourceMicroserviceInstanceRead(ctx, d, meta)
 }
@@ -431,8 +534,38 @@ func resourceMicroserviceInstanceRead(_ context.Context, d *schema.ResourceData,
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceMicroserviceInstanceUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	return nil
+func resourceMicroserviceInstanceUpdate(ctx context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	var (
+		// Creating a microservice instance in the microservice engine requires building a client based on the
+		// microservice engine's connection address, which does not use IAM authentication.
+		client     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		instanceId = d.Id()
+	)
+
+	if d.HasChange("status") {
+		instanceStatus := d.Get("status").(string)
+		err := updateMicroserviceInstanceStatus(client, d, instanceId, instanceStatus)
+		if err != nil {
+			return diag.Errorf("error updating the status of the microservice instance (%s): %s", instanceId, err)
+		}
+
+		log.Printf("[DEBUG] Waiting for the microservice instance (%s) status to become '%s'", instanceId, instanceStatus)
+		stateConf := &resource.StateChangeConf{
+			Pending:      []string{"PENDING"},
+			Target:       []string{"COMPLETED"},
+			Refresh:      microserviceInstanceStatusRefreshFunc(client, d, instanceId, []string{instanceStatus}, false),
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			Delay:        5 * time.Second,
+			PollInterval: 10 * time.Second,
+		}
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return diag.Errorf("error waiting for the microservice instance (%s) status to become '%s': %s", instanceId, instanceStatus, err)
+		}
+		return nil
+	}
+
+	return resourceMicroserviceInstanceRead(ctx, d, nil)
 }
 
 func deleteInstance(client *golangsdk.ServiceClient, authAddress, adminUser, adminPass, microserviceId, instanceId string) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Microservice instance supports update `status` parameter.
In the CreateContext:
- After create instance, the status will be in `UP` (to keep safty, waiting a few time to make sure the status is correct)
- If the status value in script is not `UP`, change it by PUT API
- waiting a few time to make sure the status is in the target value
In the UpdateContext:
- If the status value in script is different with remote value, change it by PUT API
- waiting a few time to make sure the status is in the target value

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. microservice instance supports update status
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccMicroserviceInstance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccMicroserviceInstance_basic -timeout 360m -parallel 10
=== RUN   TestAccMicroserviceInstance_basic
=== PAUSE TestAccMicroserviceInstance_basic
=== CONT  TestAccMicroserviceInstance_basic
--- PASS: TestAccMicroserviceInstance_basic (76.30s)
PASS
coverage: 32.1% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       76.373s coverage: 32.1% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
