### PR TITLE
feat(TaurusDB): add data source to query node sessions

### DIFF
--- a/docs/data-sources/taurusdb_node_sessions.md
+++ b/docs/data-sources/taurusdb_node_sessions.md
@@ -1,0 +1,61 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_node_sessions"
+description: |-
+  Use this data source to get the list of user session threads on a TaurusDB node within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_node_sessions
+
+Use this data source to get the list of user session threads on a TaurusDB node within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+
+data "huaweicloud_taurusdb_node_sessions" "test" {
+  instance_id = var.instance_id
+  node_id     = var.node_id
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+   If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the TaurusDB instance.
+
+* `node_id` - (Required, String) Specifies the ID of the node in the TaurusDB instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `processes` - The list of user session threads in the node in the TaurusDB instance.
+
+  The [processes](#processes_struct) structure is documented below.
+
+<a name="processes_struct"></a>
+The `processes` block supports:
+
+* `id` - The ID of the user session thread.
+
+* `user` - The user who starts the session thread.
+
+* `host` - The host and port that send requests.
+
+* `db` - The name of the database that is being accessed.
+
+* `command` - The command that is being executed.
+
+* `time` - The time in seconds that the user session thread remains in the current state.
+
+* `state` - The status of the SQL statement that is being executed.
+
+* `info` - The additional information, which is usually the statement that is being executed.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2383,6 +2383,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_diagnosis_statistics":     taurusdb.DataSourceTaurusDBDiagnosisStatistics(),
 			"huaweicloud_taurusdb_diagnosis_instances":      taurusdb.DataSourceTaurusDBDiagnosisInstances(),
 			"huaweicloud_taurusdb_audit_log_download_links": taurusdb.DataSourceTaurusDBAuditLogDownloadLinks(),
+			"huaweicloud_taurusdb_node_sessions":            taurusdb.DataSourceTaurusDBNodeSessions(),
 
 			"huaweicloud_tms_resource_types":      tms.DataSourceResourceTypes(),
 			"huaweicloud_tms_resource_instances":  tms.DataSourceResourceInstances(),

--- a/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_node_sessions_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_node_sessions_test.go
@@ -1,0 +1,48 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTaurusDBNodeSessions_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_taurusdb_node_sessions.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBInstanceId(t)
+			acceptance.TestAccPreCheckTaurusDBNodeId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceTaurusDBNodeSessions_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "processes.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "processes.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "processes.0.user"),
+					resource.TestCheckResourceAttrSet(dataSource, "processes.0.host"),
+					resource.TestCheckResourceAttrSet(dataSource, "processes.0.db"),
+					resource.TestCheckResourceAttrSet(dataSource, "processes.0.command"),
+					resource.TestCheckResourceAttrSet(dataSource, "processes.0.time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceTaurusDBNodeSessions_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_taurusdb_node_sessions" "test" {
+  instance_id = "%[1]s"
+  node_id     = "%[2]s"
+}
+`, acceptance.HW_TAURUSDB_INSTANCE_ID, acceptance.HW_TAURUSDB_NODE_ID)
+}

--- a/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_node_sessions.go
+++ b/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_node_sessions.go
@@ -1,0 +1,179 @@
+package taurusdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/nodes/{node_id}/processes
+func DataSourceTaurusDBNodeSessions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTaurusDBNodeSessionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the region in which to query the resource.",
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the TaurusDB instance.`,
+			},
+			"node_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the node in the TaurusDB instance.`,
+			},
+			"processes": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The list of user session threads in the node in the TaurusDB instance.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The ID of the user session thread.`,
+						},
+						"user": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The user who starts the session thread.`,
+						},
+						"host": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the database that is being accessed.`,
+						},
+						"db": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Name of the database that is being accessed.",
+						},
+						"command": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The command that is being executed.",
+						},
+						"time": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The time in seconds that the user session thread remains in the current state.",
+						},
+						"state": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The status of the SQL statement that is being executed.",
+						},
+						"info": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The additional information, which is usually the statement that is being executed.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceTaurusDBNodeSessionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/nodes/{node_id}/processes"
+		product    = "gaussdb"
+		result     = make([]interface{}, 0)
+		totalCount float64
+		offset     = 0
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating TaurusDB Client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProviderClient.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", d.Get("instance_id").(string))
+	requestPath = strings.ReplaceAll(requestPath, "{node_id}", d.Get("node_id").(string))
+
+	listOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s?limit=100&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", currentPath, &listOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving TaurusDB node sessions: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		processes := utils.PathSearch("processes", respBody, make([]interface{}, 0)).([]interface{})
+		if len(processes) == 0 {
+			break
+		}
+		result = append(result, processes...)
+
+		totalCount = utils.PathSearch("total_count", respBody, float64(0)).(float64)
+		if int(totalCount) == len(result) {
+			break
+		}
+
+		offset += len(processes)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("processes", flattenGetNodeSessionsResponseBody(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGetNodeSessionsResponseBody(resp []interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	res := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		res = append(res, map[string]interface{}{
+			"id":      utils.PathSearch("id", v, nil),
+			"user":    utils.PathSearch("user", v, nil),
+			"host":    utils.PathSearch("host", v, nil),
+			"db":      utils.PathSearch("db", v, nil),
+			"command": utils.PathSearch("command", v, nil),
+			"time":    utils.PathSearch("time", v, nil),
+			"state":   utils.PathSearch("state", v, nil),
+			"info":    utils.PathSearch("info", v, nil),
+		})
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add data source to get node sessions
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
   add data source to get node sessions
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* 

- [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/taurusdb" TESTARGS="-run TestAccDataSourceTaurusDBNodeSessions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/taurusdb -v -run TestAccDataSourceTaurusDBNodeSessions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceTaurusDBNodeSessions_basic
=== PAUSE TestAccDataSourceTaurusDBNodeSessions_basic
=== CONT  TestAccDataSourceTaurusDBNodeSessions_basic
--- PASS: TestAccDataSourceTaurusDBNodeSessions_basic (14.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb  15.018s

```
<img width="1246" height="44" alt="image" src="https://github.com/user-attachments/assets/5fe78a9b-d119-498e-a2c4-cf1fb53a8e32" />

<img width="1820" height="911" alt="image" src="https://github.com/user-attachments/assets/722e3674-d923-4182-b3d4-092f3cd7424c" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
