### PR TITLE
chore(cse): optimize the function arguments for resources and data sources

### DIFF
--- a/docs/data-sources/cse_microservice_engine_configurations.md
+++ b/docs/data-sources/cse_microservice_engine_configurations.md
@@ -22,8 +22,8 @@ locals {
 }
 
 data "huaweicloud_cse_microservice_engine_configurations" "test" {
-  auth_address    = local.fileter_engines[0].service_registry_addresses[0].public
-  connect_address = local.fileter_engines[0].config_center_addresses[0].public
+  auth_address    = local.filter_engines[0].service_registry_addresses[0].public
+  connect_address = local.filter_engines[0].config_center_addresses[0].public
 }
 ```
 
@@ -47,6 +47,17 @@ The following arguments are supported:
     (-~!@#%^*_=+?$&()|<>{}[]).
   + Cannot be the account name or account name spelled backwards.
   + The password can only start with a letter.
+
+-> Both `admin_user` and `admin_pass` are required if **RBAC** is enabled for the microservice engine.
+
+~> Please make sure that all the above parameter values ​​are correct; otherwise, **Terraform** will report a connection
+   error.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the microservice engine
+  configurations belong.  
+  If the microservice engine belongs to the non-default enterprise project, this parameter is required and is only valid
+  for enterprise users.  
+  If omitted, the provider-level enterprise project will be used.
 
 ## Attribute Reference
 

--- a/docs/data-sources/cse_microservice_engine_flavors.md
+++ b/docs/data-sources/cse_microservice_engine_flavors.md
@@ -32,6 +32,11 @@ The following arguments are supported:
 
   Defaults to **CSE2**.
 
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the microservice engine
+  flavors belong.  
+  This parameter is only valid for enterprise users.  
+  If omitted, the provider-level enterprise project will be used.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/data-sources/cse_microservice_engines.md
+++ b/docs/data-sources/cse_microservice_engines.md
@@ -23,6 +23,11 @@ The following arguments are supported:
 * `region` - (Optional, String) Specifies the region where dedicated microservice engines are located.  
   If omitted, the provider-level region will be used.
 
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the microservice engines
+  belong.  
+  This parameter is only valid for enterprise users.  
+  If omitted, the provider-level enterprise project will be used.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/data-sources/cse_microservice_instances.md
+++ b/docs/data-sources/cse_microservice_instances.md
@@ -66,6 +66,12 @@ The following arguments are supported:
 * `microservice_id` - (Required, String) Specifies the ID of the microservice to which the microservice instances
   belong.
 
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the microservice instances
+  belong.  
+  If the microservice engine belongs to the non-default enterprise project, this parameter is required and is only valid
+  for enterprise users.  
+  If omitted, the provider-level enterprise project will be used.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/data-sources/cse_microservices.md
+++ b/docs/data-sources/cse_microservices.md
@@ -86,6 +86,11 @@ The following arguments are supported:
 ~> Please make sure that all the above parameter values ​​are correct; otherwise, **Terraform** will report a connection
    error.
 
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the microservices belong.  
+  If the microservice engine belongs to the non-default enterprise project, this parameter is required and is only valid
+  for enterprise users.  
+  If omitted, the provider-level enterprise project will be used.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/data-sources/cse_nacos_namespaces.md
+++ b/docs/data-sources/cse_nacos_namespaces.md
@@ -34,7 +34,10 @@ The following arguments are supported:
 * `engine_id` - (Required, String) Specifies the ID of the Nacos microservice engine to which the namespaces belong.
 
 * `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the Nacos namespaces
-  belong.
+  belong.  
+  If the Nacos engine belongs to the non-default enterprise project, this parameter is required and is only valid
+  for enterprise users.  
+  If omitted, the provider-level enterprise project will be used.
 
 ## Attribute Reference
 

--- a/docs/resources/cse_microservice.md
+++ b/docs/resources/cse_microservice.md
@@ -19,9 +19,10 @@ Manages a microservice resource under a specified microservice engine within Hua
 ### Create a microservice in an engine with RBAC authentication disabled
 
 ```hcl
-variable "microservice_engine_id" {} // Enable the EIP access
+variable "microservice_engine_id" {} # Enable the EIP access
 variable "service_name" {}
 variable "app_name" {}
+variable "enterprise_project_id" {}  # The enterprise project ID to which the corresponding microservice engine belongs
 
 data "huaweicloud_cse_microservice_engines" "test" {}
 
@@ -33,20 +34,22 @@ resource "huaweicloud_cse_microservice" "test" {
   auth_address    = local.fileter_engines[0].service_registry_addresses[0].public
   connect_address = local.fileter_engines[0].service_registry_addresses[0].public
 
-  name        = var.service_name
-  version     = "1.0.0"
-  environment = "development"
-  app_name    = var.app_name
+  name                  = var.service_name
+  version               = "1.0.0"
+  environment           = "development"
+  app_name              = var.app_name
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
 ### Create a microservice in an engine with RBAC authentication enabled
 
 ```hcl
-variable "microservice_engine_id" {} // Enable the EIP access
+variable "microservice_engine_id" {} # Enable the EIP access
 variable "microservice_engine_admin_password" {}
 variable "service_name" {}
 variable "app_name" {}
+variable "enterprise_project_id" {}  # The enterprise project ID to which the corresponding microservice engine belongs
 
 data "huaweicloud_cse_microservice_engines" "test" {}
 
