### PR TITLE
feat(cse): microservice engine supports update description and manage tags

### DIFF
--- a/docs/resources/cse_microservice_engine.md
+++ b/docs/resources/cse_microservice_engine.md
@@ -30,6 +30,10 @@ resource "huaweicloud_cse_microservice_engine" "test" {
   availability_zones = var.availability_zones
   auth_type          = "RBAC"
   admin_pass         = var.manager_password
+
+  tags = {
+    owner = "terraform"
+  }
 }
 ```
 
@@ -45,6 +49,10 @@ resource "huaweicloud_cse_microservice_engine" "test" {
   network_id = var.network_id
   auth_type  = "NONE"
   version    = "Nacos2"
+
+  tags = {
+    owner = "terraform"
+  }
 }
 ```
 
@@ -113,6 +121,8 @@ The following arguments are supported:
   The specific parameters are subject to the state of the microservice engine.  
   This parameter will be affected by these parameters and will appear when `terraform plan` or `terraform apply`.  
   If it is inconsistent with the script configuration, it can be ignored by `ignore_changes` in non-change scenarios.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the microservice engine.
 
 ## Attribute Reference
 

--- a/docs/resources/cse_microservice_engine.md
+++ b/docs/resources/cse_microservice_engine.md
@@ -102,7 +102,7 @@ The following arguments are supported:
   microservice engine belongs.  
   If omitted and the version is **Nacos2**, the default enterprise project will be used.
 
-* `description` - (Optional, String, NonUpdatable) Specifies the description of the microservice engine.
+* `description` - (Optional, String) Specifies the description of the microservice engine.  
   The description can contain a maximum of `255` characters.
 
 * `eip_id` - (Optional, String, NonUpdatable) Specifies the EIP ID bound to the microservice engine.

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
@@ -112,6 +112,11 @@ func testAccMicroserviceEngineImportStateFunc(rName string) resource.ImportState
 
 func testAccMicroserviceEngine_base(name string) string {
 	return fmt.Sprintf(`
+variable "eip_id" {
+  type    = string
+  default = "%[1]s"
+}
+
 resource "random_string" "test" {
   length           = 16
   min_numeric      = 1
@@ -127,23 +132,8 @@ data "huaweicloud_cse_microservice_engine_flavors" "test" {
   version = "CSE2"
 }
 
-%[1]s
-
-resource "huaweicloud_vpc_eip" "test" {
-  enterprise_project_id = huaweicloud_vpc.test.enterprise_project_id != "" ? huaweicloud_vpc.test.enterprise_project_id : null
-
-  publicip {
-    type = "5_bgp"
-  }
-
-  bandwidth {
-    share_type  = "PER"
-    size        = 5
-    name        = "%[2]s"
-    charge_mode = "traffic"
-  }
-}
-`, common.TestVpc(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), name)
+%[2]s
+`, acceptance.HW_EIP_ID, common.TestVpc(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST))
 }
 
 func testAccMicroserviceEngine_basic_step1(name string) string {
@@ -155,7 +145,7 @@ resource "huaweicloud_cse_microservice_engine" "test" {
   description           = "Created by terraform test"
   flavor                = data.huaweicloud_cse_microservice_engine_flavors.test.flavors[0].id
   network_id            = huaweicloud_vpc_subnet.test.id
-  # eip_id                = huaweicloud_vpc_eip.test.id
+  eip_id                = var.eip_id != "" ? var.eip_id : null
   availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
   enterprise_project_id = huaweicloud_vpc.test.enterprise_project_id != "" ? huaweicloud_vpc.test.enterprise_project_id : null
 
@@ -174,7 +164,7 @@ resource "huaweicloud_cse_microservice_engine" "test" {
   description           = "Updated by terraform test"
   flavor                = data.huaweicloud_cse_microservice_engine_flavors.test.flavors[0].id
   network_id            = huaweicloud_vpc_subnet.test.id
-  # eip_id                = huaweicloud_vpc_eip.test.id
+  eip_id                = var.eip_id != "" ? var.eip_id : null
   availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
   enterprise_project_id = huaweicloud_vpc.test.enterprise_project_id != "" ? huaweicloud_vpc.test.enterprise_project_id : null
   

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
@@ -55,7 +55,7 @@ func TestAccMicroserviceEngine_basic(t *testing.T) {
 		CheckDestroy: rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMicroserviceEngine_basic(name),
+				Config: testAccMicroserviceEngine_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -72,6 +72,13 @@ func TestAccMicroserviceEngine_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "service_limit"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_registry_addresses.0.private"),
 					resource.TestCheckResourceAttrSet(resourceName, "config_center_addresses.0.private"),
+				),
+			},
+			{
+				Config: testAccMicroserviceEngine_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by terraform test"),
 				),
 			},
 			{
@@ -139,7 +146,7 @@ resource "huaweicloud_vpc_eip" "test" {
 `, common.TestVpc(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), name)
 }
 
