### PR TITLE
feat(dataarts): job action supports run immediately

### DIFF
--- a/docs/resources/dataarts_factory_job_action.md
+++ b/docs/resources/dataarts_factory_job_action.md
@@ -15,6 +15,8 @@ Use this resource to execute the DataArts Factory job action within HuaweiCloud.
 
 ## Example Usage
 
+### Start a batch job
+
 ```hcl
 variable "workspace_id" {}
 variable "job_name" {}
@@ -24,6 +26,35 @@ resource "huaweicloud_dataarts_factory_job_action" "test" {
   action       = "start"
   job_name     = var.job_name
   process_type = "BATCH"
+}
+```
+
+### Test a batch job immediately
+
+```hcl
+variable "workspace_id" {}
+variable "job_name" {}
+variable "job_parameters" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+}
+
+resource "huaweicloud_dataarts_factory_job_action" "test" {
+  workspace_id = var.workspace_id
+  action       = "run-immediate"
+  job_name     = var.job_name
+  process_type = "BATCH"
+
+  dynamic "job_params" {
+    for_each = var.job_parameters
+
+    content {
+      name  = job_params.value.name
+      value = job_params.value.value
+    }
+  }
 }
 ```
 
@@ -47,13 +78,16 @@ The following arguments are supported:
   The valid values are as follows:
   + **start**
   + **stop**
