### PR TITLE
feat(cfw): new datasource to query attack log statistics

### DIFF
--- a/docs/data-sources/cfw_attack_log_statistics.md
+++ b/docs/data-sources/cfw_attack_log_statistics.md
@@ -1,0 +1,166 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_attack_log_statistics"
+description: |-
+  Use this data source to get the CFW attack log statistics.
+---
+
+# huaweicloud_cfw_attack_log_statistics
+
+Use this data source to get the CFW attack log statistics.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+
+data "huaweicloud_cfw_attack_log_statistics" "test" {
+  fw_instance_id = var.fw_instance_id
+  log_type       = "internet"
+  action         = 0
+  item           = "src_region_id"
+  value          = "target-object"
+  range          = "2"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `fw_instance_id` - (Required, String) Specifies the firewall instance ID.
+
+* `log_type` - (Required, String) Specifies the log type. Valid values are:
+  + **internet**: North-South oriented log
+  + **nat**: NAT scenario log
+  + **vpc**: East-West oriented log
+  + **vgw**: VGW scenario log
+
+* `action` - (Required, Int) Specifies the action. Valid values are:
+  + `0`: All
+  + `1`: Intercept
+
+* `item` - (Required, String) Specifies the aggregation type. Valid values are:
+  + **src_region_id**: TOP external attack source regions
+  + **attack_type**: TOP attack types
+  + **in_src_ip**: TOP internal attack source IPs
+  + **out_src_ip**: TOP external attack source IPs
+  + **dst_port**: TOP destination ports
+  + **dst_ip**: TOP destination IPs
+  + **attack_rule**: TOP attack rules
+  + **src_ip**: TOP source IPs
+
+* `value` - (Required, String) Specifies the statistical objects.
+
+* `range` - (Optional, String) Specifies the time range. Valid values are:
+  + **0**: one hour
+  + **1**: one day
+  + **2**: seven days
+
+* `start_time` - (Optional, Int) Specifies the start time, in millisecond timestamp.
+
+* `end_time` - (Optional, Int) Specifies the end time, in millisecond timestamp.
+
+* `vgw_id` - (Optional, List) Specifies the VGW ID list.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data` - The data.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `app_count` - The application count.
+
+* `attack_rule_count` - The attack rule count.
+
+* `attack_type_count` - The attack type count.
+
+* `count` - The number of attacks.
+
+* `dst_ip_count` - The destination IP count.
+
+* `dst_port_count` - The destination port count.
+
+* `end_time` - The end time.
+
+* `records` - The attack details.
+
+  The [records](#data_records_struct) structure is documented below.
+
+* `src_ip_count` - The source IP count.
+
+* `start_time` - The start time.
+
+* `total` - The total number.
+
+<a name="data_records_struct"></a>
+The `records` block supports:
+
+* `action` - The action.
+
+* `app` - The application.
+
+* `attack_rule` - The attack rule.
+
+* `attack_rule_id` - The attack rule ID.
+
+* `attack_type` - The attack type.
+
+* `direction` - The attack direction.
+
+* `dst_ip` - The destination IP.
+
+* `dst_port` - The destination port.
+
+* `dst_region_id` - The destination region ID.
+
+* `dst_region_name` - The destination region name.
+
+* `dst_province_id` - The destination province ID.
+
+* `dst_province_name` - The destination province name.
+
+* `dst_city_id` - The destination city ID.
+
+* `dst_city_name` - The destination city name.
+
+* `event_time` - The event time.
+
+* `level` - The risk level.
+
+* `protocol` - The protocol.
+
+* `source` - The source.
+
+* `src_ip` - The source IP.
+
+* `real_ip` - The real IP.
+
+* `tag` - The tag.
+
+* `src_port` - The source port.
+
+* `src_region_id` - The source region ID.
+
+* `src_region_name` - The source region name.
+
+* `src_province_id` - The source province ID.
+
+* `src_province_name` - The source province name.
+
+* `src_city_id` - The source city ID.
+
+* `src_city_name` - The source city name.
+
+* `vgw_id` - The VGW ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -830,6 +830,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_firewalls":                     cfw.DataSourceFirewalls(),
 			"huaweicloud_cfw_address_groups":                cfw.DataSourceCfwAddressGroups(),
 			"huaweicloud_cfw_advanced_ips_rules":            cfw.DataSourceAdvancedIpsRules(),
+			"huaweicloud_cfw_attack_log_statistics":         cfw.DataSourceAttackLogStatistics(),
 			"huaweicloud_cfw_address_group_members":         cfw.DataSourceCfwAddressGroupMembers(),
 			"huaweicloud_cfw_black_white_lists":             cfw.DataSourceCfwBlackWhiteLists(),
 			"huaweicloud_cfw_capture_tasks":                 cfw.DataSourceCfwCaptureTasks(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_attack_log_statistics_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_attack_log_statistics_test.go
@@ -1,0 +1,53 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAttackLogStatistics_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cfw_attack_log_statistics.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAttackLogStatistics_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.app_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.attack_rule_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.attack_type_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.count"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.dst_ip_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.dst_port_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.end_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.src_ip_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.start_time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAttackLogStatistics_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_attack_log_statistics" "test" {
+  fw_instance_id = "%s"
+  log_type       = "internet"
+  action         = 0
+  item           = "src_region_id"
+  value          = "target-object"
+  range          = "2"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_attack_log_statistics.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_attack_log_statistics.go
@@ -1,0 +1,386 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/cfw/logs/attack-detail
+func DataSourceAttackLogStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAttackLogStatisticsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"log_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"action": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"item": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// This field is a numeric type in the API, but we're defining it as a string type here.
+			"range": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"start_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"vgw_id": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"app_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"attack_rule_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"attack_type_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"dst_ip_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"dst_port_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"end_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"records": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     dataAttackLogsStatisticsRecordsSchema(),
+						},
+						"src_ip_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"start_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"total": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataAttackLogsStatisticsRecordsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"action": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"app": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attack_rule": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attack_rule_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attack_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"direction": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"dst_region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_region_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_province_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_province_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_city_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_city_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"event_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"level": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"src_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"real_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tag": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"src_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"src_region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"src_region_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"src_province_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"src_province_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"src_city_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"src_city_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vgw_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildAttackLogStatisticsQueryParams(d *schema.ResourceData) string {
+	rst := fmt.Sprintf(
+		"?fw_instance_id=%s&log_type=%s&action=%d&item=%s&value=%s",
+		d.Get("fw_instance_id").(string),
+		d.Get("log_type").(string),
+		d.Get("action").(int),
+		d.Get("item").(string),
+		d.Get("value").(string),
+	)
+
+	if v, ok := d.GetOk("range"); ok {
+		rst += fmt.Sprintf("&range=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("start_time"); ok {
+		rst += fmt.Sprintf("&start_time=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("end_time"); ok {
+		rst += fmt.Sprintf("&end_time=%s", v.(string))
+	}
+
+	rawArray, ok := d.Get("vgw_id").([]interface{})
+	if ok {
+		for _, v := range rawArray {
+			rst += fmt.Sprintf("&vgw_id=%s", v.(string))
+		}
+	}
+
+	return rst
+}
+
+func dataSourceAttackLogStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cfw"
+		httpUrl = "v1/{project_id}/cfw/logs/attack-detail"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAttackLogStatisticsQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW attack log statistics: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("data", flattenLogStatisticsData(utils.PathSearch("data", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenLogStatisticsData(respBody interface{}) []interface{} {
+	if respBody == nil {
+		return nil
+	}
+
+	return []interface{}{map[string]interface{}{
+		"app_count":         utils.PathSearch("app_count", respBody, nil),
+		"attack_rule_count": utils.PathSearch("attack_rule_count", respBody, nil),
+		"attack_type_count": utils.PathSearch("attack_type_count", respBody, nil),
+		"count":             utils.PathSearch("count", respBody, nil),
+		"dst_ip_count":      utils.PathSearch("dst_ip_count", respBody, nil),
+		"dst_port_count":    utils.PathSearch("dst_port_count", respBody, nil),
+		"end_time":          utils.PathSearch("end_time", respBody, nil),
+		"records":           flattenDataRecords(utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{})),
+		"src_ip_count":      utils.PathSearch("src_ip_count", respBody, nil),
+		"start_time":        utils.PathSearch("start_time", respBody, nil),
+		"total":             utils.PathSearch("total", respBody, nil),
+	}}
+}
+
+func flattenDataRecords(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		result = append(result, map[string]interface{}{
+			"action":            utils.PathSearch("action", v, nil),
+			"app":               utils.PathSearch("app", v, nil),
+			"attack_rule":       utils.PathSearch("attack_rule", v, nil),
+			"attack_rule_id":    utils.PathSearch("attack_rule_id", v, nil),
+			"attack_type":       utils.PathSearch("attack_type", v, nil),
+			"direction":         utils.PathSearch("direction", v, nil),
+			"dst_ip":            utils.PathSearch("dst_ip", v, nil),
+			"dst_port":          utils.PathSearch("dst_port", v, nil),
+			"dst_region_id":     utils.PathSearch("dst_region_id", v, nil),
+			"dst_region_name":   utils.PathSearch("dst_region_name", v, nil),
+			"dst_province_id":   utils.PathSearch("dst_province_id", v, nil),
+			"dst_province_name": utils.PathSearch("dst_province_name", v, nil),
+			"dst_city_id":       utils.PathSearch("dst_city_id", v, nil),
+			"dst_city_name":     utils.PathSearch("dst_city_name", v, nil),
+			"event_time":        utils.PathSearch("event_time", v, nil),
+			"level":             utils.PathSearch("level", v, nil),
+			"protocol":          utils.PathSearch("protocol", v, nil),
+			"source":            utils.PathSearch("source", v, nil),
+			"src_ip":            utils.PathSearch("src_ip", v, nil),
+			"real_ip":           utils.PathSearch("real_ip", v, nil),
+			"tag":               utils.PathSearch("tag", v, nil),
+			"src_port":          utils.PathSearch("src_port", v, nil),
+			"src_region_id":     utils.PathSearch("src_region_id", v, nil),
+			"src_region_name":   utils.PathSearch("src_region_name", v, nil),
+			"src_province_id":   utils.PathSearch("src_province_id", v, nil),
+			"src_province_name": utils.PathSearch("src_province_name", v, nil),
+			"src_city_id":       utils.PathSearch("src_city_id", v, nil),
+			"src_city_name":     utils.PathSearch("src_city_name", v, nil),
+			"vgw_id":            utils.PathSearch("vgw_id", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query attack log statistics

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccDataSourceAttackLogStatistics_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccDataSourceAttackLogStatistics_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAttackLogStatistics_basic
=== PAUSE TestAccDataSourceAttackLogStatistics_basic
=== CONT  TestAccDataSourceAttackLogStatistics_basic
--- PASS: TestAccDataSourceAttackLogStatistics_basic (14.54s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       14.684s coverage: 3.8% of statements in ./huaweicloud/services/cfw
```
<img width="1287" height="75" alt="image" src="https://github.com/user-attachments/assets/ac28cbcc-0e34-49f6-aa46-a38e249acf7c" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
