### PR TITLE
feat(cfw): new datasource to query attack log trend

### DIFF
--- a/docs/data-sources/cfw_attack_log_trend.md
+++ b/docs/data-sources/cfw_attack_log_trend.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_attack_log_trend"
+description: |-
+  Use this data source to get the CFW attack log trend.
+---
+
+# huaweicloud_cfw_attack_log_trend
+
+Use this data source to get the CFW attack log trend.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+
+data "huaweicloud_cfw_attack_log_trend" "test" {
+  fw_instance_id = var.fw_instance_id
+  log_type       = "internet"
+  range          = "2"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `fw_instance_id` - (Required, String) Specifies the firewall instance ID.
+
+* `log_type` - (Required, String) Specifies the log type. Valid values are:
+  + **internet**: North-South oriented log
+  + **nat**: NAT scenario log
+  + **vpc**: East-West oriented log
+  + **vgw**: VGW scenario log
+
+* `range` - (Optional, String) Specifies the time range. Valid values are:
+  + **0**: one hour
+  + **1**: one day
+  + **2**: seven days
+
+* `start_time` - (Optional, Int) Specifies the start time, in millisecond timestamp.
+
+* `end_time` - (Optional, Int) Specifies the end time, in millisecond timestamp.
+
+* `vgw_id` - (Optional, List) Specifies the VGW ID list.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data` - The attack trends.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `deny_count` - The number of blocks.
+
+* `permit_count` - The release times.
+
+* `time` - The aggregation time.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -831,6 +831,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_address_groups":                cfw.DataSourceCfwAddressGroups(),
 			"huaweicloud_cfw_advanced_ips_rules":            cfw.DataSourceAdvancedIpsRules(),
 			"huaweicloud_cfw_attack_log_statistics":         cfw.DataSourceAttackLogStatistics(),
+			"huaweicloud_cfw_attack_log_trend":              cfw.DataSourceAttackLogTrend(),
 			"huaweicloud_cfw_address_group_members":         cfw.DataSourceCfwAddressGroupMembers(),
 			"huaweicloud_cfw_black_white_lists":             cfw.DataSourceCfwBlackWhiteLists(),
 			"huaweicloud_cfw_capture_tasks":                 cfw.DataSourceCfwCaptureTasks(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_attack_log_trend_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_attack_log_trend_test.go
@@ -1,0 +1,44 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAttackLogTrend_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cfw_attack_log_trend.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAttackLogTrend_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.deny_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.permit_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAttackLogTrend_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_attack_log_trend" "test" {
+  fw_instance_id = "%s"
+  log_type       = "internet"
+  range          = "2"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_attack_log_trend.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_attack_log_trend.go
@@ -1,0 +1,168 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/cfw/logs/trend-attack
+func DataSourceAttackLogTrend() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAttackLogTrendRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"log_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"range": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"start_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"vgw_id": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"deny_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"permit_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAttackLogTrendQueryParams(d *schema.ResourceData) string {
+	rst := fmt.Sprintf(
+		"?fw_instance_id=%s&log_type=%s",
+		d.Get("fw_instance_id").(string),
+		d.Get("log_type").(string),
+	)
+
+	if v, ok := d.GetOk("range"); ok {
+		rst += fmt.Sprintf("&range=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("start_time"); ok {
+		rst += fmt.Sprintf("&start_time=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("end_time"); ok {
+		rst += fmt.Sprintf("&end_time=%s", v.(string))
+	}
+
+	rawArray, ok := d.Get("vgw_id").([]interface{})
+	if ok {
+		for _, v := range rawArray {
+			rst += fmt.Sprintf("&vgw_id=%s", v.(string))
+		}
+	}
+
+	return rst
+}
+
+func dataSourceAttackLogTrendRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cfw"
+		httpUrl = "v1/{project_id}/cfw/logs/trend-attack"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAttackLogTrendQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW attack log trend: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("data", flattenLogTrendData(utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenLogTrendData(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"deny_count":   utils.PathSearch("deny_count", v, nil),
+			"permit_count": utils.PathSearch("permit_count", v, nil),
+			"time":         utils.PathSearch("time", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query attack log trend.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccDataSourceAttackLogTrend_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccDataSourceAttackLogTrend_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAttackLogTrend_basic
=== PAUSE TestAccDataSourceAttackLogTrend_basic
=== CONT  TestAccDataSourceAttackLogTrend_basic
--- PASS: TestAccDataSourceAttackLogTrend_basic (15.28s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       15.418s coverage: 3.7% of statements in ./huaweicloud/services/cfw
```
<img width="1292" height="86" alt="image" src="https://github.com/user-attachments/assets/3fa79df0-62ac-4b47-8b49-551515484d4e" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