+  + **run-immediate**
+
+  -> The action **run-immediate** is only available for the **BATCH** processing job.
 
 * `workspace_id` - (Optional, String, NonUpdatable) Specified the ID of the workspace to which the job belongs.
   If this parameter is not set, the default workspace is used by default.
 
 * `job_params` - (Optional, List) Specifies the parameters of the job action.  
   The [job_params](#dataarts_factory_job_action_job_params) structure is documented below.  
-  Only used when `action` is **start**.
+  Only used when `action` is **start** or **run-immediate**.
 
 * `start_date` - (Optional, Int) Specifies the start date of the job action when starting the job.  
   The format is **YYmmDD**, such as **20060102**.  
@@ -62,6 +96,14 @@ The following arguments are supported:
 * `ignore_first_self_dep` - (Optional, Bool) Specifies whether to ignore the first self dependence when starting the
   job.  
   Only used when `action` is **start**.
+
+* `use_execution_user` - (Optional, String) Specifies whether to use the execution user to execute the job when start
+  job immediately.  
+  The valid values are as follows:
+  + **true**: Use the execution account.
+  + **false**: Do not use execution account.
+
+  Only used when `action` is **run-immediate**.
 
 <a name="dataarts_factory_job_action_job_params"></a>
 The `job_params` block supports:
@@ -87,6 +129,12 @@ In addition to all arguments above, the following attributes are exported:
   + **SCHEDULING**
   + **PAUSED**
   + **EXCEPTION**
+
+* `instance_status` - The instance status after starting the job immediately.  
+  + **success**
+  + **fail**
+
+  -> Only set when `action` is **run-immediate** (empty for **start** and **stop**).
 
 ## Timeouts
 

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_job_action_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_job_action_test.go
@@ -2,6 +2,7 @@ package dataarts
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -226,8 +227,11 @@ func TestAccFactoryJobAction_batchJob(t *testing.T) {
 		startWithoutParams   = "huaweicloud_dataarts_factory_job_action.start_without_params"
 		rcStartWithoutParams = acceptance.InitResourceCheck(startWithoutParams, &obj, getFactoryJobResourceFunc)
 
-		stop   = "huaweicloud_dataarts_factory_job_action.stop"
-		rcStop = acceptance.InitResourceCheck(stop, &obj, getFactoryJobResourceFunc)
+		startImmediately   = "huaweicloud_dataarts_factory_job_action.start_immediately"
+		rcStartImmediately = acceptance.InitResourceCheck(startImmediately, &obj, getFactoryJobResourceFunc)
+
+		stopStart   = "huaweicloud_dataarts_factory_job_action.stop"
+		rcStopStart = acceptance.InitResourceCheck(stopStart, &obj, getFactoryJobResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -240,7 +244,8 @@ func TestAccFactoryJobAction_batchJob(t *testing.T) {
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			rcActionWithSequence.CheckResourceDestroy(),
 			rcStartWithoutParams.CheckResourceDestroy(),
-			rcStop.CheckResourceDestroy(),
+			rcStartImmediately.CheckResourceDestroy(),
+			rcStopStart.CheckResourceDestroy(),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -258,6 +263,12 @@ func TestAccFactoryJobAction_batchJob(t *testing.T) {
 					resource.TestCheckResourceAttr(startWithoutParams, "process_type", "BATCH"),
 					resource.TestCheckResourceAttr(startWithoutParams, "action", "start"),
 					resource.TestCheckResourceAttr(startWithoutParams, "status", "SCHEDULING"),
+					// Check the the test of third job is started successfully (immediately).
+					rcStartImmediately.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(startImmediately, "job_name", "huaweicloud_dataarts_factory_job.test.2", "name"),
+					resource.TestCheckResourceAttr(startImmediately, "process_type", "BATCH"),
+					resource.TestCheckResourceAttr(startImmediately, "action", "run-immediate"),
+					resource.TestMatchResourceAttr(startImmediately, "instance_status", regexp.MustCompile("^(success|fail)$")),
 				),
 			},
 			{
@@ -272,11 +283,11 @@ func TestAccFactoryJobAction_batchJob(t *testing.T) {
 					// Check if the one-time resource used to start the second job exists.
 					rcStartWithoutParams.CheckResourceExists(),
 					// Check the second job is stopped successfully.
-					rcStop.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(stop, "job_name", "huaweicloud_dataarts_factory_job.test.1", "name"),
-					resource.TestCheckResourceAttr(stop, "process_type", "BATCH"),
-					resource.TestCheckResourceAttr(stop, "action", "stop"),
-					resource.TestCheckResourceAttr(stop, "status", "STOPPED"),
+					rcStopStart.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(stopStart, "job_name", "huaweicloud_dataarts_factory_job.test.1", "name"),
+					resource.TestCheckResourceAttr(stopStart, "process_type", "BATCH"),
+					resource.TestCheckResourceAttr(stopStart, "action", "stop"),
+					resource.TestCheckResourceAttr(stopStart, "status", "STOPPED"),
 				),
 			},
 		},
@@ -286,7 +297,7 @@ func TestAccFactoryJobAction_batchJob(t *testing.T) {
 func testFactoryJobAction_batchPinelineJob_base(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dataarts_factory_job" "test" {
-  count = 2
+  count = 3
 
   name         = "%[1]s_${count.index}"
   workspace_id = "%[2]s"
@@ -390,6 +401,28 @@ resource "huaweicloud_dataarts_factory_job_action" "start_without_params" {
   job_name     = huaweicloud_dataarts_factory_job.test[1].name
   process_type = huaweicloud_dataarts_factory_job.test[1].process_type
 }
+
+# Create a new one-time action resource to start the third job immediately.
+resource "huaweicloud_dataarts_factory_job_action" "start_immediately" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job.test,
+  ]
+
+  workspace_id       = "%[2]s"
+  action             = "run-immediate"
+  job_name           = huaweicloud_dataarts_factory_job.test[2].name
+  process_type       = huaweicloud_dataarts_factory_job.test[2].process_type
+  use_execution_user = "true"
+
+  dynamic "job_params" {
+    for_each = try(huaweicloud_dataarts_factory_job.test[0].nodes[0].properties, [])
+
+    content {
+      name  = job_params.value.name
+      value = job_params.value.value
+    }
+  }
+}
 `, testFactoryJobAction_batchPinelineJob_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
 }
 
@@ -431,6 +464,28 @@ resource "huaweicloud_dataarts_factory_job_action" "stop" {
   action       = "stop"
   job_name     = huaweicloud_dataarts_factory_job.test[1].name
   process_type = huaweicloud_dataarts_factory_job.test[1].process_type
+}
+
+# Retain this one-time action resource.
+resource "huaweicloud_dataarts_factory_job_action" "start_immediately" {
+  depends_on = [
+    huaweicloud_dataarts_factory_job.test,
+  ]
+
+  workspace_id       = "%[2]s"
+  action             = "run-immediate"
+  job_name           = huaweicloud_dataarts_factory_job.test[2].name
+  process_type       = huaweicloud_dataarts_factory_job.test[2].process_type
+  use_execution_user = "true"
+
+  dynamic "job_params" {
+    for_each = try(huaweicloud_dataarts_factory_job.test[0].nodes[0].properties, [])
+
+    content {
+      name  = job_params.value.name
+      value = job_params.value.value
+    }
+  }
 }
 `, testFactoryJobAction_batchPinelineJob_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_action.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_action.go
@@ -3,6 +3,7 @@ package dataarts
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -31,6 +32,7 @@ var (
 
 // @API DataArtsStudio POST /v1/{project_id}/jobs/{job_name}/start
 // @API DataArtsStudio POST /v1/{project_id}/jobs/{job_name}/stop
+// @API DataArtsStudio POST /v1/{project_id}/jobs/{job_name}/run-immediate
 // @API DataArtsStudio GET /v1/{project_id}/jobs
 func ResourceFactoryJobAction() *schema.Resource {
 	return &schema.Resource{
@@ -112,12 +114,22 @@ func ResourceFactoryJobAction() *schema.Resource {
 				Optional:    true,
 				Description: `Whether to ignore the first self dependence when start job.`,
 			},
+			"use_execution_user": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Whether to use the execution user to execute the job when start job immediately.`,
+			},
 
 			// Attribute.
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `The current status of the job.`,
+			},
+			"instance_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The instance status after starting the job immediately.`,
 			},
 		},
 	}
@@ -205,6 +217,56 @@ func stopJob(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	return err
 }
 
+func buildStartJobImmediatelyJobParams(jobParams []interface{}) []interface{} {
+	if len(jobParams) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(jobParams))
+	for _, jobParam := range jobParams {
+		result = append(result, map[string]interface{}{
+			// Required parameters.
+			"name":  utils.PathSearch("name", jobParam, nil),
+			"value": utils.PathSearch("value", jobParam, nil),
+			// Optional parameters.
+			"type": utils.ValueIgnoreEmpty(utils.PathSearch("type", jobParam, nil)),
+		})
+	}
+	return result
+}
+
+func buildStartJobImmediatelyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		// Optional parameters.
+		"jobParams":        buildStartJobImmediatelyJobParams(d.Get("job_params").([]interface{})),
+		"useExecutionUser": utils.ValueIgnoreEmpty(d.Get("use_execution_user").(string)),
+	}
+}
+
+func startJobImmediately(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl     = "v1/{project_id}/jobs/{job_name}/run-immediate"
+		workspaceId = d.Get("workspace_id").(string)
+		jobName     = d.Get("job_name").(string)
+	)
+
+	actionPath := client.Endpoint + httpUrl
+	actionPath = strings.ReplaceAll(actionPath, "{project_id}", client.ProjectID)
+	actionPath = strings.ReplaceAll(actionPath, "{job_name}", jobName)
+
+	actionOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildFactoryRequestMoreHeaders(workspaceId),
+		JSONBody:         utils.RemoveNil(buildStartJobImmediatelyBodyParams(d)),
+	}
+
+	requestBody, err := client.Request("POST", actionPath, &actionOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestBody)
+}
+
 func getJobByName(client *golangsdk.ServiceClient, workspaceId, jobName, jobType string) (interface{}, error) {
 	// The maximum value of limit is 100.
 	httpUrl := "v1/{project_id}/jobs?limit=100"
@@ -279,6 +341,49 @@ func jobStateRefreshFunc(client *golangsdk.ServiceClient, workspaceId, jobName, 
 	}
 }
 
