### PR TITLE
feat(RDS): add parametergroup reset and compare resource

### DIFF
--- a/docs/resources/rds_parametergroup_compare.md
+++ b/docs/resources/rds_parametergroup_compare.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Relational Database Service (RDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rds_parametergroup_compare"
+description: |-
+  Manages an RDS parameter group compare resource within HuaweiCloud.
+---
+
+# huaweicloud_rds_parametergroup_compare
+
+Manages an RDS parameter group compare resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "source_id" {}
+variable "target_id" {}
+
+resource "huaweicloud_rds_parametergroup_compare" "test" {
+  source_id = var.source_id
+  target_id = var.target_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `source_id` - (Required, String, NonUpdatable) Specifies the source parameter template ID.
+
+* `target_id` - (Required, String, NonUpdatable) Specifies the target parameter template ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates the resource ID.
+
+* `source_name` - Indicates the source parameter template name.
+
+* `target_name` - Indicates the target parameter template name.
+
+* `parameters` - Indicates the template parameter differences..
+  The [parameters](#parameters_struct) structure is documented below.
+
+<a name="parameters_struct"></a>
+The `parameters` block supports:
+
+* `name` - Indicates the parameter name.
+
+* `source_value` - Indicates the parameter value in the source template.
+
+* `target_value` - Indicates the parameter value in the target template.

--- a/docs/resources/rds_parametergroup_reset.md
+++ b/docs/resources/rds_parametergroup_reset.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Relational Database Service (RDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rds_parametergroup_reset"
+description: |-
+  Manages an RDS parameter group copy resource within HuaweiCloud.
+---
+
+# huaweicloud_rds_parametergroup_reset
+
+Manages an RDS parameter group reset resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "config_id" {}
+
+resource "huaweicloud_rds_parametergroup_reset" "test" {
+  config_id = var.config_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `config_id` - (Required, String, NonUpdatable) Specifies the parameter template ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates the resource ID.
+
+* `config_name` - Indicates the parameter template name.
+
+* `need_restart` - Indicates whether a reboot is required.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3789,6 +3789,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_instance_eip_associate":         rds.ResourceRdsInstanceEipAssociate(),
 			"huaweicloud_rds_parametergroup":                 rds.ResourceRdsConfiguration(),
 			"huaweicloud_rds_parametergroup_copy":            rds.ResourceRdsConfigurationCopy(),
+			"huaweicloud_rds_parametergroup_reset":           rds.ResourceRdsConfigurationReset(),
+			"huaweicloud_rds_parametergroup_compare":         rds.ResourceRdsConfigurationCompare(),
 			"huaweicloud_rds_read_replica_instance":          rds.ResourceRdsReadReplicaInstance(),
 			"huaweicloud_rds_backup":                         rds.ResourceBackup(),
 			"huaweicloud_rds_backup_stop":                    rds.ResourceRdsBackupStop(),

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_parametergroup_compare_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_parametergroup_compare_test.go
@@ -1,0 +1,69 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccConfigurationCompare_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_rds_parametergroup_compare.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfigurationCompare_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "source_name", fmt.Sprintf("%s_source", name)),
+					resource.TestCheckResourceAttr(rName, "target_name", fmt.Sprintf("%s_target", name)),
+					resource.TestCheckResourceAttr(rName, "parameters.#", "1"),
+					resource.TestCheckResourceAttr(rName, "parameters.0.name", "auto_increment_increment"),
+					resource.TestCheckResourceAttr(rName, "parameters.0.source_value", "2"),
+					resource.TestCheckResourceAttr(rName, "parameters.0.target_value", "4"),
+				),
+			},
+		},
+	})
+}
+
+func testConfigurationCompare_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rds_parametergroup" "source" {
+  name = "%[1]s_source"
+
+  values = {
+    auto_increment_increment = "2"
+  }
+
+  datastore {
+    type    = "mysql"
+    version = "8.0"
+  }
+}
+
+resource "huaweicloud_rds_parametergroup" "target" {
+  name = "%[1]s_target"
+
+  values = {
+    auto_increment_increment = "4"
+  }
+
+  datastore {
+    type    = "mysql"
+    version = "8.0"
+  }
+}
+
+resource "huaweicloud_rds_parametergroup_compare" "test" {
+  source_id = huaweicloud_rds_parametergroup.source.id
+  target_id = huaweicloud_rds_parametergroup.target.id
+}
+`, name)
+}

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_parametergroup_reset_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_parametergroup_reset_test.go
@@ -1,0 +1,40 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccConfigurationReset_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_rds_parametergroup_reset.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfigurationReset_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rName, "config_name"),
+					resource.TestCheckResourceAttrSet(rName, "need_restart"),
+				),
+			},
+		},
+	})
+}
+
+func testConfigurationReset_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_parametergroup_reset" "test" {
+  config_id = huaweicloud_rds_parametergroup.test.id
+}
+`, testAccRdsConfig_basic(name))
+}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_parametergroup_compare.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_parametergroup_compare.go
@@ -1,0 +1,174 @@
+package rds
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var configurationCompareNonUpdatableParams = []string{
+	"source_id", "target_id",
+}
+
+// @API RDS PUT /v3/{project_id}/configurations/difference
+func ResourceRdsConfigurationCompare() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRdsConfigurationCompareCreate,
+		ReadContext:   resourceRdsConfigurationCompareRead,
+		UpdateContext: resourceRdsConfigurationCompareUpdate,
+		DeleteContext: resourceRdsConfigurationCompareDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(configurationCompareNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"source_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"target_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"source_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"parameters": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"target_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceRdsConfigurationCompareCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/configurations/difference"
+		product = "rds"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	createOpt.JSONBody = buildCreateConfigurationCompareBodyParams(d)
+
+	createResp, err := client.Request("PUT", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating RDS configuration compare: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", d.Get("source_id").(string), d.Get("target_id").(string)))
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("source_id", utils.PathSearch("source_id", createRespBody, nil)),
+		d.Set("target_id", utils.PathSearch("target_id", createRespBody, nil)),
+		d.Set("source_name", utils.PathSearch("source_name", createRespBody, nil)),
+		d.Set("target_name", utils.PathSearch("target_name", createRespBody, nil)),
+		d.Set("parameters", flattenCompareResponseBodyDifferences(createRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildCreateConfigurationCompareBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"source_id": d.Get("source_id"),
+		"target_id": d.Get("target_id"),
+	}
+	return bodyParams
+}
+
+func flattenCompareResponseBodyDifferences(resp interface{}) []interface{} {
+	parameters := utils.PathSearch("parameters", resp, make([]interface{}, 0)).([]interface{})
+	if len(parameters) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(parameters))
+	for _, parameter := range parameters {
+		rst = append(rst, map[string]interface{}{
+			"name":         utils.PathSearch("name", parameter, nil),
+			"source_value": utils.PathSearch("source_value", parameter, nil),
+			"target_value": utils.PathSearch("target_value", parameter, nil),
+		})
+	}
+	return rst
+}
+
+func resourceRdsConfigurationCompareRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRdsConfigurationCompareUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRdsConfigurationCompareDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting RDS parameter template compare resource is not supported. The resource is only removed from " +
+		"the state, the parameter template still remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_parametergroup_reset.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_parametergroup_reset.go
@@ -1,0 +1,120 @@
+package rds
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var configurationResetNonUpdatableParams = []string{
+	"config_id",
+}
+
+// @API RDS POST /v3/{project_id}/configurations/{config_id}/reset
+func ResourceRdsConfigurationReset() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRdsConfigurationResetCreate,
+		ReadContext:   resourceRdsConfigurationResetRead,
+		UpdateContext: resourceRdsConfigurationResetUpdate,
+		DeleteContext: resourceRdsConfigurationResetDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(configurationResetNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"config_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"config_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"need_restart": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceRdsConfigurationResetCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/configurations/{config_id}/reset"
+		product = "rds"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{config_id}", d.Get("config_id").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	createResp, err := client.Request("PUT", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating RDS configuration reset: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(d.Get("config_id").(string))
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("config_name", utils.PathSearch("config_name", createRespBody, nil)),
+		d.Set("need_restart", utils.PathSearch("need_restart", createRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceRdsConfigurationResetRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRdsConfigurationResetUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRdsConfigurationResetDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting RDS parameter template reset resource is not supported. The resource is only removed from the" +
+		"state, the parameter template still remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add parametergroup reset and compare resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add parametergroup reset and compare resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccConfigurationReset_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccConfigurationReset_basic -timeout 360m -parallel 4
=== RUN   TestAccConfigurationReset_basic
=== PAUSE TestAccConfigurationReset_basic
=== CONT  TestAccConfigurationReset_basic
--- PASS: TestAccConfigurationReset_basic (41.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       41.717s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccConfigurationCompare_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccConfigurationCompare_basic -timeout 360m -parallel 4
=== RUN   TestAccConfigurationCompare_basic
=== PAUSE TestAccConfigurationCompare_basic
=== CONT  TestAccConfigurationCompare_basic
--- PASS: TestAccConfigurationCompare_basic (55.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       55.393s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
