### PR TITLE
chore(dataarts): refactor the job action resource and acceptance test

### DIFF
--- a/docs/resources/dataarts_factory_job_action.md
+++ b/docs/resources/dataarts_factory_job_action.md
@@ -51,6 +51,30 @@ The following arguments are supported:
 * `workspace_id` - (Optional, String, NonUpdatable) Specified the ID of the workspace to which the job belongs.
   If this parameter is not set, the default workspace is used by default.
 
+* `job_params` - (Optional, List) Specifies the parameters of the job action.  
+  The [job_params](#dataarts_factory_job_action_job_params) structure is documented below.  
+  Only used when `action` is **start**.
+
+* `start_date` - (Optional, Int) Specifies the start date of the job action when starting the job.  
+  The format is **YYmmDD**, such as **20060102**.  
+  Only used when `action` is **start**.
+
+* `ignore_first_self_dep` - (Optional, Bool) Specifies whether to ignore the first self dependence when starting the
+  job.  
+  Only used when `action` is **start**.
+
+<a name="dataarts_factory_job_action_job_params"></a>
+The `job_params` block supports:
+
+* `name` - (Required, String) Specifies the name of the job parameter.
+
+* `value` - (Required, String) Specifies the value of the job parameter.
+
+* `type` - (Optional, String) Specifies the type of the job parameter.  
+  The valid values are as follows:
+  + **variable**
+  + **constants**
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/dataarts_factory_job_action.md
+++ b/docs/resources/dataarts_factory_job_action.md
@@ -2,15 +2,16 @@
 subcategory: "DataArts Studio"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_dataarts_factory_job_action"
-description:|-
-  Manages a job action resource of DataArts Factory within HuaweiCloud.
+description: |-
+  Use this resource to execute the DataArts Factory job action within HuaweiCloud.
 ---
 
 # huaweicloud_dataarts_factory_job_action
 
-Manages a job action resource of DataArts Factory within HuaweiCloud.
+Use this resource to execute the DataArts Factory job action within HuaweiCloud.
 
--> Destroying resources does not change the current action status of the job.
+-> This resource is only a one-time action resource for changing job status. Deleting this resource will
+   not change the current status, but will only remove the resource information from the tfstate file.
 
 ## Example Usage
 
@@ -30,29 +31,25 @@ resource "huaweicloud_dataarts_factory_job_action" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
-  If omitted, the provider-level region will be used.
-  Changing this creates a new resource.
+* `region` - (Optional, String, ForceNew) Specifies the region where the job is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
 
-* `workspace_id` - (Optional, String, ForceNew) Specified the ID of the workspace to which the job belongs.
-  Changing this creates a new resource.
-  If this parameter is not set, the default workspace is used by default.
+* `job_name` - (Required, String, NonUpdatable) Specified the name of the job to be performed.  
+  The valid value is limited from `1` to `128` characters, only letters, numbers, hyphens (-), underscores (_),
+  and periods (.) are allowed.
 
-* `job_name` - (Required, String, ForceNew) Specified the name of the job.
-  Changing this creates a new resource.
-  The name contains a maximum of  `128` characters, including only letters, numbers, hyphens (-),
-  underscores (_), and periods (.).
-
-* `process_type` - (Required, String, ForceNew) Specified the type of the job.
-  Changing this creates a new resource.  
+* `process_type` - (Required, String, NonUpdatable) Specified the type of the job to be performed.  
   The valid values are as follows:
   + **REAL_TIME**: Real-time processing.
   + **BATCH**: Batch processing.
 
-* `action` - (Required, String) Specified the action type of the job.  
+* `action` - (Required, String) Specified the action type of the job to be performed.  
   The valid values are as follows:
   + **start**
   + **stop**
+
+* `workspace_id` - (Optional, String, NonUpdatable) Specified the ID of the workspace to which the job belongs.
+  If this parameter is not set, the default workspace is used by default.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_job_action_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_job_action_test.go
@@ -10,15 +10,19 @@ import (
 )
 
 func TestAccFactoryJobAction_basic(t *testing.T) {
-	var obj interface{}
+	var (
+		obj interface{}
 
-	name := acceptance.RandomAccResourceName()
-	rName := "huaweicloud_dataarts_factory_job_action.test"
+		name = acceptance.RandomAccResourceName()
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getFactoryJobResourceFunc,
+		actionWithSequence   = "huaweicloud_dataarts_factory_job_action.action_with_sequence"
+		rcActionWithSequence = acceptance.InitResourceCheck(actionWithSequence, &obj, getFactoryJobResourceFunc)
+
+		startWithoutParams   = "huaweicloud_dataarts_factory_job_action.start_without_params"
+		rcStartWithoutParams = acceptance.InitResourceCheck(startWithoutParams, &obj, getFactoryJobResourceFunc)
+
+		stop   = "huaweicloud_dataarts_factory_job_action.stop"
+		rcStop = acceptance.InitResourceCheck(stop, &obj, getFactoryJobResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -27,26 +31,46 @@ func TestAccFactoryJobAction_basic(t *testing.T) {
 			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcActionWithSequence.CheckResourceDestroy(),
+			rcStartWithoutParams.CheckResourceDestroy(),
+			rcStop.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testFactoryJobAction_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "job_name", name),
-					resource.TestCheckResourceAttr(rName, "process_type", "REAL_TIME"),
-					resource.TestCheckResourceAttr(rName, "action", "start"),
-					resource.TestCheckResourceAttr(rName, "status", "NORMAL"),
+					// Check the first job is started successfully.
+					rcActionWithSequence.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(actionWithSequence, "job_name", "huaweicloud_dataarts_factory_job.test.0", "name"),
+					resource.TestCheckResourceAttr(actionWithSequence, "process_type", "REAL_TIME"),
+					resource.TestCheckResourceAttr(actionWithSequence, "action", "start"),
+					resource.TestCheckResourceAttr(actionWithSequence, "status", "NORMAL"),
+					// Check the second job is started successfully.
+					rcStartWithoutParams.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(startWithoutParams, "job_name", "huaweicloud_dataarts_factory_job.test.1", "name"),
+					resource.TestCheckResourceAttr(startWithoutParams, "process_type", "REAL_TIME"),
+					resource.TestCheckResourceAttr(startWithoutParams, "action", "start"),
+					resource.TestCheckResourceAttr(startWithoutParams, "status", "NORMAL"),
 				),
 			},
 			{
 				Config: testFactoryJobAction_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "job_name", name),
-					resource.TestCheckResourceAttr(rName, "process_type", "REAL_TIME"),
-					resource.TestCheckResourceAttr(rName, "action", "stop"),
-					resource.TestCheckResourceAttr(rName, "status", "STOPPED"),
+					// Check the first job is started successfully.
+					rcActionWithSequence.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(actionWithSequence, "job_name", "huaweicloud_dataarts_factory_job.test.0", "name"),
+					resource.TestCheckResourceAttr(actionWithSequence, "process_type", "REAL_TIME"),
+					resource.TestCheckResourceAttr(actionWithSequence, "action", "stop"),
+					resource.TestCheckResourceAttr(actionWithSequence, "status", "STOPPED"),
+					// Check if the one-time resource used to start the second job exists.
+					rcStartWithoutParams.CheckResourceExists(),
+					// Check the second job is stopped successfully.
+					rcStop.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(stop, "job_name", "huaweicloud_dataarts_factory_job.test.1", "name"),
+					resource.TestCheckResourceAttr(stop, "process_type", "REAL_TIME"),
+					resource.TestCheckResourceAttr(stop, "action", "stop"),
+					resource.TestCheckResourceAttr(stop, "status", "STOPPED"),
 				),
 			},
 		},