@@ -60,10 +63,11 @@ resource "huaweicloud_cse_microservice" "test" {
   admin_user      = "root"
   admin_pass      = var.microservice_engine_admin_password
 
-  name        = var.service_name
-  version     = "1.0.0"
-  environment = "development"
-  app_name    = var.app_name
+  name                  = var.service_name
+  version               = "1.0.0"
+  environment           = "development"
+  app_name              = var.app_name
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -121,6 +125,10 @@ The following arguments are supported:
 * `description` - (Optional, String, NonUpdatable) Specifies the description of the microservice.  
   The description can contain a maximum of `256` characters.
 
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID to which the
+  microservice belongs.  
+  If omitted, the provider-level enterprise project will be used.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -154,6 +162,12 @@ $ terraform import huaweicloud_cse_microservice.test https://124.70.26.32:30100/
 ```bash
 $ terraform import huaweicloud_cse_microservice.test 'https://124.70.26.32:30100/https://124.70.26.32:30100/f14960ba495e03f59f85aacaaafbdef3fbff3f0d/root/Test!123'
 ```
+
+For the corresponding microservice engine created with the `enterprise_project_id`, its enterprise project ID needs to
+be specified additionally when importing, the corresponding formats are as follows:
+
+* `<auth_address>/<connect_address>/<id>/<enterprise_project_id>`
+* `<auth_address>/<connect_address>/<id>/<admin_user>/<admin_pass>/<enterprise_project_id>`
 
 ## Appendix
 

--- a/docs/resources/cse_microservice_engine.md
+++ b/docs/resources/cse_microservice_engine.md
@@ -108,7 +108,7 @@ The following arguments are supported:
 
 * `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID to which the
   microservice engine belongs.  
-  If omitted and the version is **Nacos2**, the default enterprise project will be used.
+  If omitted, the provider-level enterprise project will be used.
 
 * `description` - (Optional, String) Specifies the description of the microservice engine.  
   The description can contain a maximum of `255` characters.

--- a/docs/resources/cse_microservice_engine_configuration.md
+++ b/docs/resources/cse_microservice_engine_configuration.md
@@ -18,7 +18,8 @@ Manages a key/value pair under a dedicated microservice engine (2.0+) resource w
 ### Create an engine configuration and the engine RBAC authentication is disabled
 
 ```hcl
-variable "microservice_engine_id" {} // Enable the EIP access
+variable "microservice_engine_id" {} # Enable the EIP access
+variable "enterprise_project_id" {}  # The enterprise project ID to which the corresponding microservice engine belongs
 
 data "huaweicloud_cse_microservice_engines" "test" {}
 
@@ -27,8 +28,8 @@ locals {
 }
 
 resource "huaweicloud_cse_microservice_engine_configuration" "test" {
-  auth_address    = local.fileter_engines[0].service_registry_addresses[0].public
-  connect_address = local.fileter_engines[0].config_center_addresses[0].public
+  auth_address    = local.filter_engines[0].service_registry_addresses[0].public
+  connect_address = local.filter_engines[0].config_center_addresses[0].public
 
   key        = "demo"
   value_type = "json"
@@ -56,8 +57,8 @@ locals {
 }
 
 resource "huaweicloud_cse_microservice_engine_configuration" "test" {
-  auth_address    = local.fileter_engines[0].service_registry_addresses[0].public
-  connect_address = local.fileter_engines[0].config_center_addresses[0].public
+  auth_address    = local.filter_engines[0].service_registry_addresses[0].public
+  connect_address = local.filter_engines[0].config_center_addresses[0].public
   admin_user      = "root"
   admin_pass      = var.microservice_engine_admin_password
 
@@ -78,19 +79,17 @@ resource "huaweicloud_cse_microservice_engine_configuration" "test" {
 
 The following arguments are supported:
 
-* `auth_address` - (Required, String, ForceNew) Specifies the address that used to request the access token.  
-  Changing this will create a new resource.
+* `auth_address` - (Required, String, NonUpdatable) Specifies the address that used to request the access token.
 
-* `connect_address` - (Required, String, ForceNew) Specifies the address that used to access engine and manages
-  configuration.  
-  Changing this will create a new resource.
+* `connect_address` - (Required, String, NonUpdatable) Specifies the address that used to access engine and manages
+  configuration.
 
 -> We are only support IPv4 addresses yet (for `auth_address` and `connect_address`).
 
-* `admin_user` - (Optional, String, ForceNew) Specifies the account name for **RBAC** login.
+* `admin_user` - (Optional, String, NonUpdatable) Specifies the account name for **RBAC** login.
   Changing this will create a new resource.
 
-* `admin_pass` - (Optional, String, ForceNew) Specifies the account password for **RBAC** login.
+* `admin_pass` - (Optional, String, NonUpdatable) Specifies the account password for **RBAC** login.
   The password format must meet the following conditions:
   + Must be `8` to `32` characters long.
   + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
@@ -98,16 +97,16 @@ The following arguments are supported:
   + Cannot be the account name or account name spelled backwards.
   + The password can only start with a letter.
 
-  Changing this will create a new resource.
-
 -> Both `admin_user` and `admin_pass` are required if **RBAC** is enabled for the microservice engine.
 
-* `key` - (Required, String, ForceNew) Specifies the configuration key (item name).  
-  The valid length is limited from `1` to `2,048` characters, only letters, digits, hyphens (-), underscores (_),
-  colons (:) and periods (.) are allowed.  
-  Changing this will create a new resource.
+~> Please make sure that all the above parameter values ​​are correct; otherwise, **Terraform** will assume the resource
+   does not exist and remove it from the local `.tfstate` file, after which it can only be managed by importing it.
 
-* `value_type` - (Required, String, ForceNew) Specifies the type of the configuration value.
+* `key` - (Required, String, NonUpdatable) Specifies the configuration key (item name).  
+  The valid length is limited from `1` to `2,048` characters, only letters, digits, hyphens (-), underscores (_),
+  colons (:) and periods (.) are allowed.
+
+* `value_type` - (Required, String, NonUpdatable) Specifies the type of the configuration value.
   The valid values are as follows:
   + **ini**
   + **json**
@@ -125,9 +124,14 @@ The following arguments are supported:
   + **enabled**
   + **disabled**
 
-* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the configuration that used to
-  filter resource.  
-  Changing this will create a new resource.
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID to which the
+  microservice engine configuration belongs.  
+  If the microservice engine belongs to the non-default enterprise project, this parameter is required and is only valid
+  for enterprise users.  
+  If omitted, the provider-level enterprise project will be used.
+
+* `tags` - (Optional, Map, NonUpdatable) Specifies the key/value pairs to associate with the configuration that used to
+  filter resource.
 
 ## Attribute Reference
 
@@ -169,6 +173,12 @@ $ terraform import huaweicloud_cse_microservice_engine_configuration.test https:
 ```bash
 $ terraform import huaweicloud_cse_microservice_engine_configuration.test 'https://124.70.26.32:30100/https://124.70.26.32:30110/demo/root/Test!123'
 ```
+
+For the corresponding microservice engine created with the `enterprise_project_id`, its enterprise project ID needs to
+be specified additionally when importing, the corresponding formats are as follows:
+
+* `<auth_address>/<connect_address>/<key>/<enterprise_project_id>`
+* `<auth_address>/<connect_address>/<key>/<admin_user>/<admin_pass>/<enterprise_project_id>`
 
 Note that the imported state may not be identical to your resource definition, due to security reason.
 The missing attribute is `admin_pass`. It is generally recommended running `terraform plan` after importing an instance.

--- a/docs/resources/cse_microservice_instance.md
+++ b/docs/resources/cse_microservice_instance.md
@@ -18,8 +18,9 @@ Manages a microservice instance resource under a specified microservice engine w
 ### Create a microservice instance under a microservice with RBAC authentication of engine disabled
 
 ```hcl
-variable "microservice_engine_id" {} // Enable the EIP access
+variable "microservice_engine_id" {} # Enable the EIP access
 variable "microservice_id" {}
+variable "enterprise_project_id" {}  # The enterprise project ID to which the corresponding microservice engine belongs
 variable "region_name" {}
 variable "az_name" {}
 
@@ -33,10 +34,11 @@ resource "huaweicloud_cse_microservice_instance" "test" {
   auth_address    = local.fileter_engines[0].service_registry_addresses[0].public
   connect_address = local.fileter_engines[0].service_registry_addresses[0].public
 
-  microservice_id = var.microservice_id
-  host_name       = "localhost"
-  endpoints       = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
-  version         = "1.0.0"
+  microservice_id       = var.microservice_id
+  host_name             = "localhost"
+  endpoints             = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
+  version               = "1.0.0"
+  enterprise_project_id = var.enterprise_project_id
 
   properties = {
     "_TAGS"  = "A, B"
@@ -61,9 +63,10 @@ resource "huaweicloud_cse_microservice_instance" "test" {
 ### Create a microservice instance under a microservice with RBAC authentication of engine enabled
 
 ```hcl
-variable "microservice_engine_id" {} // Enable the EIP access
+variable "microservice_engine_id" {} # Enable the EIP access
 variable "microservice_engine_admin_password" {}
 variable "microservice_id" {}
+variable "enterprise_project_id" {}  # The enterprise project ID to which the corresponding microservice engine belongs
 variable "region_name" {}
 variable "az_name" {}
 
@@ -79,10 +82,11 @@ resource "huaweicloud_cse_microservice_instance" "test" {
   admin_user      = "root"
   admin_pass      = var.microservice_engine_admin_password
 
-  microservice_id = var.microservice_id
-  host_name       = "localhost"
-  endpoints       = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
-  version         = "1.0.0"
+  microservice_id       = var.microservice_id
+  host_name             = "localhost"
+  endpoints             = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
+  version               = "1.0.0"
+  enterprise_project_id = var.enterprise_project_id
 
   properties = {
     "_TAGS"  = "A, B"
@@ -159,6 +163,10 @@ The following arguments are supported:
   + **OUTOFSERVICE**
   + **DOWN**
 
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID to which the
+  microservice instance belongs.  
+  If omitted, the provider-level enterprise project will be used.
+
 <a name="cse_microservice_instance_health_check"></a>
 The `health_check` block supports:
 
@@ -220,6 +228,12 @@ $ terraform import huaweicloud_cse_microservice_instance.test https://124.70.26.
 ```bash
 $ terraform import huaweicloud_cse_microservice_instance.test 'https://124.70.26.32:30100/https://124.70.26.32:30100/f14960ba495e03f59f85aacaaafbdef3fbff3f0d/336e7428dd9411eca913fa163e7364b7/root/Test!123'
 ```
+
+For the corresponding microservice engine created with the `enterprise_project_id`, its enterprise project ID needs to
+be specified additionally when importing, the corresponding formats are as follows:
+
+* `<auth_address>/<connect_address>/<microservice_id>/<id>/<enterprise_project_id>`
+* `<auth_address>/<connect_address>/<microservice_id>/<id>/<admin_user>/<admin_pass>/<enterprise_project_id>`
 
 ## Appendix
 

--- a/docs/resources/cse_nacos_namespace.md
+++ b/docs/resources/cse_nacos_namespace.md
@@ -15,10 +15,12 @@ Manages a namespace resource under CSE Nacos microservice engine within HuaweiCl
 ```hcl
 variable "nacos_engine_id" {}
 variable "namespace_name" {}
+variable "enterprise_project_id" {}  # The enterprise project ID to which the corresponding Nacos engine belongs
 
 resource "huaweicloud_cse_nacos_namespace" "test" {
-  engine_id = var.nacos_engine_id
-  name      = var.namespace_name
+  engine_id             = var.nacos_engine_id
+  name                  = var.namespace_name
+  enterprise_project_id = var.enterprise_project_id
 }
 ```
 
@@ -36,7 +38,8 @@ The following arguments are supported:
   The name can contain `1` to `128` characters, special characters `@#$%^&*` are not allowed.
 
 * `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the ID of the enterprise project to which the
-  Nacos namespace belongs.
+  Nacos namespace belongs.  
+  If omitted, the provider-level enterprise project will be used.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/cse/common.go
+++ b/huaweicloud/services/acceptance/cse/common.go
@@ -1,0 +1,13 @@
+package cse
+
+import "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+// getAcceptanceEpsId returns the acceptance enterprise project ID.
+// If the acceptance enterprise project ID is not set, return "0" (default enterprise project ID).
+// Notes: This function is only available for enterprise project granted users.
+func getAcceptanceEpsId() string {
+	if acceptance.HW_ENTERPRISE_PROJECT_ID_TEST == "" {
+		return "0"
+	}
+	return acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
+}

--- a/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_engine_configurations_test.go
+++ b/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_engine_configurations_test.go
@@ -34,30 +34,35 @@ func TestAccDataMicroserviceEngineConfigurations_basic(t *testing.T) {
 	})
 }
 
-func testAccDataMicroserviceEngineConfigurations_basic() string {
-	name := acceptance.RandomAccResourceNameWithDash()
-
+func testAccDataMicroserviceEngineConfigurations_basic_base(name string) string {
 	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
 data "huaweicloud_cse_microservice_engines" "test" {}
 
 locals {
   id_filter_result = [
-    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"
+    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[2]s"
   ]
 }
 
 resource "huaweicloud_cse_microservice_engine_configuration" "test" {
-  auth_address    = local.id_filter_result[0].service_registry_addresses.0.public
-  connect_address = local.id_filter_result[0].config_center_addresses.0.public
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  connect_address = try(local.id_filter_result[0].config_center_addresses[0].public, null)
   admin_user      = "root"
-  admin_pass      = "%[2]s"
+  admin_pass      = "%[3]s"
 
-  key        = "%[3]s"
+  key        = "%[4]s"
   value_type = "json"
   value      = jsonencode({
     "foo": "baar"
   })
-  status = "disabled"
+
+  status                = "disabled"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   tags = {
     owner = "terraform"
@@ -69,21 +74,33 @@ resource "huaweicloud_cse_microservice_engine_configuration" "test" {
     ]
   }
 }
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST,
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ID,
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD,
+		name)
+}
+
+func testAccDataMicroserviceEngineConfigurations_basic() string {
+	name := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+%[1]s
 
 data "huaweicloud_cse_microservice_engine_configurations" "test" {
   depends_on = [huaweicloud_cse_microservice_engine_configuration.test]
 
-  auth_address    = try(local.id_filter_result[0].service_registry_addresses.0.public, "")
-  connect_address = try(local.id_filter_result[0].config_center_addresses.0.public, "")
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  connect_address = try(local.id_filter_result[0].config_center_addresses[0].public, null)
   admin_user      = "root"
   admin_pass      = "%[2]s"
+
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
 
 output "is_configuration_queried" {
   value = contains(data.huaweicloud_cse_microservice_engine_configurations.test.configurations[*].id,
     huaweicloud_cse_microservice_engine_configuration.test.id)
 }
-`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID,
-		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD,
-		name)
+`, testAccDataMicroserviceEngineConfigurations_basic_base(name),
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD)
 }

--- a/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_engine_flavors_test.go
+++ b/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_engine_flavors_test.go
@@ -1,6 +1,7 @@
 package cse
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestAccDataMicroserviceEngineFlavors_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataMicroserviceEngineFlavors_basic,
+				Config: testAccDataMicroserviceEngineFlavors_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dcWithDefaultVersion.CheckResourceExists(),
 					resource.TestMatchResourceAttr(withDefaultVersion, "flavors.#", regexp.MustCompile(`[1-9]\d*`)),
@@ -41,8 +42,16 @@ func TestAccDataMicroserviceEngineFlavors_basic(t *testing.T) {
 	})
 }
 
-const testAccDataMicroserviceEngineFlavors_basic string = `
-data "huaweicloud_cse_microservice_engine_flavors" "version_omitted" {}
+func testAccDataMicroserviceEngineFlavors_basic() string {
+	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
+data "huaweicloud_cse_microservice_engine_flavors" "version_omitted" {
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+}
 
 # Check whether flavor ID is set
 locals {
@@ -103,4 +112,5 @@ locals {
 output "is_version_filter_useful" {
   value = length(local.version_filter_result) > 0 && alltrue(local.version_filter_result)
 }
-`
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_instances_test.go
+++ b/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_instances_test.go
@@ -53,21 +53,27 @@ func TestAccDataMicroserviceInstances_basic(t *testing.T) {
 func testAccDataMicroserviceInstances_expectErr() string {
 	randUUID, _ := uuid.GenerateUUID()
 	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
 data "huaweicloud_cse_microservice_engines" "test" {}
 
 locals {
-  id_filter_result = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"]
+  id_filter_result = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[2]s"]
 }
 
 data "huaweicloud_cse_microservice_instances" "test" {
   auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
   connect_address = local.id_filter_result[0].service_registry_addresses[0].public
   admin_user      = "root"
-  admin_pass      = "%[2]s"
+  admin_pass      = "%[3]s"
 
-  microservice_id = "%[3]s"
+  microservice_id       = "%[3]s"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : "0"
 }
-`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID, acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD, randUUID)
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID, acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD, randUUID)
 }
 
 func testAccDataMicroserviceInstances_basic(name string) string {
@@ -75,12 +81,16 @@ func testAccDataMicroserviceInstances_basic(name string) string {
 %[1]s
 
 resource "huaweicloud_cse_microservice_instance" "test" {
-  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
-  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
-  microservice_id = huaweicloud_cse_microservice.test.id
-  host_name       = "localhost_with_auth_address"
-  endpoints       = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
-  version         = "1.0.1"
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  connect_address = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  admin_user      = "root"
+  admin_pass      = "%[3]s"
+
+  microservice_id       = huaweicloud_cse_microservice.test.id
+  host_name             = "localhost_with_auth_address"
+  endpoints             = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
+  version               = "1.0.1"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   properties = {
     "nodeIP" = "127.0.0.1"
@@ -98,20 +108,18 @@ resource "huaweicloud_cse_microservice_instance" "test" {
     name              = "dc1"
     availability_zone = data.huaweicloud_availability_zones.test.names[0]
   }
-
-  admin_user = "root"
-  admin_pass = "%[3]s"
 }
 
 data "huaweicloud_cse_microservice_instances" "test" {
   depends_on = [huaweicloud_cse_microservice_instance.test]
 
-  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
-  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  connect_address = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
   admin_user      = "root"
   admin_pass      = "%[3]s"
 
-  microservice_id = huaweicloud_cse_microservice.test.id
+  microservice_id       = huaweicloud_cse_microservice.test.id
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
 
 locals {

--- a/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservices_test.go
+++ b/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservices_test.go
@@ -48,22 +48,30 @@ func TestAccDataMicroservices_basic(t *testing.T) {
 
 func testAccDataMicroservices_basic(name string) string {
 	return fmt.Sprintf(`
-data "huaweicloud_cse_microservice_engines" "test" {}
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
+data "huaweicloud_cse_microservice_engines" "test" {
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : "0"
+}
 
 locals {
   id_filter_result = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"]
 }
 
 resource "huaweicloud_cse_microservice" "test" {
-  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
-  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  connect_address = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
 
-  name        = "%[2]s"
-  app_name    = "%[2]s"
-  environment = "development"
-  version     = "1.0.1"
-  description = "Created by terraform test"
-  level       = "BACK"
+  name                  = "%[2]s"
+  app_name              = "%[2]s"
+  environment           = "development"
+  version               = "1.0.1"
+  description           = "Created by terraform test"
+  level                 = "BACK"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   admin_user = "root"
   admin_pass = "%[3]s"
@@ -78,10 +86,12 @@ resource "huaweicloud_cse_microservice" "test" {
 data "huaweicloud_cse_microservices" "test" {
   depends_on = [huaweicloud_cse_microservice.test]
 
-  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
-  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  connect_address = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
   admin_user      = "root"
   admin_pass      = "%[3]s"
+
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
 
 locals {

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_configuration_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_configuration_test.go
@@ -14,17 +14,21 @@ import (
 )
 
 func getMicroserviceEngineConfigurationFunc(_ *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	token, err := cse.GetAuthorizationToken(state.Primary.Attributes["auth_address"],
-		state.Primary.Attributes["admin_user"], state.Primary.Attributes["admin_pass"])
-	if err != nil {
-		return nil, err
-	}
-
-	client := common.NewCustomClient(true, state.Primary.Attributes["connect_address"], "v1", "default")
-	return cse.QueryMicroserviceEngineConfiguration(client, token, state.Primary.ID)
+	var (
+		// Querying microservice engine configurations requires building a client based on the microservice engine's connection address,
+		// which does not use IAM authentication.
+		client   = common.NewCustomClient(true, state.Primary.Attributes["connect_address"])
+		authInfo = cse.MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(state.Primary.Attributes),
+			AdminUser:           state.Primary.Attributes["admin_user"],
+			AdminPass:           state.Primary.Attributes["admin_pass"],
+			EnterpriseProjectId: state.Primary.Attributes["enterprise_project_id"],
+		}
+	)
+	return cse.GetMicroserviceEngineConfiguration(client, authInfo, state.Primary.ID)
 }
 
-// Beforce testing, please bind the EIP and open the access rules according to the resource ducoment appendix.
+// Before testing, please bind the EIP and open the access rules according to the resource document appendix.
 func TestAccMicroserviceEngineConfiguration_basic(t *testing.T) {
 	var (
 		configuration interface{}
@@ -51,6 +55,7 @@ func TestAccMicroserviceEngineConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "value_type", "json"),
 					resource.TestCheckResourceAttr(resourceName, "value", "{\"foo\":\"bar\"}"),
 					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", getAcceptanceEpsId()),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
@@ -75,17 +80,27 @@ func TestAccMicroserviceEngineConfiguration_basic(t *testing.T) {
 
 func testAccMicroserviceEngineConfigurationImportStateIdFunc(resName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
+		var authAddr, connAddr, keyName, username, password, enterpriseProjectId string
+
 		rs, ok := s.RootModule().Resources[resName]
 		if !ok {
 			return "", fmt.Errorf("resource (%s) not found", resName)
 		}
 
-		authAddr := rs.Primary.Attributes["auth_address"]
-		connAddr := rs.Primary.Attributes["connect_address"]
-		keyName := rs.Primary.Attributes["key"]
-		username := rs.Primary.Attributes["admin_user"]
-		password := rs.Primary.Attributes["admin_pass"]
+		authAddr = rs.Primary.Attributes["auth_address"]
+		connAddr = rs.Primary.Attributes["connect_address"]
+		keyName = rs.Primary.Attributes["key"]
+		username = rs.Primary.Attributes["admin_user"]
+		password = rs.Primary.Attributes["admin_pass"]
+		enterpriseProjectId = rs.Primary.Attributes["enterprise_project_id"]
 		if authAddr != "" && connAddr != "" {
+			if enterpriseProjectId != "" {
+				if username != "" && password != "" {
+					return fmt.Sprintf("%s/%s/%s/%s/%s/%s", authAddr, connAddr, keyName, username, password, enterpriseProjectId), nil
+				}
+				return fmt.Sprintf("%s/%s/%s/%s", authAddr, connAddr, keyName, enterpriseProjectId), nil
+			}
+
 			if username != "" && password != "" {
 				return fmt.Sprintf("%s/%s/%s/%s/%s", authAddr, connAddr, keyName, username, password), nil
 			}
@@ -95,19 +110,30 @@ func testAccMicroserviceEngineConfigurationImportStateIdFunc(resName string) res
 	}
 }
 
-func testAccMicroserviceEngineConfiguration_basic_step1(name string) string {
+func testAccMicroserviceEngineConfiguration_basic_base() string {
 	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
 data "huaweicloud_cse_microservice_engines" "test" {}
 
 locals {
   id_filter_result = [
-    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"
+    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[2]s"
   ]
 }
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID)
+}
+
+func testAccMicroserviceEngineConfiguration_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
 
 resource "huaweicloud_cse_microservice_engine_configuration" "test" {
-  auth_address    = local.id_filter_result[0].service_registry_addresses.0.public
-  connect_address = local.id_filter_result[0].config_center_addresses.0.public
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses.0.public, null)
+  connect_address = try(local.id_filter_result[0].config_center_addresses.0.public, null)
   admin_user      = "root"
   admin_pass      = "%[2]s"
 
@@ -116,7 +142,9 @@ resource "huaweicloud_cse_microservice_engine_configuration" "test" {
   value      = jsonencode({
     "foo": "bar"
   })
-  status = "enabled"
+
+  status                = "enabled"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   tags = {
     owner = "terraform"
@@ -128,22 +156,18 @@ resource "huaweicloud_cse_microservice_engine_configuration" "test" {
     ]
   }
 }
-`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID, acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD, name)
+`, testAccMicroserviceEngineConfiguration_basic_base(),
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD,
+		name)
 }
 
 func testAccMicroserviceEngineConfiguration_basic_step2(name string) string {
 	return fmt.Sprintf(`
-data "huaweicloud_cse_microservice_engines" "test" {}
-
-locals {
-  id_filter_result = [
-    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"
-  ]
-}
+%[1]s
 
 resource "huaweicloud_cse_microservice_engine_configuration" "test" {
-  auth_address    = local.id_filter_result[0].service_registry_addresses.0.public
-  connect_address = local.id_filter_result[0].config_center_addresses.0.public
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses.0.public, null)
+  connect_address = try(local.id_filter_result[0].config_center_addresses.0.public, null)
   admin_user      = "root"
   admin_pass      = "%[2]s"
 
@@ -152,7 +176,9 @@ resource "huaweicloud_cse_microservice_engine_configuration" "test" {
   value      = jsonencode({
     "foo": "baar"
   })
-  status = "disabled"
+
+  status                = "disabled"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   tags = {
     owner = "terraform"
@@ -164,5 +190,7 @@ resource "huaweicloud_cse_microservice_engine_configuration" "test" {
     ]
   }
 }
-`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID, acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD, name)
+`, testAccMicroserviceEngineConfiguration_basic_base(),
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD,
+		name)
 }

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
@@ -15,15 +15,20 @@ import (
 
 func getMicroserviceInstanceFunc(_ *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	var (
-		authAddress    = getAuthAddress(state.Primary.Attributes)
-		adminUser      = state.Primary.Attributes["admin_user"]
-		adminPass      = state.Primary.Attributes["admin_pass"]
+		// Querying microservice instances requires building a client based on the microservice engine's connection address,
+		// which does not use IAM authentication.
+		client   = common.NewCustomClient(true, state.Primary.Attributes["connect_address"])
+		authInfo = cse.MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(state.Primary.Attributes),
+			AdminUser:           state.Primary.Attributes["admin_user"],
+			AdminPass:           state.Primary.Attributes["admin_pass"],
+			EnterpriseProjectId: state.Primary.Attributes["enterprise_project_id"],
+		}
 		microserviceId = state.Primary.Attributes["microservice_id"]
 		instanceId     = state.Primary.ID
-		client         = common.NewCustomClient(true, state.Primary.Attributes["connect_address"])
 	)
 
-	return cse.GetInstance(client, authAddress, adminUser, adminPass, microserviceId, instanceId)
+	return cse.GetInstance(client, authInfo, microserviceId, instanceId)
 }
 
 // Beforce testing, please bind the EIP and open the access rules according to the resource ducoment appendix.
@@ -132,7 +137,7 @@ func TestAccMicroserviceInstance_basic(t *testing.T) {
 
 func testAccMicroserviceInstanceImportStateIdFunc(resName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
-		var authAddr, connAddr, addrPart, microserviceId, username, password, instanceId string
+		var authAddr, connAddr, addrPart, microserviceId, username, password, enterpriseProjectId, instanceId string
 		rs, ok := s.RootModule().Resources[resName]
 		if !ok {
 			return "", fmt.Errorf("resource (%s) not found", resName)
@@ -143,6 +148,7 @@ func testAccMicroserviceInstanceImportStateIdFunc(resName string) resource.Impor
 		microserviceId = rs.Primary.Attributes["microservice_id"]
 		username = rs.Primary.Attributes["admin_user"]
 		password = rs.Primary.Attributes["admin_pass"]
+		enterpriseProjectId = rs.Primary.Attributes["enterprise_project_id"]
 		instanceId = rs.Primary.ID
 
 		addrPart = connAddr
@@ -150,6 +156,13 @@ func testAccMicroserviceInstanceImportStateIdFunc(resName string) resource.Impor
 			addrPart = fmt.Sprintf("%s/%s", authAddr, addrPart)
 		}
 		if addrPart != "" && microserviceId != "" && instanceId != "" {
+			if enterpriseProjectId != "" {
+				if username != "" && password != "" {
+					return fmt.Sprintf("%s/%s/%s/%s/%s/%s", addrPart, microserviceId, instanceId, username, password, enterpriseProjectId), nil
+				}
+				return fmt.Sprintf("%s/%s/%s/%s", addrPart, microserviceId, instanceId, enterpriseProjectId), nil
+			}
+
 			if username != "" && password != "" {
 				return fmt.Sprintf("%s/%s/%s/%s/%s", addrPart, microserviceId, instanceId, username, password), nil
 			}
@@ -161,28 +174,33 @@ func testAccMicroserviceInstanceImportStateIdFunc(resName string) resource.Impor
 
 func testAccMicroserviceInstance_base(name string) string {
 	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_cse_microservice_engines" "test" {}
 
 locals {
   id_filter_result = [
-    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"
+    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[2]s"
   ]
 }
 
 resource "huaweicloud_cse_microservice" "test" {
-  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
-  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  connect_address = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  admin_user      = "root"
+  admin_pass      = "%[3]s"
 
-  name        = "%[2]s"
-  app_name    = "%[2]s"
-  environment = "development"
-  version     = "1.0.1"
-  level       = "BACK"
-
-  admin_user = "root"
-  admin_pass = "%[3]s"
+  name                  = "%[4]s"
+  app_name              = "%[4]s"
+  environment           = "development"
+  version               = "1.0.1"
+  level                 = "BACK"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   lifecycle {
     ignore_changes = [
@@ -190,9 +208,10 @@ resource "huaweicloud_cse_microservice" "test" {
     ]
   }
 }
-`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID,
-		name,
-		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD)
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST,
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ID,
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD,
+		name)
 }
 
 func testAccMicroserviceInstance_basic_with_status(name, status string) string {
@@ -200,15 +219,16 @@ func testAccMicroserviceInstance_basic_with_status(name, status string) string {
 %[1]s
 
 resource "huaweicloud_cse_microservice_instance" "with_auth_address" {
-  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
-  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  connect_address = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
   admin_user      = "root"
   admin_pass      = "%[2]s"
 
-  microservice_id = huaweicloud_cse_microservice.test.id
-  host_name       = "localhost_with_auth_address"
-  endpoints       = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
-  version         = "1.0.1"
+  microservice_id       = huaweicloud_cse_microservice.test.id
+  host_name             = "localhost_with_auth_address"
+  endpoints             = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
+  version               = "1.0.1"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   properties = {
     "nodeIP" = "127.0.0.1"
@@ -236,14 +256,16 @@ resource "huaweicloud_cse_microservice_instance" "with_auth_address" {
 }
 
 resource "huaweicloud_cse_microservice_instance" "without_auth_address" {
-  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  connect_address = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
   admin_user      = "root"
   admin_pass      = "%[2]s"
 
-  microservice_id = huaweicloud_cse_microservice.test.id
-  host_name       = "localhost_without_auth_address"
-  endpoints       = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
-  version         = "1.0.1"
+  microservice_id       = huaweicloud_cse_microservice.test.id
+  host_name             = "localhost_without_auth_address"
+  endpoints             = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
+  version               = "1.0.1"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   properties = {
     "nodeIP" = "127.0.0.1"

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_test.go
@@ -24,14 +24,17 @@ func getAuthAddress(attributes map[string]string) string {
 
 func getMicroserviceFunc(_ *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	var (
-		authAddress    = getAuthAddress(state.Primary.Attributes)
-		adminUser      = state.Primary.Attributes["admin_user"]
-		adminPass      = state.Primary.Attributes["admin_pass"]
-		microserviceId = state.Primary.ID
-		client         = common.NewCustomClient(true, state.Primary.Attributes["connect_address"])
+		// Querying microservices requires building a client based on the microservice engine's connection address,
+		// which does not use IAM authentication.
+		client   = common.NewCustomClient(true, state.Primary.Attributes["connect_address"])
+		authInfo = cse.MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(state.Primary.Attributes),
+			AdminUser:           state.Primary.Attributes["admin_user"],
+			AdminPass:           state.Primary.Attributes["admin_pass"],
+			EnterpriseProjectId: state.Primary.Attributes["enterprise_project_id"],
+		}
 	)
-
-	return cse.GetMicroservice(client, authAddress, adminUser, adminPass, microserviceId)
+	return cse.GetMicroservice(client, authInfo, state.Primary.ID)
 }
 
 // Beforce testing, please bind the EIP and open the access rules according to the resource ducoment appendix.
@@ -104,7 +107,7 @@ func TestAccMicroservice_basic(t *testing.T) {
 
 func testAccMicroserviceImportStateIdFunc(resName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
-		var authAddr, connAddr, addrPart, username, password, microserviceId string
+		var authAddr, connAddr, addrPart, username, password, enterpriseProjectId, microserviceId string
 		rs, ok := s.RootModule().Resources[resName]
 		if !ok {
 			return "", fmt.Errorf("resource (%s) not found", resName)
@@ -114,6 +117,7 @@ func testAccMicroserviceImportStateIdFunc(resName string) resource.ImportStateId
 		connAddr = rs.Primary.Attributes["connect_address"]
 		username = rs.Primary.Attributes["admin_user"]
 		password = rs.Primary.Attributes["admin_pass"]
+		enterpriseProjectId = rs.Primary.Attributes["enterprise_project_id"]
 		microserviceId = rs.Primary.ID
 
 		addrPart = connAddr
@@ -121,6 +125,12 @@ func testAccMicroserviceImportStateIdFunc(resName string) resource.ImportStateId
 			addrPart = fmt.Sprintf("%s/%s", authAddr, addrPart)
 		}
 		if addrPart != "" && microserviceId != "" {
+			if enterpriseProjectId != "" {
+				if username != "" && password != "" {
+					return fmt.Sprintf("%s/%s/%s/%s/%s", addrPart, microserviceId, username, password, enterpriseProjectId), nil
+				}
+				return fmt.Sprintf("%s/%s/%s", addrPart, microserviceId, enterpriseProjectId), nil
+			}
 			if username != "" && password != "" {
 				return fmt.Sprintf("%s/%s/%s/%s", addrPart, microserviceId, username, password), nil
 			}
@@ -132,27 +142,32 @@ func testAccMicroserviceImportStateIdFunc(resName string) resource.ImportStateId
 
 func testAccMicroservice_basic(name string) string {
 	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
 data "huaweicloud_cse_microservice_engines" "test" {}
 
 locals {
   id_filter_result = [
-    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"
+    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[2]s"
   ]
 }
 
 resource "huaweicloud_cse_microservice" "with_auth_address" {
-  auth_address    = local.id_filter_result[0].service_registry_addresses.0.public
-  connect_address = local.id_filter_result[0].service_registry_addresses.0.public
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses.0.public, null)
+  connect_address = try(local.id_filter_result[0].service_registry_addresses.0.public, null)
+  admin_user      = "root"
+  admin_pass      = "%[3]s"
 
-  name        = "%[2]s_with_auth_address"
-  app_name    = "%[2]s_with_auth_address"
-  environment = "development"
-  version     = "1.0.1"
-  description = "Created by terraform test"
-  level       = "BACK"
-
-  admin_user = "root"
-  admin_pass = "%[3]s"
+  name                  = "%[4]s_with_auth_address"
+  app_name              = "%[4]s_with_auth_address"
+  environment           = "development"
+  version               = "1.0.1"
+  description           = "Created by terraform test"
+  level                 = "BACK"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   lifecycle {
     ignore_changes = [
@@ -162,17 +177,18 @@ resource "huaweicloud_cse_microservice" "with_auth_address" {
 }
 
 resource "huaweicloud_cse_microservice" "without_auth_address" {
-  connect_address = local.id_filter_result[0].service_registry_addresses.0.public
+  auth_address    = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  connect_address = try(local.id_filter_result[0].service_registry_addresses[0].public, null)
+  admin_user      = "root"
+  admin_pass      = "%[3]s"
 
-  name        = "%[2]s_without_auth_address"
-  app_name    = "%[2]s_without_auth_address"
-  environment = "development"
-  version     = "1.0.1"
-  description = "Created by terraform test"
-  level       = "BACK"
-
-  admin_user = "root"
-  admin_pass = "%[3]s"
+  name                  = "%[4]s_without_auth_address"
+  app_name              = "%[4]s_without_auth_address"
+  environment           = "development"
+  version               = "1.0.1"
+  description           = "Created by terraform test"
+  level                 = "BACK"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   lifecycle {
     ignore_changes = [
@@ -180,7 +196,8 @@ resource "huaweicloud_cse_microservice" "without_auth_address" {
     ]
   }
 }
-`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID,
-		name,
-		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD)
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST,
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ID,
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD,
+		name)
 }

--- a/huaweicloud/services/cse/config.go
+++ b/huaweicloud/services/cse/config.go
@@ -12,6 +12,13 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+type MicroserviceEngineAuthInfo struct {
+	AuthAddress         string
+	AdminUser           string
+	AdminPass           string
+	EnterpriseProjectId string
+}
+
 const connectAddressRegex = `https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}`
 
 var connectAddressRegexPattern = regexp.MustCompile(fmt.Sprintf(`^(%[1]s)?/?(%[1]s)/(.*)$`, connectAddressRegex))

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engine_configurations.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engine_configurations.go
@@ -2,6 +2,7 @@ package cse
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
@@ -11,25 +12,34 @@ import (
 	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+// @API CSE POST /v4/token
 // @API CSE GET /v1/{project_id}/kie/kv
 func DataSourceMicroserviceEngineConfigurations() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceMicroserviceEngineConfigurationsRead,
 
 		Schema: map[string]*schema.Schema{
-			// Authentication and request parameters.
+			// Special parameters.
+			// These parameters are used to specify the address that used to request the access token and access the
+			// microservice engine.
 			"auth_address": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: `The address that used to request the access token.`,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The address that used to request the access token.`,
+					utils.SchemaDescInput{
+						Required: true,
+					}),
 			},
 			"connect_address": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `The address that used to send requests and manage configuration.`,
+				Description: `The address that used to access the engine and query configurations.`,
 			},
 			"admin_user": {
 				Type:        schema.TypeString,
@@ -43,6 +53,14 @@ func DataSourceMicroserviceEngineConfigurations() *schema.Resource {
 				RequiredWith: []string{"admin_user"},
 				Description:  `The user password that used to pass the RBAC control.`,
 			},
+
+			// Optional parameters.
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The enterprise project ID to which the microservice engine configurations belong.`,
+			},
+
 			// Attributes.
 			"configurations": {
 				Type:     schema.TypeList,
@@ -57,7 +75,7 @@ func DataSourceMicroserviceEngineConfigurations() *schema.Resource {
 						"key": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The configuration key (item name).",
+							Description: `The configuration key (item name).`,
 						},
 						"value_type": {
 							Type:        schema.TypeString,
@@ -99,48 +117,60 @@ func DataSourceMicroserviceEngineConfigurations() *schema.Resource {
 						},
 					},
 				},
-				Description: `All queried configurations of the dedicated microservice engine.`,
+				Description: `The list of configurations that matched filter parameters.`,
 			},
 		},
 	}
 }
 
-func queryMicroserviceEngineConfigurations(d *schema.ResourceData) ([]interface{}, error) {
+func listMicroserviceEngineConfigurations(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo) ([]interface{}, error) {
 	var (
-		client    = common.NewCustomClient(true, d.Get("connect_address").(string), "v1", "default")
-		httpUrl   = "kie/kv"
-		queryPath = client.ResourceBase + httpUrl
+		httpUrl  = "v1/{project_id}/kie/kv"
+		listPath = client.Endpoint + httpUrl
 	)
 
-	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
-		d.Get("admin_pass").(string))
-	if err != nil {
-		return nil, err
-	}
+	// The project ID of the microservice engine configurations is the fixed value "default".
+	// No region parameter needs to be defined because this data source does not use IAM authentication.
+	listPath = strings.ReplaceAll(listPath, "{project_id}", microserviceEngineConfigurationDefaultProjectId)
 
-	queryOpts := golangsdk.RequestOpts{
+	listOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-	}
-	if token != "" {
-		queryOpts.MoreHeaders = map[string]string{
-			"Authorization": token,
-		}
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
 	}
 
-	requestResp, err := client.Request("GET", queryPath, &queryOpts)
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `POST /v4/token` interface.
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
 	if err != nil {
 		return nil, err
 	}
+	// If the microservice instance has RBAC authentication enabled, the Authorization header will use a special token
+	// provided by the CSE service to replace the original IAM authentication information (AKSK authentication) in the
+	// request header.
+	if token != "" {
+		listOpts.MoreHeaders["Authorization"] = token
+	}
+
+	requestResp, err := client.Request("GET", listPath, &listOpts)
+	if err != nil {
+		return nil, err
+	}
+
 	respBody, err := utils.FlattenResponse(requestResp)
 	if err != nil {
 		return nil, err
 	}
+
 	return utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}), nil
 }
 
 func flattenMicroserviceEngineConfigurations(configurations []interface{}) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(configurations))
+	if len(configurations) < 1 {
+		return nil
+	}
 
+	result := make([]map[string]interface{}, 0, len(configurations))
 	for _, configuration := range configurations {
 		result = append(result, map[string]interface{}{
 			"id":              utils.PathSearch("id", configuration, nil),
@@ -149,8 +179,8 @@ func flattenMicroserviceEngineConfigurations(configurations []interface{}) []map
 			"value":           utils.PathSearch("value", configuration, nil),
 			"status":          utils.PathSearch("status", configuration, nil),
 			"tags":            utils.PathSearch("labels", configuration, nil),
-			"created_at":      utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", configuration, float64(0)).(float64)), false),
-			"updated_at":      utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", configuration, float64(0)).(float64)), false),
+			"created_at":      formatKieKvTime(utils.PathSearch("create_time", configuration, nil)),
+			"updated_at":      formatKieKvTime(utils.PathSearch("update_time", configuration, nil)),
 			"create_revision": utils.PathSearch("create_revision", configuration, nil),
 			"update_revision": utils.PathSearch("update_revision", configuration, nil),
 		})
@@ -159,17 +189,30 @@ func flattenMicroserviceEngineConfigurations(configurations []interface{}) []map
 	return result
 }
 
-func dataSourceMicroserviceEngineConfigurationsRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	configurations, err := queryMicroserviceEngineConfigurations(d)
+func dataSourceMicroserviceEngineConfigurationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg = meta.(*config.Config)
+		// Querying microservice engine configurations requires building a client based on the
+		// microservice engine's connection address, which does not use IAM authentication.
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
+	)
+
+	configurations, err := listMicroserviceEngineConfigurations(client, microserviceEngineAuthInfo)
 	if err != nil {
 		return diag.Errorf("error querying microservice engine configurations: %s", err)
 	}
 
-	uuid, err := uuid.GenerateUUID()
+	randomUUID, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
-	d.SetId(uuid)
+	d.SetId(randomUUID)
 
 	mErr := multierror.Append(nil,
 		d.Set("configurations", flattenMicroserviceEngineConfigurations(configurations)),

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engine_flavors.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engine_flavors.go
@@ -28,11 +28,20 @@ func DataSourceMicroserviceEngineFlavors() *schema.Resource {
 				Computed:    true,
 				Description: `The region where the microservice engine flavors are located.`,
 			},
+
+			// Optional parameters.
 			"version": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: `The version that used to filter the microservice engine flavors.`,
+				Description: `The version used to filter the microservice engine flavors.`,
 			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The enterprise project ID to which the microservice engine flavors belong.`,
+			},
+
+			// Attributes.
 			"flavors": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -69,34 +78,52 @@ func DataSourceMicroserviceEngineFlavors() *schema.Resource {
 						},
 					},
 				},
-				Description: `All microservice engine flavors that match the filter parameters.`,
+				Description: `The list of microservice engine flavors that matched filter parameters.`,
 			},
 		},
 	}
 }
 
-func queryMicroserviceEngineFlavors(client *golangsdk.ServiceClient, specType string) ([]interface{}, error) {
+func buildMicroserviceEngineFlavorsQueryParams(d *schema.ResourceData) string {
+	result := ""
+
+	if v, ok := d.GetOk("version"); ok {
+		result = fmt.Sprintf("%s&specType=%s", result, v)
+	}
+
+	if result != "" {
+		return "?" + result[1:]
+	}
+	return result
+}
+
+func listMicroserviceEngineFlavors(client *golangsdk.ServiceClient, d *schema.ResourceData,
+	enterpriseProjectId string) ([]interface{}, error) {
 	var (
-		httpUrl = "v2/{project_id}/enginemgr/flavors"
+		httpUrl  = "v2/{project_id}/enginemgr/flavors"
+		listPath = client.Endpoint + httpUrl
 	)
 
-	listPath := client.Endpoint + httpUrl
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
-	if specType != "" {
-		listPath = fmt.Sprintf("%s?specType=%s", listPath, specType)
-	}
+	listPath += buildMicroserviceEngineFlavorsQueryParams(d)
 
-	opt := golangsdk.RequestOpts{
+	listOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
-	requestResp, err := client.Request("GET", listPath, &opt)
+	if enterpriseProjectId != "" {
+		listOpts.MoreHeaders = buildRequestMoreHeaders(enterpriseProjectId)
+	}
+
+	requestResp, err := client.Request("GET", listPath, &listOpts)
 	if err != nil {
 		return nil, err
 	}
+
 	respBody, err := utils.FlattenResponse(requestResp)
 	if err != nil {
 		return nil, err
 	}
+
 	return utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}), nil
 }
 
@@ -115,8 +142,11 @@ func flattenMicroserviceEngineFlavorSpec(spec interface{}) []map[string]interfac
 }
 
 func flattenMicroserviceEngineFlavors(flavors []interface{}) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(flavors))
+	if len(flavors) < 1 {
+		return nil
+	}
 
+	result := make([]map[string]interface{}, 0, len(flavors))
 	for _, flavor := range flavors {
 		result = append(result, map[string]interface{}{
 			"id":   utils.PathSearch("flavor", flavor, nil),
@@ -128,26 +158,31 @@ func flattenMicroserviceEngineFlavors(flavors []interface{}) []map[string]interf
 }
 
 func dataSourceMicroserviceEngineFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-	client, err := conf.NewServiceClient("cse", region)
+	var (
+		cfg                 = meta.(*config.Config)
+		region              = cfg.GetRegion(d)
+		enterpriseProjectId = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient("cse", region)
 	if err != nil {
 		return diag.Errorf("error creating CSE client: %s", err)
 	}
 
-	flavors, err := queryMicroserviceEngineFlavors(client, d.Get("version").(string))
+	flavors, err := listMicroserviceEngineFlavors(client, d, enterpriseProjectId)
 	if err != nil {
 		return diag.Errorf("error querying microservice engine flavors: %s", err)
 	}
 
-	uuid, err := uuid.GenerateUUID()
+	randomUUID, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
-	d.SetId(uuid)
+	d.SetId(randomUUID)
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
+		d.Set("enterprise_project_id", enterpriseProjectId),
 		d.Set("flavors", flattenMicroserviceEngineFlavors(flavors)),
 	)
 

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engines.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engines.go
@@ -30,6 +30,16 @@ func DataSourceMicroserviceEngines() *schema.Resource {
 				Computed:    true,
 				Description: `The region where dedicated microservice engines are located.`,
 			},
+
+			// Optional parameters.
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The enterprise project ID to which the dedicated microservice engines belong.`,
+			},
+
+			// Attributes.
 			"engines": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -158,23 +168,26 @@ func DataSourceMicroserviceEngines() *schema.Resource {
 	}
 }
 
-func queryMicroserviceEngines(client *golangsdk.ServiceClient) ([]interface{}, error) {
+func queryMicroserviceEngines(client *golangsdk.ServiceClient, enterpriseProjectId string) ([]interface{}, error) {
 	var (
-		httpUrl = "v2/{project_id}/enginemgr/engines?type=CSE&limit=100"
-		offset  = 0
-		result  = make([]interface{}, 0)
+		httpUrl  = "v2/{project_id}/enginemgr/engines?type=CSE&limit=100"
+		listPath = client.Endpoint + httpUrl
+		offset   = 0
+		result   = make([]interface{}, 0)
 	)
 
-	listPath := client.Endpoint + httpUrl
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 
-	opt := golangsdk.RequestOpts{
+	listOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+	}
+	if enterpriseProjectId != "" {
+		listOpts.MoreHeaders = buildRequestMoreHeaders(enterpriseProjectId)
 	}
 
 	for {
 		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
-		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpts)
 		if err != nil {
 			return nil, fmt.Errorf("error querying microservice engines: %s", err)
 		}
@@ -258,7 +271,7 @@ func dataSourceMicroserviceEnginesRead(_ context.Context, d *schema.ResourceData
 		return diag.Errorf("error creating CSE client: %s", err)
 	}
 
-	engines, err := queryMicroserviceEngines(client)
+	engines, err := queryMicroserviceEngines(client, d.Get("enterprise_project_id").(string))
 	if err != nil {
 		return diag.Errorf("error querying CSE microservice engines: %s", err)
 	}

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_instances.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_instances.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -60,6 +61,13 @@ func DataSourceMicroserviceInstances() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `The ID of the microservice to which the microservice instances belong.`,
+			},
+
+			// Optional parameters.
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The enterprise project ID to which the microservice instances belong.`,
 			},
 
 			// Attributes.
@@ -171,14 +179,16 @@ func DataSourceMicroserviceInstances() *schema.Resource {
 	}
 }
 
-func listMicroserviceInstances(client *golangsdk.ServiceClient, authAddress, adminUser, adminPass,
+func listMicroserviceInstances(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo,
 	microserviceId string) ([]interface{}, error) {
-	httpUrl := "v4/{project_id}/registry/microservices/{service_id}/instances"
+	var (
+		httpUrl  = "v4/{project_id}/registry/microservices/{service_id}/instances"
+		listPath = client.Endpoint + httpUrl
+	)
 
-	listPath := client.Endpoint + httpUrl
 	// The project ID of the microservice instance is the fixed value "default".
 	// No region parameter needs to be defined because this data source does not use IAM authentication.
-	listPath = strings.ReplaceAll(listPath, "{project_id}", microserviceInstanceProjectId)
+	listPath = strings.ReplaceAll(listPath, "{project_id}", microserviceInstanceDefaultProjectId)
 	listPath = strings.ReplaceAll(listPath, "{service_id}", microserviceId)
 
 	listOpts := golangsdk.RequestOpts{
@@ -189,7 +199,7 @@ func listMicroserviceInstances(client *golangsdk.ServiceClient, authAddress, adm
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
 	// `POST /v4/token` interface.
-	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
 	if err != nil {
 		return nil, err
 	}
@@ -260,18 +270,22 @@ func flattenMicroserviceInstances(instances []interface{}) []map[string]interfac
 	return result
 }
 
-func dataSourceMicroserviceInstancesRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func dataSourceMicroserviceInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
+		cfg = meta.(*config.Config)
 		// Querying microservice instances in the microservice engine requires building a client based on the
 		// microservice engine's connection address, which does not use IAM authentication.
-		client         = common.NewCustomClient(true, d.Get("connect_address").(string))
-		authAddress    = getAuthAddress(d)
-		adminUser      = d.Get("admin_user").(string)
-		adminPass      = d.Get("admin_pass").(string)
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
 		microserviceId = d.Get("microservice_id").(string)
 	)
 
-	instances, err := listMicroserviceInstances(client, authAddress, adminUser, adminPass, microserviceId)
+	instances, err := listMicroserviceInstances(client, microserviceEngineAuthInfo, microserviceId)
 	if err != nil {
 		return diag.Errorf("error querying microservice instances: %s", err)
 	}

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservices.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservices.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -48,6 +49,13 @@ func DataSourceMicroservices() *schema.Resource {
 				Sensitive:    true,
 				RequiredWith: []string{"admin_user"},
 				Description:  `The user password that used to pass the RBAC control.`,
+			},
+
+			// Optional parameters.
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The enterprise project ID to which the microservices belong.`,
 			},
 
 			// Attributes.
@@ -164,23 +172,25 @@ func DataSourceMicroservices() *schema.Resource {
 	}
 }
 
-func listMicroservices(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+func listMicroservices(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo) ([]interface{}, error) {
 	var (
-		httpUrl = "v4/{project_id}/registry/microservices"
+		httpUrl  = "v4/{project_id}/registry/microservices"
+		listPath = client.Endpoint + httpUrl
 	)
 
-	listPath := client.Endpoint + httpUrl
+	// The project ID of the microservices is the fixed value "default".
+	// No region parameter needs to be defined because this data source does not use IAM authentication.
 	listPath = strings.ReplaceAll(listPath, "{project_id}", microserviceDefaultProjectId)
 
 	listOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
 	}
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
 	// `POST /v4/token` interface.
-	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string), d.Get("admin_pass").(string))
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
 	if err != nil {
 		return nil, err
 	}
@@ -272,10 +282,21 @@ func parseMicroservicesTime(timeStampStr string) string {
 	return utils.FormatTimeStampRFC3339(int64(r), false)
 }
 
-func dataSourceMicroservicesRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v2", "default")
+func dataSourceMicroservicesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg = meta.(*config.Config)
+		// Querying microservices requires building a client based on the
+		// microservice engine's connection address, which does not use IAM authentication.
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
+	)
 
-	microservices, err := listMicroservices(client, d)
+	microservices, err := listMicroservices(client, microserviceEngineAuthInfo)
 	if err != nil {
 		return diag.Errorf("error querying CSE microservices: %s", err)
 	}

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
@@ -120,6 +120,12 @@ func ResourceMicroservice() *schema.Resource {
 				Optional:    true,
 				Description: "The description of the microservice.",
 			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The enterprise project ID to which the microservice belongs.`,
+			},
 
 			// Attributes.
 			"status": {
@@ -167,21 +173,24 @@ func buildMicroserviceCreateOpts(d *schema.ResourceData) map[string]interface{} 
 	})
 }
 
-func createMicroservice(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
-	httpUrl := "v4/{project_id}/registry/microservices"
-	createPath := client.Endpoint + httpUrl
+func createMicroservice(client *golangsdk.ServiceClient, d *schema.ResourceData, authInfo MicroserviceEngineAuthInfo) (interface{}, error) {
+	var (
+		httpUrl    = "v4/{project_id}/registry/microservices"
+		createPath = client.Endpoint + httpUrl
+	)
+
 	createPath = strings.ReplaceAll(createPath, "{project_id}", microserviceDefaultProjectId)
 
 	createOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
 		JSONBody:         buildMicroserviceCreateOpts(d),
 	}
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
 	// `POST /v4/token` interface.
-	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string), d.Get("admin_pass").(string))
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
 	if err != nil {
 		return nil, err
 	}
@@ -200,9 +209,20 @@ func createMicroservice(client *golangsdk.ServiceClient, d *schema.ResourceData)
 }
 
 func resourceMicroserviceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := common.NewCustomClient(true, d.Get("connect_address").(string))
+	var (
+		cfg = meta.(*config.Config)
+		// Creating a microservice in the microservice engine requires building a client based on the microservice
+		// engine's connection address, which does not use IAM authentication.
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
+	)
 
-	resp, err := createMicroservice(client, d)
+	resp, err := createMicroservice(client, d, microserviceEngineAuthInfo)
 	if err != nil {
 		return diag.Errorf("error creating microservice: %s", err)
 	}
@@ -216,22 +236,24 @@ func resourceMicroserviceCreate(ctx context.Context, d *schema.ResourceData, met
 	return resourceMicroserviceRead(ctx, d, meta)
 }
 
-func GetMicroservice(client *golangsdk.ServiceClient, authAddress, adminUser, adminPass, microserviceId string) (interface{}, error) {
-	httpUrl := "v4/{project_id}/registry/microservices/{service_id}"
+func GetMicroservice(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo, microserviceId string) (interface{}, error) {
+	var (
+		httpUrl = "v4/{project_id}/registry/microservices/{service_id}"
+		getPath = client.Endpoint + httpUrl
+	)
 
-	getPath := client.Endpoint + httpUrl
 	getPath = strings.ReplaceAll(getPath, "{project_id}", microserviceDefaultProjectId)
 	getPath = strings.ReplaceAll(getPath, "{service_id}", microserviceId)
 
 	getOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
 	}
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
 	// `POST /v4/token` interface.
-	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
 	if err != nil {
 		return nil, err
 	}
@@ -250,16 +272,20 @@ func GetMicroservice(client *golangsdk.ServiceClient, authAddress, adminUser, ad
 	return utils.FlattenResponse(requestResp)
 }
 
-func resourceMicroserviceRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceMicroserviceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		client         = common.NewCustomClient(true, d.Get("connect_address").(string))
-		authAddress    = getAuthAddress(d)
-		adminUser      = d.Get("admin_user").(string)
-		adminPass      = d.Get("admin_pass").(string)
-		microserviceId = d.Id()
+		cfg                        = meta.(*config.Config)
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceId             = d.Id()
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
 	)
 
-	respBody, err := GetMicroservice(client, authAddress, adminUser, adminPass, microserviceId)
+	respBody, err := GetMicroservice(client, microserviceEngineAuthInfo, microserviceId)
 	if err != nil {
 		// When the microservice does not exist, the error code returned is 400, and the error information is:
 		// {"errorCode": "400012", "errorMessage": "Micro-service does not exist", "detail": "Service does not exist."}
@@ -278,6 +304,7 @@ func resourceMicroserviceRead(_ context.Context, d *schema.ResourceData, _ inter
 		d.Set("environment", utils.PathSearch("service.environment", respBody, "").(string)),
 		d.Set("level", utils.PathSearch("service.level", respBody, "").(string)),
 		d.Set("description", utils.PathSearch("service.description", respBody, "").(string)),
+		d.Set("enterprise_project_id", microserviceEngineAuthInfo.EnterpriseProjectId),
 		// Attributes.
 		d.Set("status", utils.PathSearch("service.status", respBody, "").(string)),
 	)
@@ -289,25 +316,24 @@ func resourceMicroserviceUpdate(_ context.Context, _ *schema.ResourceData, _ int
 	return nil
 }
 
-func deleteMicroservice(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+func deleteMicroservice(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo, microserviceId string) error {
 	var (
-		httpUrl        = "v4/{project_id}/registry/microservices/{service_id}"
-		microserviceId = d.Id()
+		httpUrl    = "v4/{project_id}/registry/microservices/{service_id}"
+		deletePath = client.Endpoint + httpUrl
 	)
 
-	deletePath := client.Endpoint + httpUrl
 	deletePath = strings.ReplaceAll(deletePath, "{project_id}", microserviceDefaultProjectId)
 	deletePath = strings.ReplaceAll(deletePath, "{service_id}", microserviceId)
 
 	deleteOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
 	}
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
 	// `POST /v4/token` interface.
-	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string), d.Get("admin_pass").(string))
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
 	if err != nil {
 		return err
 	}
@@ -325,12 +351,22 @@ func deleteMicroservice(client *golangsdk.ServiceClient, d *schema.ResourceData)
 	return nil
 }
 
-func resourceMicroserviceDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	client := common.NewCustomClient(true, d.Get("connect_address").(string))
+func resourceMicroserviceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                        = meta.(*config.Config)
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
+		microserviceId = d.Id()
+	)
 
 	// The current configuration is force deletion that delete microservices and related configuration and binding
 	// instances
-	err := deleteMicroservice(client, d)
+	err := deleteMicroservice(client, microserviceEngineAuthInfo, microserviceId)
 	if err != nil {
 		// When the microservice does not exist, the error code returned is 400, and the error information is:
 		// {"errorCode": "400012", "errorMessage": "Micro-service does not exist", "detail": "Service does not exist."}
@@ -346,8 +382,8 @@ func resourceMicroserviceDelete(_ context.Context, d *schema.ResourceData, _ int
 func resourceMicroserviceImportState(_ context.Context, d *schema.ResourceData,
 	_ interface{}) ([]*schema.ResourceData, error) {
 	var (
-		authAddr, connectAddr, importedIdWithoutAddrs, microserviceId, adminUser, adminPwd string
-		mErr                                                                               *multierror.Error
+		authAddr, connectAddr, importedIdWithoutAddrs, microserviceId, adminUser, adminPwd, enterpriseProjectId string
+		mErr                                                                                                    *multierror.Error
 
 		importedId = d.Id()
 		formatErr  = fmt.Errorf("the imported microservice ID specifies an invalid format, want "+
@@ -388,19 +424,27 @@ func resourceMicroserviceImportState(_ context.Context, d *schema.ResourceData,
 	switch len(parts) {
 	case 1:
 		microserviceId = parts[0]
+	case 2:
+		microserviceId = parts[0]
+		enterpriseProjectId = parts[1]
 	case 3:
 		microserviceId = parts[0]
 		adminUser = parts[1]
 		adminPwd = parts[2]
-
-		mErr = multierror.Append(mErr,
-			d.Set("admin_user", adminUser),
-			d.Set("admin_pass", adminPwd),
-		)
+	case 4:
+		microserviceId = parts[0]
+		adminUser = parts[1]
+		adminPwd = parts[2]
+		enterpriseProjectId = parts[3]
 	default:
 		return nil, formatErr
 	}
 
 	d.SetId(microserviceId)
+	mErr = multierror.Append(mErr,
+		d.Set("admin_user", adminUser),
+		d.Set("admin_pass", adminPwd),
+		d.Set("enterprise_project_id", enterpriseProjectId),
+	)
 	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine_configuration.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine_configuration.go
@@ -3,13 +3,14 @@ package cse
 import (
 	"context"
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -18,6 +19,20 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+const microserviceEngineConfigurationDefaultProjectId = "default"
+
+var microserviceEngineConfigurationNonUpdatableParams = []string{
+	"auth_address",
+	"connect_address",
+	"admin_user",
+	"admin_pass",
+	"key",
+	"value_type",
+	"enterprise_project_id",
+	"tags",
+}
+
+// @API CSE POST /v4/token
 // @API CSE POST /v1/{project_id}/kie/kv
 // @API CSE GET /v1/{project_id}/kie/kv/{kv_id}
 // @API CSE PUT /v1/{project_id}/kie/kv/{kv_id}
@@ -34,63 +49,78 @@ func ResourceMicroserviceEngineConfiguration() *schema.Resource {
 			StateContext: resourceMicroserviceEngineConfigurationImportState,
 		},
 
-		CustomizeDiff: config.MergeDefaultTags(),
+		CustomizeDiff: customdiff.All(
+			config.FlexibleForceNew(microserviceEngineConfigurationNonUpdatableParams),
+			config.MergeDefaultTags(),
+		),
 
 		Schema: map[string]*schema.Schema{
-			// Authentication and request parameters.
+			// Special parameters.
+			// These parameters are used to specify the address that used to request the access token and access the
+			// microservice engine.
 			"auth_address": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: `The address that used to request the access token.`,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The address that used to request the access token.`,
+					utils.SchemaDescInput{
+						Required: true,
+					}),
 			},
 			"connect_address": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: `The address that used to send requests and manage configuration.`,
