### PR TITLE
feat(cfw): support `cfw_eip_auto_protection` resource

### DIFF
--- a/docs/resources/cfw_eip_auto_protection.md
+++ b/docs/resources/cfw_eip_auto_protection.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_eip_auto_protection"
+description: |-
+  Manages the EIP auto protection resource within HuaweiCloud.
+---
+
+# huaweicloud_cfw_eip_auto_protection
+
+Manages the EIP auto protection resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+variable "object_id" {}
+
+resource "huaweicloud_cfw_eip_auto_protection" "test" {
+  fw_instance_id = var.fw_instance_id
+  object_id      = var.object_id
+  status         = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `fw_instance_id` - (Required, String, NonUpdatable) Specifies the firewall instance ID.
+
+* `object_id` - (Required, String, NonUpdatable) Specifies the protection object ID.
+
+* `status` - (Required, Int, NonUpdatable) Specifies whether to enable the addition of EIP automatic protection.  
+  The valid values are as follows:
+  + **1**: Enable auto protection for new EIPs.
+  + **0**: Disable auto protection for new EIPs.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `object_id`.
+
+* `available_eip_count` - The number of EIPs that can be protected.
+
+* `beyond_max_count` - Whether the EIP count limit is exceeded.
+
+* `eip_protected_self` - The number of protected EIPs.
+
+* `eip_total` - The total number of EIPs.
+
+* `eip_un_protected` - The number of unprotected EIPs.
+
+## Import
+
+The EIP auto protection resource can be imported using `fw_instance_id` and `id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_cfw_eip_auto_protection.test <fw_instance_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2905,6 +2905,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_alarm_config":                  cfw.ResourceAlarmConfig(),
 			"huaweicloud_cfw_anti_virus":                    cfw.ResourceAntiVirus(),
 			"huaweicloud_cfw_black_white_list":              cfw.ResourceBlackWhiteList(),
+			"huaweicloud_cfw_eip_auto_protection":           cfw.ResourceEipAutoProtection(),
 			"huaweicloud_cfw_eip_protection":                cfw.ResourceEipProtection(),
 			"huaweicloud_cfw_service_group":                 cfw.ResourceServiceGroup(),
 			"huaweicloud_cfw_service_group_member":          cfw.ResourceServiceGroupMember(),

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_eip_auto_protection_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_eip_auto_protection_test.go
@@ -1,0 +1,136 @@
+package cfw
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getEipAutoProtectionResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		httpUrl  = "v1/{project_id}/eip/auto-protect-status/{object_id}"
+		product  = "cfw"
+		objectID = state.Primary.ID
+	)
+
+	client, err := cfg.NewServiceClient(product, acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{object_id}", objectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	statusResp := utils.PathSearch("data.status", respBody, float64(0)).(float64)
+	if statusResp == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return utils.PathSearch("data", respBody, nil), nil
+}
+
+func TestAccEipAutoProtection_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_cfw_eip_auto_protection.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getEipAutoProtectionResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testEipAutoProtection_basic(1),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "status", "1"),
+					resource.TestCheckResourceAttrSet(rName, "object_id"),
+					resource.TestCheckResourceAttrSet(rName, "available_eip_count"),
+					resource.TestCheckResourceAttrSet(rName, "beyond_max_count"),
+					resource.TestCheckResourceAttrSet(rName, "eip_protected_self"),
+					resource.TestCheckResourceAttrSet(rName, "eip_total"),
+					resource.TestCheckResourceAttrSet(rName, "eip_un_protected"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testEipAutoProtectionImportState(rName),
+			},
+		},
+	})
+}
+
+func testEipAutoProtection_base() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_firewalls" "test" {
+  fw_instance_id = "%s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}
+
+func testEipAutoProtection_basic(status int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cfw_eip_auto_protection" "test" {
+  fw_instance_id = data.huaweicloud_cfw_firewalls.test.records[0].fw_instance_id
+  object_id      = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+  status         = %[2]d
+}
+`, testEipAutoProtection_base(), status)
+}
+
+func testEipAutoProtectionImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		fwInstanceID := rs.Primary.Attributes["fw_instance_id"]
+		if fwInstanceID == "" {
+			return "", fmt.Errorf("attribute (fw_instance_id) of Resource (%s) not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return "", fmt.Errorf("attribute (ID) of Resource (%s) not found", name)
+		}
+
+		return fmt.Sprintf("%s/%s", fwInstanceID, rs.Primary.ID), nil
+	}
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_eip_auto_protection.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_eip_auto_protection.go
@@ -1,0 +1,250 @@
+package cfw
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var eipAutoProtectionNonUpdatableParams = []string{"fw_instance_id", "object_id", "status", "enterprise_project_id"}
+
+// @API CFW POST /v1/{project_id}/eip/auto-protect-status/switch
+// @API CFW GET /v1/{project_id}/eip/auto-protect-status/{object_id}
+func ResourceEipAutoProtection() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEipAutoProtectionCreate,
+		ReadContext:   resourceEipAutoProtectionRead,
+		UpdateContext: resourceEipAutoProtectionUpdate,
+		DeleteContext: resourceEipAutoProtectionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceEipAutoProtectionImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(eipAutoProtectionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"object_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"status": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"available_eip_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"beyond_max_count": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"eip_protected_self": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"eip_total": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"eip_un_protected": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildEipAutoProtectionSwitchQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	return ""
+}
+
+func buildEipAutoProtectionSwitchBodyParam(fwInstanceID, objectID string, status int) map[string]interface{} {
+	return map[string]interface{}{
+		"fw_instance_id": fwInstanceID,
+		"object_id":      objectID,
+		"status":         status,
+	}
+}
+func resourceEipAutoProtectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v1/{project_id}/eip/auto-protect-status/switch"
+		product      = "cfw"
+		fwInstanceID = d.Get("fw_instance_id").(string)
+		objectID     = d.Get("object_id").(string)
+		status       = d.Get("status").(int)
+		epsId        = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildEipAutoProtectionSwitchQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildEipAutoProtectionSwitchBodyParam(fwInstanceID, objectID, status),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error enabling CFW EIP auto protection: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// The value of the `data` field is the same as the `object_id`, use it as the resource ID.
+	data := utils.PathSearch("data", respBody, "").(string)
+	if data == "" {
+		return diag.Errorf("error enabling CFW EIP auto protection: data is not found in API response")
+	}
+
+	d.SetId(data)
+
+	return resourceEipAutoProtectionRead(ctx, d, meta)
+}
+
+func resourceEipAutoProtectionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/eip/auto-protect-status/{object_id}"
+		product = "cfw"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{object_id}", d.Id())
+	requestPath += buildEipAutoProtectionSwitchQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW EIP auto protection: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// When status = 0, that is, when protection is turned off, perform checkDeleted `404` processing.
+	statusResp := utils.PathSearch("data.status", respBody, float64(0)).(float64)
+	if statusResp == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving CFW EIP auto protection")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("object_id", utils.PathSearch("data.object_id", respBody, nil)),
+		d.Set("status", statusResp),
+		d.Set("available_eip_count", utils.PathSearch("data.available_eip_count", respBody, nil)),
+		d.Set("beyond_max_count", utils.PathSearch("data.beyond_max_count", respBody, nil)),
+		d.Set("eip_protected_self", utils.PathSearch("data.eip_protected_self", respBody, nil)),
+		d.Set("eip_total", utils.PathSearch("data.eip_total", respBody, nil)),
+		d.Set("eip_un_protected", utils.PathSearch("data.eip_un_protected", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceEipAutoProtectionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceEipAutoProtectionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v1/{project_id}/eip/auto-protect-status/switch"
+		product      = "cfw"
+		fwInstanceID = d.Get("fw_instance_id").(string)
+		objectID     = d.Get("object_id").(string)
+		epsId        = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildEipAutoProtectionSwitchQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildEipAutoProtectionSwitchBodyParam(fwInstanceID, objectID, 0),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error disabling CFW EIP auto protection: %s", err)
+	}
+
+	return nil
+}
+
+func resourceEipAutoProtectionImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
+	[]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, errors.New("invalid format specified for import ID, must be <fw_instance_id>/<id>")
+	}
+
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, d.Set("fw_instance_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_eip_auto_protection` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_eip_auto_protection` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccEipAutoProtection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccEipAutoProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccEipAutoProtection_basic
=== PAUSE TestAccEipAutoProtection_basic
=== CONT  TestAccEipAutoProtection_basic
--- PASS: TestAccEipAutoProtection_basic (22.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       23.083s
```
<img width="876" height="33" alt="image" src="https://github.com/user-attachments/assets/3932fcab-b697-49b8-8ce0-012e53c828ce" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
<img width="1235" height="683" alt="image" src="https://github.com/user-attachments/assets/35ad6ee5-d258-4c0b-8334-f1cb90288474" />


    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