-func testAccMicroserviceEngine_basic(name string) string {
+func testAccMicroserviceEngine_basic_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -154,7 +161,27 @@ resource "huaweicloud_cse_microservice_engine" "test" {
 
   auth_type  = "RBAC"
   admin_pass = format("pwdPrefix%%s", random_string.test.result) // Avoid the password starting with a special character
-}`, testAccMicroserviceEngine_base(name), name)
+}
+`, testAccMicroserviceEngine_base(name), name)
+}
+
+func testAccMicroserviceEngine_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cse_microservice_engine" "test" {
+  name                  = "%[2]s"
+  description           = "Updated by terraform test"
+  flavor                = data.huaweicloud_cse_microservice_engine_flavors.test.flavors[0].id
+  network_id            = huaweicloud_vpc_subnet.test.id
+  # eip_id                = huaweicloud_vpc_eip.test.id
+  availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  enterprise_project_id = huaweicloud_vpc.test.enterprise_project_id != "" ? huaweicloud_vpc.test.enterprise_project_id : null
+  
+  auth_type  = "RBAC"
+  admin_pass = format("pwdPrefix%%s", random_string.test.result) // Avoid the password starting with a special character
+}
+`, testAccMicroserviceEngine_base(name), name)
 }
 
 func TestAccMicroserviceEngine_nacos(t *testing.T) {

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
@@ -72,6 +72,9 @@ func TestAccMicroserviceEngine_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "service_limit"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_registry_addresses.0.private"),
 					resource.TestCheckResourceAttrSet(resourceName, "config_center_addresses.0.private"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
 			},
 			{
@@ -79,6 +82,9 @@ func TestAccMicroserviceEngine_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated by terraform test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "baar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
 			{
@@ -151,6 +157,11 @@ resource "huaweicloud_cse_microservice_engine" "test" {
 
   auth_type  = "RBAC"
   admin_pass = format("pwdPrefix%%s", random_string.test.result) // Avoid the password starting with a special character
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }
 `, testAccMicroserviceEngine_base(name), name)
 }