@@ -60,12 +84,14 @@ resource "huaweicloud_smn_topic" "test" {
 }
 
 resource "huaweicloud_dataarts_factory_job" "test" {
-  name         = "%[1]s"
+  count = 2
+
+  name         = "%[1]s_${count.index}"
   workspace_id = "%[2]s"
   process_type = "REAL_TIME"
 
   nodes {
-    name = "SMN_%[1]s"
+    name = "SMN_%[1]s_${count.index}"
     type = "SMN"
 
     location {
@@ -100,15 +126,48 @@ func testFactoryJobAction_basic_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_dataarts_factory_job_action" "test" {
+# The first job is started using the start_date, ignore_first_self_dep, and job_params parameters.
+# Subsequent steps will stop this (the first) job.
+resource "huaweicloud_dataarts_factory_job_action" "action_with_sequence" {
   depends_on = [
-    "huaweicloud_dataarts_factory_job.test"
+    huaweicloud_dataarts_factory_job.test,
   ]
 
   workspace_id = "%[2]s"
   action       = "start"
-  job_name     = huaweicloud_dataarts_factory_job.test.name
-  process_type = huaweicloud_dataarts_factory_job.test.process_type
+  job_name     = huaweicloud_dataarts_factory_job.test[0].name
+  process_type = huaweicloud_dataarts_factory_job.test[0].process_type
+
+  # Obtain the start date 48 hours from now, the format is YYmmDD, such as '20060102'
+  start_date            = formatdate("YYmmDD", timeadd(timestamp(), "48h"))
+  ignore_first_self_dep = true
+
+  dynamic "job_params" {
+    for_each = try(huaweicloud_dataarts_factory_job.test[0].nodes[0].properties, [])
+
+    content {
+      name  = job_params.value.name
+      value = job_params.value.value
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      start_date,
+    ]
+  }
+}
+
+# Create a new one-time action resource to start the second job.
+resource "huaweicloud_dataarts_factory_job_action" "start_without_params" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job.test,
+  ]
+
+  workspace_id = "%[2]s"
+  action       = "start"
+  job_name     = huaweicloud_dataarts_factory_job.test[1].name
+  process_type = huaweicloud_dataarts_factory_job.test[1].process_type
 }
 `, testFactoryJobAction_realTime_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
 }
@@ -117,29 +176,58 @@ func testFactoryJobAction_basic_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_dataarts_factory_job_action" "test" {
+# Following the previous step, stop the first job that has already started by changing the Terraform resources.
+resource "huaweicloud_dataarts_factory_job_action" "action_with_sequence" {
   depends_on = [
-    "huaweicloud_dataarts_factory_job.test"
+    huaweicloud_dataarts_factory_job.test,
   ]
 
   workspace_id = "%[2]s"
   action       = "stop"
-  job_name     = huaweicloud_dataarts_factory_job.test.name
-  process_type = huaweicloud_dataarts_factory_job.test.process_type
+  job_name     = huaweicloud_dataarts_factory_job.test[0].name
+  process_type = huaweicloud_dataarts_factory_job.test[0].process_type
+}
+
+# Retain this one-time action resource.
+resource "huaweicloud_dataarts_factory_job_action" "start_without_params" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job.test,
+  ]
+
+  workspace_id = "%[2]s"
+  action       = "start"
+  job_name     = huaweicloud_dataarts_factory_job.test[1].name
+  process_type = huaweicloud_dataarts_factory_job.test[1].process_type
+}
+
+# Create a new one-time action resource to stop the second job.
+resource "huaweicloud_dataarts_factory_job_action" "stop" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job_action.start_without_params,
+  ]
+
+  workspace_id = "%[2]s"
+  action       = "stop"
+  job_name     = huaweicloud_dataarts_factory_job.test[1].name
+  process_type = huaweicloud_dataarts_factory_job.test[1].process_type
 }
 `, testFactoryJobAction_realTime_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
 }
 
 func TestAccFactoryJobAction_batchJob(t *testing.T) {
-	var obj interface{}
+	var (
+		obj interface{}
 
-	name := acceptance.RandomAccResourceName()
-	rName := "huaweicloud_dataarts_factory_job_action.test"
+		name = acceptance.RandomAccResourceName()
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getFactoryJobResourceFunc,
+		actionWithSequence   = "huaweicloud_dataarts_factory_job_action.action_with_sequence"
+		rcActionWithSequence = acceptance.InitResourceCheck(actionWithSequence, &obj, getFactoryJobResourceFunc)
+
+		startWithoutParams   = "huaweicloud_dataarts_factory_job_action.start_without_params"
+		rcStartWithoutParams = acceptance.InitResourceCheck(startWithoutParams, &obj, getFactoryJobResourceFunc)
+
+		stop   = "huaweicloud_dataarts_factory_job_action.stop"
+		rcStop = acceptance.InitResourceCheck(stop, &obj, getFactoryJobResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -149,26 +237,46 @@ func TestAccFactoryJobAction_batchJob(t *testing.T) {
 			acceptance.TestAccPreCheckDataArtsCdmName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcActionWithSequence.CheckResourceDestroy(),
+			rcStartWithoutParams.CheckResourceDestroy(),
+			rcStop.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testFactoryJobAction_batchPinelineJob_step1(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "job_name", name),
-					resource.TestCheckResourceAttr(rName, "process_type", "BATCH"),
-					resource.TestCheckResourceAttr(rName, "action", "start"),
-					resource.TestCheckResourceAttr(rName, "status", "SCHEDULING"),
+					// Check the first job is started successfully.
+					rcActionWithSequence.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(actionWithSequence, "job_name", "huaweicloud_dataarts_factory_job.test.0", "name"),
+					resource.TestCheckResourceAttr(actionWithSequence, "process_type", "BATCH"),
+					resource.TestCheckResourceAttr(actionWithSequence, "action", "start"),
+					resource.TestCheckResourceAttr(actionWithSequence, "status", "SCHEDULING"),
+					// Check the second job is started successfully.
+					rcStartWithoutParams.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(startWithoutParams, "job_name", "huaweicloud_dataarts_factory_job.test.1", "name"),
+					resource.TestCheckResourceAttr(startWithoutParams, "process_type", "BATCH"),
+					resource.TestCheckResourceAttr(startWithoutParams, "action", "start"),
+					resource.TestCheckResourceAttr(startWithoutParams, "status", "SCHEDULING"),
 				),
 			},
 			{
 				Config: testFactoryJobAction_batchPinelineJob_step2(name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "job_name", name),
-					resource.TestCheckResourceAttr(rName, "process_type", "BATCH"),
-					resource.TestCheckResourceAttr(rName, "action", "stop"),
-					resource.TestCheckResourceAttr(rName, "status", "STOPPED"),
+					// Check the first job is started successfully.
+					rcActionWithSequence.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(actionWithSequence, "job_name", "huaweicloud_dataarts_factory_job.test.0", "name"),
+					resource.TestCheckResourceAttr(actionWithSequence, "process_type", "BATCH"),
+					resource.TestCheckResourceAttr(actionWithSequence, "action", "stop"),
+					resource.TestCheckResourceAttr(actionWithSequence, "status", "STOPPED"),
+					// Check if the one-time resource used to start the second job exists.
+					rcStartWithoutParams.CheckResourceExists(),
+					// Check the second job is stopped successfully.
+					rcStop.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(stop, "job_name", "huaweicloud_dataarts_factory_job.test.1", "name"),
+					resource.TestCheckResourceAttr(stop, "process_type", "BATCH"),
+					resource.TestCheckResourceAttr(stop, "action", "stop"),
+					resource.TestCheckResourceAttr(stop, "status", "STOPPED"),
 				),
 			},
 		},