+				Description: `The address that used to access the engine and manage configuration.`,
 			},
 			"admin_user": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
-				Description: "The user name that used to pass the RBAC control.",
+				Description: `The user name that used to pass the RBAC control.`,
 			},
 			"admin_pass": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Sensitive:    true,
-				ForceNew:     true,
 				RequiredWith: []string{"admin_user"},
-				Description:  "The user password that used to pass the RBAC control.",
+				Description:  `The user password that used to pass the RBAC control.`,
 			},
-			// Resource parameters.
+
+			// Required parameters.
 			"key": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: "The configuration key (item name).",
+				Description: `The configuration key (item name).`,
 			},
 			"value_type": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The type of the configuration value.`,
 			},
 			"value": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The configuration value.",
+				Description: `The configuration value.`,
 			},
+
+			// Optional parameters.
 			"status": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 				Description: `The configuration status.`,
 			},
-			"tags": common.TagsForceNewSchema(
-				`The key/value pairs to associate with the configuration that used to filter resource.`,
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The enterprise project ID to which the microservice engine configuration belongs.`,
+			},
+			"tags": common.TagsSchema(
+				`The key/value pairs to associate with the configuration.`,
 			),
+
+			// Attributes.
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -111,101 +141,172 @@ func ResourceMicroserviceEngineConfiguration() *schema.Resource {
 				Computed:    true,
 				Description: `The update version of the configuration.`,
 			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
+			},
 		},
 	}
 }
 
 func buildMicroserviceEngineConfigurationCreateOpts(d *schema.ResourceData) map[string]interface{} {
-	return map[string]interface{}{
+	return utils.RemoveNil(map[string]interface{}{
 		"key":        d.Get("key").(string),
 		"value_type": d.Get("value_type").(string),
 		"value":      d.Get("value").(string),
-		"status":     d.Get("status").(string),
 		"labels":     d.Get("tags").(map[string]interface{}),
-	}
+		"status":     utils.ValueIgnoreEmpty(d.Get("status").(string)),
+	})
 }
 
-func resourceMicroserviceEngineConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createMicroserviceEngineConfiguration(client *golangsdk.ServiceClient, d *schema.ResourceData,
+	authInfo MicroserviceEngineAuthInfo) (interface{}, error) {
 	var (
-		client     = common.NewCustomClient(true, d.Get("connect_address").(string), "v1", "default")
-		httpUrl    = "kie/kv"
-		createPath = client.ResourceBase + httpUrl
+		httpUrl     = "v1/{project_id}/kie/kv"
+		createPath  = client.Endpoint + httpUrl
+		authAddress = getAuthAddress(d)
+		adminUser   = d.Get("admin_user").(string)
+		adminPass   = d.Get("admin_pass").(string)
 	)
 
-	// The connection address is no longer used to obtain an authentication token.
-	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
-		d.Get("admin_pass").(string))
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	// The project ID of the microservices is the fixed value "default".
+	// No region parameter needs to be defined because this data source does not use IAM authentication.
+	createPath = strings.ReplaceAll(createPath, "{project_id}", microserviceEngineConfigurationDefaultProjectId)
+
 	createOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
 		JSONBody:         buildMicroserviceEngineConfigurationCreateOpts(d),
 	}
+
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `POST /v4/token` interface.
+	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
+	if err != nil {
+		return nil, err
+	}
+	// If the microservice instance has RBAC authentication enabled, the Authorization header will use a special token
+	// provided by the CSE service to replace the original IAM authentication information (AKSK authentication) in the
+	// request header.
 	if token != "" {
-		createOpts.MoreHeaders = map[string]string{
-			"Authorization": token,
-		}
+		createOpts.MoreHeaders["Authorization"] = token
 	}
 
 	requestResp, err := client.Request("POST", createPath, &createOpts)
 	if err != nil {
-		return diag.Errorf("error creating configuration: %s", err)
+		return "", err
 	}
