### PR TITLE
feat(dws): add new action resource for adjust database schema permission space

### DIFF
--- a/docs/resources/dws_database_schema_adjust_action.md
+++ b/docs/resources/dws_database_schema_adjust_action.md
@@ -1,0 +1,55 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_database_schema_adjust_action"
+description: |-
+  Use this resource to update the space limit of a database schema in a DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_database_schema_adjust_action
+
+Use this resource to update the space limit of a database schema in a DWS cluster within HuaweiCloud.
+
+-> This resource is only a one-time action resource for updating the schema space limit. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "database_name" {}
+variable "schema_name" {}
+variable "permission_space" {}
+
+resource "huaweicloud_dws_database_schema_adjust_action" "test" {
+  cluster_id = var.cluster_id
+  database   = var.database_name
+  schema     = var.schema_name
+  perm_space = var.permission_space
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the DWS cluster is located.  
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the DWS cluster.
+
+* `database` - (Required, String, NonUpdatable) Specifies the name of the database.
+
+* `schema` - (Required, String, NonUpdatable) Specifies the name of the schema.  
+  In PostgreSQL-compatible databases (such as DWS), a schema is a namespace within a database
+  that holds objects (for example, tables and views).  
+  For instance, in the default setup you often see the `public` schema under a database.
+
+* `perm_space` - (Required, Int, NonUpdatable) Specifies the space threshold of the schema.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the action resource.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3231,6 +3231,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_cluster_restart":               dws.ResourceClusterRestart(),
 			"huaweicloud_dws_cluster_user":                  dws.ResourceClusterUser(),
 			"huaweicloud_dws_cluster":                       dws.ResourceDwsCluster(),
+			"huaweicloud_dws_database_schema_adjust_action": dws.ResourceDatabaseSchemaAdjustAction(),
 			"huaweicloud_dws_disaster_recovery_task":        dws.ResourceDwsDisasterRecoveryTask(),
 			"huaweicloud_dws_event_subscription":            dws.ResourceDwsEventSubs(),
 			"huaweicloud_dws_ext_data_source":               dws.ResourceDwsExtDataSource(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -4010,6 +4010,16 @@ func TestAccPreCheckDwsGrantTargets(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPreCheckDwsSchemaAdjust(t *testing.T) {
+	if HW_DWS_GRANT_DATABASE_NAME == "" {
+		t.Skip("HW_DWS_GRANT_DATABASE_NAME must be set for the acceptance test")
+	}
+	if HW_DWS_GRANT_SCHEMA_NAME == "" {
+		t.Skip("HW_DWS_GRANT_SCHEMA_NAME must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
 func TestAccPreCheckDwsClusterUserNames(t *testing.T) {
 	userNames := strings.Split(HW_DWS_ASSOCIATE_USER_NAMES, ",")
 	// One is used to associate to the queue, and the other is used to update the user associated with the queue.

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_database_schema_adjust_action_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_database_schema_adjust_action_test.go
@@ -1,0 +1,90 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataDatabaseSchemaAdjustAction_basic(t *testing.T) {
+	var (
+		permSpace = 20480
+		rName     = "huaweicloud_dws_database_schema_adjust_action.test"
+	)
+
+	// Avoid CheckDestroy because this resource is a one-time action resource.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+			acceptance.TestAccPreCheckDwsSchemaAdjust(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataDatabaseSchemaAdjustAction_invalidCluster(),
+				ExpectError: regexp.MustCompile("Cluster does not exist or has been deleted"),
+			},
+			{
+				// HTTP error details often mention database/schema or a DWS code; some failures surface as non-zero ret_code.
+				Config: testAccDataDatabaseSchemaAdjustAction_invalidDatabase(),
+				ExpectError: regexp.MustCompile(
+					`(?i)error adjusting database schema space:.+`),
+			},
+			{
+				Config: testAccDataDatabaseSchemaAdjustAction_basic(permSpace),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "database", acceptance.HW_DWS_GRANT_DATABASE_NAME),
+					resource.TestCheckResourceAttr(rName, "schema", acceptance.HW_DWS_GRANT_SCHEMA_NAME),
+					resource.TestCheckResourceAttr(rName, "perm_space", strconv.Itoa(permSpace)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataDatabaseSchemaAdjustAction_basic(permSpace int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_database_schema_adjust_action" "test" {
+  cluster_id = "%[1]s"
+  database   = "%[2]s"
+  schema     = "%[3]s"
+  perm_space = %[4]d
+}
+`, acceptance.HW_DWS_CLUSTER_ID,
+		acceptance.HW_DWS_GRANT_DATABASE_NAME,
+		acceptance.HW_DWS_GRANT_SCHEMA_NAME,
+		permSpace)
+}
+
+func testAccDataDatabaseSchemaAdjustAction_invalidCluster() string {
+	randomUUID, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_database_schema_adjust_action" "invalid_cluster" {
+  cluster_id = "%[1]s"
+  database   = "gaussdb"
+  schema     = "nonexistent_schema_for_acc_test"
+  perm_space = 10240
+}
+`, randomUUID)
+}
+
+func testAccDataDatabaseSchemaAdjustAction_invalidDatabase() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_database_schema_adjust_action" "invalid_database" {
+  cluster_id = "%[1]s"
+  database   = "database_name_not_exist_for_acc_test"
+  schema     = "%[2]s"
+  perm_space = 10240
+}
+`, acceptance.HW_DWS_CLUSTER_ID,
+		acceptance.HW_DWS_GRANT_SCHEMA_NAME)
+}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_database_schema_adjust_action.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_database_schema_adjust_action.go
@@ -1,0 +1,165 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var dwsDatabaseSchemaAdjustActionNonUpdatableParams = []string{
+	"cluster_id",
+	"database",
+	"schema",
+	"perm_space",
+}
+
+// @API DWS PUT /v2/{project_id}/clusters/{cluster_id}/databases/{database_name}/schemas
+func ResourceDatabaseSchemaAdjustAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDatabaseSchemaAdjustActionCreate,
+		ReadContext:   resourceDatabaseSchemaAdjustActionRead,
+		UpdateContext: resourceDatabaseSchemaAdjustActionUpdate,
+		DeleteContext: resourceDatabaseSchemaAdjustActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(dwsDatabaseSchemaAdjustActionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the DWS cluster is located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the DWS cluster.`,
+			},
+			"database": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the database.`,
+			},
+			"schema": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the schema.`,
+			},
+			"perm_space": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The space threshold of the schema.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildDatabaseSchemaAdjustActionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"schema_name": d.Get("schema"),
+		"perm_space":  d.Get("perm_space"),
+	}
+}
+
+func adjustDatabaseSchemaSpace(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl      = "v2/{project_id}/clusters/{cluster_id}/databases/{database}/schemas"
+		clusterId    = d.Get("cluster_id").(string)
+		databaseName = d.Get("database").(string)
+	)
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", clusterId)
+	updatePath = strings.ReplaceAll(updatePath, "{database}", databaseName)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildDatabaseSchemaAdjustActionBodyParams(d),
+	}
+
+	resp, err := client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	retCode := int(utils.PathSearch("ret_code", respBody, float64(-1)).(float64))
+	if retCode != 0 {
+		return fmt.Errorf("unexpected ret_code (%d), response body: %s", retCode, respBody)
+	}
+
+	return nil
+}
+
+func resourceDatabaseSchemaAdjustActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	err = adjustDatabaseSchemaSpace(client, d)
+	if err != nil {
+		return diag.Errorf("error adjusting database schema space: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceDatabaseSchemaAdjustActionRead(ctx, d, meta)
+}
+
+func resourceDatabaseSchemaAdjustActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDatabaseSchemaAdjustActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDatabaseSchemaAdjustActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for updating the schema space limit. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new action resource for adjust database schema permission space

**Which issue this PR fixes**:

**Special notes for your reviewer**:
The DWS cluster provisioning process takes too long during acceptance tests. Therefore, we have pre-provisioned a cluster via the console and configured the test cases to run against this existing environment.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccDatabaseSchemaAdjustAction -timeout 360m -parallel 10
=== RUN   TestAccDatabaseSchemaAdjustAction
=== PAUSE TestAccDatabaseSchemaAdjustAction
=== CONT  TestAccDatabaseSchemaAdjustAction
--- PASS: TestAccDatabaseSchemaAdjustAction (28.75s)
PASS
coverage: 3.2% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       28.866s coverage: 3.2% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.