### PR TITLE
feat(elb): add data source to get list of listeners filtered by tags

### DIFF
--- a/docs/data-sources/elb_listeners_by_tags.md
+++ b/docs/data-sources/elb_listeners_by_tags.md
@@ -1,0 +1,94 @@
+---
+subcategory: Dedicated Load Balance (Dedicated ELB)
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_elb_listeners_by_tags"
+description: |-
+  Use this data source to get the list of ELB listeners filtered by tags.
+---
+
+# huaweicloud_elb_listeners_by_tags
+
+Use this data source to get the list of ELB listeners filtered by tags.
+
+## Example Usage
+
+```hcl
+variable "action" {}
+
+data "huaweicloud_elb_listeners_by_tags" "test" {
+  action = var.action
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `action` - (Required, String) Specifies the action name. Possible values are **count** and **filter**.
+  + **count**: Querying count of data.
+  + **filter**: Querying details of data.
+
+* `tags` - (Optional, List) Specifies the list of the tags to be queried.
+  The [tags](#tags_struct) structure is documented below.
+
+  -> 1. The tags contains a maximum of `20` keys. Each tag key can have a maximum of `20` tag values.
+  <br/>2. The key cannot be left blank or set to an empty string.
+  <br/>3. Each tag key must be unique, and each tag value in a tag must be unique.
+
+* `matches` - (Optional, List) Specifies the search field.
+  The [matches](#matches_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - (Required, String) Specifies the key of the resource tag.
+  It contains a maximum of `128` unicode characters.
+
+* `values` - (Required, List) Specifies the list of values corresponding to the key.
+  
+  -> 1. The tag value contains up to `255` unicode characters.
+  <br/>2. The values in this list are in an OR relationship.
+
+<a name="matches_struct"></a>
+The `matches` block supports:
+
+* `key` - (Required, String) Specifies the matchs key.
+  Currently, only **resource_name** for key is supported.
+
+* `value` - (Required, String) Specifies the value corresponding to the key.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `total_count` - The total number of listeners.
+
+* `resources` - The list of listeners.
+  The [resources](#elb_listeners_resources) structure is documented below.
+
+<a name="elb_listeners_resources"></a>
+The `resources` block supports:
+
+* `resource_id` - The resource ID.
+
+* `super_resource_id` - The parent resource ID.
+
+* `resource_name` - The resource name.
+
+* `resource_detail` - The detail of the resource.
+  The value is a resource object used for extension. This parameter is left blank by default.
+
+* `tags` - The tag list.
+  The [tags](#elb_listeners_tags) structure is documented below.
+
+<a name="elb_listeners_tags"></a>
+The `tags` block supports:
+
+* `key` - The tag key.
+
+* `value` - The tag value.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1830,6 +1830,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_elb_flavors":                             elb.DataSourceElbFlavorsV3(),
 			"huaweicloud_elb_pools":                               elb.DataSourcePools(),
 			"huaweicloud_elb_active_standby_pools":                elb.DataSourceActiveStandbyPools(),
+			"huaweicloud_elb_listeners_by_tags":                   elb.DataSourceListenersByTags(),
 			"huaweicloud_elb_loadbalancers":                       elb.DataSourceElbLoadbalances(),
 			"huaweicloud_elb_loadbalancer_ports":                  elb.DataSourceElbLoadBalancerPorts(),
 			"huaweicloud_elb_loadbalancer_status":                 elb.DataSourceElbLoadBalancerStatus(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -146,6 +146,7 @@ var (
 
 	HW_ELB_CERT_ID         = os.Getenv("HW_ELB_CERT_ID")
 	HW_ELB_LOADBALANCER_ID = os.Getenv("HW_ELB_LOADBALANCER_ID")
+	HW_ELB_LISTENER_ID     = os.Getenv("HW_ELB_LISTENER_ID")
 
 	HW_DBSS_INSATNCE_ID = os.Getenv("HW_DBSS_INSATNCE_ID")
 
@@ -1558,6 +1559,13 @@ func TestAccPreCheckElbCertID(t *testing.T) {
 func TestAccPreCheckElbLoadbalancerID(t *testing.T) {
 	if HW_ELB_LOADBALANCER_ID == "" {
 		t.Skip("HW_ELB_LOADBALANCER_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckElbListenerId(t *testing.T) {
+	if HW_ELB_LISTENER_ID == "" {
+		t.Skip("HW_ELB_LISTENER_ID must be set for this acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_listeners_by_tags_test.go
+++ b/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_listeners_by_tags_test.go
@@ -1,0 +1,80 @@
+package elb
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceListenersByTags_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_elb_listeners_by_tags.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckElbListenerId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceListenersByTags_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.tags.#"),
+
+					resource.TestCheckOutput("results_is_not_empty", "true"),
+					resource.TestCheckOutput("matches_filter_is_useful", "true"),
+					resource.TestCheckOutput("tags_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceListenersByTags_basic = `
+data "huaweicloud_elb_listeners_by_tags" "test" {
+  action = "filter"
+}
+
+data "huaweicloud_elb_listeners_by_tags" "filter_by_count" {
+  action = "count"
+}
+
+data "huaweicloud_elb_listeners_by_tags" "filter_by_matches" {
+  action = "filter"
+
+  matches {
+    key   = "resource_name"
+    value = data.huaweicloud_elb_listeners_by_tags.test.resources.0.resource_name
+  }
+}
+
+data "huaweicloud_elb_listeners_by_tags" "filter_by_tags" {
+  action = "filter"
+
+  tags {
+    key    = data.huaweicloud_elb_listeners_by_tags.test.resources.0.tags.0.key
+    values = [data.huaweicloud_elb_listeners_by_tags.test.resources.0.tags.0.value]
+  }
+}
+
+output "results_is_not_empty" {
+  value = data.huaweicloud_elb_listeners_by_tags.filter_by_count.total_count > 0
+}
+
+output "matches_filter_is_useful" {
+  value = length(data.huaweicloud_elb_listeners_by_tags.filter_by_matches.resources) > 0
+}
+
+output "tags_filter_is_useful" {
+  value = length(data.huaweicloud_elb_listeners_by_tags.filter_by_tags.resources) > 0
+}
+`

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_listeners_by_tags.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_listeners_by_tags.go
@@ -1,0 +1,264 @@
+package elb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ELB POST /v2.0/{project_id}/listeners/resource_instances/action
+func DataSourceListenersByTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceListenersByTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_detail": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"super_resource_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"total_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildListenersTagsBodyParams(d *schema.ResourceData, action string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"action":  action,
+		"matches": buildListenersFilterMatchesBodyParams(d.Get("matches").([]interface{})),
+		"tags":    buildListenersFilterTagsBodyParams(d.Get("tags").([]interface{})),
+	}
+
+	return bodyParams
+}
+
+func buildListenersFilterMatchesBodyParams(matches []interface{}) []map[string]interface{} {
+	if len(matches) == 0 {
+		return nil
+	}
+
+	res := make([]map[string]interface{}, len(matches))
+	for i, matchRaw := range matches {
+		if match, ok := matchRaw.(map[string]interface{}); ok {
+			res[i] = map[string]interface{}{
+				"key":   utils.PathSearch("key", match, nil),
+				"value": utils.PathSearch("value", match, nil),
+			}
+		}
+	}
+	return res
+}
+
+func buildListenersFilterTagsBodyParams(tags []interface{}) []map[string]interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	res := make([]map[string]interface{}, len(tags))
+	for i, tagRaw := range tags {
+		if tag, ok := tagRaw.(map[string]interface{}); ok {
+			res[i] = map[string]interface{}{
+				"key":    utils.PathSearch("key", tag, nil),
+				"values": utils.PathSearch("values", tag, nil),
+			}
+		}
+	}
+
+	return res
+}
+
+func dataSourceListenersByTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2.0/{project_id}/listeners/resource_instances/action"
+		tagsAction = d.Get("action").(string)
+		limit      = 1000
+		offset     = 0
+		result     = make([]interface{}, 0)
+		totalCount float64
+	)
+
+	client, err := cfg.NewServiceClient("elb", region)
+	if err != nil {
+		return diag.Errorf("error creating ELB client: %s", err)
+	}
+
+	reqBodyParams := buildListenersTagsBodyParams(d, tagsAction)
+	if tagsAction == "filter" {
+		reqBodyParams["limit"] = limit
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		if tagsAction == "filter" {
+			reqBodyParams["offset"] = offset
+		}
+
+		listOpt.JSONBody = utils.RemoveNil(reqBodyParams)
+		resp, err := client.Request("POST", listPath, &listOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving listeners: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalCount = utils.PathSearch("total_count", respBody, float64(0)).(float64)
+		if tagsAction == "count" {
+			break
+		}
+
+		instances := utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, instances...)
+		if len(instances) < limit {
+			break
+		}
+
+		offset += len(instances)
+	}
+
+	datasourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(datasourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("resources", flattenListenersByTags(result)),
+		d.Set("total_count", totalCount),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListenersByTags(instances []interface{}) []interface{} {
+	if len(instances) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(instances))
+	for i, v := range instances {
+		rst[i] = map[string]interface{}{
+			"resource_id":       utils.PathSearch("resource_id", v, nil),
+			"resource_detail":   utils.PathSearch("resource_detail", v, nil),
+			"resource_name":     utils.PathSearch("resource_name", v, nil),
+			"super_resource_id": utils.PathSearch("super_resource_id", v, nil),
+			"tags":              flattenTagsResp(utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})),
+		}
+	}
+	return rst
+}
+
+func flattenTagsResp(tags []interface{}) []interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(tags))
+	for i, tag := range tags {
+		rst[i] = map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.PathSearch("value", tag, nil),
+		}
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to get list of listeners filtered by tags.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/elb" TESTARGS="-run TestAccDataSourceListenersByTags_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run TestAccDataSourceListenersByTags_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceListenersByTags_basic
=== PAUSE TestAccDataSourceListenersByTags_basic
=== CONT  TestAccDataSourceListenersByTags_basic
--- PASS: TestAccDataSourceListenersByTags_basic (17.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       17.525s
```
<img width="1207" height="22" alt="image" src="https://github.com/user-attachments/assets/f8985d13-8bdf-41e8-8537-bb7e41801e51" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