@@ -178,12 +286,14 @@ func TestAccFactoryJobAction_batchJob(t *testing.T) {
 func testFactoryJobAction_batchPinelineJob_base(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dataarts_factory_job" "test" {
-  name         = "%[1]s"
+  count = 2
+
+  name         = "%[1]s_${count.index}"
   workspace_id = "%[2]s"
   process_type = "BATCH"
 
   nodes {
-    name = "Rest_client_%[1]s"
+    name = "Rest_client_%[1]s_${count.index}"
     type = "RESTAPI"
 
     location {
@@ -237,15 +347,48 @@ func testFactoryJobAction_batchPinelineJob_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_dataarts_factory_job_action" "test" {
+# The first job is started using the start_date, ignore_first_self_dep, and job_params parameters.
+# Subsequent steps will stop this (the first) job.
+resource "huaweicloud_dataarts_factory_job_action" "action_with_sequence" {
   depends_on = [
-    "huaweicloud_dataarts_factory_job.test"
+    huaweicloud_dataarts_factory_job.test,
   ]
 
   workspace_id = "%[2]s"
   action       = "start"
-  job_name     = huaweicloud_dataarts_factory_job.test.name
-  process_type = huaweicloud_dataarts_factory_job.test.process_type
+  job_name     = huaweicloud_dataarts_factory_job.test[0].name
+  process_type = huaweicloud_dataarts_factory_job.test[0].process_type
+
+  # Obtain the start date 48 hours from now, the format is YYmmDD, such as '20060102'
+  start_date            = formatdate("YYmmDD", timeadd(timestamp(), "48h"))
+  ignore_first_self_dep = true
+
+  dynamic "job_params" {
+    for_each = try(huaweicloud_dataarts_factory_job.test[0].nodes[0].properties, [])
+
+    content {
+      name  = job_params.value.name
+      value = job_params.value.value
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      start_date,
+    ]
+  }
+}
+
+# Create a new one-time action resource to start the second job.
+resource "huaweicloud_dataarts_factory_job_action" "start_without_params" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job.test,
+  ]
+
+  workspace_id = "%[2]s"
+  action       = "start"
+  job_name     = huaweicloud_dataarts_factory_job.test[1].name
+  process_type = huaweicloud_dataarts_factory_job.test[1].process_type
 }
 `, testFactoryJobAction_batchPinelineJob_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
 }
@@ -254,15 +397,40 @@ func testFactoryJobAction_batchPinelineJob_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_dataarts_factory_job_action" "test" {
+# Following the previous step, stop the first job that has already started by changing the Terraform resources.
+resource "huaweicloud_dataarts_factory_job_action" "action_with_sequence" {
   depends_on = [
-    "huaweicloud_dataarts_factory_job.test"
+    huaweicloud_dataarts_factory_job.test,
   ]
 
   workspace_id = "%[2]s"
   action       = "stop"
-  job_name     = huaweicloud_dataarts_factory_job.test.name
-  process_type = huaweicloud_dataarts_factory_job.test.process_type
+  job_name     = huaweicloud_dataarts_factory_job.test[0].name
+  process_type = huaweicloud_dataarts_factory_job.test[0].process_type
+}
+
+# Retain this one-time action resource.
+resource "huaweicloud_dataarts_factory_job_action" "start_without_params" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job.test,
+  ]
+
+  workspace_id = "%[2]s"
+  action       = "start"
+  job_name     = huaweicloud_dataarts_factory_job.test[1].name
+  process_type = huaweicloud_dataarts_factory_job.test[1].process_type
+}
+
+# Create a new one-time action resource to stop the second job.
+resource "huaweicloud_dataarts_factory_job_action" "stop" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job_action.start_without_params,
+  ]
+
+  workspace_id = "%[2]s"
+  action       = "stop"
+  job_name     = huaweicloud_dataarts_factory_job.test[1].name
+  process_type = huaweicloud_dataarts_factory_job.test[1].process_type
 }
 `, testFactoryJobAction_batchPinelineJob_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_action.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_action.go
@@ -78,6 +78,40 @@ func ResourceFactoryJobAction() *schema.Resource {
 				Optional:    true,
 				Description: `The ID of the workspace to which the job belongs.`,
 			},
+			"job_params": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the job parameter.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The value of the job parameter.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The type of the job parameter.`,
+						},
+					},
+				},
+				Description: `The parameters of the job action.`,
+			},
+			"start_date": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The start date of the job action when start job.`,
+			},
+			"ignore_first_self_dep": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to ignore the first self dependence when start job.`,
+			},
 
 			// Attribute.
 			"status": {
@@ -101,6 +135,33 @@ func buildFactoryRequestMoreHeaders(workspaceId string) map[string]string {
 	return results
 }
 
+func buildStartJobJobParams(jobParams []interface{}) []interface{} {
+	if len(jobParams) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(jobParams))
+	for _, jobParam := range jobParams {
+		result = append(result, map[string]interface{}{
+			// Required parameters.
+			"name":  utils.PathSearch("name", jobParam, nil),
+			"value": utils.PathSearch("value", jobParam, nil),
+			// Optional parameters.
+			"paramType": utils.ValueIgnoreEmpty(utils.PathSearch("type", jobParam, nil)),
+		})
+	}
+	return result
+}
+
+func buildStartJobBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		// Optional parameters.
+		"jobParams":                    utils.ValueIgnoreEmpty(buildStartJobJobParams(d.Get("job_params").([]interface{}))),
+		"start_date":                   utils.ValueIgnoreEmpty(d.Get("start_date").(int)),
+		"ignore_first_self_dependence": utils.ValueIgnoreEmpty(d.Get("ignore_first_self_dep").(bool)),
+	}
+}
+
 func startJob(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	var (
 		httpUrl     = "v1/{project_id}/jobs/{job_name}/start"
@@ -115,6 +176,8 @@ func startJob(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	actionOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      buildFactoryRequestMoreHeaders(workspaceId),
+		JSONBody:         utils.RemoveNil(buildStartJobBodyParams(d)),
+		OkCodes:          []int{204},
 	}
 
 	_, err := client.Request("POST", actionPath, &actionOpts)
@@ -135,6 +198,7 @@ func stopJob(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	actionOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      buildFactoryRequestMoreHeaders(workspaceId),
+		OkCodes:          []int{204},
 	}
 
 	_, err := client.Request("POST", actionPath, &actionOpts)
@@ -191,7 +255,8 @@ func getJobByName(client *golangsdk.ServiceClient, workspaceId, jobName, jobType
 	}
 }
 
-func jobStateRefreshFunc(client *golangsdk.ServiceClient, workspaceId, jobName, jobType string) resource.StateRefreshFunc {
+func jobStateRefreshFunc(client *golangsdk.ServiceClient, workspaceId, jobName, jobType string,
+	targets []string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		respBody, err := getJobByName(client, workspaceId, jobName, jobType)
 		if err != nil {
@@ -206,7 +271,7 @@ func jobStateRefreshFunc(client *golangsdk.ServiceClient, workspaceId, jobName, 
 			return respBody, "ERROR", fmt.Errorf("unexpected job status (%s)", jobStatus)
 		}
 
-		if utils.StrSliceContains([]string{"NORMAL", "STOPPED", "SCHEDULING"}, jobStatus) {
+		if utils.StrSliceContains(targets, jobStatus) {
 			return respBody, "COMPLETED", nil
 		}
 
@@ -221,13 +286,16 @@ func doActionJob(ctx context.Context, client *golangsdk.ServiceClient, d *schema
 		processType = d.Get("process_type").(string)
 		actionType  = d.Get("action").(string)
 		err         error
+		targets     []string
 	)
 
 	switch actionType {
 	case "start":
 		err = startJob(client, d)
+		targets = []string{"NORMAL", "SCHEDULING"}
 	case "stop":
 		err = stopJob(client, d)
+		targets = []string{"STOPPED", "PAUSED"}
 	default:
 		return fmt.Errorf("invalid action type (%s)", actionType)
 	}
@@ -239,7 +307,7 @@ func doActionJob(ctx context.Context, client *golangsdk.ServiceClient, d *schema
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"PENDING"},
 		Target:       []string{"COMPLETED"},
-		Refresh:      jobStateRefreshFunc(client, workspaceId, jobName, processType),
+		Refresh:      jobStateRefreshFunc(client, workspaceId, jobName, processType, targets),
 		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: 20 * time.Second,
@@ -279,6 +347,7 @@ func resourceFactoryJobActionRead(_ context.Context, d *schema.ResourceData, met
 		workspaceId = d.Get("workspace_id").(string)
 		jobName     = d.Get("job_name").(string)
 		jobType     = d.Get("process_type").(string)
+		actionType  = d.Get("action").(string)
 	)
 
 	client, err := cfg.NewServiceClient("dataarts-dlf", region)
@@ -296,7 +365,7 @@ func resourceFactoryJobActionRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("region", region),
 		d.Set("job_name", utils.PathSearch("name", job, nil)),
 		d.Set("status", utils.PathSearch("status", job, nil)),
-		d.Set("action", jobType),
+		d.Set("action", actionType),
 	)
 	if err = mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error saving the fields of the job action: %s", err)
@@ -312,7 +381,7 @@ func resourceFactoryJobActionUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if d.HasChange("action") {
-		jobName := d.Get("name").(string)
+		jobName := d.Get("job_name").(string)
 		err = doActionJob(ctx, client, d, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return diag.Errorf("error updating DataArts job (%s) status: %s", jobName, err)

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_action.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_action.go
@@ -3,7 +3,6 @@ package dataarts
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -19,7 +18,16 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var actionResourceNotFoundCodes = "DLF.0819" // The workspace ID does not exist.
+var (
+	actionResourceNotFoundCodes = []string{
+		"DLF.0819", // The workspace ID does not exist.
+	}
+	jobActionNonUpdatableParams = []string{
+		"job_name",
+		"process_type",
+		"workspace_id",
+	}
+)
 
 // @API DataArtsStudio POST /v1/{project_id}/jobs/{job_name}/start
 // @API DataArtsStudio POST /v1/{project_id}/jobs/{job_name}/stop
@@ -30,6 +38,9 @@ func ResourceFactoryJobAction() *schema.Resource {
 		ReadContext:   resourceFactoryJobActionRead,
 		UpdateContext: resourceFactoryJobActionUpdate,
 		DeleteContext: resourceFactoryJobActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(jobActionNonUpdatableParams),
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
 			Update: schema.DefaultTimeout(20 * time.Minute),
@@ -37,34 +48,38 @@ func ResourceFactoryJobAction() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-			"workspace_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
-				Description: `Specified the ID of the workspace.`,
+				Description: `The region where the job is located.`,
 			},
+
+			// Required parameters.
 			"job_name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: `Specified the name of the job.`,
+				Description: `The name of the job to be performed.`,
 			},
 			"process_type": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: `Specified the type of the job.`,
+				Description: `The type of the job to be performed.`,
 			},
 			"action": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `Specified the action type of the job.`,
+				Description: `The action type of the job to be performed.`,
 			},
+
+			// Optional parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the workspace to which the job belongs.`,
+			},
+
+			// Attribute.
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -74,75 +89,56 @@ func ResourceFactoryJobAction() *schema.Resource {
 	}
 }
 
