### PR TITLE
feat(NAT): refactor nat gateway resource

### DIFF
--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -79,22 +79,20 @@ The following arguments are supported:
 
 -> Fields `name`, `spec` and `description` only support editing for pay-per-use billing mode NAT gateways.
 
-* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the NAT gateway.
+* `charging_mode` - (Optional, String) Specifies the charging mode of the NAT gateway.
   The valid values are as follows:
   + **prePaid**: the yearly/monthly billing mode.
   + **postPaid**: the pay-per-use billing mode.
 
-  Defaults to **postPaid**. Changing this will create a new resource.
+  Defaults to **postPaid**.
 
-* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the NAT gateway.
+* `period_unit` - (Optional, String) Specifies the charging period unit of the NAT gateway.
   Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.
-  Changing this will create a new resource.
 
-* `period` - (Optional, Int, ForceNew) Specifies the charging period of the NAT gateway.
+* `period` - (Optional, Int) Specifies the charging period of the NAT gateway.
   If `period_unit` is set to **month**, the value ranges from `1` to `9`.
   If `period_unit` is set to **year**, the value ranges from `1` to `3`.
   This parameter is mandatory if `charging_mode` is set to **prePaid**.
-  Changing this will create a new resource.
 
 * `auto_renew` - (Optional, String) Specifies whether auto-renew is enabled. This parameter is only valid when
   `charging_mode` is set to **prePaid**. Valid values are **true** and **false**. Defaults to **false**.

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
@@ -280,3 +280,133 @@ resource "huaweicloud_nat_gateway" "test" {
 }
 `, relatedConfig, name)
 }
+
+func TestAccPublicGateway_postpaid_to_prepaid(t *testing.T) {
+	var (
+		obj           interface{}
+		rName         = "huaweicloud_nat_gateway.test"
+		name          = acceptance.RandomAccResourceNameWithDash()
+		updateName    = acceptance.RandomAccResourceNameWithDash()
+		relatedConfig = common.TestBaseNetwork(name)
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPublicGatewayResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPublicGateway_postpaid_to_prepaid_step_1(name, relatedConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "spec", "1"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_session_expire_time", "1000"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.udp_session_expire_time", "400"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.icmp_session_expire_time", "20"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_time_wait_time", "10"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "dnat_rules_limit"),
+					resource.TestCheckResourceAttrSet(rName, "snat_rule_public_ip_limit"),
+				),
+			},
+			{
+				Config: testAccPublicGateway_postpaid_to_prepaid_step_2(updateName, relatedConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "spec", "2"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_session_expire_time", "900"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.udp_session_expire_time", "300"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.icmp_session_expire_time", "10"),
+					resource.TestCheckResourceAttr(rName, "session_conf.0.tcp_time_wait_time", "5"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "baaar"),
+					resource.TestCheckResourceAttr(rName, "tags.newkey", "value"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"charging_mode",
+					"period_unit",
+					"period",
+					"auto_renew",
+				},
+			},
+		},
+	})
+}
+
+func testAccPublicGateway_postpaid_to_prepaid_step_1(name, relatedConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_gateway" "test" {
+  name              = "%[2]s"
+  spec              = "1"
+  description       = "Created by acc test"
+  ngport_ip_address = "192.168.0.101"
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+
+  session_conf {
+    tcp_session_expire_time  = 1000
+    udp_session_expire_time  = 400
+    icmp_session_expire_time = 20
+    tcp_time_wait_time       = 10
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, relatedConfig, name)
+}
+
+func testAccPublicGateway_postpaid_to_prepaid_step_2(name, relatedConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_gateway" "test" {
+  name              = "%[2]s"
+  spec              = "2"
+  ngport_ip_address = "192.168.0.101"
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+
+  session_conf {
+    tcp_session_expire_time  = 900
+    udp_session_expire_time  = 300
+    icmp_session_expire_time = 10
+    tcp_time_wait_time       = 5
+  }
+
+  tags = {
+    foo    = "baaar"
+    newkey = "value"
+  }
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = "1"
+  auto_renew    = "false"
+}
+`, relatedConfig, name)
+}

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
@@ -2,6 +2,7 @@ package nat
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -22,6 +24,7 @@ import (
 
 // @API NAT POST /v2/{project_id}/nat_gateways
 // @API NAT GET /v2/{project_id}/nat_gateways/{nat_gateway_id}
+// @API NAT POST /v2/{project_id}/nat_gateways/{nat_gateway_id}/change_to_period
 // @API NAT PUT /v2/{project_id}/nat_gateways/{nat_gateway_id}
 // @API NAT DELETE /v2/{project_id}/nat_gateways/{nat_gateway_id}
 // @API NAT POST /v2.0/{project_id}/nat_gateways/{nat_gateway_id}/tags/action
@@ -76,10 +79,28 @@ func ResourcePublicGateway() *schema.Resource {
 				Required:    true,
 				Description: "The specification of the NAT gateway.",
 			},
-			"charging_mode": common.SchemaChargingMode(nil),
-			"period_unit":   common.SchemaPeriodUnit(nil),
-			"period":        common.SchemaPeriod(nil),
-			"auto_renew":    common.SchemaAutoRenewUpdatable(nil),
+			"charging_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"prePaid", "postPaid",
+				}, false),
+			},
+			"period_unit": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"period"},
+				ValidateFunc: validation.StringInSlice([]string{
+					"month", "year",
+				}, false),
+			},
+			"period": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"period_unit"},
+			},
+			"auto_renew": common.SchemaAutoRenewUpdatable(nil),
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -410,75 +431,40 @@ func flattenGatewaySessionConfig(sessionConfig interface{}) []map[string]interfa
 	}
 }
 