-	respBody, err := utils.FlattenResponse(requestResp)
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceMicroserviceEngineConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg = meta.(*config.Config)
+		// Creating a microservice engine configuration requires building a client based on the
+		// microservice engine's connection address, which does not use IAM authentication.
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
+	)
+
+	respBody, err := createMicroserviceEngineConfiguration(client, d, microserviceEngineAuthInfo)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	configId := utils.PathSearch("id", respBody, "").(string)
 	if configId == "" {
-		return diag.Errorf("enable to find the CSE microservice configuration ID from the API response")
+		return diag.Errorf("unable to find the CSE microservice configuration ID from the API response")
 	}
 	d.SetId(configId)
 
 	return resourceMicroserviceEngineConfigurationRead(ctx, d, meta)
 }
 
-func QueryMicroserviceEngineConfiguration(client *golangsdk.ServiceClient, token, configId string) (interface{}, error) {
-	httpUrl := "kie/kv/{kv_id}"
+// formatKieKvTime converts KIE KV create_time/update_time (Unix milliseconds as float64) to RFC3339.
+func formatKieKvTime(val interface{}) string {
+	if val == nil {
+		return ""
+	}
 
-	queryPath := client.ResourceBase + httpUrl
-	queryPath = strings.ReplaceAll(queryPath, "{kv_id}", configId)
+	f, ok := val.(float64)
+	if !ok || f == 0 {
+		return ""
+	}
 
-	queryOpts := golangsdk.RequestOpts{
+	return utils.FormatTimeStampRFC3339(int64(f)/1000, false)
+}
+
+// GetMicroserviceEngineConfiguration queries a single KIE KV configuration by ID.
+func GetMicroserviceEngineConfiguration(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo,
+	configId string) (interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/kie/kv/{kv_id}"
+		getPath = client.Endpoint + httpUrl
+	)
+
+	// The project ID of the microservice engine configuration is the fixed value "default".
+	// No region parameter needs to be defined because this data source does not use IAM authentication.
+	getPath = strings.ReplaceAll(getPath, "{project_id}", microserviceEngineConfigurationDefaultProjectId)
+	getPath = strings.ReplaceAll(getPath, "{kv_id}", configId)
+
+	getOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json",
-		},
-	}
-	if token != "" {
-		queryOpts.MoreHeaders = map[string]string{
-			"Authorization": token,
-		}
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
 	}
 