-func resourceFactoryJobActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.NewServiceClient("dataarts-dlf", cfg.GetRegion(d))
-	if err != nil {
-		return diag.Errorf("error creating DataArts client: %s", err)
+func buildFactoryRequestMoreHeaders(workspaceId string) map[string]string {
+	results := map[string]string{
+		"Content-Type": "application/json",
 	}
 
-	jobName := d.Get("job_name").(string)
-	workspaceId := d.Get("workspace_id").(string)
-	_, err = doActionJob(client, workspaceId, jobName, d.Get("action").(string))
-	if err != nil {
-		return diag.Errorf("unable to operate status of the job (%s): %s", jobName, err)
+	if workspaceId != "" {
+		results["workspace"] = workspaceId
 	}
 
-	d.SetId(jobName)
-
-	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"PENDING"},
-		Target:       []string{"COMPLETED"},
-		Refresh:      jobStateRefreshFunc(client, workspaceId, jobName, d.Get("process_type").(string)),
-		Timeout:      d.Timeout(schema.TimeoutCreate),
-		Delay:        10 * time.Second,
-		PollInterval: 20 * time.Second,
-	}
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return diag.Errorf("error waiting for the status of job (%s) to become running: %s", jobName, err)
-	}
-	return resourceFactoryJobActionRead(ctx, d, meta)
+	return results
 }
 
