### PR TITLE
feat(cse): microservice engine supports retry when create failed

### DIFF
--- a/docs/resources/cse_microservice_engine.md
+++ b/docs/resources/cse_microservice_engine.md
@@ -124,6 +124,9 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the microservice engine.
 
+* `max_retries` - (Optional, Int) Specifies the maximum number of retries for the microservice engine creation.
+  Defaults to `0`.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -172,7 +175,7 @@ $ terraform import huaweicloud_cse_microservice_engine.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes are `admin_pass` and `extend_params`.
+API response, security or some other reason. The missing attributes are `admin_pass`, `extend_params` and `max_retries`.
 It is generally recommended running `terraform plan` after importing an instance.
 You can then decide if changes should be applied to the instance, or the resource definition should be updated to
 align with the instance. Also you can ignore changes as below.
@@ -185,6 +188,7 @@ resource "huaweicloud_cse_microservice_engine" "test" {
     ignore_changes = [
       admin_pass,
       extend_params,
+      max_retries,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_test.go
@@ -94,6 +94,7 @@ func TestAccMicroserviceEngine_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"admin_pass",
 					"extend_params",
+					"max_retries",
 				},
 				ImportStateIdFunc: testAccMicroserviceEngineImportStateFunc(resourceName),
 			},
@@ -162,6 +163,8 @@ resource "huaweicloud_cse_microservice_engine" "test" {
     foo = "bar"
     key = "value"
   }
+
+  max_retries = 2
 }
 `, testAccMicroserviceEngine_base(name), name)
 }
@@ -186,6 +189,8 @@ resource "huaweicloud_cse_microservice_engine" "test" {
     foo   = "baar"
     owner = "terraform"
   }
+
+  max_retries = 3
 }
 `, testAccMicroserviceEngine_base(name), name)
 }

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
@@ -50,6 +50,7 @@ var (
 // @API VPC GET /v1/{project_id}/subnets/{subnet_id}
 // @API VPC GET /v1/{project_id}/vpcs/{vpc_id}
 // @API CSE POST /v2/{project_id}/enginemgr/engines
+// @API CSE PUT /v2/{project_id}/enginemgr/engines/{engine_id}/actions
 // @API CSE GET /v2/{project_id}/enginemgr/engines/{engine_id}/jobs/{job_id}
 // @API CSE POST /v2/{project_id}/{resource_type}/{resource_id}/tags/create
 // @API CSE GET /v2/{project_id}/enginemgr/engines/{engine_id}
@@ -201,6 +202,11 @@ func ResourceMicroserviceEngine() *schema.Resource {
 					},
 				},
 				Description: `The config center addresses of the microservice engine.`,
+			},
+			"max_retries": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The maximum number of retries for the microservice engine creation.`,
 			},
 
 			// Internal parameters.
@@ -469,11 +475,37 @@ func updateMicroserviceEngineTags(client *golangsdk.ServiceClient, d *schema.Res
 	return nil
 }
 
+func buildRetryMicroserviceEngineBodyParams() map[string]interface{} {
+	return map[string]interface{}{
+		"action": "Retry",
+	}
+}
+
+func retryMicroserviceEngine(client *golangsdk.ServiceClient, engineId, enterpriseProjectId string) error {
+	var (
+		httpUrl = "v2/{project_id}/enginemgr/engines/{engine_id}/actions"
+	)
+
+	retryPath := client.Endpoint + httpUrl
+	retryPath = strings.ReplaceAll(retryPath, "{project_id}", client.ProjectID)
+	retryPath = strings.ReplaceAll(retryPath, "{engine_id}", engineId)
+
+	retryOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildRequestMoreHeaders(enterpriseProjectId),
+		JSONBody:         utils.RemoveNil(buildRetryMicroserviceEngineBodyParams()),
+	}
+
+	_, err := client.Request("PUT", retryPath, &retryOpts)
+	return err
+}
+
 func resourceMicroserviceEngineCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg                 = meta.(*config.Config)
 		region              = cfg.GetRegion(d)
 		enterpriseProjectId = cfg.GetEnterpriseProjectID(d)
+		retryCount          = 0
 	)
 
 	cseClient, err := cfg.NewServiceClient("cse", region)
@@ -496,19 +528,31 @@ func resourceMicroserviceEngineCreate(ctx context.Context, d *schema.ResourceDat
 	}
 	d.SetId(engineId)
 
-	log.Printf("[DEBUG] Waiting for the microservice engine to become running, the engine ID is %s", engineId)
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING"},
-		Target:  []string{"COMPLETED"},
-		Refresh: refreshMicroserviceEngineJobFunc(cseClient, engineId,
-			strconv.Itoa(int(utils.PathSearch("jobId", createOpts, float64(0)).(float64))), enterpriseProjectId, []string{"Finished"}),
-		Timeout:      d.Timeout(schema.TimeoutCreate),
-		Delay:        3 * time.Minute,
-		PollInterval: 15 * time.Second,
-	}
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return diag.Errorf("error waiting for the creation of microservice engine (%s) to complete: %s", engineId, err)
+	jobId := strconv.Itoa(int(utils.PathSearch("jobId", createOpts, float64(0)).(float64)))
+	for {
+		log.Printf("[DEBUG] Waiting for the microservice engine to become running, the engine ID is %s", engineId)
+		stateConf := &resource.StateChangeConf{
+			Pending:      []string{"PENDING"},
+			Target:       []string{"COMPLETED"},
+			Refresh:      refreshMicroserviceEngineJobFunc(cseClient, engineId, jobId, enterpriseProjectId, []string{"Finished"}),
+			Timeout:      d.Timeout(schema.TimeoutCreate),
+			Delay:        3 * time.Minute,
+			PollInterval: 15 * time.Second,
+		}
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			if retryCount < d.Get("max_retries").(int) {
+				retryCount++
+				log.Printf("[DEBUG] Prepare to retry the failed task of microservice engine (%s), retry count: %d", engineId, retryCount)
+				err = retryMicroserviceEngine(cseClient, engineId, enterpriseProjectId)
+				if err != nil {
+					return diag.Errorf("error retrying failed task of microservice engine: %s", err)
+				}
+				continue
+			}
+			return diag.Errorf("error waiting for the creation of microservice engine (%s) to complete: %s", engineId, err)
+		}
+		break
 	}
 
 	if d.HasChange("tags") {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Microservice engine supports retry when create failed.
new parameter: `max_retries`, defaults to `0`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. microservice engine supports retry when create failed
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cse -f TestAccMicroserviceEngine_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccMicroserviceEngine_basic -timeout 360m -parallel 10
=== RUN   TestAccMicroserviceEngine_basic
=== PAUSE TestAccMicroserviceEngine_basic
=== CONT  TestAccMicroserviceEngine_basic
--- PASS: TestAccMicroserviceEngine_basic (1214.00s)
PASS
coverage: 23.3% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       1214.086s       coverage: 23.3% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
