### PR TITLE
feat(mrs): add a new data source to get cluster available flavors

### DIFF
--- a/docs/data-sources/mapreduce_available_flavors.md
+++ b/docs/data-sources/mapreduce_available_flavors.md
@@ -1,0 +1,60 @@
+---
+subcategory: "MapReduce Service (MRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_mapreduce_available_flavors"
+description: |-
+  Use this data source to get the available flavors of MRS cluster within HuaweiCloud.
+---
+
+# huaweicloud_mapreduce_available_flavors
+
+Use this data source to get the available flavors of MRS cluster within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "version_name" {}
+
+data "huaweicloud_mapreduce_available_flavors" "test" {
+  version_name = var.version_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the flavors are located.  
+  If omitted, the provider-level region will be used.
+
+* `version_name` - (Required, String) Specifies the version name of the cluster. e.g. `MRS 3.5.0-LTS`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `available_flavors` - The list of available flavors.  
+  The [available_flavors](#available_flavors_struct) structure is documented below.
+
+<a name="available_flavors_struct"></a>
+The `available_flavors` block supports:
+
+* `az_code` - The availability zone code.
+
+* `az_name` - The availability zone name.
+
+* `master` - The list of flavors supported by master nodes.  
+  The [master](#node_available_flavors_struct) structure is documented below.
+
+* `core` - The list of flavors supported by core nodes.  
+  The [core](#node_available_flavors_struct) structure is documented below.
+
+* `task` - The list of flavors supported by task nodes.  
+  The [task](#node_available_flavors_struct) structure is documented below.
+
+<a name="node_available_flavors_struct"></a>
+The `master`, `core` and `task` blocks support:
+
+* `flavor_name` - The flavor name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1887,6 +1887,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelartsv2_resource_pools":      modelarts.DataSourceV2ResourcePools(),
 
 			"huaweicloud_mapreduce_availability_zones": mrs.DataSourceAvailabilityZones(),
+			"huaweicloud_mapreduce_available_flavors":  mrs.DataSourceAvailableFlavors(),
 			"huaweicloud_mapreduce_cluster_nodes":      mrs.DataSourceClusterNodes(),
 			"huaweicloud_mapreduce_clusters":           mrs.DataSourceMrsClusters(),
 			"huaweicloud_mapreduce_versions":           mrs.DataSourceMrsVersions(),

--- a/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_available_flavors_test.go
+++ b/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_available_flavors_test.go
@@ -1,0 +1,50 @@
+package mrs
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataAvailableFlavors_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_mapreduce_available_flavors.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataAvailableFlavors_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(all, "version_name"),
+					resource.TestMatchResourceAttr(all, "available_flavors.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "available_flavors.0.az_code"),
+					resource.TestCheckResourceAttrSet(all, "available_flavors.0.az_name"),
+					resource.TestMatchResourceAttr(all, "available_flavors.0.master.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "available_flavors.0.master.0.flavor_name"),
+					resource.TestMatchResourceAttr(all, "available_flavors.0.core.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "available_flavors.0.core.0.flavor_name"),
+					resource.TestMatchResourceAttr(all, "available_flavors.0.task.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "available_flavors.0.task.0.flavor_name"),
+				),
+			},
+		},
+	})
+}
+
+const testDataAvailableFlavors_basic = `
+data "huaweicloud_mapreduce_versions" "test" {}
+
+data "huaweicloud_mapreduce_available_flavors" "test" {
+  version_name = try(data.huaweicloud_mapreduce_versions.test.versions[0], null)
+}
+`

--- a/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_available_flavors.go
+++ b/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_available_flavors.go
@@ -1,0 +1,183 @@
+package mrs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API MRS GET /v2/{project_id}/metadata/version/{version_name}/available-flavor
+func DataSourceAvailableFlavors() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAvailableFlavorsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the flavors are located.`,
+			},
+			"version_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The version name of the cluster.`,
+			},
+			"available_flavors": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of available flavors.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"az_code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The availability zone code.`,
+						},
+						"az_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The availability zone name.`,
+						},
+						"master": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of flavors supported by master nodes.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"flavor_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The flavor name.`,
+									},
+								},
+							},
+						},
+						"core": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of flavors supported by core nodes.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"flavor_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The flavor name.`,
+									},
+								},
+							},
+						},
+						"task": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of flavors supported by task nodes.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"flavor_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The flavor name.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listAvailableFlavors(client *golangsdk.ServiceClient, versionName string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/metadata/version/{version_name}/available-flavor"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{version_name}", versionName)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func dataSourceAvailableFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("mrs", region)
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	respBody, err := listAvailableFlavors(client, d.Get("version_name").(string))
+	if err != nil {
+		return diag.Errorf("error retrieving cluster available flavors: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("version_name", utils.PathSearch("version_name", respBody, nil)),
+		d.Set("available_flavors", flattenAvailableFlavors(utils.PathSearch("available_flavors", respBody,
+			make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAvailableFlavors(flavors []interface{}) []interface{} {
+	if len(flavors) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(flavors))
+	for _, v := range flavors {
+		rst = append(rst, map[string]interface{}{
+			"az_code": utils.PathSearch("az_code", v, nil),
+			"az_name": utils.PathSearch("az_name", v, nil),
+			"master":  flattenNodeAvailableFlavors(utils.PathSearch("master", v, make([]interface{}, 0)).([]interface{})),
+			"core":    flattenNodeAvailableFlavors(utils.PathSearch("core", v, make([]interface{}, 0)).([]interface{})),
+			"task":    flattenNodeAvailableFlavors(utils.PathSearch("task", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenNodeAvailableFlavors(flavors []interface{}) []interface{} {
+	if len(flavors) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(flavors))
+	for _, v := range flavors {
+		rst = append(rst, map[string]interface{}{
+			"flavor_name": utils.PathSearch("flavor_name", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_mapreduce_available_flavors`) to get cluster available flavors.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o mrs -f TestAccDataAvailableFlavors_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccDataAvailableFlavors_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAvailableFlavors_basic
=== PAUSE TestAccDataAvailableFlavors_basic
=== CONT  TestAccDataAvailableFlavors_basic
--- PASS: TestAccDataAvailableFlavors_basic (73.23s)
PASS
coverage: 6.6% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       73.314s coverage: 6.6% of statements in ./huaweicloud/services/mrs
```
<img width="1378" height="36" alt="image" src="https://github.com/user-attachments/assets/5baf6836-1d14-406b-893b-9e132158f3fc" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