-func doActionJob(client *golangsdk.ServiceClient, workspaceId, jobName, action string) (*http.Response, error) {
-	httpUrl := "v1/{project_id}/jobs/{job_name}/{action}"
+func startJob(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl     = "v1/{project_id}/jobs/{job_name}/start"
+		workspaceId = d.Get("workspace_id").(string)
+		jobName     = d.Get("job_name").(string)
+	)
+
 	actionPath := client.Endpoint + httpUrl
 	actionPath = strings.ReplaceAll(actionPath, "{project_id}", client.ProjectID)
 	actionPath = strings.ReplaceAll(actionPath, "{job_name}", jobName)
-	actionPath = strings.ReplaceAll(actionPath, "{action}", action)
 
 	actionOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"workspace": workspaceId,
-		},
-		OkCodes: []int{
-			204,
-		},
+		MoreHeaders:      buildFactoryRequestMoreHeaders(workspaceId),
 	}
 
-	return client.Request("POST", actionPath, &actionOpts)
+	_, err := client.Request("POST", actionPath, &actionOpts)
+	return err
 }
 
-func jobStateRefreshFunc(client *golangsdk.ServiceClient, workspaceId, jobName, jobType string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		respBody, err := getJobByName(client, workspaceId, jobName, jobType)
-		if err != nil {
-			return respBody, "ERROR", err
-		}
+func stopJob(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl     = "v1/{project_id}/jobs/{job_name}/stop"
+		workspaceId = d.Get("workspace_id").(string)
+		jobName     = d.Get("job_name").(string)
+	)
 
-		statusResp := utils.PathSearch("status", respBody, "").(string)
-		if utils.StrSliceContains([]string{"EXCEPTION"}, statusResp) {
-			return respBody, "ERROR", fmt.Errorf("unexpect status (%s)", statusResp)
-		}
+	actionPath := client.Endpoint + httpUrl
+	actionPath = strings.ReplaceAll(actionPath, "{project_id}", client.ProjectID)
+	actionPath = strings.ReplaceAll(actionPath, "{job_name}", jobName)
 
-		if utils.StrSliceContains([]string{"NORMAL", "STOPPED", "SCHEDULING"}, statusResp) {
-			return respBody, "COMPLETED", nil
-		}
-		// Intermediate state: "STARTING" "STOPPING"
-		return respBody, "PENDING", nil
+	actionOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildFactoryRequestMoreHeaders(workspaceId),
 	}