-	requestResp, err := client.Request("GET", queryPath, &queryOpts)
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `POST /v4/token` interface.
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
 	if err != nil {
 		return nil, err
 	}
+	// If the microservice instance has RBAC authentication enabled, the Authorization header will use a special token
+	// provided by the CSE service to replace the original IAM authentication information (AKSK authentication) in the
+	// request header.
+	if token != "" {
+		getOpts.MoreHeaders["Authorization"] = token
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
 	return utils.FlattenResponse(requestResp)
 }
 
-func resourceMicroserviceEngineConfigurationRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceMicroserviceEngineConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		client   = common.NewCustomClient(true, d.Get("connect_address").(string), "v1", "default")
+		cfg = meta.(*config.Config)
+		// Creating a microservice engine configuration requires building a client based on the
+		// microservice engine's connection address, which does not use IAM authentication.
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
 		configId = d.Id()
 	)
-	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
-		d.Get("admin_pass").(string))
-	if err != nil {
-		// When the engine does not exist, obtaining a token will cause a request connection exception.
-		// To ensure that the resource is available on RFS platform, this situation is specially handled as a 404 error.
-		log.Printf("[ERROR] %s", err)
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
-	}
 
-	respBody, err := QueryMicroserviceEngineConfiguration(client, token, configId)
+	respBody, err := GetMicroserviceEngineConfiguration(client, microserviceEngineAuthInfo, configId)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying configuration (%s)", configId))
 	}
@@ -215,9 +316,10 @@ func resourceMicroserviceEngineConfigurationRead(_ context.Context, d *schema.Re
 		d.Set("value_type", utils.PathSearch("value_type", respBody, nil)),
 		d.Set("value", utils.PathSearch("value", respBody, nil)),
 		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("enterprise_project_id", microserviceEngineAuthInfo.EnterpriseProjectId),
 		d.Set("tags", utils.PathSearch("labels", respBody, nil)),
-		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", respBody, float64(0)).(float64))/1000, false)),
-		d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", respBody, float64(0)).(float64))/1000, false)),
+		d.Set("created_at", formatKieKvTime(utils.PathSearch("create_time", respBody, nil))),
+		d.Set("updated_at", formatKieKvTime(utils.PathSearch("update_time", respBody, nil))),
 		d.Set("create_revision", utils.PathSearch("create_revision", respBody, nil)),
 		d.Set("update_revision", utils.PathSearch("update_revision", respBody, nil)),
 	)
@@ -226,108 +328,139 @@ func resourceMicroserviceEngineConfigurationRead(_ context.Context, d *schema.Re
 }
 
 func buildMicroserviceEngineConfigurationUpdateOpts(d *schema.ResourceData) map[string]interface{} {
-	return map[string]interface{}{
+	return utils.RemoveNil(map[string]interface{}{
 		"value":  d.Get("value").(string),
-		"status": d.Get("status").(string),
+		"status": utils.ValueIgnoreEmpty(d.Get("status").(string)),
+	})
+}
+
+func updateMicroserviceEngineConfiguration(client *golangsdk.ServiceClient, d *schema.ResourceData, authInfo MicroserviceEngineAuthInfo,
+	configId string) error {
+	var (
+		httpUrl    = "v1/{project_id}/kie/kv/{kv_id}"
+		updatePath = client.Endpoint + httpUrl
+	)
+
+	// The project ID of the microservice engine configuration is the fixed value "default".
+	// No region parameter needs to be defined because this data source does not use IAM authentication.
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", microserviceEngineConfigurationDefaultProjectId)
+	updatePath = strings.ReplaceAll(updatePath, "{kv_id}", configId)
+
+	updateOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
+		JSONBody:         buildMicroserviceEngineConfigurationUpdateOpts(d),
 	}
+
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `POST /v4/token` interface.
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
+	if err != nil {
+		return err
+	}
+	// If the microservice instance has RBAC authentication enabled, the Authorization header will use a special token
+	// provided by the CSE service to replace the original IAM authentication information (AKSK authentication) in the
+	// request header.
+	if token != "" {
+		updateOpts.MoreHeaders["Authorization"] = token
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpts)
+	return err
 }
 
 func resourceMicroserviceEngineConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		client   = common.NewCustomClient(true, d.Get("connect_address").(string), "v1", "default")
-		httpUrl  = "kie/kv/{kv_id}"
-		configId = d.Id()
+		cfg = meta.(*config.Config)
+		// Creating a microservice engine configuration requires building a client based on the
+		// microservice engine's connection address, which does not use IAM authentication.
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
 	)
 
-	updatePath := client.ResourceBase + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{kv_id}", configId)
-
-	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
-		d.Get("admin_pass").(string))
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	updateOpts := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		JSONBody:         buildMicroserviceEngineConfigurationUpdateOpts(d),
-	}
-	if token != "" {
-		updateOpts.MoreHeaders = map[string]string{
-			"Authorization": token,
-		}
+	if err := updateMicroserviceEngineConfiguration(client, d, microserviceEngineAuthInfo, d.Id()); err != nil {
+		return diag.Errorf("error updating configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = client.Request("PUT", updatePath, &updateOpts)
-	if err != nil {
-		return diag.Errorf("error updating configuration (%s): %s", configId, err)
-	}
 	return resourceMicroserviceEngineConfigurationRead(ctx, d, meta)
 }
 
-func resourceMicroserviceEngineConfigurationDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func deleteMicroserviceEngineConfiguration(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo, configId string) error {
 	var (
-		client   = common.NewCustomClient(true, d.Get("connect_address").(string), "v1", "default")
-		httpUrl  = "kie/kv/{kv_id}"
-		configId = d.Id()
+		httpUrl    = "v1/{project_id}/kie/kv/{kv_id}"
+		deletePath = client.Endpoint + httpUrl
 	)
 
-	deletePath := client.ResourceBase + httpUrl
+	// The project ID of the microservice engine configuration is the fixed value "default".
+	// No region parameter needs to be defined because this data source does not use IAM authentication.
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", microserviceEngineConfigurationDefaultProjectId)
 	deletePath = strings.ReplaceAll(deletePath, "{kv_id}", configId)
 
-	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
-		d.Get("admin_pass").(string))
-	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving the authorization token")
-	}
 	deleteOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
 	}
