### PR TITLE
feat(cfw): new datasource to query eip count

### DIFF
--- a/docs/data-sources/cfw_eip_count.md
+++ b/docs/data-sources/cfw_eip_count.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_eip_count"
+description: |-
+  Use this data source to get the CFW EIP count.
+---
+
+# huaweicloud_cfw_eip_count
+
+Use this data source to get the CFW EIP count.
+
+## Example Usage
+
+```hcl
+variable object_id {}
+
+data "huaweicloud_cfw_eip_count" "test" {
+  object_id = var.object_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `object_id` - (Required, String) Specifies the protected object ID. This ID is used to distinguish
+  between Internet boundary protection and VPC boundary protection after the cloud firewall is created.
+  You can get this value from data source `huaweicloud_cfw_firewalls`.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  For enterprise users, if omitted, all enterprise project will be used.
+
+* `fw_instance_id` - (Optional, String) Specifies the firewall instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `eip_protected` - The total number of EIPs protected by all firewalls in the account.
+
+* `eip_protected_self` - The number of EIPs protected by the current firewall.
+
+* `eip_total` - The total number of EIPs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -837,6 +837,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_domain_name_groups":            cfw.DataSourceCfwDomainNameGroups(),
 			"huaweicloud_cfw_domain_name_parse_ip_list":     cfw.DataSourceCfwDomainNameParseIpList(),
 			"huaweicloud_cfw_eip_auto_protect_status":       cfw.DataSourceEipAutoProtectStatus(),
+			"huaweicloud_cfw_eip_count":                     cfw.DataSourceEipCount(),
 			"huaweicloud_cfw_protection_rules":              cfw.DataSourceCfwProtectionRules(),
 			"huaweicloud_cfw_service_groups":                cfw.DataSourceCfwServiceGroups(),
 			"huaweicloud_cfw_service_group_members":         cfw.DataSourceCfwServiceGroupMembers(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_eip_count_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_eip_count_test.go
@@ -1,0 +1,44 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEipCount_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cfw_eip_count.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceEipCount_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "eip_protected"),
+					resource.TestCheckResourceAttrSet(dataSource, "eip_protected_self"),
+					resource.TestCheckResourceAttrSet(dataSource, "eip_total"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceEipCount_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cfw_eip_count" "test" {
+  object_id = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+}
+`, testAccDatasourceFirewalls_basic())
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_eip_count.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_eip_count.go
@@ -1,0 +1,122 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/eip-count/{object_id}
+func DataSourceEipCount() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEipCountRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"object_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"eip_protected": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"eip_protected_self": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"eip_total": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildQueryEipCountQueryParams(cfg *config.Config, d *schema.ResourceData) string {
+	queryParam := ""
+
+	if v := cfg.GetEnterpriseProjectID(d); v != "" {
+		queryParam += fmt.Sprintf("&enterprise_project_id=%s", v)
+	}
+
+	if v, ok := d.GetOk("fw_instance_id"); ok {
+		queryParam += fmt.Sprintf("&fw_instance_id=%s", v.(string))
+	}
+
+	if len(queryParam) > 0 {
+		queryParam = "?" + queryParam[1:]
+	}
+
+	return queryParam
+}
+
+func dataSourceEipCountRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cfw"
+		httpUrl = "v1/{project_id}/eip-count/{object_id}"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{object_id}", d.Get("object_id").(string))
+	requestPath += buildQueryEipCountQueryParams(cfg, d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW EIP count: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("eip_protected", utils.PathSearch("data.eip_protected", respBody, nil)),
+		d.Set("eip_protected_self", utils.PathSearch("data.eip_protected_self", respBody, nil)),
+		d.Set("eip_total", utils.PathSearch("data.eip_total", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query eip count

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccDataSourceEipCount_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccDataSourceEipCount_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceEipCount_basic
=== PAUSE TestAccDataSourceEipCount_basic
=== CONT  TestAccDataSourceEipCount_basic
--- PASS: TestAccDataSourceEipCount_basic (14.28s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       14.376s coverage: 4.6% of statements in ./huaweicloud/services/cfw
```
<img width="1392" height="75" alt="image" src="https://github.com/user-attachments/assets/7c10f61d-d1c5-48e5-9540-4081de5566cf" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