+
+	_, err := client.Request("POST", actionPath, &actionOpts)
+	return err
 }
 
 func getJobByName(client *golangsdk.ServiceClient, workspaceId, jobName, jobType string) (interface{}, error) {
@@ -185,22 +181,114 @@ func getJobByName(client *golangsdk.ServiceClient, workspaceId, jobName, jobType
 		offset += len(jobs)
 	}
 
-	return nil, golangsdk.ErrDefault404{}
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/v1/{project_id}/jobs",
+			RequestId: "NONE",
+			Body:      []byte(fmt.Sprintf("the job (%s) is not found", jobName)),
+		},
+	}
+}
+
+func jobStateRefreshFunc(client *golangsdk.ServiceClient, workspaceId, jobName, jobType string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := getJobByName(client, workspaceId, jobName, jobType)
+		if err != nil {
+			return respBody, "ERROR", err
+		}
+
+		var (
+			jobStatus           = utils.PathSearch("status", respBody, "").(string)
+			unexpectedJobStatus = []string{"EXCEPTION"}
+		)
+		if utils.StrSliceContains(unexpectedJobStatus, jobStatus) {
+			return respBody, "ERROR", fmt.Errorf("unexpected job status (%s)", jobStatus)
+		}
+
+		if utils.StrSliceContains([]string{"NORMAL", "STOPPED", "SCHEDULING"}, jobStatus) {
+			return respBody, "COMPLETED", nil
+		}
+
+		return respBody, "PENDING", nil
+	}
+}
+
+func doActionJob(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData, timeout time.Duration) error {
+	var (
+		workspaceId = d.Get("workspace_id").(string)
+		jobName     = d.Get("job_name").(string)
+		processType = d.Get("process_type").(string)
+		actionType  = d.Get("action").(string)
+		err         error
+	)
+
+	switch actionType {
+	case "start":
+		err = startJob(client, d)
+	case "stop":
+		err = stopJob(client, d)
+	default:
+		return fmt.Errorf("invalid action type (%s)", actionType)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      jobStateRefreshFunc(client, workspaceId, jobName, processType),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 20 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for the job (%s) action to become completed: %s", jobName, err)
+	}
+	return nil
+}
+
+func resourceFactoryJobActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		jobName = d.Get("job_name").(string)
+	)
+	client, err := cfg.NewServiceClient("dataarts-dlf", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	err = doActionJob(ctx, client, d, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("unable to operate status of the job (%s): %s", jobName, err)
+	}
+
+	d.SetId(jobName)
+
+	return resourceFactoryJobActionRead(ctx, d, meta)
 }
 
 func resourceFactoryJobActionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		jobName     = d.Get("job_name").(string)