+	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
+	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
+	// `POST /v4/token` interface.
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
+	if err != nil {
+		return err
+	}
+	// If the microservice instance has RBAC authentication enabled, the Authorization header will use a special token
+	// provided by the CSE service to replace the original IAM authentication information (AKSK authentication) in the
+	// request header.
 	if token != "" {
-		deleteOpts.MoreHeaders = map[string]string{
-			"Authorization": token,
-		}
+		deleteOpts.MoreHeaders["Authorization"] = token
 	}
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpts)
-	if err != nil {
+	return err
+}
+
+func resourceMicroserviceEngineConfigurationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg = meta.(*config.Config)
+		// Creating a microservice engine configuration requires building a client based on the
+		// microservice engine's connection address, which does not use IAM authentication.
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
+		configId = d.Id()
+	)
+
+	if err := deleteMicroserviceEngineConfiguration(client, microserviceEngineAuthInfo, configId); err != nil {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting configuration (%s)", configId))
 	}
+
 	return nil
 }
 
-func queryMicroserviceEngineConfigurationByKey(connectAddress, token, keyName string) (interface{}, error) {
-	var (
-		client  = common.NewCustomClient(true, connectAddress, "v1", "default")
-		httpUrl = "kie/kv"
-	)
-	queryPath := client.ResourceBase + httpUrl
-
-	queryOpts := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	if token != "" {
-		queryOpts.MoreHeaders = map[string]string{
-			"Authorization": token,
-		}
-	}
-
-	requestResp, err := client.Request("GET", queryPath, &queryOpts)
+func getMicroserviceEngineConfigurationByKey(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo,
+	keyName string) (interface{}, error) {
+	configurations, err := listMicroserviceEngineConfigurations(client, authInfo)
 	if err != nil {
 		return nil, err
 	}
-	respBody, err := utils.FlattenResponse(requestResp)
-	if err != nil {
-		return nil, err
-	}
-	return utils.PathSearch(fmt.Sprintf("data[?key=='%s']|[0]", keyName), respBody, nil), nil
+
+	return utils.PathSearch(fmt.Sprintf("[?key=='%s']|[0]", keyName), configurations, nil), nil
 }
 
 func resourceMicroserviceEngineConfigurationImportState(_ context.Context, d *schema.ResourceData,
 	_ interface{}) ([]*schema.ResourceData, error) {
 	var (
-		token, authAddr, connectAddr, keyName, adminUser, adminPwd string
-		err                                                        error
-		mErr                                                       *multierror.Error
+		authAddr, connectAddr, keyName, adminUser, adminPwd, enterpriseProjectId string
+		mErr                                                                     *multierror.Error
 
 		importedId   = d.Id()
 		addressRegex = `https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}`
@@ -336,6 +469,7 @@ func resourceMicroserviceEngineConfigurationImportState(_ context.Context, d *sc
 			"'<auth_address>/<connect_address>/<key>' or '<auth_address>/<connect_address>/<key>/<admin_user>/<admin_pass>', but got '%s'",
 			importedId)
 	)
+
 	if !re.MatchString(d.Id()) {
 		return nil, formatErr
 	}
@@ -354,26 +488,43 @@ func resourceMicroserviceEngineConfigurationImportState(_ context.Context, d *sc
 		switch len(parts) {
 		case 1:
 			keyName = parts[0]
+		case 2:
+			keyName = parts[0]
+			enterpriseProjectId = parts[1]
 		case 3:
 			keyName = parts[0]
 			adminUser = parts[1]
 			adminPwd = parts[2]
-			token, err = GetAuthorizationToken(authAddr, adminUser, adminPwd)
-			if err != nil {
-				return nil, err
-			}
-			mErr = multierror.Append(mErr,
-				d.Set("admin_user", adminUser),
-				d.Set("admin_pass", adminPwd),
-			)
+		case 4:
+			keyName = parts[0]
+			adminUser = parts[1]
+			adminPwd = parts[2]
+			enterpriseProjectId = parts[3]
 		default:
 			return nil, formatErr
 		}
-		engineDetail, err := queryMicroserviceEngineConfigurationByKey(connectAddr, token, keyName)
-		if err != nil {
-			return nil, err
+
+		client := common.NewCustomClient(true, connectAddr)
+		authInfo := MicroserviceEngineAuthInfo{
+			AuthAddress:         authAddr,
+			AdminUser:           adminUser,
+			AdminPass:           adminPwd,
+			EnterpriseProjectId: enterpriseProjectId,
 		}
+		engineDetail, lookupErr := getMicroserviceEngineConfigurationByKey(client, authInfo, keyName)
+		if lookupErr != nil {
+			return nil, lookupErr
+		}
+
 		d.SetId(utils.PathSearch("id", engineDetail, "").(string))
+		mErr = multierror.Append(mErr,
+			d.Set("auth_address", authAddr),
+			d.Set("connect_address", connectAddr),
+			d.Set("key", keyName),
+			d.Set("admin_user", adminUser),
+			d.Set("admin_pass", adminPwd),
+			d.Set("enterprise_project_id", enterpriseProjectId),
+		)
 		return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 	}
 

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
@@ -40,12 +40,13 @@ var (
 		"data_center.*.name",
 		"data_center.*.region",
 		"data_center.*.availability_zone",
+		"enterprise_project_id",
 	}
 	// The project ID of the microservice instance is the fixed value "default".
 	// No region parameter needs to be defined because this resource does not use IAM authentication.
-	microserviceInstanceProjectId     = "default"
-	internalPropertyKeys              = []string{"engineID", "engineName"}
-	microserviceInstanceNotFoundCodes = []string{
+	microserviceInstanceDefaultProjectId = "default"
+	internalPropertyKeys                 = []string{"engineID", "engineName"}
+	microserviceInstanceNotFoundCodes    = []string{
 		"400017",
 	}
 )
@@ -201,6 +202,12 @@ func ResourceMicroserviceInstance() *schema.Resource {
 				Computed:    true,
 				Description: `The status of the microservice instance.`,
 			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The enterprise project ID to which the microservice instance belongs.`,
+			},
 
 			// Internal parameters.
 			"enable_force_new": {
@@ -277,26 +284,28 @@ func buildInstanceCreateOpts(d *schema.ResourceData) map[string]interface{} {
 	})
 }
 
-func createInstance(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+func createInstance(client *golangsdk.ServiceClient, d *schema.ResourceData, authInfo MicroserviceEngineAuthInfo) (interface{}, error) {
 	var (
 		httpUrl        = "v4/{project_id}/registry/microservices/{service_id}/instances"
+		createPath     = client.Endpoint + httpUrl
 		microserviceId = d.Get("microservice_id").(string)
 	)
 
-	createPath := client.Endpoint + httpUrl
-	createPath = strings.ReplaceAll(createPath, "{project_id}", microserviceInstanceProjectId)
+	// The project ID of the microservice instance is the fixed value "default".
+	// No region parameter needs to be defined because this resource does not use IAM authentication.
+	createPath = strings.ReplaceAll(createPath, "{project_id}", microserviceInstanceDefaultProjectId)
 	createPath = strings.ReplaceAll(createPath, "{service_id}", microserviceId)
 
 	createOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
 		JSONBody:         buildInstanceCreateOpts(d),
 	}
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
 	// `POST /v4/token` interface.
-	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string), d.Get("admin_pass").(string))
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
 	if err != nil {
 		return nil, err
 	}
@@ -314,17 +323,10 @@ func createInstance(client *golangsdk.ServiceClient, d *schema.ResourceData) (in
 	return utils.FlattenResponse(requestResp)
 }
 
-func microserviceInstanceStatusRefreshFunc(client *golangsdk.ServiceClient, d *schema.ResourceData, instanceId string,
-	targets []string, allowNotFound bool) resource.StateRefreshFunc {
+func microserviceInstanceStatusRefreshFunc(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo,
+	microserviceId, instanceId string, targets []string, allowNotFound bool) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		var (
-			authAddress    = getAuthAddress(d)
-			adminUser      = d.Get("admin_user").(string)
-			adminPass      = d.Get("admin_pass").(string)
-			microserviceId = d.Get("microservice_id").(string)
-		)
-
-		respBody, err := GetInstance(client, authAddress, adminUser, adminPass, microserviceId, instanceId)
+		respBody, err := GetInstance(client, authInfo, microserviceId, instanceId)
 		if err != nil {
 			convertedErr := common.ConvertExpected400ErrInto404Err(err, "errorCode", microserviceInstanceNotFoundCodes...)
 			if _, ok := convertedErr.(golangsdk.ErrDefault404); ok && allowNotFound {
@@ -341,27 +343,26 @@ func microserviceInstanceStatusRefreshFunc(client *golangsdk.ServiceClient, d *s
 	}
 }
 
-func updateMicroserviceInstanceStatus(client *golangsdk.ServiceClient, d *schema.ResourceData, instanceId, status string) error {
+func updateMicroserviceInstanceStatus(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo,
+	microserviceId, instanceId, status string) error {
 	var (
-		httpUrl        = "v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}/status"
-		authAddress    = getAuthAddress(d)
-		adminUser      = d.Get("admin_user").(string)
-		adminPass      = d.Get("admin_pass").(string)
-		microserviceId = d.Get("microservice_id").(string)
+		httpUrl    = "v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}/status"
+		updatePath = client.Endpoint + httpUrl
 	)
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", microserviceInstanceProjectId)
+	// The project ID of the microservice instance is the fixed value "default".
+	// No region parameter needs to be defined because this resource does not use IAM authentication.
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", microserviceInstanceDefaultProjectId)
 	updatePath = strings.ReplaceAll(updatePath, "{service_id}", microserviceId)
 	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceId)
 	updatePath = fmt.Sprintf("%s?value=%s", updatePath, status)
 
 	updateOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
 	}
 
-	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
 	if err != nil {
 		return err
 	}
@@ -377,11 +378,21 @@ func updateMicroserviceInstanceStatus(client *golangsdk.ServiceClient, d *schema
 }
 
 func resourceMicroserviceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// Creating a microservice instance in the microservice engine requires building a client based on the microservice
-	// engine's connection address, which does not use IAM authentication.
-	client := common.NewCustomClient(true, d.Get("connect_address").(string))
+	var (
+		cfg = meta.(*config.Config)
+		// Creating a microservice instance in the microservice engine requires building a client based on the microservice
+		// engine's connection address, which does not use IAM authentication.
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
+		microserviceId = d.Get("microservice_id").(string)
+	)
 
-	resp, err := createInstance(client, d)
+	resp, err := createInstance(client, d, microserviceEngineAuthInfo)
 	if err != nil {
 		return diag.Errorf("error creating microservice instance: %s", err)
 	}
@@ -396,7 +407,7 @@ func resourceMicroserviceInstanceCreate(ctx context.Context, d *schema.ResourceD
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"PENDING"},
 		Target:       []string{"COMPLETED"},
-		Refresh:      microserviceInstanceStatusRefreshFunc(client, d, instanceId, []string{"UP"}, true),
+		Refresh:      microserviceInstanceStatusRefreshFunc(client, microserviceEngineAuthInfo, microserviceId, instanceId, []string{"UP"}, true),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        5 * time.Second,
 		PollInterval: 10 * time.Second,
@@ -410,15 +421,16 @@ func resourceMicroserviceInstanceCreate(ctx context.Context, d *schema.ResourceD
 	// In this case, an additional update status request is required to keep the instance status consistent.
 	if v, ok := d.GetOk("status"); ok && utils.PathSearch("instance.status", resp, "").(string) != v.(string) {
 		instanceStatus := v.(string)
-		if err := updateMicroserviceInstanceStatus(client, d, instanceId, instanceStatus); err != nil {
+		if err := updateMicroserviceInstanceStatus(client, microserviceEngineAuthInfo, microserviceId, instanceId, instanceStatus); err != nil {
 			return diag.Errorf("error updating the status of the microservice instance (%s): %s", instanceId, err)
 		}
 
 		log.Printf("[DEBUG] Waiting for the microservice instance (%s) status to become '%s'", instanceId, instanceStatus)
 		stateConf := &resource.StateChangeConf{
-			Pending:      []string{"PENDING"},
-			Target:       []string{"COMPLETED"},
-			Refresh:      microserviceInstanceStatusRefreshFunc(client, d, instanceId, []string{instanceStatus}, false),
+			Pending: []string{"PENDING"},
+			Target:  []string{"COMPLETED"},
+			Refresh: microserviceInstanceStatusRefreshFunc(client, microserviceEngineAuthInfo, microserviceId, instanceId,
+				[]string{instanceStatus}, false),
 			Timeout:      d.Timeout(schema.TimeoutUpdate),
 			Delay:        5 * time.Second,
 			PollInterval: 10 * time.Second,
@@ -434,23 +446,27 @@ func resourceMicroserviceInstanceCreate(ctx context.Context, d *schema.ResourceD
 }
 
 // GetInstance retrieves the microservice instance details by authorization parameters, microservice ID, and instance ID.
-func GetInstance(client *golangsdk.ServiceClient, authAddress, adminUser, adminPass, microserviceId, instanceId string) (interface{}, error) {
-	httpUrl := "v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}"
+func GetInstance(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo, microserviceId, instanceId string) (interface{}, error) {
+	var (
+		httpUrl = "v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}"
+		getPath = client.Endpoint + httpUrl
+	)
 
-	getPath := client.Endpoint + httpUrl
-	getPath = strings.ReplaceAll(getPath, "{project_id}", microserviceInstanceProjectId)
+	// The project ID of the microservice instance is the fixed value "default".
+	// No region parameter needs to be defined because this resource does not use IAM authentication.
+	getPath = strings.ReplaceAll(getPath, "{project_id}", microserviceInstanceDefaultProjectId)
 	getPath = strings.ReplaceAll(getPath, "{service_id}", microserviceId)
 	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
 
 	getOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
 	}
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
 	// `POST /v4/token` interface.
-	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
 	if err != nil {
 		return nil, err
 	}
@@ -498,19 +514,23 @@ func flattenDataCenter(dataCenter interface{}) []map[string]interface{} {
 	}
 }
 
-func resourceMicroserviceInstanceRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceMicroserviceInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
+		cfg = meta.(*config.Config)
 		// Creating a microservice instance in the microservice engine requires building a client based on the
 		// microservice engine's connection address, which does not use IAM authentication.
-		client         = common.NewCustomClient(true, d.Get("connect_address").(string))
-		authAddress    = getAuthAddress(d)
-		adminUser      = d.Get("admin_user").(string)
-		adminPass      = d.Get("admin_pass").(string)
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
 		microserviceId = d.Get("microservice_id").(string)
 		instanceId     = d.Id()
 	)
 
-	respBody, err := GetInstance(client, authAddress, adminUser, adminPass, microserviceId, instanceId)
+	respBody, err := GetInstance(client, microserviceEngineAuthInfo, microserviceId, instanceId)
 	if err != nil {
 		// When the microservice instance does not exist, the error code returned is 400, and the error information is:
 		// {"errorCode": "400017", "errorMessage": "Instance does not exist", "detail": "... instance does not exist"}
@@ -529,31 +549,41 @@ func resourceMicroserviceInstanceRead(_ context.Context, d *schema.ResourceData,
 		d.Set("health_check", flattenHealthCheck(utils.PathSearch("instance.healthCheck", respBody, nil))),
 		d.Set("data_center", flattenDataCenter(utils.PathSearch("instance.dataCenterInfo", respBody, nil))),
 		d.Set("status", utils.PathSearch("instance.status", respBody, nil)),
+		d.Set("enterprise_project_id", microserviceEngineAuthInfo.EnterpriseProjectId),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceMicroserviceInstanceUpdate(ctx context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceMicroserviceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
+		cfg = meta.(*config.Config)
 		// Creating a microservice instance in the microservice engine requires building a client based on the
 		// microservice engine's connection address, which does not use IAM authentication.
-		client     = common.NewCustomClient(true, d.Get("connect_address").(string))
-		instanceId = d.Id()
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
+		microserviceId = d.Get("microservice_id").(string)
+		instanceId     = d.Id()
 	)
 
 	if d.HasChange("status") {
 		instanceStatus := d.Get("status").(string)
-		err := updateMicroserviceInstanceStatus(client, d, instanceId, instanceStatus)
+		err := updateMicroserviceInstanceStatus(client, microserviceEngineAuthInfo, microserviceId, instanceId, instanceStatus)
 		if err != nil {
 			return diag.Errorf("error updating the status of the microservice instance (%s): %s", instanceId, err)
 		}
 
 		log.Printf("[DEBUG] Waiting for the microservice instance (%s) status to become '%s'", instanceId, instanceStatus)
 		stateConf := &resource.StateChangeConf{
-			Pending:      []string{"PENDING"},
-			Target:       []string{"COMPLETED"},
-			Refresh:      microserviceInstanceStatusRefreshFunc(client, d, instanceId, []string{instanceStatus}, false),
+			Pending: []string{"PENDING"},
+			Target:  []string{"COMPLETED"},
+			Refresh: microserviceInstanceStatusRefreshFunc(client, microserviceEngineAuthInfo, microserviceId, instanceId,
+				[]string{instanceStatus}, false),
 			Timeout:      d.Timeout(schema.TimeoutUpdate),
 			Delay:        5 * time.Second,
 			PollInterval: 10 * time.Second,
@@ -568,23 +598,27 @@ func resourceMicroserviceInstanceUpdate(ctx context.Context, d *schema.ResourceD
 	return resourceMicroserviceInstanceRead(ctx, d, nil)
 }
 
-func deleteInstance(client *golangsdk.ServiceClient, authAddress, adminUser, adminPass, microserviceId, instanceId string) error {
-	httpUrl := "v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}"
+func deleteInstance(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo, microserviceId, instanceId string) error {
+	var (
+		httpUrl    = "v4/{project_id}/registry/microservices/{service_id}/instances/{instance_id}"
+		deletePath = client.Endpoint + httpUrl
+	)
 
-	deletePath := client.Endpoint + httpUrl
-	deletePath = strings.ReplaceAll(deletePath, "{project_id}", microserviceInstanceProjectId)
+	// The project ID of the microservice instance is the fixed value "default".
+	// No region parameter needs to be defined because this resource does not use IAM authentication.
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", microserviceInstanceDefaultProjectId)
 	deletePath = strings.ReplaceAll(deletePath, "{service_id}", microserviceId)
 	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
 
 	deleteOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      buildRequestMoreHeaders(client.ProjectID),
+		MoreHeaders:      buildRequestMoreHeaders(authInfo.EnterpriseProjectId),
 	}
 
 	// When a user configures both the `admin_user` and `admin_pass` fields, it indicates that the microservice engine
 	// has enabled RBAC authentication. Subsequent requests will require the token information obtained via the
 	// `POST /v4/token` interface.
-	token, err := GetAuthorizationToken(authAddress, adminUser, adminPass)
+	token, err := GetAuthorizationToken(authInfo.AuthAddress, authInfo.AdminUser, authInfo.AdminPass)
 	if err != nil {
 		return err
 	}
@@ -602,10 +636,10 @@ func deleteInstance(client *golangsdk.ServiceClient, authAddress, adminUser, adm
 	return nil
 }
 
-func instanceStatusRefreshFunc(client *golangsdk.ServiceClient, authAddress, adminUser, adminPass,
+func instanceStatusRefreshFunc(client *golangsdk.ServiceClient, authInfo MicroserviceEngineAuthInfo,
 	microserviceId, instanceId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		respBody, err := GetInstance(client, authAddress, adminUser, adminPass, microserviceId, instanceId)
+		respBody, err := GetInstance(client, authInfo, microserviceId, instanceId)
 		if err != nil {
 			// Convert 400 error to 404 error if it matches instance not found codes.
 			convertedErr := common.ConvertExpected400ErrInto404Err(err, "errorCode", microserviceInstanceNotFoundCodes...)
@@ -621,19 +655,23 @@ func instanceStatusRefreshFunc(client *golangsdk.ServiceClient, authAddress, adm
 	}
 }
 
-func resourceMicroserviceInstanceDelete(ctx context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceMicroserviceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
+		cfg = meta.(*config.Config)
 		// Creating a microservice instance in the microservice engine requires building a client based on the
 		// microservice engine's connection address, which does not use IAM authentication.
-		client         = common.NewCustomClient(true, d.Get("connect_address").(string))
-		authAddress    = getAuthAddress(d)
-		adminUser      = d.Get("admin_user").(string)
-		adminPass      = d.Get("admin_pass").(string)
+		client                     = common.NewCustomClient(true, d.Get("connect_address").(string))
+		microserviceEngineAuthInfo = MicroserviceEngineAuthInfo{
+			AuthAddress:         getAuthAddress(d),
+			AdminUser:           d.Get("admin_user").(string),
+			AdminPass:           d.Get("admin_pass").(string),
+			EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
+		}
 		microserviceId = d.Get("microservice_id").(string)
 		instanceId     = d.Id()
 	)
 
-	err := deleteInstance(client, authAddress, adminUser, adminPass, microserviceId, instanceId)
+	err := deleteInstance(client, microserviceEngineAuthInfo, microserviceId, instanceId)
 	if err != nil {
 		// When the microservice instance does not exist, the error code returned is 400, and the error information is:
 		// {"errorCode": "400017", "errorMessage": "Instance does not exist", "detail": "... instance does not exist"}
@@ -647,7 +685,7 @@ func resourceMicroserviceInstanceDelete(ctx context.Context, d *schema.ResourceD
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"PENDING"},
 		Target:       []string{"COMPLETED"},
-		Refresh:      instanceStatusRefreshFunc(client, authAddress, adminUser, adminPass, microserviceId, instanceId),
+		Refresh:      instanceStatusRefreshFunc(client, microserviceEngineAuthInfo, microserviceId, instanceId),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
@@ -663,8 +701,8 @@ func resourceMicroserviceInstanceDelete(ctx context.Context, d *schema.ResourceD
 func resourceMicroserviceInstanceImportState(_ context.Context, d *schema.ResourceData,
 	_ interface{}) ([]*schema.ResourceData, error) {
 	var (
-		authAddr, connectAddr, idWithoutAddrs, microserviceId, instanceId, adminUser, adminPwd string
-		mErr                                                                                   *multierror.Error
+		authAddr, connectAddr, idWithoutAddrs, microserviceId, instanceId, adminUser, adminPwd, enterpriseProjectId string
+		mErr                                                                                                        *multierror.Error
 
 		importedId = d.Id()
 		formatErr  = fmt.Errorf("the imported microservice ID specifies an invalid format, want "+
@@ -705,21 +743,31 @@ func resourceMicroserviceInstanceImportState(_ context.Context, d *schema.Resour
 	case 2:
 		microserviceId = parts[0]
 		instanceId = parts[1]
+	case 3:
+		microserviceId = parts[0]
+		instanceId = parts[1]
+		enterpriseProjectId = parts[2]
 	case 4:
 		microserviceId = parts[0]
 		instanceId = parts[1]
 		adminUser = parts[2]
 		adminPwd = parts[3]
-
-		mErr = multierror.Append(mErr,
-			d.Set("admin_user", adminUser),
-			d.Set("admin_pass", adminPwd),
-		)
+	case 5:
+		microserviceId = parts[0]
+		instanceId = parts[1]
+		adminUser = parts[2]
+		adminPwd = parts[3]
+		enterpriseProjectId = parts[4]
 	default:
 		return nil, formatErr
 	}
 
-	mErr = multierror.Append(mErr, d.Set("microservice_id", microserviceId))
 	d.SetId(instanceId)
+	mErr = multierror.Append(mErr,
+		d.Set("microservice_id", microserviceId),
+		d.Set("admin_user", adminUser),
+		d.Set("admin_pass", adminPwd),
+		d.Set("enterprise_project_id", enterpriseProjectId),
+	)
 	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Optimize some function's argument design to avoid too much arguments (grant than 5).
Supplement the enterprise project ID for all of resource and data source.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. optimize the function arguments for resources and data sources
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccMicroserviceEngineConfiguration_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccMicroserviceEngineConfiguration_basic -timeout 360m -parallel 10
=== RUN   TestAccMicroserviceEngineConfiguration_basic
=== PAUSE TestAccMicroserviceEngineConfiguration_basic
=== CONT  TestAccMicroserviceEngineConfiguration_basic
--- PASS: TestAccMicroserviceEngineConfiguration_basic (30.01s)
PASS
coverage: 17.2% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       30.105s coverage: 17.2% of statements in ./huaweicloud/services/cse
```
```
./scripts/coverage.sh -o cse -f TestAccMicroserviceEngineConfiguration_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccMicroserviceEngineConfiguration_basic -timeout 360m -parallel 10
=== RUN   TestAccMicroserviceEngineConfiguration_basic
=== PAUSE TestAccMicroserviceEngineConfiguration_basic
=== CONT  TestAccMicroserviceEngineConfiguration_basic
--- PASS: TestAccMicroserviceEngineConfiguration_basic (29.23s)
PASS
coverage: 17.2% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       29.322s coverage: 17.2% of statements in ./huaweicloud/services/cse
```
```
./scripts/coverage.sh -o cse -f TestAccMicroserviceInstance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccMicroserviceInstance_basic -timeout 360m -parallel 10
=== RUN   TestAccMicroserviceInstance_basic
=== PAUSE TestAccMicroserviceInstance_basic
=== CONT  TestAccMicroserviceInstance_basic
--- PASS: TestAccMicroserviceInstance_basic (79.22s)
PASS
coverage: 26.6% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       79.354s coverage: 26.6% of statements in ./huaweicloud/services/cse
```
```
./scripts/coverage.sh -o cse -f TestAccDataMicroserviceInstances_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccDataMicroserviceInstances_basic -timeout 360m -parallel 10
=== RUN   TestAccDataMicroserviceInstances_basic
=== PAUSE TestAccDataMicroserviceInstances_basic
=== CONT  TestAccDataMicroserviceInstances_basic
--- PASS: TestAccDataMicroserviceInstances_basic (34.29s)
PASS
coverage: 24.8% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       34.380s coverage: 24.8% of statements in ./huaweicloud/services/cse
```
```
./scripts/coverage.sh -o cse -f TestAccDataMicroserviceEngineFlavors_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccDataMicroserviceEngineFlavors_basic -timeout 360m -parallel 10
=== RUN   TestAccDataMicroserviceEngineFlavors_basic
=== PAUSE TestAccDataMicroserviceEngineFlavors_basic
=== CONT  TestAccDataMicroserviceEngineFlavors_basic
--- PASS: TestAccDataMicroserviceEngineFlavors_basic (12.81s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       12.928s coverage: 4.6% of statements in ./huaweicloud/services/cse
```
```
./scripts/coverage.sh -o cse -f TestAccDataMicroservices_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccDataMicroservices_basic -timeout 360m -parallel 10
=== RUN   TestAccDataMicroservices_basic
=== PAUSE TestAccDataMicroservices_basic
=== CONT  TestAccDataMicroservices_basic
--- PASS: TestAccDataMicroservices_basic (15.05s)
PASS
coverage: 15.3% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       15.124s coverage: 15.3% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
