### PR TITLE
feat(ECS): ecs instance support update image

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -205,11 +205,11 @@ The following arguments are supported:
 
 * `flavor_id` - (Required, String) Specifies the flavor ID of the instance to be created.
 
-* `image_id` - (Optional, String, ForceNew) Required if `image_name` is empty. Specifies the image ID of the desired
-  image for the instance. Changing this creates a new instance.
+* `image_id` - (Optional, String) Required if `image_name` is empty. Specifies the image ID of the desired image for the
+  instance.
 
-* `image_name` - (Optional, String, ForceNew) Required if `image_id` is empty. Specifies the name of the desired image
-  for the instance. Changing this creates a new instance.
+* `image_name` - (Optional, String) Required if `image_id` is empty. Specifies the name of the desired image for the
+  instance.
 
 * `security_group_ids` - (Optional, List) Specifies an array of one or more security group IDs to associate with the
   instance.
@@ -228,7 +228,7 @@ The following arguments are supported:
 
 * `key_pair` - (Optional, String) Specifies the SSH keypair name used for logging in to the instance.
 
-* `private_key` - (Optional, String) Specifies the the private key of the keypair in use. This parameter is mandatory
+* `private_key` - (Optional, String) Specifies the private key of the keypair in use. This parameter is mandatory
   when replacing or unbinding a keypair and the instance is in **Running** state.
 
 * `system_disk_type` - (Optional, String, ForceNew) Specifies the system disk type of the instance. Defaults to `GPSSD`.
@@ -250,8 +250,8 @@ The following arguments are supported:
 * `system_disk_size` - (Optional, Int) Specifies the system disk size in GB, The value range is 1 to 1024.
   Shrinking the disk is not supported.
 
-* `system_disk_kms_key_id` - (Optional, String, ForceNew) Specifies the ID of a KMS key used to encrypt the system disk.
-  Changing this creates a new instance.
+* `system_disk_kms_key_id` - (Optional, String) Specifies the ID of a KMS key used to encrypt the system disk. It can
+  only be modified when `image_id` or `image_name` is modified.
 
   -> **NOTE:** This parameter is only supported in some regions, such as ap-southeast-3.
     If not supported, please contact technical support.

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
@@ -30,6 +30,10 @@ func TestAccComputeInstance_basic(t *testing.T) {
 					testAccCheckComputeInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "terraform test"),