+		jobType     = d.Get("process_type").(string)
+	)
 
 	client, err := cfg.NewServiceClient("dataarts-dlf", region)
 	if err != nil {
 		return diag.Errorf("error creating DataArts client: %s", err)
 	}
 
-	jobName := d.Get("job_name").(string)
-	job, err := getJobByName(client, d.Get("workspace_id").(string), jobName, d.Get("process_type").(string))
+	job, err := getJobByName(client, workspaceId, jobName, jobType)
 	if err != nil {
-		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", actionResourceNotFoundCodes),
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", actionResourceNotFoundCodes...),
 			fmt.Sprintf("job (%s) not found: %s", jobName, err))
 	}
 
@@ -208,19 +296,12 @@ func resourceFactoryJobActionRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("region", region),
 		d.Set("job_name", utils.PathSearch("name", job, nil)),
 		d.Set("status", utils.PathSearch("status", job, nil)),
-		d.Set("action", paserAction(utils.PathSearch("status", job, "").(string))),
+		d.Set("action", jobType),
 	)
 	if err = mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error saving the fields of the job action: %s", err)
 	}
 	return nil
-}
-
-func paserAction(action string) string {
-	if utils.StrSliceContains([]string{"NORMAL", "SCHEDULING"}, action) {
-		return "start"
-	}
-	return "stop"
 }
 
 func resourceFactoryJobActionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -231,26 +312,13 @@ func resourceFactoryJobActionUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if d.HasChange("action") {
-		jobName := d.Get("job_name").(string)
-		workspaceId := d.Get("workspace_id").(string)
-		_, err = doActionJob(client, workspaceId, jobName, d.Get("action").(string))
+		jobName := d.Get("name").(string)
+		err = doActionJob(ctx, client, d, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return diag.Errorf("error updating DataArts job (%s) status: %s", jobName, err)
 		}
-
-		stateConf := &resource.StateChangeConf{
-			Pending:      []string{"PENDING"},
-			Target:       []string{"COMPLETED"},
-			Refresh:      jobStateRefreshFunc(client, workspaceId, jobName, d.Get("process_type").(string)),
-			Timeout:      d.Timeout(schema.TimeoutUpdate),
-			Delay:        10 * time.Second,
-			PollInterval: 20 * time.Second,
-		}
-		_, err = stateConf.WaitForStateContext(ctx)
-		if err != nil {
-			return diag.Errorf("error waiting for the status of job (%s) to become running: %s", jobName, err)
-		}
 	}
