### PR TITLE
feat(dws): add new resource for manage cluster user

### DIFF
--- a/docs/resources/dws_cluster_user.md
+++ b/docs/resources/dws_cluster_user.md
@@ -1,0 +1,280 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_user"
+description: |-
+  Manages a DWS cluster user or role resource within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_user
+
+Manages a DWS cluster user or role resource within HuaweiCloud.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+variable "cluster_id" {}
+variable "user_name" {}
+variable "user_password" {}
+
+resource "huaweicloud_dws_cluster_user" "test" {
+  cluster_id   = var.cluster_id
+  type         = "user"
+  name         = var.user_name
+  password     = var.user_password
+}
+```
+
+### Granting object permissions
+
+```hcl
+variable "cluster_id" {}
+variable "user_name" {}
+variable "user_password" {}
+variable "user_type" {}
+
+variable "grant_list" {
+  type = list(object({
+    type       = string
+    database   = string
+    privileges = list(object({
+      permission = string
+      grant_with = bool
+    }))
+  }))
+}
+
+resource "huaweicloud_dws_cluster_user" "with_grants" {
+  cluster_id = var.cluster_id
+  type       = var.user_type
+  name       = var.user_name
+  password   = var.user_password
+
+  dynamic "grant_list" {
+    for_each = var.grant_list
+    content {
+      type     = grant_list.value.type
+      database = grant_list.value.database
+
+      dynamic "privileges" {
+        for_each = grant_list.value.privileges
+        content {
+          permission = privileges.value.permission
+          grant_with = privileges.value.grant_with
+        }
+      }
+    }
+  }
+}
+```
+
+### Configuring user attributes
+
+```hcl
+variable "cluster_id" {}
+variable "user_name" {}
+variable "user_password" {}
+variable "user_login" {}
+variable "user_create_role" {}
+variable "user_create_db" {}
+variable "user_inherit" {}
+variable "user_conn_limit" {}
+variable "user_lock" {}
+
+resource "huaweicloud_dws_cluster_user" "attributes_only" {
+  cluster_id  = var.cluster_id
+  type        = "user"
+  name        = var.user_name
+  password    = var.user_password
+  login       = var.user_login
+  create_role = var.user_create_role
+  create_db   = var.user_create_db
+  inherit     = var.user_inherit
+  conn_limit  = var.user_conn_limit
+  lock        = var.user_lock
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the cluster user is located.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the DWS cluster.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the cluster user or role.
+
+* `type` - (Optional, String) Specifies the object type.
+  The valid values are as follows:
+  + **user**
+  + **role**
+
+  Defaults to **user**.
+
+* `password` - (Optional, String, NonUpdatable) Specifies the password of the user.
+  Changing this parameter will create a new resource.
+
+  -> Required if the `type` is **user**.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the user or role.
+
+* `password_disable` - (Optional, Bool, NonUpdatable) Specifies whether to disable password authentication.
+
+* `logical_cluster` - (Optional, String, NonUpdatable) Specifies the logical cluster name.
+
+* `cascade` - (Optional, Bool) Specifies whether to cascade delete dependencies when deleting the user or role.
+
+* `grant_list` - (Optional, List, NonUpdatable) Specifies the set of grants.
+  The [grant_list](#dws_cluster_user_grant_list) structure is documented below.
+
+* `login` - (Optional, Bool) Specifies whether to allow the user to log in.
+
+* `create_role` - (Optional, Bool) Specifies whether to grant the permission to create roles.
+
+* `create_db` - (Optional, Bool) Specifies whether to grant the permission to create databases.
+
+* `system_admin` - (Optional, Bool) Specifies whether to grant the system administrator permission.
+
+* `audit_admin` - (Optional, Bool) Specifies whether to grant the audit administrator permission.
+
+* `inherit` - (Optional, Bool) Specifies whether to inherit permissions from roles.
+
+* `use_ft` - (Optional, Bool) Specifies whether to grant the external table permission.
+
+* `conn_limit` - (Optional, Int) Specifies the maximum number of concurrent connections.
+
+* `replication` - (Optional, Bool) Specifies whether to grant the replication permission.
+
+* `valid_begin` - (Optional, String) Specifies the valid begin time.
+
+* `valid_until` - (Optional, String) Specifies the valid until time.
+
+* `lock` - (Optional, Bool) Specifies whether the user is locked.
+
+<a name="dws_cluster_user_grant_list"></a>
+The `grant_list` block supports:
+
+* `type` - (Required, String) The object type.
+  The valid values are as follows:
+  + **DATABASE**
+  + **SCHEMA**
+  + **TABLE**
+  + **VIEW**
+  + **COLUMN**
+  + **FUNCTION**
+  + **SEQUENCE**
+  + **NODEGROUP**
+
+* `database` - (Optional, String) The database name.
+
+* `schema_name` - (Optional, String) The schema name.
+
+* `object_name` - (Optional, String) The object name.
+
+* `all_object` - (Optional, Bool) Whether all objects are effective.
+
+* `future` - (Optional, Bool) Whether future objects are effective.
+
+* `future_object_owners` - (Optional, String) The owners of future objects.
+
+* `column_names` - (Optional, List) The set of column names.
+
+* `privileges` - (Required, List) The set of privileges.
+  The [privileges](#dws_cluster_user_privileges) structure is documented below.
+
+<a name="dws_cluster_user_privileges"></a>
+The `privileges` block supports:
+
+* `permission` - (Required, String) The privilege name.
+  The valid values are as follows:
+  + When `type` is **DATABASE**:
+    - **CREATE**
+    - **CONNECT**
+    - **TEMPORARY**
+    - **TEMP ALL PRIVILEGES**
+  + When `type` is **SCHEMA**:
+    - **CREATE**
+    - **USAGE**
+    - **ALTER**
+    - **DROP ALL PRIVILEGES**
+  + When `type` is **TABLE**:
+    - **SELECT**
+    - **INSERT**
+    - **UPDATE**
+    - **DELETE**
+    - **TRUNCATE**
+    - **REFERENCES**
+    - **TRIGGER**
+    - **ANALYZE**
+    - **VACUUM**
+    - **ALTER**
+    - **DROP ALL PRIVILEGES**
+  + When `type` is **VIEW**:
+    - **SELECT**
+    - **INSERT**
+    - **UPDATE**
+    - **DELETE**
+    - **TRUNCATE**
+    - **REFERENCES**
+    - **TRIGGER**
+    - **ANALYZE**
+    - **VACUUM**
+    - **ALTER**
+    - **DROP ALL PRIVILEGES**
+  + When `type` is **COLUMN**:
+    - **SELECT**
+    - **INSERT**
+    - **UPDATE**
+    - **REFERENCES ALL PRIVILEGES**
+  + When `type` is **FUNCTION**:
+    - **EXECUTE ALL PRIVILEGES**
+  + When `type` is **SEQUENCE**:
+    - **SELECT**
+    - **UPDATE**
+    - **USAGE ALL PRIVILEGES**
+  + When `type` is **NODEGROUP**:
+    - **CREATE**
+    - **USAGE**
+    - **COMPUTE ALL PRIVILEGES**
+
+* `grant_with` - (Required, Bool) Whether the grant option is included.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The DWS cluster user resource can be imported using the region where the cluster is located, the ID of the DWS cluster,
+and the name of the cluster user or role, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_dws_cluster_user.test <region>/<cluster_id>/<name>
+```
+
+Please add the followings if some attributes are missing when importing the resource.
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `password`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_dws_cluster_user" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      type,
+      password,
+      cascade,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3209,6 +3209,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_dws_alarm_subscription":            dws.ResourceDwsAlarmSubs(),
 			"huaweicloud_dws_cluster_restart":               dws.ResourceClusterRestart(),
+			"huaweicloud_dws_cluster_user":                  dws.ResourceClusterUser(),
 			"huaweicloud_dws_cluster":                       dws.ResourceDwsCluster(),
 			"huaweicloud_dws_disaster_recovery_task":        dws.ResourceDwsDisasterRecoveryTask(),
 			"huaweicloud_dws_event_subscription":            dws.ResourceDwsEventSubs(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -712,6 +712,9 @@ var (
 	HW_DWS_LOGICAL_MODE_CLUSTER_ID = os.Getenv("HW_DWS_LOGICAL_MODE_CLUSTER_ID")
 	HW_DWS_LOGICAL_CLUSTER_NAME    = os.Getenv("HW_DWS_LOGICAL_CLUSTER_NAME")
 	HW_DWS_SNAPSHOT_POLICY_NAME    = os.Getenv("HW_DWS_SNAPSHOT_POLICY_NAME")
+	HW_DWS_GRANT_DATABASE_NAME     = os.Getenv("HW_DWS_GRANT_DATABASE_NAME")
+	HW_DWS_GRANT_SCHEMA_NAME       = os.Getenv("HW_DWS_GRANT_SCHEMA_NAME")
+	HW_DWS_GRANT_OBJECT_NAME       = os.Getenv("HW_DWS_GRANT_OBJECT_NAME")
 	// The list of the user names under specified DWS cluster. Using commas (,) to separate multiple names.
 	HW_DWS_ASSOCIATE_USER_NAMES  = os.Getenv("HW_DWS_ASSOCIATE_USER_NAMES")
 	HW_DWS_AUTOMATED_SNAPSHOT_ID = os.Getenv("HW_DWS_AUTOMATED_SNAPSHOT_ID")
@@ -3966,6 +3969,19 @@ func TestAccPreCheckDwsLogicalClusterName(t *testing.T) {
 func TestAccPreCheckDwsSnapshotPolicyName(t *testing.T) {
 	if HW_DWS_SNAPSHOT_POLICY_NAME == "" {
 		t.Skip("HW_DWS_SNAPSHOT_POLICY_NAME must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDwsGrantTargets(t *testing.T) {
+	if HW_DWS_GRANT_DATABASE_NAME == "" {
+		t.Skip("HW_DWS_GRANT_DATABASE_NAME must be set for the acceptance test")
+	}
+	if HW_DWS_GRANT_SCHEMA_NAME == "" {
+		t.Skip("HW_DWS_GRANT_SCHEMA_NAME must be set for the acceptance test")
+	}
+	if HW_DWS_GRANT_OBJECT_NAME == "" {
+		t.Skip("HW_DWS_GRANT_OBJECT_NAME must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_user_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_user_test.go
@@ -1,0 +1,339 @@
+package dws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
+)
+
+func getClusterUserResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region    = acceptance.HW_REGION_NAME
+		clusterId = state.Primary.Attributes["cluster_id"]
+		name      = state.Primary.Attributes["name"]
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DWS client: %s", err)
+	}
+
+	return dws.GetClusterUser(client, clusterId, name)
+}
+
+func TestAccResourceClusterUser_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_dws_cluster_user.test"
+		obj          interface{}
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getClusterUserResourceFunc)
+
+		rName = strings.ToLower(acceptance.RandomAccResourceName())
+	)
+
+	const userType = "user"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+			acceptance.TestAccPreCheckDwsGrantTargets(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceClusterUser_user_step1(rName, userType),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", userType),
+					resource.TestCheckResourceAttr(resourceName, "login", "true"),
+					resource.TestCheckResourceAttr(resourceName, "create_db", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "false"),
+				),
+			},
+			{
+				Config: testAccResourceClusterUser_user_step2(rName, userType),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "false"),
+					resource.TestCheckResourceAttr(resourceName, "create_db", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cascade", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceClusterUserImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"type",
+					"cascade",
+				},
+			},
+		},
+	})
+}
+
+func testAccResourceClusterUser_user_step1(name, userType string) string {
+	return testAccResourceClusterUser_basic(name, userType)
+}
+
+func testAccResourceClusterUser_user_step2(name, userType string) string {
+	return testAccResourceClusterUser_update(name, userType)
+}
+
+func TestAccResourceClusterUser_role(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_dws_cluster_user.test"
+		obj          interface{}
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getClusterUserResourceFunc)
+
+		rName = strings.ToLower(acceptance.RandomAccResourceName())
+	)
+
+	const userType = "role"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+			acceptance.TestAccPreCheckDwsGrantTargets(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceClusterUser_role_step1(rName, userType),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", userType),
+					resource.TestCheckResourceAttr(resourceName, "login", "true"),
+					resource.TestCheckResourceAttr(resourceName, "create_db", "false"),
+				),
+			},
+			{
+				Config: testAccResourceClusterUser_role_step2(rName, userType),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "false"),
+					resource.TestCheckResourceAttr(resourceName, "create_db", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceClusterUserImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"type",
+					"cascade",
+				},
+			},
+		},
+	})
+}
+
+func testAccResourceClusterUser_role_step1(name, userType string) string {
+	return testAccResourceClusterUser_basic(name, userType)
+}
+
+func testAccResourceClusterUser_role_step2(name, userType string) string {
+	return testAccResourceClusterUser_update(name, userType)
+}
+
+func testAccResourceClusterUser_basic(name, userType string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_cluster_user" "test" {
+  cluster_id  = "%[1]s"
+  name        = "%[2]s"
+  type        = "%[3]s"
+  password    = "HuaweiTest@123456789"
+  cascade     = false
+  login       = true
+  create_role = false
+  create_db   = false
+  inherit     = true
+  conn_limit  = -1
+}
+`, acceptance.HW_DWS_CLUSTER_ID, name, userType)
+}
+
+func testAccResourceClusterUser_update(name, userType string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_cluster_user" "test" {
+  cluster_id  = "%[1]s"
+  name        = "%[2]s"
+  type        = "%[3]s"
+  password    = "HuaweiTest@123456789"
+  cascade     = true
+  login       = false
+  create_role = false
+  create_db   = true
+  inherit     = true
+  conn_limit  = -1
+}
+`, acceptance.HW_DWS_CLUSTER_ID, name, userType)
+}
+
+func testAccResourceClusterUserImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var clusterId, name string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "huaweicloud_dws_cluster_user" {
+				clusterId = rs.Primary.Attributes["cluster_id"]
+				name = rs.Primary.Attributes["name"]
+			}
+		}
+		if clusterId == "" || name == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", clusterId, name)
+		}
+
+		return fmt.Sprintf("%s/%s/%s", acceptance.HW_REGION_NAME, clusterId, name), nil
+	}
+}
+
+func TestAccResourceClusterUser_advanced(t *testing.T) {
+	var (
+		rName = strings.ToLower(acceptance.RandomAccResourceName())
+
+		obj                interface{}
+		grantsResourceName = "huaweicloud_dws_cluster_user.test"
+		rcGrants           = acceptance.InitResourceCheck(
+			grantsResourceName,
+			&obj,
+			getClusterUserResourceFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rcGrants.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceClusterUser_withGrants(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rcGrants.CheckResourceExists(),
+					resource.TestCheckResourceAttr(grantsResourceName, "name", fmt.Sprintf("%s_grants", rName)),
+					resource.TestCheckResourceAttr(grantsResourceName, "type", "user"),
+					resource.TestCheckResourceAttr(grantsResourceName, "grant_list.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(grantsResourceName, "grant_list.*", map[string]string{
+						"type":         "DATABASE",
+						"database":     acceptance.HW_DWS_GRANT_DATABASE_NAME,
+						"privileges.#": "2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(grantsResourceName, "grant_list.*", map[string]string{
+						"type":         "TABLE",
+						"database":     acceptance.HW_DWS_GRANT_DATABASE_NAME,
+						"schema_name":  acceptance.HW_DWS_GRANT_SCHEMA_NAME,
+						"object_name":  acceptance.HW_DWS_GRANT_OBJECT_NAME,
+						"privileges.#": "2",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceClusterUser_withGrants(name string) string {
+	return fmt.Sprintf(`
+variable "grants" {
+  type = list(object({
+    type        = string
+    database    = string
+    schema_name = optional(string)
+    object_name = optional(string)
+
+    privileges = list(object({
+      permission = string
+      grant_with = bool
+    }))
+  }))
+
+  default = [
+    {
+      type     = "DATABASE"
+      database = "%[1]s"
+
+      privileges = [
+        {
+          permission = "CONNECT"
+          grant_with = false
+        },
+        {
+          permission = "CREATE"
+          grant_with = false
+        }
+      ]
+    },
+    {
+      type        = "TABLE"
+      database    = "%[1]s"
+      schema_name = "%[2]s"
+      object_name = "%[3]s"
+
+      privileges = [
+        {
+          permission = "SELECT"
+          grant_with = false
+        },
+        {
+          permission = "INSERT"
+          grant_with = false
+        }
+      ]
+    }
+  ]
+}
+
+resource "huaweicloud_dws_cluster_user" "test" {
+  cluster_id = "%[4]s"
+  name       = "%[5]s_grants"
+  type       = "user"
+  password   = "HuaweiTest@123456789"
+
+  dynamic "grant_list" {
+    for_each = var.grants
+
+    content {
+      type        = grant_list.value.type
+      database    = grant_list.value.database
+      schema_name = lookup(grant_list.value, "schema_name", null)
+      object_name = lookup(grant_list.value, "object_name", null)
+
+      dynamic "privileges" {
+        for_each = grant_list.value.privileges
+
+        content {
+          permission = privileges.value.permission
+          grant_with = privileges.value.grant_with
+        }
+      }
+    }
+  }
+}`, acceptance.HW_DWS_GRANT_DATABASE_NAME,
+		acceptance.HW_DWS_GRANT_SCHEMA_NAME,
+		acceptance.HW_DWS_GRANT_OBJECT_NAME,
+		acceptance.HW_DWS_CLUSTER_ID,
+		name)
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_user_authorities.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_user_authorities.go
@@ -47,63 +47,13 @@ func DataSourceClusterUserAuthorities() *schema.Resource {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: `The list of user or role authorities.`,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: `The authority type.`,
-						},
-						"database": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: `The database name.`,
-						},
-						"schema_name": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: `The schema name.`,
-						},
-						"object_name": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: `The object name.`,
-						},
-						"all_object": {
-							Type:        schema.TypeBool,
-							Computed:    true,
-							Description: `Whether all objects are effective.`,
-						},
-						"future": {
-							Type:        schema.TypeBool,
-							Computed:    true,
-							Description: `Whether future objects are effective.`,
-						},
-						"future_object_owners": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: `The owners of future objects.`,
-						},
-						"column_names": {
-							Type:        schema.TypeList,
-							Computed:    true,
-							Elem:        &schema.Schema{Type: schema.TypeString},
-							Description: `The list of column names.`,
-						},
-						"privileges": {
-							Type:        schema.TypeList,
-							Computed:    true,
-							Elem:        clusterUserAuthorityPrivilegeSchema(),
-							Description: `The privilege list under this authority record.`,
-						},
-					},
-				},
+				Elem:        clusterUserAuthoritiesElemSchema(),
 			},
 		},
 	}
 }
 
-func clusterUserAuthorityPrivilegeSchema() *schema.Resource {
+func dataClusterUserAuthorityPrivilegeSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"permission": {
@@ -115,6 +65,60 @@ func clusterUserAuthorityPrivilegeSchema() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: `Whether the grant option is included.`,
+			},
+		},
+	}
+}
+
+func clusterUserAuthoritiesElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The authority type.`,
+			},
+			"database": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The database name.`,
+			},
+			"schema_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The schema name.`,
+			},
+			"object_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The object name.`,
+			},
+			"all_object": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether all objects are effective.`,
+			},
+			"future": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether future objects are effective.`,
+			},
+			"future_object_owners": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The owners of future objects.`,
+			},
+			"column_names": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of column names.`,
+			},
+			"privileges": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataClusterUserAuthorityPrivilegeSchema(),
+				Description: `The privilege list under this authority record.`,
 			},
 		},
 	}
