### PR TITLE
feat(dataarts): add new resource for job export

### DIFF
--- a/docs/resources/dataarts_factory_job_export.md
+++ b/docs/resources/dataarts_factory_job_export.md
@@ -1,0 +1,68 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_factory_job_export"
+description: |-
+  Manages a one-time resource to export a specified DataArts Factory job within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_factory_job_export
+
+Manages a one-time resource to export a specified DataArts Factory job within HuaweiCloud.
+
+-> This resource is a one-time action resource used to export a job package to a specified OBS storage path. Deleting
+   this resource will not clear the export task, but will only remove the resource information from the tfstate file.
+
+-> After the resource is created, a job export folder will be generated in the target OBS storage path, which contains
+   the job export object (ZIP package, names `{job_name}.zip`). Generating the ZIP package takes some time (it will not
+   be generated instantly after the resource is created).
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "job_name" {}
+variable "obs_storage_path" {}
+
+resource "huaweicloud_dataarts_factory_job_export" "test" {
+  workspace_id  = var.workspace_id
+  job_name      = var.job_name
+  export_depend = true
+  export_status = "SUBMIT"
+  obs_path      = var.obs_storage_path
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `job_name` - (Required, String, NonUpdatable) Specifies the name of the job to be exported.
+
+* `obs_path` - (Required, String, NonUpdatable) Specifies the OBS path for storing the exported job package.
+  For example, `obs://test_bucket/job_nodes/`.
+
+* `workspace_id` - (Optional, String, NonUpdatable) Specifies the workspace ID to which the job belongs.  
+  If omitted, the default workspace (`default`) will be used.
+
+* `export_depend` - (Optional, Bool, NonUpdatable) Specifies whether to export scripts and resources depended on
+  by the job. If omitted, the default value defined by the API is used.
+
+* `export_status` - (Optional, String, NonUpdatable) Specifies the job status to be exported.  
+  The valid values are as follows:
+  + **DEVELOP**
+  + **SUBMIT**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `folder_path` - The folder path suffix parsed from the response `obsPath` relative to the input `obs_path`.  
+  For example, if `obs_path` is `obs://dataarts-test/jobs-storage/` and the response `obsPath` is
+  `obs://dataarts-test/jobs-storage/job_6278_exported/1774334941255`, this attribute will be
+  `job_6278_exported/1774334941255`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3715,9 +3715,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_data_standard_template": dataarts.ResourceDataStandardTemplate(),
 			"huaweicloud_dataarts_architecture_reviewer":               dataarts.ResourceDataArtsArchitectureReviewer(),
 			// DataArts Factory
-			"huaweicloud_dataarts_factory_resource":   dataarts.ResourceFactoryResource(),
-			"huaweicloud_dataarts_factory_job_action": dataarts.ResourceFactoryJobAction(),
 			"huaweicloud_dataarts_factory_job":        dataarts.ResourceFactoryJob(),
+			"huaweicloud_dataarts_factory_job_action": dataarts.ResourceFactoryJobAction(),
+			"huaweicloud_dataarts_factory_job_export": dataarts.ResourceFactoryJobExport(),
+			"huaweicloud_dataarts_factory_resource":   dataarts.ResourceFactoryResource(),
 			"huaweicloud_dataarts_factory_script":     dataarts.ResourceDataArtsFactoryScript(),
 			// DataArts Security
 			"huaweicloud_dataarts_security_data_recognition_rule":    dataarts.ResourceSecurityRule(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -112,10 +112,11 @@ var (
 	HW_CNAD_ENABLE_FLAG       = os.Getenv("HW_CNAD_ENABLE_FLAG")
 	HW_CNAD_PROJECT_OBJECT_ID = os.Getenv("HW_CNAD_PROJECT_OBJECT_ID")
 
-	HW_OBS_DESTINATION_BUCKET = os.Getenv("HW_OBS_DESTINATION_BUCKET")
-	HW_OBS_USER_DOMAIN_NAME1  = os.Getenv("HW_OBS_USER_DOMAIN_NAME1")
-	HW_OBS_USER_DOMAIN_NAME2  = os.Getenv("HW_OBS_USER_DOMAIN_NAME2")
-	HW_OBS_ENDPOINT           = os.Getenv("HW_OBS_ENDPOINT")
+	HW_OBS_DESTINATION_BUCKET  = os.Getenv("HW_OBS_DESTINATION_BUCKET")
+	HW_OBS_ENDPOINT            = os.Getenv("HW_OBS_ENDPOINT")
+	HW_OBS_OBJECT_STORAGE_PATH = os.Getenv("HW_OBS_OBJECT_STORAGE_PATH")
+	HW_OBS_USER_DOMAIN_NAME1   = os.Getenv("HW_OBS_USER_DOMAIN_NAME1")
+	HW_OBS_USER_DOMAIN_NAME2   = os.Getenv("HW_OBS_USER_DOMAIN_NAME2")
 
 	HW_OMS_ENABLE_FLAG     = os.Getenv("HW_OMS_ENABLE_FLAG")
 	HW_OMS_SYNC_TASK_ID    = os.Getenv("HW_OMS_SYNC_TASK_ID")
@@ -1745,16 +1746,23 @@ func TestAccPreCheckOBSDestinationBucket(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckOBSUserDomainNames(t *testing.T) {
-	if HW_OBS_USER_DOMAIN_NAME1 == "" || HW_OBS_USER_DOMAIN_NAME2 == "" {
-		t.Skip("HW_OBS_USER_DOMAIN_NAME1 and HW_OBS_USER_DOMAIN_NAME2 must be set for OBS user domain name tests")
+func TestAccPreCheckOBSEndpoint(t *testing.T) {
+	if HW_OBS_ENDPOINT == "" {
+		t.Skip("HW_OBS_ENDPOINT must be set for the acceptance test")
 	}
 }
 
 // lintignore:AT003
-func TestAccPreCheckOBSEndpoint(t *testing.T) {
-	if HW_OBS_ENDPOINT == "" {
-		t.Skip("HW_OBS_ENDPOINT must be set for the acceptance test")
+func TestAccPreCheckOBSObjectStoragePath(t *testing.T) {
+	if HW_OBS_OBJECT_STORAGE_PATH == "" {
+		t.Skip("HW_OBS_OBJECT_STORAGE_PATH must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckOBSUserDomainNames(t *testing.T) {
+	if HW_OBS_USER_DOMAIN_NAME1 == "" || HW_OBS_USER_DOMAIN_NAME2 == "" {
+		t.Skip("HW_OBS_USER_DOMAIN_NAME1 and HW_OBS_USER_DOMAIN_NAME2 must be set for OBS user domain name tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_job_export_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_job_export_test.go
@@ -1,0 +1,139 @@
+package dataarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before testing, please ensure that you have created an OBS bucket and set the root directory of the bucket to the log
+// storage path of your DataArts workspace.
+func TestAccFactoryJobExport_basic(t *testing.T) {
+	var (
+		name                  = acceptance.RandomAccResourceName()
+		withExportDependTrue  = "huaweicloud_dataarts_factory_job_export.with_export_depend_true"
+		withExportDependFalse = "huaweicloud_dataarts_factory_job_export.with_export_depend_false"
+		withoutExportDepend   = "huaweicloud_dataarts_factory_job_export.without_export_depend"
+	)
+
+	// Avoid CheckDestroy because this resource is a one-time action resource and there is nothing in the destroy
+	// method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsCdmName(t)
+			acceptance.TestAccPreCheckOBSObjectStoragePath(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFactoryJobExport_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(withExportDependTrue, "folder_path"),
+					resource.TestCheckResourceAttrSet(withExportDependFalse, "folder_path"),
+					resource.TestCheckResourceAttrSet(withoutExportDepend, "folder_path"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFactoryJobExport_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_factory_job" "test" {
+  name         = "%[1]s"
+  workspace_id = "%[2]s"
+  process_type = "BATCH"
+
+  nodes {
+    name = "Rest_client_%[1]s"
+    type = "RESTAPI"
+
+    location {
+      x = 10
+      y = 11
+    }
+
+    properties {
+      name  = "url"
+      value = "https://www.huaweicloud.com/"
+    }
+
+    properties {
+      name  = "method"
+      value = "GET"
+    }
+
+    properties {
+      name  = "retry"
+      value = "false"
+    }
+
+    properties {
+      name  = "requestMode"
+      value = "sync"
+    }
+
+    properties {
+      name  = "securityAuthentication"
+      value = "NONE"
+    }
+
+    properties {
+      name  = "agentName"
+      value = "%[3]s" # The agentName obtained from the DataArts Migration side.
+    }
+  }
+
+  schedule {
+    type = "EXECUTE_ONCE"
+  }
+}
+`, name, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_CDM_NAME)
+}
+
+func testAccFactoryJobExport_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_factory_job_export" "with_export_depend_true" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job.test
+  ]
+
+  workspace_id  = "%[2]s"
+  job_name      = huaweicloud_dataarts_factory_job.test.name
+  export_depend = true
+  export_status = "DEVELOP"
+  obs_path      = "%[3]s" # The OBS path for storing the exported job package, such as obs://dataarts-test/jobs-storage/
+}
+
+resource "huaweicloud_dataarts_factory_job_export" "with_export_depend_false" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job.test
+  ]
+
+  workspace_id  = "%[2]s"
+  job_name      = huaweicloud_dataarts_factory_job.test.name
+  export_depend = false
+  export_status = "DEVELOP"
+  obs_path      = "%[3]s" # The OBS path for storing the exported job package, such as obs://dataarts-test/jobs-storage/
+}
+
+resource "huaweicloud_dataarts_factory_job_export" "without_export_depend" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job.test
+  ]
+
+  workspace_id  = "%[2]s"
+  job_name      = huaweicloud_dataarts_factory_job.test.name
+  export_status = "DEVELOP"
+  obs_path      = "%[3]s" # The OBS path for storing the exported job package, such as obs://dataarts-test/jobs-storage/
+}
+`, testAccFactoryJobExport_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_OBS_OBJECT_STORAGE_PATH)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_export.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_export.go
@@ -1,0 +1,221 @@
+package dataarts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var factoryJobExportNonUpdatableParams = []string{
+	"job_name",
+	"obs_path",
+	"workspace_id",
+	"export_depend",
+	"export_status",
+}
+
+// @API DataArtsStudio POST /v1/{project_id}/jobs/{job_name}/export
+func ResourceFactoryJobExport() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFactoryJobExportCreate,
+		ReadContext:   resourceFactoryJobExportRead,
+		UpdateContext: resourceFactoryJobExportUpdate,
+		DeleteContext: resourceFactoryJobExportDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(factoryJobExportNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the job is located.`,
+			},
+
+			// Required parameters.
+			"job_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The job name.`,
+			},
+			"obs_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: utils.SchemaDesc(
+					`The OBS target path for storing the exported job package.`,
+					utils.SchemaDescInput{
+						Required: true,
+					},
+				),
+			},
+
+			// Optional parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The workspace ID to which the job belongs.`,
+			},
+			"export_depend": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to export the scripts and resources depended on by the job.`,
+			},
+			"export_status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The job status to export.`,
+			},
+
+			// Attributes.
+			"folder_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The folder path suffix in the returned OBS path relative to the input OBS path.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
+			},
+		},
+	}
+}
+
+func buildFactoryJobExportBodyParams(d *schema.ResourceData) map[string]interface{} {
+	rawConfig := d.GetRawConfig()
+	return utils.RemoveNil(map[string]interface{}{
+		// When the export_depend parameter is explicitly filled with 'true' or 'false', the exportDepend parameter must be set,
+		// and the boolean default value 'false' is not used.
+		"exportDepend": utils.ValueIgnoreEmpty(utils.GetNestedObjectFromRawConfig(rawConfig, "export_depend")),
+		"obsPath":      utils.ValueIgnoreEmpty(d.Get("obs_path")),
+		"exportStatus": utils.ValueIgnoreEmpty(d.Get("export_status")),
+	})
+}
+
+func buildFactoryJobExportRequestMoreHeaders(workspaceId string) map[string]string {
+	moreHeaders := map[string]string{
+		"Content-Type": "application/json",
+	}
+
+	if workspaceId != "" {
+		moreHeaders["workspace"] = workspaceId
+	}
+
+	return moreHeaders
+}
+
+func buildFactoryJobExportFolderPath(inputObsPath, outputObsPath string) string {
+	if outputObsPath == "" {
+		return ""
+	}
+	if inputObsPath == "" {
+		return outputObsPath
+	}
+
+	normalizedInputObsPath := inputObsPath
+	if !strings.HasSuffix(normalizedInputObsPath, "/") {
+		normalizedInputObsPath += "/"
+	}
+
+	if strings.HasPrefix(outputObsPath, normalizedInputObsPath) {
+		return strings.TrimPrefix(outputObsPath, normalizedInputObsPath)
+	}
+	return outputObsPath
+}
+
+func exportFactoryJob(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl     = "v1/{project_id}/jobs/{job_name}/export"
+		exportPath  = client.Endpoint + httpUrl
+		jobName     = d.Get("job_name").(string)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	exportPath = strings.ReplaceAll(exportPath, "{project_id}", client.ProjectID)
+	exportPath = strings.ReplaceAll(exportPath, "{job_name}", jobName)
+	exportOpts := golangsdk.RequestOpts{
+		JSONBody:         utils.RemoveNil(buildFactoryJobExportBodyParams(d)),
+		KeepResponseBody: true,
+		MoreHeaders:      buildFactoryJobExportRequestMoreHeaders(workspaceId),
+		OkCodes:          []int{200},
+	}
+
+	resp, err := client.Request("POST", exportPath, &exportOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceFactoryJobExportCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		jobName = d.Get("job_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts-dlf", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	respBody, err := exportFactoryJob(client, d)
+	if err != nil {
+		return diag.Errorf("error exporting DataArts Factory job (%s): %s", jobName, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	outputObsPath := utils.PathSearch("obsPath", respBody, "").(string)
+	if err := d.Set("folder_path", buildFactoryJobExportFolderPath(d.Get("obs_path").(string), outputObsPath)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceFactoryJobExportRead(ctx, d, meta)
+}
+
+func resourceFactoryJobExportRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceFactoryJobExportUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceFactoryJobExportDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to export a job package to a specified OBS storage
+path. Deleting this resource will not clear the export task, but will only remove the resource information from the
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new one-time action resource to export DataArts Studio (Factory) job to a specified OBS storage.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Set `export_depend` parameter and with the **false** value in script:
<img width="1162" height="227" alt="image" src="https://github.com/user-attachments/assets/dc0a1f3d-ba0d-419c-b892-1e0fa8c63314" />

Set `export_depend` parameter and with the **true** value in script:
<img width="1154" height="222" alt="image" src="https://github.com/user-attachments/assets/4719d505-1730-4342-81a0-69a694aa6a35" />

Omit `export_depend` parameter in script:
<img width="1151" height="209" alt="image" src="https://github.com/user-attachments/assets/2e3ffe6c-73bf-41fa-9c4a-e0dd5f86f103" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource for job export
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccFactoryJobExport_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccFactoryJobExport_basic -timeout 360m -parallel 10
=== RUN   TestAccFactoryJobExport_basic
=== PAUSE TestAccFactoryJobExport_basic
=== CONT  TestAccFactoryJobExport_basic
--- PASS: TestAccFactoryJobExport_basic (12.51s)
PASS
coverage: 8.2% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  12.620s coverage: 8.2% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
