### PR TITLE
feat(cfw): new datasource to query acl rule tags

### DIFF
--- a/docs/data-sources/cfw_acl_rule_tags.md
+++ b/docs/data-sources/cfw_acl_rule_tags.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_acl_rule_tags"
+description: |-
+  Use this data source to get the list of CFW acl rule tags.
+---
+
+# huaweicloud_cfw_acl_rule_tags
+
+Use this data source to get the list of CFW acl rule tags.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+
+data "huaweicloud_cfw_acl_rule_tags" "test" {
+  fw_instance_id = var.fw_instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `fw_instance_id` - (Required, String) Specifies the firewall instance ID.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  For enterprise users, if omitted, all enterprise project will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The rule tags list.
+
+  The [records](#data_records_struct) structure is documented below.
+
+<a name="data_records_struct"></a>
+The `records` block supports:
+
+* `tag_value` - The rule tag value.
+
+* `tag_id` - The rule ID.
+
+* `tag_key` - The rule tag key.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -851,6 +851,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_schedules":                     cfw.DataSourceSchedules(),
 			"huaweicloud_cfw_tags":                          cfw.DataSourceCfwTags(),
 			"huaweicloud_cfw_acl_rule_export_status":        cfw.DataSourceAclRuleExportStatus(),
+			"huaweicloud_cfw_acl_rule_tags":                 cfw.DataSourceAclRuleTags(),
 			"huaweicloud_cfw_ip_blacklist":                  cfw.DataSourceIpBlacklist(),
 			"huaweicloud_cfw_ip_blacklist_switch":           cfw.DataSourceIpBlacklistSwitch(),
 			"huaweicloud_cfw_report_profiles":               cfw.DataSourceReportProfiles(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_acl_rule_tags_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_acl_rule_tags_test.go
@@ -1,0 +1,43 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAclRuleTags_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cfw_acl_rule_tags.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare the test data in advance under the CFW firewall.
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAclRuleTags_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.tag_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.tag_key"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.tag_value"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAclRuleTags_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_acl_rule_tags" "test" {
+  fw_instance_id = "%s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_acl_rule_tags.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_acl_rule_tags.go
@@ -1,0 +1,145 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v2/{project_id}/cfw-acl/tags
+func DataSourceAclRuleTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAclRuleTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tag_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tag_key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildQueryAclRuleTagsQueryParams(cfg *config.Config, d *schema.ResourceData) string {
+	queryParam := fmt.Sprintf("?fw_instance_id=%s&limit=1024", d.Get("fw_instance_id").(string))
+
+	if v := cfg.GetEnterpriseProjectID(d); v != "" {
+		queryParam += fmt.Sprintf("&enterprise_project_id=%s", v)
+	}
+
+	return queryParam
+}
+
+func dataSourceAclRuleTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "cfw"
+		httpUrl    = "v2/{project_id}/cfw-acl/tags"
+		offset     = 0
+		allResults = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildQueryAclRuleTagsQueryParams(cfg, d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%d", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving CFW acl rule tags: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		records := utils.PathSearch("data.records", respBody, make([]interface{}, 0)).([]interface{})
+		if len(records) == 0 {
+			break
+		}
+
+		allResults = append(allResults, records...)
+		offset += len(records)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("records", flattenAclRuleTagsResponse(allResults)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAclRuleTagsResponse(respArray []interface{}) []map[string]interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"tag_id":    utils.PathSearch("tag_id", v, nil),
+			"tag_key":   utils.PathSearch("tag_key", v, nil),
+			"tag_value": utils.PathSearch("tag_value", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query acl rule tags.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccDataSourceAclRuleTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccDataSourceAclRuleTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAclRuleTags_basic
=== PAUSE TestAccDataSourceAclRuleTags_basic
=== CONT  TestAccDataSourceAclRuleTags_basic
--- PASS: TestAccDataSourceAclRuleTags_basic (13.49s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       13.602s coverage: 3.4% of statements in ./huaweicloud/services/cfw
```
<img width="1302" height="83" alt="image" src="https://github.com/user-attachments/assets/67beda8c-103b-4730-8fed-5c94fc6446ab" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
