### PR TITLE
feat(dataarts): add new resource for job import

### DIFF
--- a/docs/resources/dataarts_factory_job_export.md
+++ b/docs/resources/dataarts_factory_job_export.md
@@ -3,12 +3,12 @@ subcategory: "DataArts Studio"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_dataarts_factory_job_export"
 description: |-
-  Manages a one-time resource to export a specified DataArts Factory job within HuaweiCloud.
+  Use this resource to export a DataArts Factory job to a specified OBS storage path within HuaweiCloud.
 ---
 
 # huaweicloud_dataarts_factory_job_export
 
-Manages a one-time resource to export a specified DataArts Factory job within HuaweiCloud.
+Use this resource to export a DataArts Factory job to a specified OBS storage path within HuaweiCloud.
 
 -> This resource is a one-time action resource used to export a job package to a specified OBS storage path. Deleting
    this resource will not clear the export task, but will only remove the resource information from the tfstate file.

--- a/docs/resources/dataarts_factory_job_import.md
+++ b/docs/resources/dataarts_factory_job_import.md
@@ -1,0 +1,58 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_factory_job_import"
+description: |-
+  Use this resource to import a DataArts Factory job from an specified OBS storage path within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_factory_job_import
+
+Use this resource to import a DataArts Factory job from an OBS storage path within HuaweiCloud.
+
+-> This resource is a one-time action resource used to import jobs from a specified OBS storage path. Deleting this
+   resource will not clear the import task, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "obs_storage_path" {}
+
+resource "huaweicloud_dataarts_factory_job_import" "test" {
+  workspace_id     = var.workspace_id
+  path             = var.obs_storage_path
+  same_name_policy = "OVERWRITE"
+  target_status    = "SAVED"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the job is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `path` - (Required, String, NonUpdatable) Specifies the OBS path where the job package is stored.  
+  For example, `obs://myBucket/jobs.zip`.
+
+* `same_name_policy` - (Optional, String, NonUpdatable) Specifies the duplicate name handling policy.  
+  The valid values are as follows:
+  + **SKIP**
+  + **OVERWRITE**
+
+* `target_status` - (Optional, String, NonUpdatable) Specifies the target status of imported jobs.  
+  The valid values are as follows:
+  + **SAVED**
+  + **SUBMITTED**
+  + **PRODUCTION**
+
+* `workspace_id` - (Optional, String, NonUpdatable) Specifies the workspace ID to which the imported jobs belong.  
+  If omitted, the default workspace (`default`) will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3720,6 +3720,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_factory_job":        dataarts.ResourceFactoryJob(),
 			"huaweicloud_dataarts_factory_job_action": dataarts.ResourceFactoryJobAction(),
 			"huaweicloud_dataarts_factory_job_export": dataarts.ResourceFactoryJobExport(),
+			"huaweicloud_dataarts_factory_job_import": dataarts.ResourceFactoryJobImport(),
 			"huaweicloud_dataarts_factory_resource":   dataarts.ResourceFactoryResource(),
 			"huaweicloud_dataarts_factory_script":     dataarts.ResourceDataArtsFactoryScript(),
 			// DataArts Security

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_job_import_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_job_import_test.go
@@ -1,0 +1,131 @@
+package dataarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccFactoryJobImport_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	// Avoid CheckDestroy because this resource is a one-time action resource and there is nothing in the destroy
+	// method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsCdmName(t)
+			acceptance.TestAccPreCheckOBSObjectStoragePath(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.12.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFactoryJobImport_basic(name),
+			},
+		},
+	})
+}
+
+func testAccFactoryJobImport_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_factory_job" "test" {
+  name         = "%[1]s"
+  workspace_id = "%[2]s"
+  process_type = "BATCH"
+
+  nodes {
+    name = "Rest_client_%[1]s"
+    type = "RESTAPI"
+
+    location {
+      x = 10
+      y = 11
+    }
+
+    properties {
+      name  = "url"
+      value = "https://www.huaweicloud.com/"
+    }
+
+    properties {
+      name  = "method"
+      value = "GET"
+    }
+
+    properties {
+      name  = "retry"
+      value = "false"
+    }
+
+    properties {
+      name  = "requestMode"
+      value = "sync"
+    }
+
+    properties {
+      name  = "securityAuthentication"
+      value = "NONE"
+    }
+
+    properties {
+      name  = "agentName"
+      value = "%[3]s" # The agentName obtained from the DataArts Migration side.
+    }
+  }
+
+  schedule {
+    type = "EXECUTE_ONCE"
+  }
+}
+
+resource "huaweicloud_dataarts_factory_job_export" "test" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job.test
+  ]
+
+  workspace_id  = "%[2]s"
+  job_name      = huaweicloud_dataarts_factory_job.test.name
+  export_status = "DEVELOP"
+  obs_path      = "%[4]s" # The OBS path for storing the exported job package, such as obs://dataarts-test/jobs-storage/
+}
+`, name, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_CDM_NAME, acceptance.HW_OBS_OBJECT_STORAGE_PATH)
+}
+
+func testAccFactoryJobImport_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "time_sleep" "test" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job_export.test
+  ]
+
+  create_duration = "10s"
+}
+
+resource "huaweicloud_dataarts_factory_job_import" "test" {
+  depends_on = [
+    time_sleep.test
+  ]
+
+  workspace_id     = "%[2]s"
+  path             = format("%[3]s%%s/%[4]s.zip", huaweicloud_dataarts_factory_job_export.test.folder_path)
+  same_name_policy = "OVERWRITE"
+  target_status    = "SAVED"
+}
+`, testAccFactoryJobImport_base(name),
+		acceptance.HW_DATAARTS_WORKSPACE_ID,
+		acceptance.HW_OBS_OBJECT_STORAGE_PATH,
+		name)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_import.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_import.go
@@ -1,0 +1,219 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var factoryJobImportNonUpdatableParams = []string{
+	"path",
+	"workspace_id",
+	"target_status",
+	"same_name_policy",
+}
+
+// @API DataArtsStudio POST /v1/{project_id}/jobs/import
+func ResourceFactoryJobImport() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFactoryJobImportCreate,
+		ReadContext:   resourceFactoryJobImportRead,
+		UpdateContext: resourceFactoryJobImportUpdate,
+		DeleteContext: resourceFactoryJobImportDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(factoryJobImportNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the job is located.`,
+			},
+
+			// Required parameters.
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The OBS path where the job package is stored.`,
+			},
+
+			// Optional parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The workspace ID to which the imported jobs belong.`,
+			},
+			"target_status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The target status of imported jobs.`,
+			},
+			"same_name_policy": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The duplicate name handling policy.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
+			},
+		},
+	}
+}
+
+func buildFactoryJobImportBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return utils.RemoveNil(map[string]interface{}{
+		// Required parameters.
+		"path": d.Get("path"),
+		// Optional parameters.
+		"sameNamePolicy": utils.ValueIgnoreEmpty(d.Get("same_name_policy")),
+		"targetStatus":   utils.ValueIgnoreEmpty(d.Get("target_status")),
+	})
+}
+
+func importFactoryJob(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl     = "v1/{project_id}/jobs/import"
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildFactoryJobExportRequestMoreHeaders(workspaceId),
+		JSONBody:         utils.RemoveNil(buildFactoryJobImportBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func getFactoryJobImportSystemTask(client *golangsdk.ServiceClient, workspaceId, taskId string) (interface{}, error) {
+	var httpUrl = "v1/{project_id}/system-tasks/{task_id}"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{task_id}", taskId)
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildFactoryJobExportRequestMoreHeaders(workspaceId),
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func factoryJobImportTaskStateRefreshFunc(client *golangsdk.ServiceClient, workspaceId, taskId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		taskResp, err := getFactoryJobImportSystemTask(client, workspaceId, taskId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", taskResp, "").(string)
+		if status == "FAILED" {
+			return taskResp, "ERROR", fmt.Errorf("the import task (%s) is failed", taskId)
+		}
+		if status == "SUCCESSFUL" {
+			return taskResp, "COMPLETED", nil
+		}
+		return taskResp, "PENDING", nil
+	}
+}
+
+func resourceFactoryJobImportCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts-dlf", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	respBody, err := importFactoryJob(client, d)
+	if err != nil {
+		return diag.Errorf("error importing DataArts Factory jobs: %s", err)
+	}
+
+	taskId := utils.PathSearch("taskId", respBody, "").(string)
+	if taskId == "" {
+		return diag.Errorf("unable to find the import task ID from the API response")
+	}
+
+	workspaceId := d.Get("workspace_id").(string)
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      factoryJobImportTaskStateRefreshFunc(client, workspaceId, taskId),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the import task (%s) to become successful: %s", taskId, err)
+	}
+
+	d.SetId(taskId)
+
+	return resourceFactoryJobImportRead(ctx, d, meta)
+}
+
+func resourceFactoryJobImportRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceFactoryJobImportUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceFactoryJobImportDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to import jobs from a specified OBS storage path.
+Deleting this resource will not clear the import task, but will only remove the resource information from the tfstate
+file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new one-time action resource to import a DataArts Factory job from a specified OBS storage path via ZIP file.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource for job import
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccFactoryJobImport_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccFactoryJobImport_basic -timeout 360m -parallel 10
=== RUN   TestAccFactoryJobImport_basic
=== PAUSE TestAccFactoryJobImport_basic
=== CONT  TestAccFactoryJobImport_basic
--- PASS: TestAccFactoryJobImport_basic (33.02s)
PASS
coverage: 9.1% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  33.117s coverage: 9.1% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