+func getJobInstanceById(client *golangsdk.ServiceClient, workspaceId, jobName, instanceId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/jobs/{job_name}/instances/{instance_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{job_name}", jobName)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildFactoryRequestMoreHeaders(workspaceId),
+	}
+
+	requestBody, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestBody)
+}
+
+func jobInstanceStateRefreshFunc(client *golangsdk.ServiceClient, workspaceId, jobName, jobType string,
+	targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := getJobInstanceById(client, workspaceId, jobName, jobType)
+		if err != nil {
+			return respBody, "ERROR", err
+		}
+
+		var (
+			jobStatus           = utils.PathSearch("status", respBody, "").(string)
+			unexpectedJobStatus = []string{"running-exception"}
+		)
+		if utils.StrSliceContains(unexpectedJobStatus, jobStatus) {
+			return respBody, "ERROR", fmt.Errorf("unexpected job status (%s)", jobStatus)
+		}
+
+		if utils.StrSliceContains(targets, jobStatus) {
+			return respBody, "COMPLETED", nil
+		}
+
+		return respBody, "PENDING", nil
+	}
+}
+
 func doActionJob(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData, timeout time.Duration) error {
 	var (
 		workspaceId = d.Get("workspace_id").(string)
@@ -296,6 +401,30 @@ func doActionJob(ctx context.Context, client *golangsdk.ServiceClient, d *schema
 	case "stop":
 		err = stopJob(client, d)
 		targets = []string{"STOPPED", "PAUSED"}
+	case "run-immediate":
+		respBody, err := startJobImmediately(client, d)
+		if err != nil {
+			return err
+		}
+		// Immediate execution will not affect the current state, but it will generate an execution instance, whose
+		// state needs to be monitored separately.
+		instanceId := strconv.FormatFloat(utils.PathSearch("instanceId", respBody, float64(0)).(float64), 'f', -1, 64)
+		instanceStateConf := &resource.StateChangeConf{
+			Pending: []string{"PENDING"},
+			Target:  []string{"COMPLETED"},
+			// For the test run, failure is also a final status.
+			Refresh:      jobInstanceStateRefreshFunc(client, workspaceId, jobName, instanceId, []string{"success", "fail"}),
+			Timeout:      timeout,
+			Delay:        10 * time.Second,
+			PollInterval: 20 * time.Second,
+		}
+		respBody, err = instanceStateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return fmt.Errorf("error waiting for the job (%s) action to become completed: %s", jobName, err)
+		}
+		// Set the instance status to the state file and skip the state refresh of the job (run immediately test just
+		// checks the instance status).
+		return d.Set("instance_status", utils.PathSearch("status", respBody, ""))
 	default:
 		return fmt.Errorf("invalid action type (%s)", actionType)
 	}
@@ -330,12 +459,12 @@ func resourceFactoryJobActionCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("error creating DataArts client: %s", err)
 	}
 
+	d.SetId(jobName)
+
 	err = doActionJob(ctx, client, d, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("unable to operate status of the job (%s): %s", jobName, err)
 	}
-
-	d.SetId(jobName)
 
 	return resourceFactoryJobActionRead(ctx, d, meta)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Job action resource supports run immediately

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. job action resource supports run immediately
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccFactoryJobAction_batchJob
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccFactoryJobAction_batchJob -timeout 360m -parallel 10
=== RUN   TestAccFactoryJobAction_batchJob
=== PAUSE TestAccFactoryJobAction_batchJob
=== CONT  TestAccFactoryJobAction_batchJob
--- PASS: TestAccFactoryJobAction_batchJob (645.90s)
PASS
coverage: 10.5% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  646.002s        coverage: 10.5% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