@@ -164,7 +168,7 @@ func listClusterUserAuthorities(client *golangsdk.ServiceClient, clusterId, name
 	return result, nil
 }
 
-func flattenClusterUserAuthorityPrivileges(privileges []interface{}) []map[string]interface{} {
+func flattenDataClusterUserAuthorityPrivileges(privileges []interface{}) []map[string]interface{} {
 	if len(privileges) < 1 {
 		return nil
 	}
@@ -180,7 +184,7 @@ func flattenClusterUserAuthorityPrivileges(privileges []interface{}) []map[strin
 	return result
 }
 
-func flattenClusterUserAuthorities(authorities []interface{}) []map[string]interface{} {
+func flattenDataClusterUserAuthorities(authorities []interface{}) []map[string]interface{} {
 	if len(authorities) < 1 {
 		return nil
 	}
@@ -196,7 +200,7 @@ func flattenClusterUserAuthorities(authorities []interface{}) []map[string]inter
 			"future":               utils.PathSearch("future", authority, false),
 			"future_object_owners": utils.PathSearch("future_object_owners", authority, nil),
 			"column_names":         utils.PathSearch("column_name", authority, make([]interface{}, 0)),
-			"privileges": flattenClusterUserAuthorityPrivileges(utils.PathSearch("privileges", authority,
+			"privileges": flattenDataClusterUserAuthorityPrivileges(utils.PathSearch("privileges", authority,
 				make([]interface{}, 0)).([]interface{})),
 		})
 	}
@@ -230,7 +234,7 @@ func dataSourceClusterUserAuthoritiesRead(_ context.Context, d *schema.ResourceD
 
 	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("authorities", flattenClusterUserAuthorities(authorities)),
+		d.Set("authorities", flattenDataClusterUserAuthorities(authorities)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_user.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_user.go
@@ -1,0 +1,592 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var clusterUserNonUpdatableParams = []string{
+	"cluster_id",
+	"name",
+	"type",
+	"password",
+	"description",
+	"password_disable",
+	"logical_cluster",
+	"grant_list",
+}
+
+// @API DWS POST /v1/{project_id}/clusters/{cluster_id}/db-manager/users
+// @API DWS GET /v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}
+// @API DWS GET /v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}/authority
+// @API DWS POST /v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}
+// @API DWS DELETE /v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}
+func ResourceClusterUser() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceClusterUserCreate,
+		ReadContext:   resourceClusterUserRead,
+		UpdateContext: resourceClusterUserUpdate,
+		DeleteContext: resourceClusterUserDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(clusterUserNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceClusterUserImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the cluster user is located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the DWS cluster.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The object type.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the cluster user or role.`,
+			},
+
+			// Optional parameters.
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `The password of the user.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the user or role.`,
+			},
+			"password_disable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to disable password authentication.`,
+			},
+			"logical_cluster": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The logical cluster name.`,
+			},
+			"grant_list": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        clusterUserGrantListElemSchema(),
+				Description: `The list of grants.`,
+			},
+			"cascade": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether to cascade delete the dependencies when deleting the user or role.`,
+			},
+			"login": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to allow the user to log in.`,
+			},
+			"create_role": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to grant the permission to create roles.`,
+			},
+			"create_db": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to grant the permission to create databases.`,
+			},
+			"system_admin": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to grant the system administrator permission.`,
+			},
+			"audit_admin": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to grant the audit administrator permission.`,
+			},
+			"inherit": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to inherit permissions from roles.`,
+			},
+			"use_ft": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to grant the external table permission.`,
+			},
+			"conn_limit": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The maximum number of concurrent connections.`,
+			},
+			"replication": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to grant the replication permission.`,
+			},
+			"valid_begin": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The valid begin time.`,
+			},
+			"valid_until": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The valid until time.`,
+			},
+			"lock": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether the user is locked.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func clusterUserGrantListElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The object type.`,
+			},
+			"database": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The database name.`,
+			},
+			"schema_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The schema name.`,
+			},
+			"object_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The object name.`,
+			},
+			"all_object": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether all objects are included.`,
+			},
+			"future": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to grant privileges on future objects.`,
+			},
+			"future_object_owners": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The owners of the future objects.`,
+			},
+			"column_names": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of column names.`,
+			},
+			"privileges": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        clusterUserAuthorityPrivilegeSchema(),
+				Description: `The list of privileges.`,
+			},
+		},
+	}
+}
+
+func clusterUserAuthorityPrivilegeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"permission": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The privilege name.`,
+			},
+			"grant_with": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: `Whether the grant option is included.`,
+			},
+		},
+	}
+}
+
+func buildClusterUserAuthorityPrivileges(privileges []interface{}) []map[string]interface{} {
+	if len(privileges) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(privileges))
+	for _, privilege := range privileges {
+		result = append(result, map[string]interface{}{
+			"permission": utils.PathSearch("permission", privilege, nil),
+			"grant_with": utils.PathSearch("grant_with", privilege, nil),
+		})
+	}
+
+	return result
+}
+
+func buildClusterUserGrantList(grants []interface{}) []map[string]interface{} {
+	if len(grants) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(grants))
+	for _, grant := range grants {
+		result = append(result, map[string]interface{}{
+			"type":                 utils.PathSearch("type", grant, nil),
+			"database":             utils.ValueIgnoreEmpty(utils.PathSearch("database", grant, "")),
+			"schema":               utils.ValueIgnoreEmpty(utils.PathSearch("schema_name", grant, "")),
+			"obj_name":             utils.ValueIgnoreEmpty(utils.PathSearch("object_name", grant, "")),
+			"all_object":           utils.ValueIgnoreEmpty(utils.PathSearch("all_object", grant, nil)),
+			"future":               utils.ValueIgnoreEmpty(utils.PathSearch("future", grant, nil)),
+			"future_object_owners": utils.ValueIgnoreEmpty(utils.PathSearch("future_object_owners", grant, "")),
+			"column_name": utils.ValueIgnoreEmpty(
+				utils.ExpandToStringListBySet(utils.PathSearch("column_names", grant, &schema.Set{}).(*schema.Set)),
+			),
+			"privileges": buildClusterUserAuthorityPrivileges(
+				utils.PathSearch("privileges", grant, &schema.Set{}).(*schema.Set).List(),
+			),
+		})
+	}
+
+	return result
+}
+
+func buildClusterUserBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"type":             d.Get("type"),
+		"name":             d.Get("name"),
+		"password":         utils.ValueIgnoreEmpty(d.Get("password")),
+		"desc":             utils.ValueIgnoreEmpty(d.Get("description")),
+		"password_disable": utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "password_disable"),
+		"logical_cluster":  utils.ValueIgnoreEmpty(d.Get("logical_cluster")),
+		"grant_list":       utils.ValueIgnoreEmpty(buildClusterUserGrantList(d.Get("grant_list").(*schema.Set).List())),
+		"login":            utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "login"),
+		"create_role":      utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "create_role"),
+		"create_db":        utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "create_db"),
+		"system_admin":     utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "system_admin"),
+		"inherit":          utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "inherit"),
+		"conn_limit":       utils.ValueIgnoreEmpty(utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "conn_limit")),
+	}
+}
+
+func buildClusterUserUpdateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"login":       utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "login"),
+		"createrole":  utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "create_role"),
+		"createdb":    utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "create_db"),
+		"systemadmin": utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "system_admin"),
+		"auditadmin":  utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "audit_admin"),
+		"inherit":     utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "inherit"),
+		"useft":       utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "use_ft"),
+		"conn_limit":  utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "conn_limit"),
+		"replication": utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "replication"),
+		"valid_begin": utils.ValueIgnoreEmpty(d.Get("valid_begin")),
+		"valid_until": utils.ValueIgnoreEmpty(d.Get("valid_until")),
+		"lock":        utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "lock"),
+	}
+}
+
+// Some parameters (such as createdb, systemadmin, etc.) are not supported by the Create API and must be
+// initialized through the Update API after the user is created.
+func resourceClusterUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		clusterId     = d.Get("cluster_id").(string)
+		name          = d.Get("name").(string)
+		createHttpUrl = "v1/{project_id}/clusters/{cluster_id}/db-manager/users"
+		updateHttpUrl = "v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}"
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{cluster_id}", clusterId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      requestOpts.MoreHeaders,
+		JSONBody:         utils.RemoveNil(buildClusterUserBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating cluster user: %s", err)
+	}
+
+	id := fmt.Sprintf("%s/%s/%s", region, clusterId, name)
+	d.SetId(id)
+
+	updatePath := client.Endpoint + updateHttpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", clusterId)
+	updatePath = strings.ReplaceAll(updatePath, "{name}", name)
+
+	updateBody := utils.RemoveNil(buildClusterUserUpdateBodyParams(d))
+	if len(updateBody) < 1 {
+		return resourceClusterUserRead(ctx, d, meta)
+	}
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      requestOpts.MoreHeaders,
+		JSONBody:         updateBody,
+	}
+
+	_, err = client.Request("POST", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating cluster user after create: %s", err)
+	}
+
+	return resourceClusterUserRead(ctx, d, meta)
+}
+
+func flattenClusterUserAuthorityPrivileges(privileges []interface{}) []map[string]interface{} {
+	if len(privileges) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(privileges))
+	for _, privilege := range privileges {
+		result = append(result, map[string]interface{}{
+			"permission": utils.PathSearch("permission", privilege, nil),
+			"grant_with": utils.PathSearch("grant_with", privilege, false),
+		})
+	}
+
+	return result
+}
+
+func flattenClusterUserAuthorities(authorities []interface{}) []map[string]interface{} {
+	if len(authorities) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(authorities))
+	for _, authority := range authorities {
+		result = append(result, map[string]interface{}{
+			"type":                 utils.PathSearch("type", authority, nil),
+			"database":             utils.PathSearch("database", authority, nil),
+			"schema_name":          utils.PathSearch("schema", authority, nil),
+			"object_name":          utils.PathSearch("obj_name", authority, nil),
+			"all_object":           utils.PathSearch("all_object", authority, false),
+			"future":               utils.PathSearch("future", authority, false),
+			"future_object_owners": utils.PathSearch("future_object_owners", authority, nil),
+			"column_names":         utils.PathSearch("column_name", authority, make([]interface{}, 0)),
+			"privileges": flattenClusterUserAuthorityPrivileges(utils.PathSearch("privileges", authority,
+				make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func resourceClusterUserRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+		name      = d.Get("name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	userDetail, err := GetClusterUser(client, clusterId, name)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving cluster user")
+	}
+	authorities, err := listClusterUserAuthorities(client, clusterId, name)
+	if err != nil {
+		return diag.Errorf("error querying cluster user authorities: %s", err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("description", utils.PathSearch("desc", userDetail, nil)),
+		d.Set("logical_cluster", utils.PathSearch("logical_cluster", userDetail, nil)),
+		d.Set("login", utils.PathSearch("login", userDetail, nil)),
+		d.Set("create_role", utils.PathSearch("createrole", userDetail, nil)),
+		d.Set("create_db", utils.PathSearch("createdb", userDetail, nil)),
+		d.Set("system_admin", utils.PathSearch("systemadmin", userDetail, nil)),
+		d.Set("audit_admin", utils.PathSearch("auditadmin", userDetail, nil)),
+		d.Set("inherit", utils.PathSearch("inherit", userDetail, nil)),
+		d.Set("use_ft", utils.PathSearch("useft", userDetail, nil)),
+		d.Set("conn_limit", utils.PathSearch("conn_limit", userDetail, nil)),
+		d.Set("replication", utils.PathSearch("replication", userDetail, nil)),
+		d.Set("valid_begin", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("valid_begin", userDetail, float64(0)).(float64))/1000, false)),
+		d.Set("valid_until", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("valid_until", userDetail, float64(0)).(float64))/1000, false)),
+		d.Set("lock", utils.PathSearch("lock", userDetail, nil)),
+		d.Set("grant_list", flattenClusterUserAuthorities(authorities)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceClusterUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+		name      = d.Get("name").(string)
+		httpUrl   = "v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}"
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", clusterId)
+	updatePath = strings.ReplaceAll(updatePath, "{name}", name)
+
+	updateBody := utils.RemoveNil(buildClusterUserUpdateBodyParams(d))
+	if len(updateBody) < 1 {
+		return resourceClusterUserRead(ctx, d, meta)
+	}
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      requestOpts.MoreHeaders,
+		JSONBody:         updateBody,
+	}
+
+	_, err = client.Request("POST", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating cluster user: %s", err)
+	}
+
+	return resourceClusterUserRead(ctx, d, meta)
+}
+
+func resourceClusterUserDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+		name      = d.Get("name").(string)
+		cascade   = d.Get("cascade").(bool)
+		httpUrl   = "v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}"
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", clusterId)
+	deletePath = strings.ReplaceAll(deletePath, "{name}", name)
+	deletePathWithQuery := fmt.Sprintf("%s?cascade=%t", deletePath, cascade)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      requestOpts.MoreHeaders,
+	}
+
+	_, err = client.Request("DELETE", deletePathWithQuery, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting cluster user")
+	}
+
+	return nil
+}
+
+// GetClusterUser is a method used to query the database user or role details from the DWS API.
+// It returns the user details as an interface{} and any error encountered.
+func GetClusterUser(client *golangsdk.ServiceClient, clusterId, name string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/clusters/{cluster_id}/db-manager/users/{name}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
+	getPath = strings.ReplaceAll(getPath, "{name}", name)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      requestOpts.MoreHeaders,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceClusterUserImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid format specified for resource ID, want '<region>/<cluster_id>/<name>', but got '%s'", d.Id())
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", parts[0]),
+		d.Set("cluster_id", parts[1]),
+		d.Set("name", parts[2]),
+	)
+	d.SetId(fmt.Sprintf("%s/%s/%s", parts[0], parts[1], parts[2]))
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add resource for cluster user management and permission configuration.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
Due to the prolonged creation time of DWS clusters, we are now importing DWS cluster resources from external environment variables. Additionally, the grant_members attribute has been removed as it is non-functional.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccResourceClusterUser_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceClusterUser_basic
=== PAUSE TestAccResourceClusterUser_basic
=== CONT  TestAccResourceClusterUser_basic
--- PASS: TestAccResourceClusterUser_basic (84.20s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       84.315s coverage: 5.3% of statements in ./huaweicloud/services/dws

Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccResourceClusterUser_role -timeout 360m -parallel 10
=== RUN   TestAccResourceClusterUser_role
=== PAUSE TestAccResourceClusterUser_role
=== CONT  TestAccResourceClusterUser_role
--- PASS: TestAccResourceClusterUser_role (90.90s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       91.024s coverage: 5.3% of statements in ./huaweicloud/services/dws

Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccResourceClusterUser_advanced -timeout 360m -parallel 10
=== RUN   TestAccResourceClusterUser_advanced
=== PAUSE TestAccResourceClusterUser_advanced
=== CONT  TestAccResourceClusterUser_advanced
--- PASS: TestAccResourceClusterUser_advanced (45.78s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       45.895s coverage: 5.1% of statements in ./huaweicloud/services/dws
```
<img width="1918" height="1100" alt="image" src="https://github.com/user-attachments/assets/b4fba21f-2026-4c9b-b360-1af00acd074e" />
<img width="1567" height="1057" alt="image" src="https://github.com/user-attachments/assets/38d54ff5-f736-4624-b50b-2570050fccdf" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.