-func buildUpdatePublicGatewayBodyParams(d *schema.ResourceData) map[string]interface{} {
-	natGatewayBodyParams := map[string]interface{}{
-		"name":        utils.ValueIgnoreEmpty(d.Get("name")),
-		"spec":        utils.ValueIgnoreEmpty(d.Get("spec")),
-		"description": d.Get("description"),
-	}
-	return map[string]interface{}{
-		"nat_gateway": natGatewayBodyParams,
-	}
-}
-
-func buildUpdateSessionConfigBodyParams(d *schema.ResourceData) map[string]interface{} {
-	sessionConfParams := map[string]interface{}{
-		"session_conf": buildSessionConfigBodyParams(d.Get("session_conf").([]interface{})),
-	}
-	return map[string]interface{}{
-		"nat_gateway": sessionConfParams,
-	}
-}
-
 func resourcePublicGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg          = meta.(*config.Config)
-		region       = cfg.GetRegion(d)
-		product      = "nat"
-		chargingMode = d.Get("charging_mode").(string)
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "nat"
 	)
 
 	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating NAT v2 client: %s", err)
 	}
+	bssClient, err := cfg.BssV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating BSS v2 client: %s", err)
+	}
 
-	updatePath := client.Endpoint + "v2/{project_id}/nat_gateways/{nat_gateway_id}"
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{nat_gateway_id}", d.Id())
-
-	// Due to API limitations, the prepaid NAT gateway does not support editing.
-	if d.HasChanges("name", "spec", "description") && chargingMode != "prePaid" {
-		updateOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-			JSONBody:         utils.RemoveNil(buildUpdatePublicGatewayBodyParams(d)),
+	if d.HasChange("charging_mode") {
+		if d.Get("charging_mode").(string) == "postPaid" {
+			return diag.Errorf("error updating the charging mode of the NAT gateway (%s): %s", d.Id(),
+				"only support changing post-paid instance to pre-paid")
 		}
-
-		_, err = client.Request("PUT", updatePath, &updateOpt)
-		if err != nil {
-			return diag.Errorf("error updating NAT gateway (%s): %s", d.Id(), err)
+		if err = updatePublicGatewayChargingMode(ctx, d, client, bssClient); err != nil {
+			return diag.FromErr(err)
 		}
-
-		if err := waitingForPublicGatewayStatusActive(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("error waiting for NAT gateway (%s) to become active in"+
-				" update operation: %s", d.Id(), err)
+	} else if d.HasChange("auto_renew") {
+		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+			return diag.Errorf("error updating the auto-renew of the NAT gateway (%s): %s", d.Id(), err)
 		}
 	}
 
-	if d.HasChange("session_conf") {
-		updateOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-			JSONBody:         utils.RemoveNil(buildUpdateSessionConfigBodyParams(d)),
-		}
-
-		_, err = client.Request("PUT", updatePath, &updateOpt)
+	if d.HasChanges("name", "spec", "description", "session_conf") {
+		err = updatePublicGateway(ctx, d, client, bssClient)
 		if err != nil {
-			return diag.Errorf("error updating NAT gateway (%s): %s", d.Id(), err)
-		}
-
-		if err := waitingForPublicGatewayStatusActive(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("error waiting for NAT gateway (%s) to become active in"+
-				" update operation: %s", d.Id(), err)
+			return diag.FromErr(err)
 		}
 	}
 
@@ -493,18 +479,116 @@ func resourcePublicGatewayUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	// Only prepaid NAT gateway supports editing `auto_renew`.
-	if d.HasChange("auto_renew") && chargingMode == "prePaid" {
-		bssClient, err := cfg.BssV2Client(region)
+	return resourcePublicGatewayRead(ctx, d, meta)
+}
+
+func updatePublicGatewayChargingMode(ctx context.Context, d *schema.ResourceData, client, bssClient *golangsdk.ServiceClient) error {
+	httpUrl := "v2/{project_id}/nat_gateways/{nat_gateway_id}/change_to_period"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{nat_gateway_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdatePublicGatewayChargingModeBodyParams(d)),
+	}
+
+	updateResp, err := client.Request("POST", updatePath, &updateOpt)
+	if err != nil {
+		return fmt.Errorf("error updating NAT gateway(%s) charging mode: %s", d.Id(), err)
+	}
+
+	updateRespBody, err := utils.FlattenResponse(updateResp)
+	if err != nil {
+		return err
+	}
+
+	orderId := utils.PathSearch("order_id", updateRespBody, "").(string)
+	if orderId == "" {
+		return errors.New("error updating NAT gateway charging mode, order_id is not found in the response")
+	}
+	err = common.WaitOrderComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func buildUpdatePublicGatewayChargingModeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"period_type":   d.Get("period_unit"),
+		"period_num":    d.Get("period"),
+		"is_auto_renew": d.Get("auto_renew"),
+		"is_auto_pay":   true,
+	}
+	if v, ok := d.GetOk("auto_renew"); ok {
+		autoRenew, _ := strconv.ParseBool(v.(string))
+		bodyParams["is_auto_renew"] = autoRenew
+	}
+
+	return map[string]interface{}{
+		"prepaid_options": bodyParams,
+	}
+}
+
+func updatePublicGateway(ctx context.Context, d *schema.ResourceData, client, bssClient *golangsdk.ServiceClient) error {
+	httpUrl := "v2/{project_id}/nat_gateways/{nat_gateway_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{nat_gateway_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdatePublicGatewayBodyParams(d)),
+	}
+
+	updateResp, err := client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return fmt.Errorf("error updating NAT gateway (%s): %s", d.Id(), err)
+	}
+
+	// order_id is returned only when spec is updated
+	if d.Get("charging_mode").(string) == "prePaid" && d.HasChange("spec") {
+		updateRespBody, err := utils.FlattenResponse(updateResp)
 		if err != nil {
-			return diag.Errorf("error creating BSS V2 client: %s", err)
+			return err
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
-			return diag.Errorf("error updating the auto-renew of the NAT gateway (%s): %s", d.Id(), err)
+
+		orderId := utils.PathSearch("order_id", updateRespBody, "").(string)
+		if orderId == "" {
+			return errors.New("error updating NAT gateway, order_id is not found in the response")
+		}
+		err = common.WaitOrderComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return err
 		}
 	}
 
