### PR TITLE
feat(cfw): new datasource to query advanced ips rules

### DIFF
--- a/docs/data-sources/cfw_advanced_ips_rules.md
+++ b/docs/data-sources/cfw_advanced_ips_rules.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_advanced_ips_rules"
+description: |-
+  Use this data source to get the list of CFW advanced ips rules.
+---
+
+# huaweicloud_cfw_advanced_ips_rules
+
+Use this data source to get the list of CFW advanced ips rules.
+
+## Example Usage
+
+```hcl
+variable "object_id" {}
+
+data "huaweicloud_cfw_advanced_ips_rules" "test" {
+  object_id = var.object_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `object_id` - (Required, String) Specifies the protected object ID. This ID is used to distinguish
+  between Internet boundary protection and VPC boundary protection after the cloud firewall is created.
+  You can get this value from data source `huaweicloud_cfw_firewalls`.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  For enterprise users, if omitted, all enterprise project will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `advanced_ips_rules` - The list of advanced ips rules.
+
+  The [advanced_ips_rules](#data_advanced_ips_rules_struct) structure is documented below.
+
+<a name="data_advanced_ips_rules_struct"></a>
+The `advanced_ips_rules` block supports:
+
+* `action` - The action of the advanced ips rule. The value can be:
+  + `0`: Record only
+  + `1`: Block session
+  + `2`: Block IP
+
+* `ips_rule_id` - The ID of the advanced ips rule.
+
+* `ips_rule_type` - The type of the advanced ips rule. The value can be:
+  + `0`: Sensitive directory scan
+  + `1`: Reverse shell
+
+* `param` - The parameter of the advanced ips rule.
+
+* `status` - The status of the advanced ips rule. The value can be:
+  + `0`: Closed
+  + `1`: Opened

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -829,6 +829,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_sn_firewall_protection_status": cfw.DataSourceSnFirewallProtectionStatus(),
 			"huaweicloud_cfw_firewalls":                     cfw.DataSourceFirewalls(),
 			"huaweicloud_cfw_address_groups":                cfw.DataSourceCfwAddressGroups(),
+			"huaweicloud_cfw_advanced_ips_rules":            cfw.DataSourceAdvancedIpsRules(),
 			"huaweicloud_cfw_address_group_members":         cfw.DataSourceCfwAddressGroupMembers(),
 			"huaweicloud_cfw_black_white_lists":             cfw.DataSourceCfwBlackWhiteLists(),
 			"huaweicloud_cfw_capture_tasks":                 cfw.DataSourceCfwCaptureTasks(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_advanced_ips_rules_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_advanced_ips_rules_test.go
@@ -1,0 +1,46 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAdvancedIpsRules_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cfw_advanced_ips_rules.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAdvancedIpsRules_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "advanced_ips_rules.0.action"),
+					resource.TestCheckResourceAttrSet(dataSource, "advanced_ips_rules.0.ips_rule_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "advanced_ips_rules.0.ips_rule_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "advanced_ips_rules.0.param"),
+					resource.TestCheckResourceAttrSet(dataSource, "advanced_ips_rules.0.status"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAdvancedIpsRules_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cfw_advanced_ips_rules" "test" {
+  object_id = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+}
+`, testAccDatasourceFirewalls_basic())
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_advanced_ips_rules.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_advanced_ips_rules.go
@@ -1,0 +1,143 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/advanced-ips-rules
+func DataSourceAdvancedIpsRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAdvancedIpsRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"object_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"advanced_ips_rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"action": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ips_rule_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ips_rule_type": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"param": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildQueryAdvancedIpsRulesQueryParams(cfg *config.Config, d *schema.ResourceData) string {
+	queryParam := fmt.Sprintf("?object_id=%s", d.Get("object_id").(string))
+
+	if v := cfg.GetEnterpriseProjectID(d); v != "" {
+		queryParam += fmt.Sprintf("&enterprise_project_id=%s", v)
+	}
+
+	return queryParam
+}
+
+func dataSourceAdvancedIpsRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cfw"
+		httpUrl = "v1/{project_id}/advanced-ips-rules"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildQueryAdvancedIpsRulesQueryParams(cfg, d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW advanced ips rules: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	records := utils.PathSearch("data.advanced_ips_rules", respBody, make([]interface{}, 0)).([]interface{})
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("advanced_ips_rules", flattenAdvancedIpsRulesResponse(records)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAdvancedIpsRulesResponse(respArray []interface{}) []map[string]interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"action":        utils.PathSearch("action", v, nil),
+			"ips_rule_id":   utils.PathSearch("ips_rule_id", v, nil),
+			"ips_rule_type": utils.PathSearch("ips_rule_type", v, nil),
+			"param":         utils.PathSearch("param", v, nil),
+			"status":        utils.PathSearch("status", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query advanced ips rules

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccDataSourceAdvancedIpsRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccDataSourceAdvancedIpsRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAdvancedIpsRules_basic
=== PAUSE TestAccDataSourceAdvancedIpsRules_basic
=== CONT  TestAccDataSourceAdvancedIpsRules_basic
--- PASS: TestAccDataSourceAdvancedIpsRules_basic (15.38s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       15.511s coverage: 4.6% of statements in ./huaweicloud/services/cfw
```
<img width="1267" height="80" alt="image" src="https://github.com/user-attachments/assets/c2a71ee7-b552-42bb-91f5-4f30d300ac96" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
