### PR TITLE
feat(elb): add new data source to query the list of loadbalancer tags

### DIFF
--- a/docs/data-sources/elb_loadbalancer_tags.md
+++ b/docs/data-sources/elb_loadbalancer_tags.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Dedicated Load Balance (Dedicated ELB)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_elb_loadbalancer_tags"
+description: |-
+  Use this data source to get the list of loadbalancer tags.
+---
+
+# huaweicloud_elb_loadbalancer_tags
+
+Use this data source to get the list of loadbalancer tags.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_elb_loadbalancer_tags" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of tags.  
+  The [tags](#tags_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - The tag key.
+
+* `values` - The list of tag values.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1833,6 +1833,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_elb_loadbalancers":                       elb.DataSourceElbLoadbalances(),
 			"huaweicloud_elb_loadbalancer_ports":                  elb.DataSourceElbLoadBalancerPorts(),
 			"huaweicloud_elb_loadbalancer_status":                 elb.DataSourceElbLoadBalancerStatus(),
+			"huaweicloud_elb_loadbalancer_tags":                   elb.DataSourceLoadbalancerTags(),
 			"huaweicloud_elb_listeners":                           elb.DataSourceElbListeners(),
 			"huaweicloud_elb_members":                             elb.DataSourceElbMembers(),
 			"huaweicloud_elb_all_members":                         elb.DataSourceElbAllMembers(),

--- a/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_loadbalancer_tags_test.go
+++ b/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_loadbalancer_tags_test.go
@@ -1,0 +1,36 @@
+package elb
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceLoadbalancerTags_basic(t *testing.T) {
+	var (
+		dataSourcename = "data.huaweicloud_elb_loadbalancer_tags.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourcename)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceLoadbalancerTags_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourcename, "tags.#"),
+					resource.TestCheckResourceAttrSet(dataSourcename, "tags.0.key"),
+					resource.TestCheckResourceAttrSet(dataSourcename, "tags.0.values.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceLoadbalancerTags_basic = `data "huaweicloud_elb_loadbalancer_tags" "test" {}`

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_loadbalancer_tags.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_loadbalancer_tags.go
@@ -1,0 +1,109 @@
+package elb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ELB GET /v2.0/{project_id}/loadbalancers/tags
+func DataSourceLoadbalancerTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceLoadbalancerTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceLoadbalancerTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		getHttpUrl = "v2.0/{project_id}/loadbalancers/tags"
+	)
+
+	client, err := cfg.NewServiceClient("elb", region)
+	if err != nil {
+		return diag.Errorf("error creating ELB client: %s", err)
+	}
+
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving ELB loadbalancer tags: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tagsList := utils.PathSearch("tags", getRespBody, make([]interface{}, 0)).([]interface{})
+
+	datasourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(datasourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("tags", flattenLoadbalancerTags(tagsList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenLoadbalancerTags(tags []interface{}) []interface{} {
+	if len(tags) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"key":    utils.PathSearch("key", tag, nil),
+			"values": utils.PathSearch("values", tag, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query the list of loadbalancer tags.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/elb" TESTARGS="-run TestAccDataSourceLoadbalancerTags_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run TestAccDataSourceLoadbalancerTags_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceLoadbalancerTags_basic
=== PAUSE TestAccDataSourceLoadbalancerTags_basic
=== CONT  TestAccDataSourceLoadbalancerTags_basic
--- PASS: TestAccDataSourceLoadbalancerTags_basic (18.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       18.354s
```
<img width="1207" height="22" alt="image" src="https://github.com/user-attachments/assets/2e4dc81b-83f7-49b7-b20b-b15c6d243745" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