-	return resourcePublicGatewayRead(ctx, d, meta)
+	if err := waitingForPublicGatewayStatusActive(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return fmt.Errorf("error waiting for NAT gateway (%s) to become active in"+
+			" update operation: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func buildUpdatePublicGatewayBodyParams(d *schema.ResourceData) map[string]interface{} {
+	natGatewayBodyParams := map[string]interface{}{
+		"name":         utils.ValueIgnoreEmpty(d.Get("name")),
+		"spec":         utils.ValueIgnoreEmpty(d.Get("spec")),
+		"description":  d.Get("description"),
+		"session_conf": buildSessionConfigBodyParams(d.Get("session_conf").([]interface{})),
+	}
+	if d.Get("charging_mode").(string) == "prePaid" {
+		natGatewayBodyParams["prepaid_options"] = map[string]interface{}{
+			"is_auto_pay": true,
+		}
+	}
+
+	return map[string]interface{}{
+		"nat_gateway": natGatewayBodyParams,
+	}
 }
 
 func waitingForPublicGatewayDelete(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. support update charging_mode from postPaid to prePaid
2. support update spec when charging_mode is prePaid

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  refactor nat gateway resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/nat/ TESTARGS='-run TestAccPublicGateway_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat/ -v -run TestAccPublicGateway_ -timeout 360m -parallel 4
=== RUN   TestAccPublicGateway_basic
=== PAUSE TestAccPublicGateway_basic
=== RUN   TestAccPublicGateway_prepaid
=== PAUSE TestAccPublicGateway_prepaid
=== RUN   TestAccPublicGateway_postpaid_to_prepaid
=== PAUSE TestAccPublicGateway_postpaid_to_prepaid
=== CONT  TestAccPublicGateway_basic
=== CONT  TestAccPublicGateway_postpaid_to_prepaid
=== CONT  TestAccPublicGateway_prepaid
--- PASS: TestAccPublicGateway_basic (261.54s)
--- PASS: TestAccPublicGateway_postpaid_to_prepaid (323.47s)
--- PASS: TestAccPublicGateway_prepaid (325.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       325.687s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
