### PR TITLE
feat(cse): add new data source support for microservices query

### DIFF
--- a/docs/data-sources/cse_microservices.md
+++ b/docs/data-sources/cse_microservices.md
@@ -1,0 +1,160 @@
+---
+subcategory: "Cloud Service Engine (CSE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cse_microservices"
+description: |-
+  Use this data source to get the list of microservices registered under a specified microservice engine within
+  HuaweiCloud.
+---
+
+# huaweicloud_cse_microservices
+
+Use this data source to get the list of microservices registered under a specified microservice engine within
+HuaweiCloud.
+
+-> Before querying microservices, make sure that the engine is bound to the EIP and that the rules shown in the
+   appendix [table](#cse_microservices_default_engine_access_rules) are enabled in the corresponding security group.
+
+## Example Usage
+
+### Query microservices with RBAC authentication disabled
+
+```hcl
+variable "microservice_engine_id" {} // Enable the EIP access
+
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  filter_engines = [
+    for o in data.huaweicloud_cse_microservice_engines.test.engines : o
+    if o.id == var.microservice_engine_id
+  ]
+}
+
+data "huaweicloud_cse_microservices" "test" {
+  auth_address    = local.filter_engines[0].service_registry_addresses[0].public
+  connect_address = local.filter_engines[0].service_registry_addresses[0].public
+}
+```
+
+### Query microservices with RBAC authentication enabled
+
+```hcl
+variable "microservice_engine_id" {} // Enable the EIP access
+variable "admin_user" {}
+variable "admin_password" {}
+
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  filter_engines = [
+    for o in data.huaweicloud_cse_microservice_engines.test.engines : o
+    if o.id == var.microservice_engine_id
+  ]
+}
+
+data "huaweicloud_cse_microservices" "test" {
+  auth_address    = local.filter_engines[0].service_registry_addresses[0].public
+  connect_address = local.filter_engines[0].service_registry_addresses[0].public
+  admin_user      = var.admin_user
+  admin_pass      = var.admin_password
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `auth_address` - (Required, String) Specifies the address that used to request the access token.
+
+* `connect_address` - (Required, String) Specifies the address that used to access the engine and query microservices.
+
+-> We are only support IPv4 addresses yet (for `auth_address` and `connect_address`).
+
+* `admin_user` - (Optional, String) Specifies the user name that used to pass the **RBAC** control.
+
+* `admin_pass` - (Optional, String) Specifies the user password that used to pass the **RBAC** control.  
+  The password format must meet the following conditions:
+  + Must be `8` to `32` characters long.
+  + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
+    (-~!@#%^*_=+?$&()|<>{}[]).
+  + Cannot be the account name or account name spelled backwards.
+  + The password can only start with a letter.
+
+-> Both `admin_user` and `admin_pass` are required if **RBAC** is enabled for the microservice engine.
+
+~> Please make sure that all the above parameter values ​​are correct; otherwise, **Terraform** will report a connection
+   error.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `microservices` - The list of all microservices.  
+  The [microservices](#cse_microservices_list) structure is documented below.
+
+<a name="cse_microservices_list"></a>
+The `microservices` block supports:
+
+* `id` - The ID of the microservice.
+
+* `name` - The name of the microservice.
+
+* `app_id` - The application ID of the microservice.
+
+* `version` - The version of the microservice.
+
+* `environment` - The environment type of the microservice.
+
+* `level` - The level of the microservice.
+
+* `description` - The description of the microservice.
+
+* `status` - The status of the microservice.
+
+* `framework` - The framework information of the microservice.  
+  The [framework](#cse_microservices_framework) structure is documented below.
+
+* `schemas` - The list of schemas supported by the microservice.
+
+* `paths` - The list of paths exposed by the microservice.  
+  The [paths](#cse_microservices_paths) structure is documented below.
+
+* `properties` - The extended attributes of the microservice, in key/value format.
+
+* `created_at` - The creation time of the microservice, in RFC3339 format.
+
+* `updated_at` - The latest update time of the microservice, in RFC3339 format.
+
+<a name="cse_microservices_framework"></a>
+The `framework` block supports:
+
+* `name` - The name of the framework.
+
+* `version` - The version of the framework.
+
+<a name="cse_microservices_paths"></a>
+The `paths` block supports:
+
+* `path` - The path of the microservice route.
+
+* `properties` - The properties of the microservice route, in JSON string format.
+
+## Appendix
+
+<a name="cse_microservices_default_engine_access_rules"></a>
+Security group rules required to access the engine:
+(Remote is not the minimum range and can be adjusted according to business needs)
+
+| Direction | Priority | Action | Protocol | Ports         | Ethertype | Remote                |
+| --------- | -------- | ------ | -------- | ------------- | --------- | --------------------- |
+| Ingress   | 1        | Allow  | ICMP     | All           | Ipv6      | ::/0                  |
+| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv6      | ::/0                  |
+| Ingress   | 1        | Allow  | All      | All           | Ipv6      | cse-engine-default-sg |
+| Ingress   | 1        | Allow  | ICMP     | All           | Ipv4      | A CIDR containing the public IP address of the machine from which you executed this terraform script, such as **0.0.0.0/0** |
+| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv4      | A CIDR containing the public IP address of the machine from which you executed this terraform script, such as **0.0.0.0/0** |
+| Ingress   | 1        | Allow  | All      | All           | Ipv4      | cse-engine-default-sg |
+| Egress    | 100      | Allow  | All      | All           | Ipv6      | ::/0                  |
+| Egress    | 100      | Allow  | All      | All           | Ipv4      | 0.0.0.0/0             |

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -992,6 +992,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cse_microservice_engine_flavors":        cse.DataSourceMicroserviceEngineFlavors(),
 			"huaweicloud_cse_microservice_engines":               cse.DataSourceMicroserviceEngines(),
 			"huaweicloud_cse_microservice_instances":             cse.DataSourceMicroserviceInstances(),
+			"huaweicloud_cse_microservices":                      cse.DataSourceMicroservices(),
 			"huaweicloud_cse_nacos_namespaces":                   cse.DataSourceNacosNamespaces(),
 
 			"huaweicloud_cpcs_app_access_keys":     dew.DataSourceCpcsAppAccessKeys(),

--- a/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservices_test.go
+++ b/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservices_test.go
@@ -1,0 +1,131 @@
+package cse
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataMicroservices_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_cse_microservices.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCSEMicroserviceEngineID(t)
+			acceptance.TestAccPreCheckCSEMicroserviceEngineAdminPassword(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataMicroservices_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "microservices.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckOutput("is_microservice_listed", "true"),
+					resource.TestCheckOutput("is_microservice_name_set", "true"),
+					resource.TestCheckOutput("is_microservice_app_id_set", "true"),
+					resource.TestCheckOutput("is_microservice_version_set", "true"),
+					resource.TestCheckOutput("is_microservice_environment_set", "true"),
+					resource.TestCheckOutput("is_microservice_description_set", "true"),
+					resource.TestCheckOutput("is_microservice_level_set", "true"),
+					resource.TestCheckOutput("is_created_at_set_and_valid", "true"),
+					resource.TestCheckOutput("is_updated_at_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataMicroservices_basic(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  id_filter_result = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"]
+}
+
+resource "huaweicloud_cse_microservice" "test" {
+  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
+  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+
+  name        = "%[2]s"
+  app_name    = "%[2]s"
+  environment = "development"
+  version     = "1.0.1"
+  description = "Created by terraform test"
+  level       = "BACK"
+
+  admin_user = "root"
+  admin_pass = "%[3]s"
+
+  lifecycle {
+    ignore_changes = [
+      admin_pass,
+    ]
+  }
+}
+
+data "huaweicloud_cse_microservices" "test" {
+  depends_on = [huaweicloud_cse_microservice.test]
+
+  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
+  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+  admin_user      = "root"
+  admin_pass      = "%[3]s"
+}
+
+locals {
+  filter_result = try([
+    for o in data.huaweicloud_cse_microservices.test.microservices : o if o.id == huaweicloud_cse_microservice.test.id
+  ][0], null)
+}
+
+output "is_microservice_listed" {
+  value = try(length(data.huaweicloud_cse_microservices.test.microservices) > 0, false)
+}
+
+output "is_microservice_name_set" {
+  value = try(local.filter_result.name == huaweicloud_cse_microservice.test.name, false)
+}
+
+output "is_microservice_app_id_set" {
+  value = try(local.filter_result.app_id == huaweicloud_cse_microservice.test.app_name, false)
+}
+
+output "is_microservice_version_set" {
+  value = try(local.filter_result.version == huaweicloud_cse_microservice.test.version, false)
+}
+
+output "is_microservice_environment_set" {
+  value = try(local.filter_result.environment == huaweicloud_cse_microservice.test.environment, false)
+}
+
+output "is_microservice_description_set" {
+  value = try(local.filter_result.description == huaweicloud_cse_microservice.test.description, false)
+}
+
+output "is_microservice_level_set" {
+  value = try(local.filter_result.level == huaweicloud_cse_microservice.test.level, false)
+}
+
+output "is_created_at_set_and_valid" {
+  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+    local.filter_result.created_at)) > 0, false)
+}
+
+output "is_updated_at_set_and_valid" {
+  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+    local.filter_result.updated_at)) > 0, false)
+}
+`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID, name, acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD)
+}

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservices.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservices.go
@@ -1,0 +1,294 @@
+package cse
+
+import (
+	"context"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSE GET /v4/{project_id}/registry/microservices
+func DataSourceMicroservices() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMicroservicesRead,
+
+		Schema: map[string]*schema.Schema{
+			// Special parameters.
+			// These parameters are used to specify the address that used to request the access token and access the
+			// microservice engine.
+			"auth_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The address that used to request the access token.`,
+			},
+			"connect_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The address that used to send requests and manage configuration.`,
+			},
+			"admin_user": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"admin_pass"},
+				Description:  `The user name that used to pass the RBAC control.`,
+			},
+			"admin_pass": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				RequiredWith: []string{"admin_user"},
+				Description:  `The user password that used to pass the RBAC control.`,
+			},
+
+			// Attributes.
+			"microservices": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the microservice.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the microservice.`,
+						},
+						"app_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The application ID of the microservice.`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version of the microservice.`,
+						},
+						"environment": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The environment type of the microservice.`,
+						},
+						"level": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The level of the microservice.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the microservice.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the microservice.`,
+						},
+						"framework": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the framework.`,
+									},
+									"version": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The version of the framework.`,
+									},
+								},
+							},
+							Description: `The framework information of the microservice.`,
+						},
+						"schemas": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of schemas supported by the microservice.`,
+						},
+						"paths": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"path": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The path of the microservice route.`,
+									},
+									"properties": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The properties of the microservice route.`,
+									},
+								},
+							},
+							Description: `The list of paths exposed by the microservice.`,
+						},
+						"properties": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The extended attributes of the microservice, in key/value format.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the microservice, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the microservice, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `The list of all microservices.`,
+			},
+		},
+	}
+}
+
+func listMicroservices(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v4/{project_id}/registry/microservices"
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", microserviceDefaultProjectId)
+
+	listOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+	}
+
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `POST /v4/token` interface.
+	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string), d.Get("admin_pass").(string))
+	if err != nil {
+		return nil, err
+	}
+	// If the microservice instance has RBAC authentication enabled, the Authorization header will use a special token
+	// provided by the CSE service to replace the original IAM authentication information (AKSK authentication) in the
+	// request header.
+	if token != "" {
+		listOpts.MoreHeaders["Authorization"] = token
+	}
+
+	requestResp, err := client.Request("GET", listPath, &listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("services", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenMicroservicesFramework(framework map[string]interface{}) []map[string]interface{} {
+	if len(framework) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"name":    utils.PathSearch("name", framework, nil),
+			"version": utils.PathSearch("version", framework, nil),
+		},
+	}
+}
+
+func flattenMicroservicesPaths(paths []interface{}) []map[string]interface{} {
+	if len(paths) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(paths))
+	for _, path := range paths {
+		result = append(result, map[string]interface{}{
+			"path":       utils.PathSearch("Path", path, nil),
+			"properties": utils.JsonToString(utils.PathSearch("properties", path, make(map[string]interface{})).(map[string]interface{})),
+		})
+	}
+	return result
+}
+
+func flattenMicroservices(microservices []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(microservices))
+
+	for _, microservice := range microservices {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("serviceId", microservice, nil),
+			"name":        utils.PathSearch("serviceName", microservice, nil),
+			"app_id":      utils.PathSearch("appId", microservice, nil),
+			"version":     utils.PathSearch("version", microservice, nil),
+			"environment": utils.PathSearch("environment", microservice, nil),
+			"level":       utils.PathSearch("level", microservice, nil),
+			"description": utils.PathSearch("description", microservice, nil),
+			"status":      utils.PathSearch("status", microservice, nil),
+			"framework": flattenMicroservicesFramework(utils.PathSearch("framework",
+				microservice, make(map[string]interface{})).(map[string]interface{})),
+			"schemas":    utils.PathSearch("schemas", microservice, make([]interface{}, 0)).([]interface{}),
+			"paths":      flattenMicroservicesPaths(utils.PathSearch("paths", microservice, make([]interface{}, 0)).([]interface{})),
+			"properties": utils.PathSearch("properties", microservice, make(map[string]interface{})).(map[string]interface{}),
+			"created_at": parseMicroservicesTime(utils.PathSearch("timestamp", microservice, "").(string)),
+			"updated_at": parseMicroservicesTime(utils.PathSearch("modTimestamp", microservice, "").(string)),
+		})
+	}
+
+	return result
+}
+
+func parseMicroservicesTime(timeStampStr string) string {
+	if timeStampStr == "" {
+		return ""
+	}
+
+	r, err := strconv.Atoi(timeStampStr)
+	if err != nil {
+		log.Printf("[ERROR] unable to convert the string (%s) to int", timeStampStr)
+		return ""
+	}
+
+	return utils.FormatTimeStampRFC3339(int64(r), false)
+}
+
+func dataSourceMicroservicesRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v2", "default")
+
+	microservices, err := listMicroservices(client, d)
+	if err != nil {
+		return diag.Errorf("error querying CSE microservices: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("microservices", flattenMicroservices(microservices)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new data source for CSE microservices query.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports a new data source for CSE microservices query
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccDataMicroservices_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccDataMicroservices_basic -timeout 360m -parallel 10
=== RUN   TestAccDataMicroservices_basic
=== PAUSE TestAccDataMicroservices_basic
=== CONT  TestAccDataMicroservices_basic
--- PASS: TestAccDataMicroservices_basic (15.80s)
PASS
coverage: 17.6% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       15.884s coverage: 17.6% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
