### PR TITLE
feat(mrs): add new data source to query tags quota

### DIFF
--- a/docs/data-sources/mapreduce_tags_quota.md
+++ b/docs/data-sources/mapreduce_tags_quota.md
@@ -1,0 +1,40 @@
+---
+subcategory: "MapReduce Service (MRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_mapreduce_tags_quota"
+description: |-
+  Use this data source to query the tags quota information of cluster within HuaweiCloud.
+---
+
+# huaweicloud_mapreduce_tags_quota
+
+Use this data source to query the tags quota information of cluster within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_mapreduce_tags_quota" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the tags quota is located.  
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of the cluster.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_quota` - The total quota of tags.
+
+* `available_quota` - The available quota of tags.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1890,6 +1890,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_mapreduce_available_flavors":  mrs.DataSourceAvailableFlavors(),
 			"huaweicloud_mapreduce_cluster_nodes":      mrs.DataSourceClusterNodes(),
 			"huaweicloud_mapreduce_clusters":           mrs.DataSourceMrsClusters(),
+			"huaweicloud_mapreduce_tags_quota":         mrs.DataSourceTagsQuota(),
 			"huaweicloud_mapreduce_versions":           mrs.DataSourceMrsVersions(),
 
 			"huaweicloud_obs_buckets":       obs.DataSourceObsBuckets(),

--- a/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_tags_quota_test.go
+++ b/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_tags_quota_test.go
@@ -1,0 +1,44 @@
+package mrs
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataTagsQuota_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_mapreduce_tags_quota.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMrsClusterID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataTagsQuota_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "total_quota", regexp.MustCompile(`^[1-9]\d*$`)),
+					resource.TestMatchResourceAttr(all, "available_quota", regexp.MustCompile(`^\d+$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataTagsQuota_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_mapreduce_tags_quota" "test" {
+  cluster_id = "%s"
+}
+`, acceptance.HW_MRS_CLUSTER_ID)
+}

--- a/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_tags_quota.go
+++ b/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_tags_quota.go
@@ -1,0 +1,98 @@
+package mrs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API MRS GET /v2/{project_id}/clusters/{cluster_id}/tags/quota
+func DataSourceTagsQuota() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTagsQuotaRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the tags quota is located.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster.`,
+			},
+			"total_quota": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The total quota of tags.`,
+			},
+			"available_quota": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The available quota of tags.`,
+			},
+		},
+	}
+}
+
+func getTagsQuota(client *golangsdk.ServiceClient, clusterId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/tags/quota"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func dataSourceTagsQuotaRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("mrs", region)
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	clusterId := d.Get("cluster_id").(string)
+	respBody, err := getTagsQuota(client, clusterId)
+	if err != nil {
+		return diag.Errorf("error querying tags quota of the cluster (%s): %s", clusterId, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("total_quota", utils.PathSearch("total_quota", respBody, nil)),
+		d.Set("available_quota", utils.PathSearch("available_quota", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_mapreduce_tags_quota`) to query tags quota.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o mrs -f TestAccDataTagsQuota_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccDataTagsQuota_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTagsQuota_basic
=== PAUSE TestAccDataTagsQuota_basic
=== CONT  TestAccDataTagsQuota_basic
--- PASS: TestAccDataTagsQuota_basic (14.05s)
PASS
coverage: 4.9% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       14.149s coverage: 4.9% of statements in ./huaweicloud/services/mrs
```
<img width="1378" height="70" alt="image" src="https://github.com/user-attachments/assets/de7b30f3-b284-45c5-b10b-631c03279911" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
