### PR TITLE
feat(dws): add new action resource to update resource pool config

### DIFF
--- a/docs/resources/dws_workload_queue_update_action.md
+++ b/docs/resources/dws_workload_queue_update_action.md
@@ -1,0 +1,87 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_workload_queue_update_action"
+description: |-
+  Use this resource to update the resource configuration of workload queue within HuaweiCloud.
+---
+
+# huaweicloud_dws_workload_queue_update_action
+
+Use this resource to update the resource configuration of workload queue within HuaweiCloud.
+
+-> This resource performs a one-time for updating the configuration of workload queue. Deleting this resource will
+   not revert the configuration on the cluster, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "queue_name" {}
+
+variable "configuration_list" {
+  type = list(object({
+    resource_name  = string
+    resource_value = number
+  }))
+}
+
+resource "huaweicloud_dws_workload_queue_update_action" "test" {
+  cluster_id = var.cluster_id
+  name       = var.queue_name
+
+  dynamic "configuration" {
+    for_each = var.configuration_list
+
+    content {
+      resource_name  = configuration.value.resource_name
+      resource_value = configuration.value.resource_value
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the workload queue is located.  
+  If omitted, the provider-level region will be used.  
+  Changing this parameter will create a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster to which the workload queue belongs.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the workload queue to be updated.
+
+* `logical_cluster_name` - (Optional, String, NonUpdatable) Specifies the name of the logical cluster to
+  which the workload queue belongs.
+
+* `configuration` - (Required, List, NonUpdatable) Specifies the list of workload queue resource items to be updated.
+  The [configuration](#dws_workload_queue_configuration) structure is documented below.
+
+  -> The configuration requires the simultaneous declaration of memory, tablespace, activestatements, cpu_limit,
+     and cpu_share.  
+     Missing any of these fields will cause the parameter validation to fail.
+
+<a name="dws_workload_queue_configuration"></a>
+The `configuration` block supports:
+
+* `resource_name` - (Required, String, NonUpdatable) Specifies the resource attribute name.  
+  The valid values are as follows:
+  + **memory**
+  + **tablespace**
+  + **activestatements**
+  + **cpu_limit**
+  + **cpu_share**
+
+* `resource_value` - (Required, Int, NonUpdatable) Specifies the resource attribute value.
+
+* `value_unit` - (Optional, String, NonUpdatable) Specifies the unit of the resource attribute.
+
+* `resource_description` - (Optional, String, NonUpdatable) Specifies the description of the resource attribute.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3458,6 +3458,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_workload_plan_execution":         dws.ResourceWorkLoadPlanExecution(),
 			"huaweicloud_dws_workload_plan_stage":             dws.ResourceWorkLoadPlanStage(),
 			"huaweicloud_dws_workload_plan":                   dws.ResourceWorkLoadPlan(),
+			"huaweicloud_dws_workload_queue_update_action":    dws.ResourceWorkLoadQueueUpdateAction(),
 			"huaweicloud_dws_workload_queue_user_associate":   dws.ResourceWorkloadQueueUserAssociate(),
 			"huaweicloud_dws_workload_queue":                  dws.ResourceWorkLoadQueue(),
 

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_workload_queue_update_action_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_workload_queue_update_action_test.go
@@ -1,0 +1,135 @@
+package dws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccWorkloadQueueUpdateAction_basic(t *testing.T) {
+	var (
+		queueName    = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_dws_workload_queue_update_action.test"
+	)
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkloadQueueUpdateAction_basic(queueName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(resourceName, "name", queueName),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "5"),
+				),
+			},
+		},
+	})
+}
+
+func testAccWorkloadQueueUpdateAction_basic(name string) string {
+	return fmt.Sprintf(`
+variable "queue_configuration_list" {
+  type        = list(object({
+    resource_name  = string
+    resource_value = number
+  }))
+  description = "The configuration list to create the workload queue"
+
+  default = [
+    {
+      resource_name  = "cpu_limit"
+      resource_value = 10
+    },
+    {
+      resource_name  = "cpu_share"
+      resource_value = 10
+    },
+    {
+      resource_name  = "memory"
+      resource_value = 10
+    },
+    {
+      resource_name  = "tablespace"
+      resource_value = -1
+    },
+    {
+      resource_name  = "activestatements"
+      resource_value = -1
+    },
+  ]
+}
+
+variable "update_configuration_list" {
+  type        = list(object({
+    resource_name  = string
+    resource_value = number
+  }))
+  description = "The configuration list to update the workload queue"
+
+  default = [
+    {
+      resource_name  = "cpu_limit"
+      resource_value = 12
+    },
+    {
+      resource_name  = "cpu_share"
+      resource_value = 12
+    },
+    {
+      resource_name  = "memory"
+      resource_value = 15
+    },
+    {
+      resource_name  = "tablespace"
+      resource_value = -1
+    },
+    {
+      resource_name  = "activestatements"
+      resource_value = -1
+    },
+  ]
+}
+
+resource "huaweicloud_dws_workload_queue" "test" {
+  cluster_id           = "%[1]s"
+  name                 = "%[2]s"
+  logical_cluster_name = "%[3]s"
+
+  dynamic "configuration" {
+    for_each = var.queue_configuration_list
+
+    content {
+      resource_name  = configuration.value.resource_name
+      resource_value = configuration.value.resource_value
+    }
+  }
+}
+
+resource "huaweicloud_dws_workload_queue_update_action" "test" {
+  cluster_id           = "%[1]s"
+  name                 = "%[2]s"
+  logical_cluster_name = "%[3]s"
+
+  dynamic "configuration" {
+    for_each = var.update_configuration_list
+
+    content {
+      resource_name  = configuration.value.resource_name
+      resource_value = configuration.value.resource_value
+    }
+  }
+
+  depends_on = [huaweicloud_dws_workload_queue.test]
+}
+  `, acceptance.HW_DWS_CLUSTER_ID, name, acceptance.HW_DWS_LOGICAL_CLUSTER_NAME)
+}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_workload_queue_update_action.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_workload_queue_update_action.go
@@ -1,0 +1,226 @@
+package dws
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var workloadQueueUpdateActionNonUpdatableParams = []string{
+	"cluster_id",
+	"name",
+	"configuration",
+	"configuration.*.resource_name",
+	"configuration.*.resource_value",
+	"configuration.*.value_unit",
+	"configuration.*.resource_description",
+	"logical_cluster_name",
+}
+
+// @API DWS PUT /v2/{project_id}/clusters/{cluster_id}/workload/queues/{queue_name}/resources
+func ResourceWorkLoadQueueUpdateAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWorkLoadQueueUpdateActionCreate,
+		ReadContext:   resourceWorkLoadQueueUpdateActionRead,
+		UpdateContext: resourceWorkLoadQueueUpdateActionUpdate,
+		DeleteContext: resourceWorkLoadQueueUpdateActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(workloadQueueUpdateActionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the workload queue is located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster to which the workload queue belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the workload queue to be updated.`,
+			},
+			"configuration": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        workloadQueueUpdateActionConfigurationSchema(),
+				Description: `The list of workload queue resource items to be updated.`,
+			},
+
+			// Optional parameters.
+			"logical_cluster_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the logical cluster to which the workload queue belongs.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
+			},
+		},
+	}
+}
+
+func workloadQueueUpdateActionConfigurationSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"resource_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource attribute name.`,
+			},
+			"resource_value": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The resource attribute value.`,
+			},
+			"value_unit": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The unit of the resource attribute.`,
+			},
+			"resource_description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the resource attribute.`,
+			},
+		},
+	}
+}
+
+func buildWorkloadQueueUpdateActionResourceItemList(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"resource_name":        utils.PathSearch("resource_name", item, "").(string),
+			"resource_value":       utils.PathSearch("resource_value", item, 0).(int),
+			"value_unit":           utils.ValueIgnoreEmpty(utils.PathSearch("value_unit", item, "").(string)),
+			"resource_description": utils.ValueIgnoreEmpty(utils.PathSearch("resource_description", item, "").(string)),
+		})
+	}
+
+	return result
+}
+
+func buildWorkloadQueueUpdateActionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"workload_queue": map[string]interface{}{
+			"workload_queue_name":  d.Get("name"),
+			"resource_item_list":   buildWorkloadQueueUpdateActionResourceItemList(d.Get("configuration").([]interface{})),
+			"logical_cluster_name": utils.ValueIgnoreEmpty(d.Get("logical_cluster_name")),
+		},
+	}
+}
+
+func updateWorkloadQueueResource(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl   = "v2/{project_id}/clusters/{cluster_id}/workload/queues/{queue_name}/resources"
+		clusterId = d.Get("cluster_id").(string)
+		queueName = d.Get("name").(string)
+	)
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", clusterId)
+	updatePath = strings.ReplaceAll(updatePath, "{queue_name}", queueName)
+
+	updateOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildWorkloadQueueUpdateActionBodyParams(d)),
+	}
+
+	resp, err := client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	resCode := utils.PathSearch("workload_res_code", respBody, float64(0)).(float64)
+	if resCode != 0 {
+		resMsg := utils.PathSearch("workload_res_str", respBody, "").(string)
+		return errors.New(resMsg)
+	}
+
+	return nil
+}
+
+func resourceWorkLoadQueueUpdateActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		queueName = d.Get("name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	if err := updateWorkloadQueueResource(client, d); err != nil {
+		return diag.Errorf("error updating workload queue resources (%s): %s", queueName, err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceWorkLoadQueueUpdateActionRead(ctx, d, meta)
+}
+
+func resourceWorkLoadQueueUpdateActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceWorkLoadQueueUpdateActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceWorkLoadQueueUpdateActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource performs a one-time for updating the configuration of workload queue. Deleting
+this resource will not revert the configuration on the cluster, but will only remove the resource information
+from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new action resource to update resource pool config

**Which issue this PR fixes**:

**Special notes for your reviewer**:
The DWS cluster provisioning process takes too long during acceptance tests. Therefore, we have pre-provisioned a cluster via the console and configured the test cases to run against this existing environment.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccResourceWorkloadQueueUpdateAction_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceWorkloadQueueUpdateAction_basic
=== PAUSE TestAccResourceWorkloadQueueUpdateAction_basic
=== CONT  TestAccResourceWorkloadQueueUpdateAction_basic
--- PASS: TestAccResourceWorkloadQueueUpdateAction_basic (41.38s)
PASS
coverage: 4.8% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       41.558s coverage: 4.8% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.