+					resource.TestCheckResourceAttrPair(resourceName, "image_id",
+						"data.huaweicloud_images_image.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "image_name", "Ubuntu 18.04 server 64bit"),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test"),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttrSet(resourceName, "system_disk_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "security_groups.#"),
@@ -58,6 +62,9 @@ func TestAccComputeInstance_basic(t *testing.T) {
 					testAccCheckComputeInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", rName+"-update"),
 					resource.TestCheckResourceAttr(resourceName, "description", "terraform test update"),
+					resource.TestCheckResourceAttrPair(resourceName, "image_id",
+						"data.huaweicloud_images_image.test_update", "id"),
+					resource.TestCheckResourceAttr(resourceName, "image_name", "Ubuntu 20.04 server 64bit"),
 					resource.TestCheckResourceAttr(resourceName, "system_disk_size", "60"),
 					resource.TestCheckResourceAttr(resourceName, "agency_name", "test222"),
 					resource.TestCheckResourceAttr(resourceName, "agent_list", "ces"),
@@ -600,16 +607,27 @@ func testAccComputeInstance_update(rName string) string {
 	return fmt.Sprintf(`
 %s
 
+data "huaweicloud_images_image" "test_update" {
+  name        = "Ubuntu 20.04 server 64bit"
+  most_recent = true
+}
+
 resource "huaweicloud_compute_instance" "test" {
   name                = "%s-update"
   description         = "terraform test update"
-  image_id            = data.huaweicloud_images_image.test.id
+  image_id            = data.huaweicloud_images_image.test_update.id
   flavor_id           = data.huaweicloud_compute_flavors.test.ids[0]
   security_group_ids  = [data.huaweicloud_networking_secgroup.test.id]
   stop_before_destroy = true
   agency_name         = "test222"
   agent_list          = "ces"
   auto_terminate_time = ""
+
+  user_data = <<EOF
+#! /bin/bash
+echo user_test > /home/user.txt
+echo "hello wrold"
+EOF
 
   network {
     uuid              = data.huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/services/bms/resource_huaweicloud_bms_volume_attach.go
+++ b/huaweicloud/services/bms/resource_huaweicloud_bms_volume_attach.go
@@ -268,7 +268,7 @@ func bmsJobRefreshFunc(client *golangsdk.ServiceClient, jobId string) resource.S
 		}
 
 		if status == "FAIL" {
-			return getRespBody, "FAIL", fmt.Errorf("the connection status is: %s", status)
+			return getRespBody, "FAIL", fmt.Errorf("the BMS job status is: %s", status)
 		}
 		if status == "SUCCESS" {
 			return getRespBody, "SUCCESS", nil

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -2,6 +2,7 @@ package ecs
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"log"
@@ -42,6 +43,8 @@ var (
 // @API ECS POST /v1.1/{project_id}/cloudservers
 // @API ECS POST /v1/{project_id}/cloudservers/delete
 // @API ECS PUT /v1/{project_id}/cloudservers/{server_id}
+// @API ECS POST /v2/{project_id}/cloudservers/{server_id}/changeos
+// @API ECS POST /v1/{project_id}/cloudservers/{server_id}/changeos
 // @API ECS POST /v1/{project_id}/cloudservers/action
 // @API ECS POST /v1/{project_id}/cloudservers/{server_id}/metadata
 // @API ECS DELETE /v1/{project_id}/cloudservers/{server_id}/metadata/{key}
@@ -106,14 +109,12 @@ func ResourceComputeInstance() *schema.Resource {
 			"image_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Computed:    true,
 				DefaultFunc: schema.EnvDefaultFunc("HW_IMAGE_ID", nil),
 			},
 			"image_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Computed:    true,
 				DefaultFunc: schema.EnvDefaultFunc("HW_IMAGE_NAME", nil),
 			},
@@ -229,7 +230,6 @@ func ResourceComputeInstance() *schema.Resource {
 			"system_disk_kms_key_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"system_disk_iops": {
@@ -1125,6 +1125,10 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		return diag.Errorf("error creating compute V1 client: %s", err)
 	}
+	imsClient, err := cfg.ImageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating image client: %s", err)
+	}
 	ecsV11Client, err := cfg.ComputeV11Client(region)
 	if err != nil {
 		return diag.Errorf("error creating compute V1.1 client: %s", err)
@@ -1146,6 +1150,41 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 	} else if d.HasChange("auto_renew") {
 		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), serverID); err != nil {
 			return diag.Errorf("error updating the auto-renew of the instance (%s): %s", serverID, err)
+		}
+	}
+
+	if d.HasChanges("image_id", "image_name") {
+		err = updateInstanceImage(ctx, d, ecsClient, imsClient)
+		if err != nil {
+			return diag.Errorf("error updating ECS instance image (%s): %s", serverID, err)
+		}
+	} else {
+		if d.HasChange("admin_pass") {
+			if newPwd, ok := d.Get("admin_pass").(string); ok {
+				err := cloudservers.ChangeAdminPassword(ecsClient, serverID, newPwd).ExtractErr()
+				if err != nil {
+					return diag.Errorf("error changing admin password of server (%s): %s", serverID, err)
+				}
+			}
+		}
+		if d.HasChange("key_pair") {
+			kmsClient, err := cfg.KmsV3Client(region)
+			if err != nil {
+				return diag.Errorf("error creating KMS v3 client: %s", err)
+			}
+
+			o, n := d.GetChange("key_pair")
+			keyPairOpts := &common.KeypairAuthOpts{
+				InstanceID:       serverID,
+				InUsedKeyPair:    o.(string),
+				NewKeyPair:       n.(string),
+				InUsedPrivateKey: d.Get("private_key").(string),
+				Password:         d.Get("admin_pass").(string),
+				Timeout:          d.Timeout(schema.TimeoutUpdate),
+			}
+			if err := common.UpdateEcsInstanceKeyPair(ctx, ecsClient, kmsClient, keyPairOpts); err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 
@@ -1214,15 +1253,6 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 				return diag.Errorf("error adding security group (%s) to server (%s): %s", g, serverID, err)
 			}
 			log.Printf("[DEBUG] added security group (%s) to instance (%s)", g, serverID)
-		}
-	}
-
-	if d.HasChange("admin_pass") {
-		if newPwd, ok := d.Get("admin_pass").(string); ok {
-			err := cloudservers.ChangeAdminPassword(ecsClient, serverID, newPwd).ExtractErr()
-			if err != nil {
-				return diag.Errorf("error changing admin password of server (%s): %s", serverID, err)
-			}
 		}
 	}
 
@@ -1335,27 +1365,6 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
-	// update the key_pair before power action
-	if d.HasChange("key_pair") {
-		kmsClient, err := cfg.KmsV3Client(region)
-		if err != nil {
-			return diag.Errorf("error creating KMS v3 client: %s", err)
-		}
-
-		o, n := d.GetChange("key_pair")
-		keyPairOpts := &common.KeypairAuthOpts{
-			InstanceID:       serverID,
-			InUsedKeyPair:    o.(string),
-			NewKeyPair:       n.(string),
-			InUsedPrivateKey: d.Get("private_key").(string),
-			Password:         d.Get("admin_pass").(string),
-			Timeout:          d.Timeout(schema.TimeoutUpdate),
-		}
-		if err := common.UpdateEcsInstanceKeyPair(ctx, ecsClient, kmsClient, keyPairOpts); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
 	// The instance power status update needs to be done at the end
 	if d.HasChange("power_action") {
 		action := d.Get("power_action").(string)
@@ -1407,6 +1416,95 @@ func cloudVolumeRefreshFunc(c *golangsdk.ServiceClient, volumeId string) resourc
 		}
 		return response, "ERROR", nil
 	}
+}
+
+func updateInstanceImage(ctx context.Context, d *schema.ResourceData, ecsClient, imsClient *golangsdk.ServiceClient) error {
+	image, err := getImageFromConfig(d, imsClient)
+	if err != nil {
+		return err
+	}
+
+	var (
+		httpUrlWithoutCloudInit = "v1/{project_id}/cloudservers/{server_id}/changeos"
+		httpUrlWithCloudInit    = "v2/{project_id}/cloudservers/{server_id}/changeos"
+	)
+
+	updatePath := ""
+	if image.SupportFcInject == "true" {
+		updatePath = ecsClient.Endpoint + httpUrlWithCloudInit
+	} else {
+		updatePath = ecsClient.Endpoint + httpUrlWithoutCloudInit
+	}
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", ecsClient.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{server_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	updateOpt.JSONBody = utils.RemoveNil(buildUpdateInstanceImageBodyParams(d, image.ID))
+
+	updateResp, err := ecsClient.Request("POST", updatePath, &updateOpt)
+	if err != nil {
+		return fmt.Errorf("error updating ECS instance image: %s", err)
+	}
+	updateRespBody, err := utils.FlattenResponse(updateResp)
+	if err != nil {
+		return err
+	}
+
+	jobId := utils.PathSearch("job_id", updateRespBody, "").(string)
+	if jobId == "" {
+		return errors.New("error updating ECS instance image: job_id is not found in API response")
+	}
+
+	return waitForJobComplete(ctx, ecsClient, jobId, d.Timeout(schema.TimeoutUpdate))
+}
+
+func buildUpdateInstanceImageBodyParams(d *schema.ResourceData, imageId string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"imageid":   imageId,
+		"adminpass": utils.ValueIgnoreEmpty(d.Get("admin_pass")),
+		"keyname":   utils.ValueIgnoreEmpty(d.Get("key_pair")),
+		"userid":    utils.ValueIgnoreEmpty(d.Get("user_id")),
+		"metadata":  buildUpdateInstanceImageMetadataBodyParams(d),
+		"mode":      "withStopServer",
+	}
+
+	if d.Get("charging_mode") == "prePaid" {
+		bodyParams["isAutoPay"] = "true"
+	}
+
+	return map[string]interface{}{
+		"os-change": bodyParams,
+	}
+}
+
+func buildUpdateInstanceImageMetadataBodyParams(d *schema.ResourceData) map[string]interface{} {
+	v, ok := d.GetOk("user_data")
+	if !ok {
+		return nil
+	}
+	userData := v.(string)
+	if _, err := base64.StdEncoding.DecodeString(userData); err != nil {
+		userData = base64.StdEncoding.EncodeToString([]byte(userData))
+	}
+	bodyParams := map[string]interface{}{
+		"user_data": userData,
+	}
+	if v, ok = d.GetOk("system_disk_kms_key_id"); ok {
+		bodyParams["__system__encrypted"] = "1"
+		bodyParams["__system__cmkid"] = v
+	}
+
+	return bodyParams
+}
+
+func getImageFromConfig(d *schema.ResourceData, imsClient *golangsdk.ServiceClient) (*cloudimages.Image, error) {
+	if d.HasChange("image_id") {
+		return getImage(imsClient, d.Get("image_id").(string), "")
+	}
+	return getImage(imsClient, "", d.Get("image_name").(string))
 }
 
 func updateInstanceMetaData(d *schema.ResourceData, client *golangsdk.ServiceClient, serverID string) error {
@@ -2259,4 +2357,59 @@ func buildInstanceDataVolumes(d *schema.ResourceData) []cloudservers.DataVolume 
 		volRequests = append(volRequests, volRequest)
 	}
 	return volRequests
+}
+
+func waitForJobComplete(ctx context.Context, client *golangsdk.ServiceClient, jobId string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      ecsJobRefreshFunc(client, jobId),
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for ECS job(%s) to complete: %s ", jobId, err)
+	}
+	return nil
+}
+
+func ecsJobRefreshFunc(client *golangsdk.ServiceClient, jobId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var (
+			httpUrl = "v1/{project_id}/jobs/{job_id}"
+		)
+
+		getPath := client.Endpoint + httpUrl
+		getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+		getPath = strings.ReplaceAll(getPath, "{job_id}", jobId)
+
+		getOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		}
+		getResp, err := client.Request("GET", getPath, &getOpt)
+		if err != nil {
+			return nil, "FAIL", err
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return nil, "FAIL", err
+		}
+
+		status := utils.PathSearch("status", getRespBody, "").(string)
+		if status == "" {
+			return getRespBody, "FAIL", errors.New("status is not found in the response")
+		}
+
+		if status == "FAIL" {
+			return getRespBody, "FAIL", fmt.Errorf("the ECS job status is: %s", status)
+		}
+		if status == "SUCCESS" {
+			return getRespBody, "SUCCESS", nil
+		}
+
+		return getRespBody, "PENDING", nil
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  ecs instance support update image
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  ecs instance support update image
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/ecs/ TESTARGS='-run TestAccComputeInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs/ -v -run TestAccComputeInstance_ -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== RUN   TestAccComputeInstance_prePaid
=== PAUSE TestAccComputeInstance_prePaid
=== RUN   TestAccComputeInstance_spot
=== PAUSE TestAccComputeInstance_spot
=== RUN   TestAccComputeInstance_powerAction
=== PAUSE TestAccComputeInstance_powerAction
=== RUN   TestAccComputeInstance_disk_encryption
=== PAUSE TestAccComputeInstance_disk_encryption
=== RUN   TestAccComputeInstance_diskIopsThroughput
=== PAUSE TestAccComputeInstance_diskIopsThroughput
=== RUN   TestAccComputeInstance_withEPS
=== PAUSE TestAccComputeInstance_withEPS
=== RUN   TestAccComputeInstance_changeNetwork
=== PAUSE TestAccComputeInstance_changeNetwork
=== RUN   TestAccComputeInstance_with_deh
=== PAUSE TestAccComputeInstance_with_deh
=== RUN   TestAccComputeInstance_change_charging_mode_to_prepaid
=== PAUSE TestAccComputeInstance_change_charging_mode_to_prepaid
=== CONT  TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_diskIopsThroughput
=== CONT  TestAccComputeInstance_powerAction
=== CONT  TestAccComputeInstance_spot
--- PASS: TestAccComputeInstance_spot (214.73s)
=== CONT  TestAccComputeInstance_disk_encryption
    acceptance.go:2343: This environment does not support KMS tests
--- SKIP: TestAccComputeInstance_disk_encryption (0.01s)
=== CONT  TestAccComputeInstance_prePaid
--- PASS: TestAccComputeInstance_basic (474.39s)
=== CONT  TestAccComputeInstance_with_deh
    acceptance.go:4451: HW_DEDICATED_HOST_ID must be set for the acceptance test
--- SKIP: TestAccComputeInstance_with_deh (0.03s)
=== CONT  TestAccComputeInstance_change_charging_mode_to_prepaid
--- PASS: TestAccComputeInstance_prePaid (424.01s)
=== CONT  TestAccComputeInstance_changeNetwork
--- PASS: TestAccComputeInstance_diskIopsThroughput (739.10s)
=== CONT  TestAccComputeInstance_withEPS
    acceptance.go:1244: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccComputeInstance_withEPS (0.01s)
--- PASS: TestAccComputeInstance_powerAction (903.07s)
--- PASS: TestAccComputeInstance_change_charging_mode_to_prepaid (461.79s)
--- PASS: TestAccComputeInstance_changeNetwork (468.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       1107.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