@@ -170,6 +181,11 @@ resource "huaweicloud_cse_microservice_engine" "test" {
   
   auth_type  = "RBAC"
   admin_pass = format("pwdPrefix%%s", random_string.test.result) // Avoid the password starting with a special character
+
+  tags = {
+    foo   = "baar"
+    owner = "terraform"
+  }
 }
 `, testAccMicroserviceEngine_base(name), name)
 }

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
@@ -21,7 +21,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-const DefaultVersion = "CSE2"
+const (
+	DefaultVersion                     = "CSE2"
+	MicroserviceEngineTagsResourceType = "cseEngines"
+)
 
 var (
 	microserviceEngineNotFoundCodes = []string{
@@ -46,9 +49,11 @@ var (
 // @API VPC GET /v1/{project_id}/subnets/{subnet_id}
 // @API VPC GET /v1/{project_id}/vpcs/{vpc_id}
 // @API CSE POST /v2/{project_id}/enginemgr/engines
+// @API CSE POST /v2/{project_id}/{resource_type}/{resource_id}/tags/create
 // @API CSE GET /v2/{project_id}/enginemgr/engines/{engine_id}/jobs/{job_id}
 // @API CSE GET /v2/{project_id}/enginemgr/engines/{engine_id}
 // @API CSE PUT /v2/{project_id}/enginemgr/engines/{engine_id}
+// @API CSE DELETE /v2/{project_id}/{resource_type}/{resource_id}/tags/delete
 // @API CSE DELETE /v2/{project_id}/enginemgr/engines/{engine_id}
 func ResourceMicroserviceEngine() *schema.Resource {
 	return &schema.Resource{
@@ -143,6 +148,9 @@ func ResourceMicroserviceEngine() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `The extended parameters of the microservice engine.`,
 			},
+			"tags": common.TagsSchema(
+				`The key/value pairs to associate with the microservice engine.`,
+			),
 
 			// Attributes.
 			"service_limit": {
@@ -366,6 +374,100 @@ func refreshMicroserviceEngineJobFunc(client *golangsdk.ServiceClient, engineId,
 	}
 }
 
+func getMicroserviceEngineTagsChange(d *schema.ResourceData) (removeTags, addTags []interface{}) {
+	oRaw, nRaw := d.GetChange("tags")
+	oMap := oRaw.(map[string]interface{})
+	nMap := nRaw.(map[string]interface{})
+
+	for k, v := range oMap {
+		if _, ok := nMap[k]; !ok || nMap[k] != v {
+			removeTags = append(removeTags, map[string]interface{}{
+				"key":   k,
+				"value": v,
+			})
+		}
+	}
+
+	for k, v := range nMap {
+		if _, ok := oMap[k]; !ok || oMap[k] != v {
+			addTags = append(addTags, map[string]interface{}{
+				"key":   k,
+				"value": v,
+			})
+		}
+	}
+
+	return removeTags, addTags
+}
+
+func buildCreateMicroserviceEngineTagsBodyParams(tags []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"tags": tags,
+	}
+}
+
+func createMicroserviceEngineTags(client *golangsdk.ServiceClient, engineId, epsId string, tags []interface{}) (interface{}, error) {
+	httpUrl := "v2/{project_id}/{resource_type}/{resource_id}/tags/create"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{resource_type}", MicroserviceEngineTagsResourceType)
+	createPath = strings.ReplaceAll(createPath, "{resource_id}", engineId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(epsId),
+		JSONBody:         utils.RemoveNil(buildCreateMicroserviceEngineTagsBodyParams(tags)),
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	return nil, err
+}
+
+func buildDeleteMicroserviceEngineTagsBodyParams(tags []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"tags": tags,
+	}
+}
+
+func deleteMicroserviceEngineTags(client *golangsdk.ServiceClient, engineId, epsId string, tags []interface{}) (interface{}, error) {
+	httpUrl := "v2/{project_id}/{resource_type}/{resource_id}/tags/delete"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{resource_type}", MicroserviceEngineTagsResourceType)
+	deletePath = strings.ReplaceAll(deletePath, "{resource_id}", engineId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(epsId),
+		JSONBody:         utils.RemoveNil(buildDeleteMicroserviceEngineTagsBodyParams(tags)),
+		OkCodes:          []int{204},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return nil, err
+}
+
+func updateMicroserviceEngineTags(client *golangsdk.ServiceClient, d *schema.ResourceData, engineId, epsId string) error {
+	removeTags, addTags := getMicroserviceEngineTagsChange(d)
+
+	if len(removeTags) > 0 {
+		_, err := deleteMicroserviceEngineTags(client, engineId, epsId, removeTags)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(addTags) > 0 {
+		_, err := createMicroserviceEngineTags(client, engineId, epsId, addTags)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func resourceMicroserviceEngineCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg                 = meta.(*config.Config)
@@ -406,6 +508,13 @@ func resourceMicroserviceEngineCreate(ctx context.Context, d *schema.ResourceDat
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return diag.Errorf("error waiting for the creation of microservice engine (%s) to complete: %s", engineId, err)
+	}
+
+	if d.HasChange("tags") {
+		err = updateMicroserviceEngineTags(cseClient, d, engineId, enterpriseProjectId)
+		if err != nil {
+			return diag.Errorf("error updating microservice engine tags: %s", err)
+		}
 	}
 
 	return resourceMicroserviceEngineRead(ctx, d, meta)
@@ -487,6 +596,7 @@ func resourceMicroserviceEngineRead(_ context.Context, d *schema.ResourceData, m
 		d.Set("description", utils.PathSearch("description", respBody, "").(string)),
 		d.Set("eip_id", utils.PathSearch("reference.publicIpId", respBody, "").(string)),
 		d.Set("extend_params", utils.PathSearch("reference.inputs", respBody, map[string]interface{}{}).(map[string]interface{})),
+		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("tags", respBody, make([]interface{}, 0)).([]interface{}))),
 		// Attributes.
 		d.Set("service_registry_addresses", flattenServiceRegistryAddresses(utils.PathSearch("externalEntrypoint",
 			respBody, make(map[string]interface{})).(map[string]interface{}))),
@@ -567,6 +677,13 @@ func resourceMicroserviceEngineUpdate(ctx context.Context, d *schema.ResourceDat
 		_, err := updateMicroserviceEngine(client, d, engineId, enterpriseProjectId)
 		if err != nil {
 			return diag.Errorf("error updating microservice engine: %s", err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		err = updateMicroserviceEngineTags(client, d, engineId, enterpriseProjectId)
+		if err != nil {
+			return diag.Errorf("error updating microservice engine tags: %s", err)
 		}
 	}
 

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
@@ -38,7 +38,6 @@ var (
 		"version",
 		"admin_pass",
 		"enterprise_project_id",
-		"description",
 		"eip_id",
 		"extend_params",
 	}
@@ -49,6 +48,7 @@ var (
 // @API CSE POST /v2/{project_id}/enginemgr/engines
 // @API CSE GET /v2/{project_id}/enginemgr/engines/{engine_id}/jobs/{job_id}
 // @API CSE GET /v2/{project_id}/enginemgr/engines/{engine_id}
+// @API CSE PUT /v2/{project_id}/enginemgr/engines/{engine_id}
 // @API CSE DELETE /v2/{project_id}/enginemgr/engines/{engine_id}
 func ResourceMicroserviceEngine() *schema.Resource {
 	return &schema.Resource{
@@ -128,6 +128,7 @@ func ResourceMicroserviceEngine() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `The description of the microservice engine.`,
 			},
 			"eip_id": {
@@ -526,8 +527,50 @@ func resourceMicroserviceEngineRead(_ context.Context, d *schema.ResourceData, m
 	return diagErr
 }
 
-func resourceMicroserviceEngineUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	return nil
+func buildUpdateMicroserviceEngineBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		// The description does not support changing an empty string, so we need to pass a null value.
+		"description": utils.ValueIgnoreEmpty(d.Get("description").(string)),
+	}
+}
+
+func updateMicroserviceEngine(client *golangsdk.ServiceClient, d *schema.ResourceData, engineId, epsId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/enginemgr/engines/{engine_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{engine_id}", engineId)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(epsId),
+		JSONBody:         utils.RemoveNil(buildUpdateMicroserviceEngineBodyParams(d)),
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return nil, err
+}
+
+func resourceMicroserviceEngineUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                 = meta.(*config.Config)
+		region              = cfg.GetRegion(d)
+		engineId            = d.Id()
+		enterpriseProjectId = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("cse", region)
+	if err != nil {
+		return diag.Errorf("error creating CSE client: %s", err)
+	}
+
+	if d.HasChange("description") {
+		_, err := updateMicroserviceEngine(client, d, engineId, enterpriseProjectId)
+		if err != nil {
+			return diag.Errorf("error updating microservice engine: %s", err)
+		}
+	}
+
+	return resourceMicroserviceEngineRead(ctx, d, meta)
 }
 
 func deleteMicroserviceEngine(client *golangsdk.ServiceClient, engineId, epsId string) (interface{}, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Two features are supported for CSE microservice engine:
- Update description
- Manage resource tags

Refactor the EIP usage for the microservice engine test, using environment variable HW_EIP_ID to specified whether executor want to bind the public IP to the microservice engine

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. microservice engine supports update description and manage tags
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccMicroserviceEngine_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccMicroserviceEngine_basic -timeout 360m -parallel 10
=== RUN   TestAccMicroserviceEngine_basic
=== PAUSE TestAccMicroserviceEngine_basic
=== CONT  TestAccMicroserviceEngine_basic
--- PASS: TestAccMicroserviceEngine_basic (1287.90s)
PASS
coverage: 25.3% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       1287.982s       coverage: 25.3% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
