### PR TITLE
chore(cse): optimize the nacos namespace resource and datasource

### DIFF
--- a/docs/data-sources/cse_nacos_namespaces.md
+++ b/docs/data-sources/cse_nacos_namespaces.md
@@ -14,9 +14,13 @@ Use this data source to query available Nacos namespaces within HuaweiCloud.
 
 ```hcl
 variable "nacos_engine_id" {}
+variable "enterprise_project_id" {}
 
 data "huaweicloud_cse_nacos_namespaces" "test" {
-  engine_id = var.nacos_engine_id
+  engine_id             = var.nacos_engine_id
+  # If the Nacos engine is located under a specific enterprise project, you can only retrieve the list of namespaces
+  # under the target engine by specifying the corresponding enterprise project.
+  enterprise_project_id = var.enterprise_project_id 
 }
 ```
 
@@ -29,16 +33,19 @@ The following arguments are supported:
 
 * `engine_id` - (Required, String) Specifies the ID of the Nacos microservice engine to which the namespaces belong.
 
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the Nacos namespaces
+  belong.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `namespaces` - All queried Nacos namespaces.  
-  The [namespaces](#cse_nacos_namespaces) structure is documented below.
+* `namespaces` - All queried Nacos namespaces that match the filter parameters.
+  The [namespaces](#cse_nacos_namespaces_attr) structure is documented below.
 
-<a name="cse_nacos_namespaces"></a>
+<a name="cse_nacos_namespaces_attr"></a>
 The `namespaces` block supports:
 
 * `id` - The ID of the Nacos namespace.

--- a/docs/resources/cse_nacos_namespace.md
+++ b/docs/resources/cse_nacos_namespace.md
@@ -29,11 +29,14 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region where the Nacos namespace is located.  
   If omitted, the provider-level region will be used. Changing this will create a new resource.
 
-* `engine_id` - (Required, String, ForceNew) Specifies the ID of the Nacos microservice engine to which the namespace
-  belongs. Changing this will create a new resource.
+* `engine_id` - (Required, String, NonUpdatable) Specifies the ID of the Nacos microservice engine to which the
+  namespace belongs.
 
-* `name` - (Required, String) Specifies the name of the Nacos namespace.
+* `name` - (Required, String) Specifies the name of the Nacos namespace.  
   The name can contain `1` to `128` characters, special characters `@#$%^&*` are not allowed.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the ID of the enterprise project to which the
+  Nacos namespace belongs.
 
 ## Attribute Reference
 
@@ -47,4 +50,11 @@ Nacos namespace can be imported using related `engine_id` and their `id`, separa
 
 ```bash
 $ terraform import huaweicloud_cse_nacos_namespace.test <engine_id>/<id>
+```
+
+For the corresponding Nacos engine created with the `enterprise_project_id`, its enterprise project ID needs to be
+specified additionally when importing, the format is `<engine_id>/<id>/<enterprise_project_id>`, e.g.
+
+```bash
+$ terraform import huaweicloud_cse_nacos_namespace.test <engine_id>/<id>/<enterprise_project_id>
 ```

--- a/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_nacos_namespaces_test.go
+++ b/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_nacos_namespaces_test.go
@@ -33,7 +33,7 @@ func TestAccDataNacosNamespaces_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestMatchResourceAttr(all, "namespaces.#", regexp.MustCompile(`[1-9]\d*`)),
-					resource.TestCheckOutput("all_custom_namespace_ids_set", "true"),
+					resource.TestCheckOutput("all_custom_namespaces_set", "true"),
 				),
 			},
 		},
