### PR TITLE
feat(cfw): new datasource to query inspection vpcs

### DIFF
--- a/docs/data-sources/cfw_inspection_vpcs.md
+++ b/docs/data-sources/cfw_inspection_vpcs.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_inspection_vpcs"
+description: |-
+  Use this data source to get the CFW east-west associated VPC.
+---
+
+# huaweicloud_cfw_inspection_vpcs
+
+Use this data source to get the CFW east-west associated VPC.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+
+data "huaweicloud_cfw_inspection_vpcs" "test" {
+  fw_instance_id = var.fw_instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `fw_instance_id` - (Required, String) Specifies the firewall instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `inspection_vpc_list` - The list of VPCs using traffic redirection.
+
+  The [inspection_vpc_list](#data_inspection_vpc_list_struct) structure is documented below.
+
+<a name="data_inspection_vpc_list_struct"></a>
+The `inspection_vpc_list` block supports:
+
+* `inspection_vpc_id` - The VPC ID for referral.
+
+* `name` - The VPC name for referral.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -844,6 +844,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_access_control_logs":           cfw.DataSourceCfwAccessControlLogs(),
 			"huaweicloud_cfw_attack_logs":                   cfw.DataSourceCfwAttackLogs(),
 			"huaweicloud_cfw_flow_logs":                     cfw.DataSourceCfwFlowLogs(),
+			"huaweicloud_cfw_inspection_vpcs":               cfw.DataSourceInspectionVpcs(),
 			"huaweicloud_cfw_regions":                       cfw.DataSourceCfwRegions(),
 			"huaweicloud_cfw_ips_rules":                     cfw.DataSourceCfwIpsRules(),
 			"huaweicloud_cfw_ips_custom_rules":              cfw.DataSourceCfwIpsCustomRules(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_inspection_vpcs_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_inspection_vpcs_test.go
@@ -1,0 +1,40 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceInspectionVpcs_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cfw_inspection_vpcs.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDataSourceInspectionVpcs_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "inspection_vpc_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDataSourceInspectionVpcs_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_inspection_vpcs" "test" {
+  fw_instance_id = "%s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_inspection_vpcs.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_inspection_vpcs.go
@@ -1,0 +1,114 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/firewall/east-west/inspection-vpc
+func DataSourceInspectionVpcs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInspectionVpcsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"inspection_vpc_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"inspection_vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceInspectionVpcsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cfw"
+		httpUrl = "v1/{project_id}/firewall/east-west/inspection-vpc"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?fw_instance_id=%s", d.Get("fw_instance_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW east-west associated VPC: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	vpcs := utils.PathSearch("data.inspection_vpc_list", respBody, make([]interface{}, 0)).([]interface{})
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("inspection_vpc_list", flattenInspectionVpcListResponse(vpcs)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInspectionVpcListResponse(respArray []interface{}) []map[string]interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"inspection_vpc_id": utils.PathSearch("inspection_vpc_id", v, nil),
+			"name":              utils.PathSearch("name", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query inspection vpcs

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- The data source lacks a testing environment and has no test data.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccDataSourceInspectionVpcs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccDataSourceInspectionVpcs_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceInspectionVpcs_basic
=== PAUSE TestAccDataSourceInspectionVpcs_basic
=== CONT  TestAccDataSourceInspectionVpcs_basic
--- PASS: TestAccDataSourceInspectionVpcs_basic (12.57s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       12.697s coverage: 3.5% of statements in ./huaweicloud/services/cfw
```
<img width="1296" height="81" alt="image" src="https://github.com/user-attachments/assets/c45e0f92-11b6-421e-8741-72875bf63ae7" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
