### PR TITLE
feat(mrs): add new data source to get file list

### DIFF
--- a/docs/data-sources/mapreduce_cluster_files.md
+++ b/docs/data-sources/mapreduce_cluster_files.md
@@ -1,0 +1,72 @@
+---
+subcategory: "MapReduce Service (MRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_mapreduce_cluster_files"
+description: |-
+  Use this data source to query the file list under the specified directory within HuaweiCloud.
+---
+
+# huaweicloud_mapreduce_cluster_files
+
+Use this data source to query the file list under the specified directory within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "file_path" {}
+
+data "huaweicloud_mapreduce_cluster_files" "test" {
+  cluster_id = var.cluster_id
+  path       = var.file_path
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the cluster files are located.  
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of the cluster.
+
+* `path` - (Required, String) Specifies the directory path of the file.  
+  The maximum length is `255` characters.  
+  This parameter cannot start and end with a dot (.), and cannot include special characters (``*?"<>|;&,'`!{}[]$%+``).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `files` - The list of files under the specified path.  
+  The [files](#cluster_files) structure is documented below.
+
+<a name="cluster_files"></a>
+The `files` block supports:
+
+* `path_suffix` - The path suffix of the file under the queried directory.
+
+* `owner` - The owner of the file.
+
+* `group` - The group to which the file belongs.
+
+* `permission` - The permission of the file.
+
+* `replication` - The replication factor of the file.
+
+* `block_size` - The block size of the file.
+
+* `length` - The length of the file.
+
+* `type` - The type of the file.
+  - **FILE**
+  - **DIRECTORY**
+
+* `children_num` - The number of entries under the queried directory.
+
+* `access_time` - The time when the file was accessed, in RFC3339 format.
+
+* `modification_time` - The time when the file was modified, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1892,6 +1892,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_mapreduce_availability_zones": mrs.DataSourceAvailabilityZones(),
 			"huaweicloud_mapreduce_available_flavors":  mrs.DataSourceAvailableFlavors(),
+			"huaweicloud_mapreduce_cluster_files":      mrs.DataSourceClusterFiles(),
 			"huaweicloud_mapreduce_cluster_jobs":       mrs.DataSourceClusterJobs(),
 			"huaweicloud_mapreduce_cluster_nodes":      mrs.DataSourceClusterNodes(),
 			"huaweicloud_mapreduce_clusters":           mrs.DataSourceMrsClusters(),

--- a/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_cluster_files_test.go
+++ b/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_cluster_files_test.go
@@ -1,0 +1,52 @@
+package mrs
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataClusterFiles_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_mapreduce_cluster_files.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMrsClusterID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataClusterFiles_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "files.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "files.0.path_suffix"),
+					resource.TestCheckResourceAttrSet(all, "files.0.owner"),
+					resource.TestCheckResourceAttrSet(all, "files.0.group"),
+					resource.TestCheckResourceAttrSet(all, "files.0.permission"),
+					resource.TestCheckResourceAttrSet(all, "files.0.replication"),
+					resource.TestCheckResourceAttrSet(all, "files.0.type"),
+					// The block_size, length, children_num, access_time, and modification_time attributes are not guaranteed
+					// to be non-empty, so they are not validated.
+				),
+			},
+		},
+	})
+}
+
+func testAccDataClusterFiles_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_mapreduce_cluster_files" "test" {
+  cluster_id = "%s"
+  path       = "user"
+}
+`, acceptance.HW_MRS_CLUSTER_ID)
+}

--- a/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_cluster_files.go
+++ b/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_cluster_files.go
@@ -1,0 +1,211 @@
+package mrs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API MRS GET /v2/{project_id}/clusters/{cluster_id}/files
+func DataSourceClusterFiles() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterFilesRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the cluster files are located.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster.`,
+			},
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The directory path of the file.`,
+			},
+			"files": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of files under the specified path.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"path_suffix": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The path suffix of the under the queried directory.`,
+						},
+						"owner": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The owner of the file.`,
+						},
+						"group": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The group to which the file belongs.`,
+						},
+						"permission": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The permission of the file.`,
+						},
+						"replication": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The replication factor of the file.`,
+						},
+						"block_size": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The block size of the file.`,
+						},
+						"length": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The length of the file.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the file.`,
+						},
+						"children_num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of entries under this directory.`,
+						},
+						"access_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the file was accessed, in RFC3339 format.`,
+						},
+						"modification_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the file was modified, in RFC3339 format.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listClusterFiles(client *golangsdk.ServiceClient, clusterId, directory string) ([]interface{}, error) {
+	var (
+		httpURL = "v2/{project_id}/clusters/{cluster_id}/files"
+		result  = make([]interface{}, 0)
+		limit   = 100
+		// The offset indicates the number of pages, starts from 1.
+		offset = 1
+	)
+
+	listPath := client.Endpoint + httpURL
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{cluster_id}", clusterId)
+	listPath = fmt.Sprintf("%s?limit=%d&path=%s", listPath, limit, directory)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		files := utils.PathSearch("files", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, files...)
+		if len(files) < limit {
+			break
+		}
+
+		offset++
+	}
+
+	return result, nil
+}
+
+func dataSourceClusterFilesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("mrs", region)
+	if err != nil {
+		return diag.Errorf("error creating MRS client: %s", err)
+	}
+
+	directory := d.Get("path").(string)
+	clusterId := d.Get("cluster_id").(string)
+	files, err := listClusterFiles(client, clusterId, directory)
+	if err != nil {
+		return diag.Errorf("error retrieving cluster (%s) file list under the specified path (%s): %s",
+			clusterId, directory, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("files", flattenClusterFiles(files)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenClusterFiles(files []interface{}) []map[string]interface{} {
+	if len(files) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(files))
+	for _, v := range files {
+		rst = append(rst, map[string]interface{}{
+			"path_suffix":  utils.PathSearch("path_suffix", v, nil),
+			"owner":        utils.PathSearch("owner", v, nil),
+			"group":        utils.PathSearch("group", v, nil),
+			"permission":   utils.PathSearch("permission", v, nil),
+			"replication":  utils.PathSearch("replication", v, nil),
+			"block_size":   utils.PathSearch("block_size", v, nil),
+			"length":       utils.PathSearch("length", v, nil),
+			"type":         utils.PathSearch("type", v, nil),
+			"children_num": utils.PathSearch("children_num", v, nil),
+			"access_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("access_time",
+				v, float64(0)).(float64))/1000, false),
+			"modification_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("modification_time",
+				v, float64(0)).(float64))/1000, false),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source (`huaweicloud_mapreduce_cluster_files`) to query files list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
2. add corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o mrs -f TestAccDataClusterFiles_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccDataClusterFiles_basic -timeout 360m -parallel 10
=== RUN   TestAccDataClusterFiles_basic
=== PAUSE TestAccDataClusterFiles_basic
=== CONT  TestAccDataClusterFiles_basic
--- PASS: TestAccDataClusterFiles_basic (94.32s)
PASS
coverage: 5.8% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       94.497s coverage: 5.8% of statements in ./huaweicloud/services/mrs
```
<img width="1304" height="38" alt="image" src="https://github.com/user-attachments/assets/209fcc1f-0c39-4b2f-a311-3b67fff35f89" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