@@ -44,36 +44,49 @@ func testAccDataNacosNamespaces_basic_invalidEngine() string {
 	randUUID, _ := uuid.GenerateUUID()
 
 	return fmt.Sprintf(`
-data "huaweicloud_cse_nacos_namespaces" "test" {
-  engine_id = "%[1]s"
+variable "enterprise_project_id" {
+  default = "%[1]s"
 }
-`, randUUID)
+
+data "huaweicloud_cse_nacos_namespaces" "test" {
+  engine_id             = "%[1]s"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, randUUID)
 }
 
 func testAccDataNacosNamespaces_basic() string {
 	name := acceptance.RandomAccResourceName()
 
 	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  default = "%[1]s"
+}
+
 resource "huaweicloud_cse_nacos_namespace" "test" {
-  engine_id = "%[1]s"
-  name      = "%[2]s"
+  engine_id             = "%[2]s"
+  name                  = "%[3]s"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
 
 data "huaweicloud_cse_nacos_namespaces" "test" {
   depends_on = [huaweicloud_cse_nacos_namespace.test]
 
-  engine_id = "%[1]s"
+  engine_id             = "%[2]s"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
 
 # Check whether custom namespace ID is set
 locals {
-  namespace_id_validate_result = [
-    for o in data.huaweicloud_cse_nacos_namespaces.test.namespaces : o.id != "" if o.name != "public" 
+  namespaces_result = [
+    for o in data.huaweicloud_cse_nacos_namespaces.test.namespaces : o if o.id == huaweicloud_cse_nacos_namespace.test.id &&
+	  o.name == huaweicloud_cse_nacos_namespace.test.name && o.name != "public"
   ]
 }
 
-output "all_custom_namespace_ids_set" {
-  value = length(local.namespace_id_validate_result) > 0 && alltrue(local.namespace_id_validate_result)
+output "all_custom_namespaces_set" {
+  value = length(local.namespaces_result) > 0
 }
-`, acceptance.HW_CSE_NACOS_MICROSERVICE_ENGINE_ID, name)
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST,
+		acceptance.HW_CSE_NACOS_MICROSERVICE_ENGINE_ID, name)
 }

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_nacos_namespace_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_nacos_namespace_test.go
@@ -20,7 +20,8 @@ func getNacosNamespaceFunc(cfg *config.Config, state *terraform.ResourceState) (
 		return nil, fmt.Errorf("error creating CSE client: %s", err)
 	}
 
-	return cse.GetNacosNamespaceById(client, state.Primary.Attributes["engine_id"], state.Primary.ID)
+	return cse.GetNacosNamespaceById(client, state.Primary.Attributes["engine_id"],
+		state.Primary.Attributes["enterprise_project_id"], state.Primary.ID)
 }
 
 func TestAccNacosNamespace_basic(t *testing.T) {
@@ -30,7 +31,7 @@ func TestAccNacosNamespace_basic(t *testing.T) {
 		name       = acceptance.RandomAccResourceName()
 		updateName = acceptance.RandomAccResourceName()
 
-		uuid, _ = uuid.GenerateUUID()
+		randUUID, _ = uuid.GenerateUUID()
 
 		resourceName = "huaweicloud_cse_nacos_namespace.test"
 		rc           = acceptance.InitResourceCheck(resourceName, &obj, getNacosNamespaceFunc)
@@ -45,8 +46,9 @@ func TestAccNacosNamespace_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccNacosNamespace_basic(uuid, name),
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`unable to create the namespace because the Nacos engine \(%s\) does not exist`, uuid)),
+				Config: testAccNacosNamespace_basic(randUUID, name),
+				ExpectError: regexp.MustCompile(
+					fmt.Sprintf(`unable to create the namespace because the Nacos engine \(%s\) does not exist`, randUUID)),
 			},
 			{
 				Config: testAccNacosNamespace_basic(acceptance.HW_CSE_NACOS_MICROSERVICE_ENGINE_ID, name),
@@ -74,7 +76,7 @@ func TestAccNacosNamespace_basic(t *testing.T) {
 
 func testAccNacosNamespaceImportStateIdFunc(resName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
-		var engineId, namespaceId string
+		var engineId, namespaceId, enterpriseProjectId string
 		rs, ok := s.RootModule().Resources[resName]
 		if !ok {
 			return "", fmt.Errorf("resource (%s) not found", resName)
@@ -82,20 +84,27 @@ func testAccNacosNamespaceImportStateIdFunc(resName string) resource.ImportState
 
 		engineId = rs.Primary.Attributes["engine_id"]
 		namespaceId = rs.Primary.ID
+		enterpriseProjectId = rs.Primary.Attributes["enterprise_project_id"]
 
-		if engineId == "" || namespaceId == "" {
-			return "", fmt.Errorf("missing some attributes, want '<engine_id>/<id>', but got '%s/%s'", engineId, namespaceId)
+		if engineId == "" || namespaceId == "" || enterpriseProjectId == "" {
+			return "", fmt.Errorf("missing some attributes, want '<engine_id>/<id>/<enterprise_project_id>', but got '%s/%s/%s'",
+				engineId, namespaceId, enterpriseProjectId)
 		}
 
-		return fmt.Sprintf("%s/%s", engineId, namespaceId), nil
+		return fmt.Sprintf("%s/%s/%s", engineId, namespaceId, enterpriseProjectId), nil
 	}
 }
 
 func testAccNacosNamespace_basic(engineId, name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_cse_nacos_namespace" "test" {
-  engine_id = "%[1]s"
-  name      = "%[2]s"
+variable "enterprise_project_id" {
+  default = "%[1]s"
 }
-`, engineId, name)
+
+resource "huaweicloud_cse_nacos_namespace" "test" {
+  engine_id             = "%[2]s"
+  name                  = "%[3]s"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, engineId, name)
 }

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_nacos_namespaces.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_nacos_namespaces.go
@@ -24,11 +24,23 @@ func DataSourceNacosNamespaces() *schema.Resource {
 				Computed:    true,
 				Description: `The region where the Nacos namespaces are located.`,
 			},
+
+			// Required parameters.
 			"engine_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `The ID of the Nacos microservice engine to which the namespaces belong.`,
 			},
+
+			// Optional parameters.
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The ID of the enterprise project to which the Nacos namespaces belong.`,
+			},
+
+			// Attributes.
 			"namespaces": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -46,7 +58,7 @@ func DataSourceNacosNamespaces() *schema.Resource {
 						},
 					},
 				},
-				Description: `All queried Nacos namespaces.`,
+				Description: `All queried Nacos namespaces that match the filter parameters.`,
 			},
 		},
 	}
@@ -67,16 +79,17 @@ func flattenNacosNamespaces(namespaces []interface{}) []map[string]interface{} {
 
 func dataSourceNacosNamespacesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		conf     = meta.(*config.Config)
-		region   = conf.GetRegion(d)
-		engineId = d.Get("engine_id").(string)
+		conf                = meta.(*config.Config)
+		region              = conf.GetRegion(d)
+		engineId            = d.Get("engine_id").(string)
+		enterpriseProjectId = conf.GetEnterpriseProjectID(d)
 	)
 	client, err := conf.NewServiceClient("cse", region)
 	if err != nil {
 		return diag.Errorf("error creating CSE client: %s", err)
 	}
 
-	namespaces, err := listNacosNamespaces(client, engineId)
+	namespaces, err := listNacosNamespaces(client, engineId, enterpriseProjectId)
 	if err != nil {
 		return diag.Errorf("error querying namespaces under Nacos engine (%s): %s", engineId, err)
 	}
@@ -89,6 +102,11 @@ func dataSourceNacosNamespacesRead(_ context.Context, d *schema.ResourceData, me
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
+		// Required parameters.
+		d.Set("engine_id", engineId),
+		// Optional parameters.
+		d.Set("enterprise_project_id", enterpriseProjectId),
+		// Attributes.
 		d.Set("namespaces", flattenNacosNamespaces(namespaces)),
 	)
 

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
@@ -25,6 +25,7 @@ var (
 	DefaultVersion = "CSE2"
 
 	microserviceEngineNotFoundCodes = []string{
+		"SVCSTG.00401116",
 		"SVCSTG.00501116",
 		"SVCSTG.00501125",
 	}

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_nacos_namespace.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_nacos_namespace.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -16,6 +17,11 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var nacosNamespaceNonUpdatableParams = []string{
+	"engine_id",
+	"enterprise_project_id",
+}
 
 // @API CSE POST /v1/{project_id}/nacos/v1/console/namespaces
 // @API CSE GET /v1/{project_id}/nacos/v1/console/namespaces
@@ -27,6 +33,8 @@ func ResourceNacosNamespace() *schema.Resource {
 		ReadContext:   resourceNacosNamespaceRead,
 		UpdateContext: resourceNacosNamespaceUpdate,
 		DeleteContext: resourceNacosNamespaceDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nacosNamespaceNonUpdatableParams),
 
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceNacosNamespaceImportState,
@@ -40,6 +48,8 @@ func ResourceNacosNamespace() *schema.Resource {
 				ForceNew:    true,
 				Description: `The region where the Nacos namespace is located.`,
 			},
+
+			// Required parameters.
 			"engine_id": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -50,50 +60,91 @@ func ResourceNacosNamespace() *schema.Resource {
 				Required:    true,
 				Description: `The name of the Nacos namespace.`,
 			},
+
+			// Optional parameters.
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The ID of the enterprise project to which the Nacos namespace belongs.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
+			},
 		},
 	}
 }
 
+func buildNacosNamespaceRequestHeaders(engineId, enterpriseProjectId string) map[string]string {
+	moreHeaders := map[string]string{
+		"Content-Type": "application/json",
+		"x-engine-id":  engineId,
+	}
+
+	if enterpriseProjectId != "" {
+		moreHeaders["X-Enterprise-Project-ID"] = enterpriseProjectId
+	}
+	return moreHeaders
+}
+
+func createNacosNamespace(client *golangsdk.ServiceClient, engineId, enterpriseProjectId, namespaceId, namespaceName string) error {
+	httpUrl := "v1/{project_id}/nacos/v1/console/namespaces?customNamespaceId={namespace_id}&namespaceName={namespace_name}"
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{namespace_id}", namespaceId)
+	createPath = strings.ReplaceAll(createPath, "{namespace_name}", namespaceName)
+
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildNacosNamespaceRequestHeaders(engineId, enterpriseProjectId),
+	}
+
+	_, err := client.Request("POST", createPath, &createOpts)
+	return err
+}
+
 func resourceNacosNamespaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		httpUrl = "v1/{project_id}/nacos/v1/console/namespaces?customNamespaceId={namespace_id}&namespaceName={namespace_name}"
-
-		engineId = d.Get("engine_id").(string)
-		name     = d.Get("name").(string)
+		cfg                 = meta.(*config.Config)
+		region              = cfg.GetRegion(d)
+		engineId            = d.Get("engine_id").(string)
+		enterpriseProjectId = cfg.GetEnterpriseProjectID(d)
+		name                = d.Get("name").(string)
 	)
-
-	resourceId, err := uuid.GenerateUUID()
-	if err != nil {
-		return diag.Errorf("unable to generate resource ID for CSE Nacos namespace (%s): %s", name, err)
-	}
 
 	client, err := cfg.NewServiceClient("cse", region)
 	if err != nil {
 		return diag.Errorf("error creating CSE client: %s", err)
 	}
 
-	createPath := client.Endpoint + httpUrl
-	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
-	createPath = strings.ReplaceAll(createPath, "{namespace_id}", resourceId)
-	createPath = strings.ReplaceAll(createPath, "{namespace_name}", name)
-
-	opt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-			"x-engine-id":  engineId,
-		},
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate resource ID of Nacos namespace (%s): %s", name, err)
 	}
 
-	_, err = client.Request("POST", createPath, &opt)
+	err = createNacosNamespace(client, engineId, enterpriseProjectId, resourceId, name)
 	if err != nil {
-		if _, ok := err.(golangsdk.ErrDefault502); ok {
+		// When the microservice instance does not exist, the error code returned is 400, and the error information is:
+		// {"error_code": "SVCSTG.00401116", "error_message": "engine does not exist"}
+		// So, we need to convert the error code to 404 error and specify the key of the error code to be "error_code".
+		parsedErr := common.ConvertExpected400ErrInto404Err(err, "error_code", microserviceEngineNotFoundCodes...)
+		switch parsedErr.(type) {
+		case golangsdk.ErrDefault404, golangsdk.ErrDefault502:
 			// Bad gateway means Nacos engine does not exist.
 			return diag.Errorf("unable to create the namespace because the Nacos engine (%s) does not exist", engineId)
+		default:
+			return diag.Errorf("error creating namespace under Nacos microservice engine (%s): %s", engineId, err)
 		}
-		return diag.Errorf("error creating namespace under Nacos microservice engine (%s): %s", engineId, err)
 	}
 
 	d.SetId(resourceId)
@@ -101,23 +152,22 @@ func resourceNacosNamespaceCreate(ctx context.Context, d *schema.ResourceData, m
 	return resourceNacosNamespaceRead(ctx, d, meta)
 }
 
-func listNacosNamespaces(client *golangsdk.ServiceClient, engineId string) ([]interface{}, error) {
+func listNacosNamespaces(client *golangsdk.ServiceClient, engineId, enterpriseProjectId string) ([]interface{}, error) {
 	httpUrl := "v1/{project_id}/nacos/v1/console/namespaces"
 
-	queryPath := client.Endpoint + httpUrl
-	queryPath = strings.ReplaceAll(queryPath, "{project_id}", client.ProjectID)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 
-	opt := golangsdk.RequestOpts{
+	listOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-			"x-engine-id":  engineId,
-		},
+		MoreHeaders:      buildNacosNamespaceRequestHeaders(engineId, enterpriseProjectId),
 	}
 
-	requestResp, err := client.Request("GET", queryPath, &opt)
+	requestResp, err := client.Request("GET", listPath, &listOpts)
 	if err != nil {
-		if _, ok := err.(golangsdk.ErrDefault502); ok {
+		parsedErr := common.ConvertExpected400ErrInto404Err(err, "error_code", microserviceEngineNotFoundCodes...)
+		switch parsedErr.(type) {
+		case golangsdk.ErrDefault404, golangsdk.ErrDefault502:
 			// Bad gateway means Nacos engine does not exist.
 			return nil, golangsdk.ErrDefault404{
 				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
@@ -127,8 +177,9 @@ func listNacosNamespaces(client *golangsdk.ServiceClient, engineId string) ([]in
 					Body:      []byte(fmt.Sprintf("the Nacos engine (%s) does not exist", engineId)),
 				},
 			}
+		default:
+			return nil, err
 		}
-		return nil, err
 	}
 	respBody, err := utils.FlattenResponse(requestResp)
 	if err != nil {
@@ -138,8 +189,9 @@ func listNacosNamespaces(client *golangsdk.ServiceClient, engineId string) ([]in
 	return utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}), nil
 }
 
-func GetNacosNamespaceById(client *golangsdk.ServiceClient, engineId, namespaceId string) (interface{}, error) {
-	namespaces, err := listNacosNamespaces(client, engineId)
+// GetNacosNamespaceById retrieves the Nacos namespace by its ID.
+func GetNacosNamespaceById(client *golangsdk.ServiceClient, engineId, enterpriseProjectId, namespaceId string) (interface{}, error) {
+	namespaces, err := listNacosNamespaces(client, engineId, enterpriseProjectId)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +204,7 @@ func GetNacosNamespaceById(client *golangsdk.ServiceClient, engineId, namespaceI
 				URL:       "v1/{project_id}/nacos/v1/console/namespaces",
 				RequestId: "NONE",
 				Body: []byte(fmt.Sprintf("the namespace (%s) has been removed from the Nacos microservice engine (%s)",
-					engineId, namespaceId)),
+					namespaceId, engineId)),
 			},
 		}
 	}
@@ -161,35 +213,59 @@ func GetNacosNamespaceById(client *golangsdk.ServiceClient, engineId, namespaceI
 
 func resourceNacosNamespaceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg         = meta.(*config.Config)
-		region      = cfg.GetRegion(d)
-		engineId    = d.Get("engine_id").(string)
-		namespaceId = d.Id()
+		cfg                 = meta.(*config.Config)
+		region              = cfg.GetRegion(d)
+		engineId            = d.Get("engine_id").(string)
+		enterpriseProjectId = cfg.GetEnterpriseProjectID(d)
+		namespaceId         = d.Id()
 	)
 	client, err := cfg.NewServiceClient("cse", region)
 	if err != nil {
 		return diag.Errorf("error creating CSE client: %s", err)
 	}
 
-	respBody, err := GetNacosNamespaceById(client, engineId, namespaceId)
+	respBody, err := GetNacosNamespaceById(client, engineId, enterpriseProjectId, namespaceId)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying Nacos namespace (%s)", namespaceId))
 	}
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
+		// Required parameters.
+		d.Set("engine_id", engineId),
 		d.Set("name", utils.PathSearch("namespaceShowName", respBody, nil)),
+		// Optional parameters.
+		d.Set("enterprise_project_id", enterpriseProjectId),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceNacosNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		httpUrl = "v1/{project_id}/nacos/v1/console/namespaces?namespace={namespace_id}&namespaceShowName={namespace_name}"
+func updateNacosNamespace(client *golangsdk.ServiceClient, engineId, enterpriseProjectId, namespaceId, namespaceName string) error {
+	httpUrl := "v1/{project_id}/nacos/v1/console/namespaces?namespace={namespace_id}&namespaceShowName={namespace_name}"
 
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{namespace_id}", namespaceId)
+	updatePath = strings.ReplaceAll(updatePath, "{namespace_name}", namespaceName)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildNacosNamespaceRequestHeaders(engineId, enterpriseProjectId),
+	}
+
+	_, err := client.Request("PUT", updatePath, &opt)
+	return err
+}
+
+func resourceNacosNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	if !d.HasChange("name") {
+		return resourceNacosNamespaceRead(ctx, d, meta)
+	}
+
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
 		engineId   = d.Get("engine_id").(string)
 		name       = d.Get("name").(string)
 		resourceId = d.Id()
@@ -200,20 +276,7 @@ func resourceNacosNamespaceUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error creating CSE client: %s", err)
 	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{namespace_id}", resourceId)
-	updatePath = strings.ReplaceAll(updatePath, "{namespace_name}", name)
-
-	opt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-			"x-engine-id":  engineId,
-		},
-	}
-
-	_, err = client.Request("PUT", updatePath, &opt)
+	err = updateNacosNamespace(client, engineId, cfg.GetEnterpriseProjectID(d), resourceId, name)
 	if err != nil {
 		if _, ok := err.(golangsdk.ErrDefault502); ok {
 			// Bad gateway means Nacos engine does not exist.
@@ -225,20 +288,8 @@ func resourceNacosNamespaceUpdate(ctx context.Context, d *schema.ResourceData, m
 	return resourceNacosNamespaceRead(ctx, d, meta)
 }
 
-func resourceNacosNamespaceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		httpUrl = "v1/{project_id}/nacos/v1/console/namespaces?namespaceId={namespace_id}"
-
-		engineId    = d.Get("engine_id").(string)
-		namespaceId = d.Id()
-	)
-
-	client, err := cfg.NewServiceClient("cse", region)
-	if err != nil {
-		return diag.Errorf("error creating CSE client: %s", err)
-	}
+func deleteNacosNamespace(client *golangsdk.ServiceClient, engineId, enterpriseProjectId, namespaceId string) error {
+	httpUrl := "v1/{project_id}/nacos/v1/console/namespaces?namespaceId={namespace_id}"
 
 	deletePath := client.Endpoint + httpUrl
 	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
@@ -246,27 +297,46 @@ func resourceNacosNamespaceDelete(_ context.Context, d *schema.ResourceData, met
 
 	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-			"x-engine-id":  engineId,
-		},
+		MoreHeaders:      buildNacosNamespaceRequestHeaders(engineId, enterpriseProjectId),
 	}
 
-	_, err = client.Request("DELETE", deletePath, &opt)
+	_, err := client.Request("DELETE", deletePath, &opt)
+	return err
+}
+
+func resourceNacosNamespaceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                 = meta.(*config.Config)
+		region              = cfg.GetRegion(d)
+		engineId            = d.Get("engine_id").(string)
+		enterpriseProjectId = cfg.GetEnterpriseProjectID(d)
+		namespaceId         = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("cse", region)
+	if err != nil {
+		return diag.Errorf("error creating CSE client: %s", err)
+	}
+
+	// Delete method always return a 200 status code whether namespace is exist.
+	err = deleteNacosNamespace(client, engineId, enterpriseProjectId, namespaceId)
 	if err != nil {
 		if _, ok := err.(golangsdk.ErrDefault502); ok {
 			// Bad gateway means Nacos engine has been removed and returns override the error with 404 status code.
 			err = golangsdk.ErrDefault404{
 				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
 					Method:    "DELETE",
-					URL:       httpUrl,
+					URL:       "v1/{project_id}/nacos/v1/console/namespaces?namespaceId={namespace_id}",
 					RequestId: "NONE",
-					Body:      []byte(fmt.Sprintf("unable to delete the namespace because the Nacos engine (%s) does not exist", engineId)),
+					Body: []byte(fmt.Sprintf("unable to delete the namespace because the Nacos microserivce engine (%s) does not exist",
+						engineId)),
 				},
 			}
 		}
-		// Delete method always return a 200 status code whether namespace is exist.
-		return common.CheckDeletedDiag(d, err,
+		// When the microservice instance does not exist, the error code returned is 400, and the error information is:
+		// {"error_code": "SVCSTG.00401116", "error_message": "engine does not exist"}
+		// So, we need to convert the error code to 404 error and specify the key of the error code to be "error_code".
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", microserviceEngineNotFoundCodes...),
 			fmt.Sprintf("error deleting namespace (%s) from the Nacos microserivce engine (%s)", namespaceId, engineId))
 	}
 	return nil
@@ -277,8 +347,13 @@ func resourceNacosNamespaceImportState(_ context.Context, d *schema.ResourceData
 	importedId := d.Id()
 	parts := strings.Split(importedId, "/")
 
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid format specified for import ID, want '<engine_id>/<id>', but got '%s'",
+	switch len(parts) {
+	case 2:
+		d.Set("enterprise_project_id", nil)
+	case 3:
+		d.Set("enterprise_project_id", parts[2])
+	default:
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<engine_id>/<id>/<enterprise_project_id>', but got '%s'",
 			importedId)
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Namespace supports enterprise project scenarios, if the environment variable set it or schema set it, supplement it to the MoreHeaders.
Optimize some resource and datasource codings:
- format the 404 error handling
- refactor the acceptance test
- using NonUpdatable to replace the ForceNew
- adjust the function coding and using auto-generate style

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. optimize the nacos namespace resource and datasource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccDataNacosNamespaces_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccDataNacosNamespaces_basic -timeout 360m -parallel 10
=== RUN   TestAccDataNacosNamespaces_basic
=== PAUSE TestAccDataNacosNamespaces_basic
=== CONT  TestAccDataNacosNamespaces_basic
--- PASS: TestAccDataNacosNamespaces_basic (13.76s)
PASS
coverage: 10.9% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       13.844s coverage: 10.9% of statements in ./huaweicloud/services/cse
```
```
./scripts/coverage.sh -o cse -f TestAccNacosNamespace_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccNacosNamespace_basic -timeout 360m -parallel 10
=== RUN   TestAccNacosNamespace_basic
=== PAUSE TestAccNacosNamespace_basic
=== CONT  TestAccNacosNamespace_basic
--- PASS: TestAccNacosNamespace_basic (32.48s)
PASS
coverage: 11.8% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       32.620s coverage: 11.8% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
