### PR TITLE
feat(mrs): add new data source to query cluster node list

### DIFF
--- a/docs/data-sources/mapreduce_cluster_nodes.md
+++ b/docs/data-sources/mapreduce_cluster_nodes.md
@@ -1,0 +1,233 @@
+---
+subcategory: "MapReduce Service (MRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_mapreduce_cluster_nodes"
+description: |-
+  Use this data source to query the node list under the specified cluster within HuaweiCloud.
+---
+
+# huaweicloud_mapreduce_cluster_nodes
+
+Use this data source to query the node list under the specified cluster within HuaweiCloud.
+
+## Example Usage
+
+### Query all nodes under the specified cluster
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_mapreduce_cluster_nodes" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+### Query Nodes under the specified node group
+
+```hcl
+variable "cluster_id" {}
+variable "node_group_name" {}
+
+data "huaweicloud_mapreduce_cluster_nodes" "test" {
+  cluster_id = var.cluster_id
+  node_group = var.node_group_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the nodes are located.  
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of the cluster.
+
+* `node_group` - (Optional, String) Specifies the name of the node group to which the node belongs.
+
+* `node_name` - (Optional, String) Specifies the name of the node.  
+  Fuzzy search is supported.
+
+* `query_node_detail` - (Optional, Bool) Specifies whether to query node detail.  
+  Default to **false**.
+
+* `query_ecs_detail` - (Optional, Bool) Specifies whether to query ECS detail.
+  Default to **false**.
+
+* `internal_ip` - (Optional, String) Specifies the internal IP address of the node.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `nodes` - The list of nodes that match the filter parameters.  
+  The [nodes](#cluster_nodes) structure is documented below.
+
+<a name="cluster_nodes"></a>
+The `nodes` block supports:
+
+* `node_name` - The name of the node.
+
+* `resource_id` - The resource ID of the node.
+
+* `node_group_name` - The name of the node group to which the node belongs.
+
+* `node_type` - The type of the node.
+  + **Master**
+  + **Core**
+  + **Task**
+
+* `charging_mode` - The billing type of the node.
+  + **prePaid**
+  + **postPaid**
+
+* `deployment_type` - The deployment type of the node.
+  + **SERVER**: Host type.
+
+* `server_info` - The server information of the node.  
+  The [server_info](#cluster_nodes_server_info) structure is documented below.
+
+* `tags` - The key/value pairs associated with the node.
+
+* `node_detail` - The monitoring information of the node.  
+  The [node_detail](#cluster_nodes_node_detail) structure is documented below.  
+  It is not empty only when `query_node_detail` is set to **true**.
+
+* `node_status` - The status of the node.
+  + **error**
+  + **delete_fail**
+  + **shutdown**
+  + **started**
+  + **attached**
+  + **detached**
+  + **detached_no_subscription**
+  + **detach_fail**
+  + **destroyed**
+  + **lost**
+  + **unknown**
+  + **scaling-up**
+  + **decommissioned**
+  + **decommission_fail**
+  + **restore_fail**
+
+* `component_infos` - The list of components deployed on the node.  
+  The [component_infos](#cluster_nodes_component_infos) structure is documented below.  
+  It is not empty only when `query_node_detail` is set to **true**.
+
+<a name="cluster_nodes_server_info"></a>
+The `server_info` block supports:
+
+* `server_id` - The ID of the server.
+
+* `server_name` - The name of the server.
+
+* `server_type` - The type of the server.
+  + **ECS**
+  + **BMS**
+
+* `data_volumes` - The data disks of the server.  
+  The [data_volumes](#cluster_nodes_server_info_volume) structure is documented below.
+
+* `root_volume` - The system disk configuration of the server.  
+  The [root_volume](#cluster_nodes_server_info_volume) structure is documented below.
+
+* `cpu_type` - The CPU type of the server.
+  + **X86**
+  + **ARM**
+
+* `cpu` - The CPU size of the server.  
+  It is not empty only when `query_ecs_detail` is set to **true**.
+
+* `mem` - The memory size of the server, in MB.
+  It is not empty only when `query_ecs_detail` is set to **true**.
+
+* `internal_ip` - The internal IP address of the server.
+
+<a name="cluster_nodes_server_info_volume"></a>
+The `data_volumes` and `root_volume` blocks support:
+
+* `type` - The disk type.
+  + **SATA**
+  + **SAS**
+  + **SSD**
+  + **GPSSD**
+
+* `size` - The disk size, in GB.
+
+* `count` - The disk count.
+
+<a name="cluster_nodes_node_detail"></a>
+The `node_detail` block supports:
+
+* `running_status` - The running status.
+  + **running**
+  + **BAD**
+  + **UNKNOWN**
+  + **ISOLATED**
+  + **SUSPENDED**
+
+* `cpu_usage` - The CPU usage.
+
+* `memory_usage` - The memory usage.
+
+* `disk_usage` - The disk usage.
+
+* `total_memory` - The total memory, in MB.
+
+* `available_memory` - The available memory, in MB.
+
+* `total_hard_disk_space` - The total hard disk space, in GB.
+
+* `available_hard_disk_space` - The available hard disk space, in GB.
+
+* `network_read` - The network read speed, in Byte/s.
+
+* `network_write` - The network write speed, in Byte/s.
+
+<a name="cluster_nodes_component_infos"></a>
+The `component_infos` block supports:
+
+* `id` - The component ID.
+
+* `name` - The component name.
+
+* `instance_group_name` - The component instance group name.
+
+* `running_status` - The component running status.
+  + **running**
+  + **BAD**
+  + **UNKNOWN**
+  + **ISOLATED**
+  + **SUSPENDED**
+  
+* `ha_status` - The HA status.
+  + **ACTIVE**
+  + **STANDBY**
+  + **OBSERVER**
+  + **UNKNOWN**
+
+* `config_status` - The config status.
+  + **SYNCHRONIZED**  
+  + **EXPIRED**
+  + **FAILED**
+  + **UNKNOWN**
+
+* `role_name` - The role name.
+
+* `role_short_name` - The role short name.
+
+* `role_type` - The role type.
+
+* `service_name` - The service name.
+
+* `pair_name` - The pair name.
+
+* `relation_pairs` - The relation pairs.
+
+* `support_decom` - Whether Decom is supported.
+
+* `support_reinstall` - Whether reinstall is supported.
+
+* `support_collect_stack_info` - Whether stack info collection is supported.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1886,6 +1886,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelartsv2_resource_pools":      modelarts.DataSourceV2ResourcePools(),
 
 			"huaweicloud_mapreduce_availability_zones": mrs.DataSourceAvailabilityZones(),
+			"huaweicloud_mapreduce_cluster_nodes":      mrs.DataSourceClusterNodes(),
 			"huaweicloud_mapreduce_clusters":           mrs.DataSourceMrsClusters(),
 			"huaweicloud_mapreduce_versions":           mrs.DataSourceMrsVersions(),
 

--- a/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_cluster_nodes_test.go
+++ b/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_cluster_nodes_test.go
@@ -1,0 +1,195 @@
+package mrs
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataClusterNodes_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_mapreduce_cluster_nodes.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byNodeGroup = "data.huaweicloud_mapreduce_cluster_nodes.filter_by_node_group"
+		dcByGroup   = acceptance.InitDataSourceCheck(byNodeGroup)
+
+		byNodeName = "data.huaweicloud_mapreduce_cluster_nodes.filter_by_node_name"
+		dcByName   = acceptance.InitDataSourceCheck(byNodeName)
+
+		byQueryNodeDetail   = "data.huaweicloud_mapreduce_cluster_nodes.filter_by_query_node_detail"
+		dcByQueryNodeDetail = acceptance.InitDataSourceCheck(byQueryNodeDetail)
+
+		byQueryEcsDetail   = "data.huaweicloud_mapreduce_cluster_nodes.filter_by_query_ecs_detail"
+		dcByQueryEcsDetail = acceptance.InitDataSourceCheck(byQueryEcsDetail)
+
+		byInternalIp   = "data.huaweicloud_mapreduce_cluster_nodes.filter_by_internal_ip"
+		dcByInternalIp = acceptance.InitDataSourceCheck(byInternalIp)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMrsClusterID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceClusterNodes_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "nodes.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.node_name"),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.resource_id"),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.node_group_name"),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.node_type"),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.charging_mode"),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.deployment_type"),
+					resource.TestCheckResourceAttr(all, "nodes.0.server_info.#", "1"),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.server_info.0.server_id"),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.server_info.0.server_name"),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.server_info.0.server_type"),
+					resource.TestMatchResourceAttr(all, "nodes.0.server_info.0.data_volumes.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.server_info.0.data_volumes.0.type"),
+					resource.TestMatchResourceAttr(all, "nodes.0.server_info.0.data_volumes.0.size", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(all, "nodes.0.server_info.0.data_volumes.0.count", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(all, "nodes.0.server_info.0.root_volume.#", "1"),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.server_info.0.root_volume.0.type"),
+					resource.TestMatchResourceAttr(all, "nodes.0.server_info.0.root_volume.0.size", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(all, "nodes.0.server_info.0.root_volume.0.count", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.server_info.0.cpu_type"),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.server_info.0.internal_ip"),
+					resource.TestCheckResourceAttrSet(all, "nodes.0.node_status"),
+					// Filter by 'node_group' parameter.
+					dcByGroup.CheckResourceExists(),
+					resource.TestCheckOutput("is_node_group_filter_useful", "true"),
+					// Filter by 'node_name' parameter.
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_node_name_filter_useful", "true"),
+					// Filter by 'query_node_detail' parameter.
+					dcByQueryNodeDetail.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byQueryNodeDetail, "nodes.0.node_detail.#", "1"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.node_detail.0.running_status"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.node_detail.0.cpu_usage"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.node_detail.0.memory_usage"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.node_detail.0.disk_usage"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.node_detail.0.total_memory"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.node_detail.0.available_memory"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.node_detail.0.total_hard_disk_space"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.node_detail.0.available_hard_disk_space"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.node_detail.0.network_read"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.node_detail.0.network_write"),
+					resource.TestMatchResourceAttr(byQueryNodeDetail, "nodes.0.component_infos.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.id"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.name"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.instance_group_name"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.running_status"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.ha_status"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.config_status"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.role_name"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.role_short_name"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.role_type"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.service_name"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.support_decom"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.support_reinstall"),
+					resource.TestCheckResourceAttrSet(byQueryNodeDetail, "nodes.0.component_infos.0.support_collect_stack_info"),
+					// some components not have 'pair_name' and 'relation_pairs', so we don't check them.
+					// Filter by 'query_ecs_detail' parameter.
+					dcByQueryEcsDetail.CheckResourceExists(),
+					resource.TestMatchResourceAttr(byQueryEcsDetail, "nodes.0.server_info.0.cpu", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(byQueryEcsDetail, "nodes.0.server_info.0.mem", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'internal_ip' parameter.
+					dcByInternalIp.CheckResourceExists(),
+					resource.TestCheckOutput("is_internal_ip_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceClusterNodes_basic() string {
+	return fmt.Sprintf(`
+# Without any filter parameters.
+data "huaweicloud_mapreduce_cluster_nodes" "test" {
+  cluster_id = "%[1]s"
+}
+
+# Filter by 'node_group' parameter.
+# For a cluster, the master node group name is always 'master_node_default_group'
+locals {
+  node_group_name = "master_node_default_group"
+}
+
+data "huaweicloud_mapreduce_cluster_nodes" "filter_by_node_group" {
+  cluster_id = "%[1]s"
+  node_group = local.node_group_name
+}
+
+locals {
+  node_group_filter_result = [for v in data.huaweicloud_mapreduce_cluster_nodes.filter_by_node_group.nodes[*].node_group_name :
+  v == local.node_group_name]
+}
+
+output "is_node_group_filter_useful" {
+  value = length(local.node_group_filter_result) > 0 && alltrue(local.node_group_filter_result)
+}
+
+# Filter by 'node_name' parameter.
+# Fuzzy matching. The node name must contain the 'master' string.
+locals {
+  node_name = "master"
+}
+
+data "huaweicloud_mapreduce_cluster_nodes" "filter_by_node_name" {
+  cluster_id = "%[1]s"
+  node_name  = local.node_name
+}
+
+locals {
+  node_name_filter_result = [for v in data.huaweicloud_mapreduce_cluster_nodes.filter_by_node_name.nodes[*].node_name :
+  strcontains(v, local.node_name)]
+}
+
+output "is_node_name_filter_useful" {
+  value = length(local.node_name_filter_result) > 0 && alltrue(local.node_name_filter_result)
+}
+
+# Filter by 'query_node_detail' parameters.
+data "huaweicloud_mapreduce_cluster_nodes" "filter_by_query_node_detail" {
+  cluster_id        = "%[1]s"
+  query_node_detail = true
+}
+
+# Filter by 'query_ecs_detail' parameters.
+data "huaweicloud_mapreduce_cluster_nodes" "filter_by_query_ecs_detail" {
+  cluster_id       = "%[1]s"
+  query_ecs_detail = true
+}
+
+# Filter by 'internal_ip' parameters.
+locals {
+  internal_ip = try(data.huaweicloud_mapreduce_cluster_nodes.test.nodes[0].server_info[0].internal_ip, null)
+}
+
+data "huaweicloud_mapreduce_cluster_nodes" "filter_by_internal_ip" {
+  cluster_id  = "%[1]s"
+  internal_ip = local.internal_ip
+}
+
+locals {
+  internal_ip_filter_result = [
+    for v in flatten(data.huaweicloud_mapreduce_cluster_nodes.filter_by_internal_ip.nodes[*].server_info[*].internal_ip) :
+    v == local.internal_ip
+  ]
+}
+
+output "is_internal_ip_filter_useful" {
+  value = length(local.internal_ip_filter_result) > 0 && alltrue(local.internal_ip_filter_result)
+}
+`, acceptance.HW_MRS_CLUSTER_ID)
+}

--- a/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_cluster_nodes.go
+++ b/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_cluster_nodes.go
@@ -1,0 +1,575 @@
+package mrs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API MRS GET /v2/{project_id}/clusters/{cluster_id}/nodes
+func DataSourceClusterNodes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceClusterNodesRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the nodes are located.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster.`,
+			},
+			"node_group": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the node group to which the node belongs.`,
+			},
+			"node_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the node.`,
+			},
+			"query_node_detail": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to query node detail.`,
+			},
+			"query_ecs_detail": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to query ECS detail.`,
+			},
+			"internal_ip": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The internal IP address of the node.`,
+			},
+			"nodes": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of nodes that match the filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"node_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the node.`,
+						},
+						"resource_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The resource ID of the node.`,
+						},
+						"node_group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the node group to which the node belongs.`,
+						},
+						"node_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the node.`,
+						},
+						"charging_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The billing type of the node.`,
+						},
+						"deployment_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The deployment type of the node.`,
+						},
+						"server_info": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The server information of the node.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"server_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the server.`,
+									},
+									"server_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the server.`,
+									},
+									"server_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The type of the server.`,
+									},
+									"data_volumes": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: `The data disks of the server.`,
+										Elem:        clusterNodesVolumeSchema(),
+									},
+									"root_volume": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: `The system disk configuration of the server.`,
+										Elem:        clusterNodesVolumeSchema(),
+									},
+									"cpu_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The CPU type of the server.`,
+									},
+									"cpu": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The CPU size of the server.`,
+									},
+									"mem": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The memory size of the server, in MB.`,
+									},
+									"internal_ip": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The internal IP address of the server.`,
+									},
+								},
+							},
+						},
+						"tags": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The key/value pairs associated with the node.`,
+						},
+						"node_detail": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The monitoring information of the node.`,
+							Elem:        clusterNodesNodeDetailSchema(),
+						},
+						"node_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the node.`,
+						},
+						"component_infos": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of components deployed on the node.`,
+							Elem:        clusterNodesComponentInfoSchema(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func clusterNodesVolumeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The disk type.`,
+			},
+			"size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The disk size, in GB.`,
+			},
+			"count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The disk count.`,
+			},
+		},
+	}
+}
+
+func clusterNodesNodeDetailSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"running_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The running status.`,
+			},
+			"cpu_usage": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The CPU usage.`,
+			},
+			"memory_usage": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The memory usage.`,
+			},
+			"disk_usage": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The disk usage.`,
+			},
+			"total_memory": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The total memory, in MB.`,
+			},
+			"available_memory": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The available memory, in MB.`,
+			},
+			"total_hard_disk_space": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The total hard disk space, in GB.`,
+			},
+			"available_hard_disk_space": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The available hard disk space, in GB.`,
+			},
+			"network_read": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The network read speed, in Byte/s.`,
+			},
+			"network_write": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The network write speed, in Byte/s.`,
+			},
+		},
+	}
+}
+
+func clusterNodesComponentInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The component ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The component name.`,
+			},
+			"instance_group_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The component instance group name.`,
+			},
+			"running_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The component running status.`,
+			},
+			"ha_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The HA status.`,
+			},
+			"config_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The config status.`,
+			},
+			"role_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The role name.`,
+			},
+			"role_short_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The role short name.`,
+			},
+			"role_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The role type.`,
+			},
+			"service_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The service name.`,
+			},
+			"pair_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The pair name.`,
+			},
+			"relation_pairs": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The relation pairs.`,
+			},
+			"support_decom": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Whether Decom is supported.`,
+			},
+			"support_reinstall": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Whether reinstall is supported.`,
+			},
+			"support_collect_stack_info": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Whether stack info collection is supported.`,
+			},
+		},
+	}
+}
+
+func listClusterNodes(client *golangsdk.ServiceClient, d *schema.ResourceData, clusterId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/clusters/{cluster_id}/nodes"
+		// `offset` means the page number, starts from 1.
+		offset = 1
+		limit  = 100
+		result = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{cluster_id}", clusterId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	listPath = fmt.Sprintf("%s?limit=%d%s", listPath, limit, buildListClusterNodesQueryParams(d))
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		nodes := utils.PathSearch("nodes", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, nodes...)
+		if len(nodes) < limit {
+			break
+		}
+
+		offset++
+	}
+
+	return result, nil
+}
+
+func buildListClusterNodesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("node_group"); ok {
+		res = fmt.Sprintf("%s&node_group=%v", res, v)
+	}
+	if v, ok := d.GetOk("node_name"); ok {
+		res = fmt.Sprintf("%s&node_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("query_node_detail"); ok {
+		res = fmt.Sprintf("%s&query_node_detail=%v", res, v)
+	}
+	if v, ok := d.GetOk("query_ecs_detail"); ok {
+		res = fmt.Sprintf("%s&query_ecs_detail=%v", res, v)
+	}
+	if v, ok := d.GetOk("internal_ip"); ok {
+		res = fmt.Sprintf("%s&internal_ip=%v", res, v)
+	}
+
+	return res
+}
+
+func resourceClusterNodesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("mrs", region)
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	nodes, err := listClusterNodes(client, d, clusterId)
+	if err != nil {
+		return diag.Errorf("error retrieving nodes under the specified cluster (%s): %s", clusterId, err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("nodes", flattenClusterNodes(nodes)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenClusterNodes(nodes []interface{}) []interface{} {
+	if len(nodes) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(nodes))
+	for _, v := range nodes {
+		result = append(result, map[string]interface{}{
+			"node_name":       utils.PathSearch("node_name", v, nil),
+			"resource_id":     utils.PathSearch("resource_id", v, nil),
+			"node_group_name": utils.PathSearch("node_group_name", v, nil),
+			"node_type":       utils.PathSearch("node_type", v, nil),
+			"charging_mode":   parseClusterNodeChargingMode(utils.PathSearch("billing_type", v, "").(string)),
+			"deployment_type": utils.PathSearch("deployment_type", v, nil),
+			"server_info":     flattenClusterNodeServerInfo(utils.PathSearch("server_info", v, nil)),
+			"tags":            utils.FlattenTagsToMap(utils.PathSearch("tags", v, nil)),
+			"node_detail":     flattenClusterNodeDetail(utils.PathSearch("node_detail", v, nil)),
+			"node_status":     utils.PathSearch("node_status", v, nil),
+			"component_infos": flattenClusterNodeComponentInfos(utils.PathSearch("component_infos",
+				v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result
+}
+
+func parseClusterNodeChargingMode(chargingMode string) string {
+	switch chargingMode {
+	case "on-period":
+		return "prePaid"
+	case "on-quantity":
+		return "postPaid"
+	}
+
+	return chargingMode
+}
+
+func flattenClusterNodeServerInfo(serverInfo interface{}) []interface{} {
+	if serverInfo == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"server_id":   utils.PathSearch("server_id", serverInfo, nil),
+			"server_name": utils.PathSearch("server_name", serverInfo, nil),
+			"server_type": utils.PathSearch("server_type", serverInfo, nil),
+			"data_volumes": flattenClusterNodesServerInfoVolumes(utils.PathSearch("data_volumes",
+				serverInfo, make([]interface{}, 0)).([]interface{})),
+			"root_volume": flattenClusterNodesServerInfoRootVolume(utils.PathSearch("root_volume", serverInfo, nil)),
+			"cpu_type":    utils.PathSearch("cpu_type", serverInfo, nil),
+			"cpu":         utils.PathSearch("cpu", serverInfo, nil),
+			"mem":         utils.PathSearch("mem", serverInfo, nil),
+			"internal_ip": utils.PathSearch("internal_ip", serverInfo, nil),
+		},
+	}
+}
+
+func flattenClusterNodesServerInfoVolumes(volumes []interface{}) []interface{} {
+	if len(volumes) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(volumes))
+	for _, v := range volumes {
+		result = append(result, map[string]interface{}{
+			"type":  utils.PathSearch("type", v, nil),
+			"size":  utils.PathSearch("size", v, nil),
+			"count": utils.PathSearch("count", v, nil),
+		})
+	}
+	return result
+}
+
+func flattenClusterNodesServerInfoRootVolume(rootVolume interface{}) []interface{} {
+	if rootVolume == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"type":  utils.PathSearch("type", rootVolume, nil),
+			"size":  utils.PathSearch("size", rootVolume, nil),
+			"count": utils.PathSearch("count", rootVolume, nil),
+		},
+	}
+}
+
+func flattenClusterNodeDetail(nodeDetail interface{}) []interface{} {
+	if nodeDetail == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"running_status":            utils.PathSearch("running_status", nodeDetail, nil),
+			"cpu_usage":                 utils.PathSearch("cpu_usage", nodeDetail, nil),
+			"memory_usage":              utils.PathSearch("memory_usage", nodeDetail, nil),
+			"disk_usage":                utils.PathSearch("disk_usage", nodeDetail, nil),
+			"total_memory":              utils.PathSearch("total_memory", nodeDetail, nil),
+			"available_memory":          utils.PathSearch("available_memory", nodeDetail, nil),
+			"total_hard_disk_space":     utils.PathSearch("total_hard_disk_space", nodeDetail, nil),
+			"available_hard_disk_space": utils.PathSearch("available_hard_disk_space", nodeDetail, nil),
+			"network_read":              utils.PathSearch("network_read", nodeDetail, nil),
+			"network_write":             utils.PathSearch("network_write", nodeDetail, nil),
+		},
+	}
+}
+
+func flattenClusterNodeComponentInfos(components []interface{}) []interface{} {
+	if len(components) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(components))
+	for _, v := range components {
+		result = append(result, map[string]interface{}{
+			"id":                         utils.PathSearch("id", v, nil),
+			"name":                       utils.PathSearch("name", v, nil),
+			"instance_group_name":        utils.PathSearch("instance_group_name", v, nil),
+			"running_status":             utils.PathSearch("running_status", v, nil),
+			"ha_status":                  utils.PathSearch("ha_status", v, nil),
+			"config_status":              utils.PathSearch("config_status", v, nil),
+			"role_name":                  utils.PathSearch("role_name", v, nil),
+			"role_short_name":            utils.PathSearch("role_short_name", v, nil),
+			"role_type":                  utils.PathSearch("role_type", v, nil),
+			"service_name":               utils.PathSearch("service_name", v, nil),
+			"pair_name":                  utils.PathSearch("pair_name", v, nil),
+			"relation_pairs":             utils.PathSearch("relation_pairs", v, nil),
+			"support_decom":              utils.PathSearch("support_decom", v, nil),
+			"support_reinstall":          utils.PathSearch("support_reinstall", v, nil),
+			"support_collect_stack_info": utils.PathSearch("support_collect_stack_info", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source (`huaweicloud_mapreduce_cluster_nodes`) to query cluster node list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding documentation and accpetance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o mrs -f TestAccDataClusterNodes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccDataClusterNodes_basic -timeout 360m -parallel 10
=== RUN   TestAccDataClusterNodes_basic
=== PAUSE TestAccDataClusterNodes_basic
=== CONT  TestAccDataClusterNodes_basic
--- PASS: TestAccDataClusterNodes_basic (30.94s)
PASS
coverage: 8.1% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       31.090s coverage: 8.1% of statements in ./huaweicloud/services/mrs
```
<img width="1058" height="61" alt="image" src="https://github.com/user-attachments/assets/a477d383-77cd-476d-b992-625baac178c5" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