+
 	return resourceFactoryJobActionRead(ctx, d, meta)
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor the resource style and supports some parameter for start job action.
Adjust the acceptance test for action resource and increase the coverage.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1041" height="281" alt="image" src="https://github.com/user-attachments/assets/295efd6e-8c40-4874-a0f9-bcd7436ecc3c" />

Start the job:
<img width="899" height="844" alt="image" src="https://github.com/user-attachments/assets/2cdf6c3e-5530-4a87-95ca-815b5c864519" />

Stop the job after when job is running (through update method):
<img width="880" height="843" alt="image" src="https://github.com/user-attachments/assets/a8c2dde7-26f9-4790-9c5c-09cd4191bead" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. refactor the job action resource and acceptance test
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccFactoryJobAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccFactoryJobAction_basic -timeout 360m -parallel 10
=== RUN   TestAccFactoryJobAction_basic
=== PAUSE TestAccFactoryJobAction_basic
=== CONT  TestAccFactoryJobAction_basic
--- PASS: TestAccFactoryJobAction_basic (52.66s)
PASS
coverage: 9.6% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  52.744s coverage: 9.6% of statements in ./huaweicloud/services/dataarts
```
```
./scripts/coverage.sh -o dataarts -f TestAccFactoryJobAction_batchJob
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccFactoryJobAction_batchJob -timeout 360m -parallel 10
=== RUN   TestAccFactoryJobAction_batchJob
=== PAUSE TestAccFactoryJobAction_batchJob
=== CONT  TestAccFactoryJobAction_batchJob
--- PASS: TestAccFactoryJobAction_batchJob (43.79s)
PASS
coverage: 9.9% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  43.884s coverage: 9.9% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
