### PR TITLE
fix(tms): fix mrs binding resource tags error

### DIFF
--- a/docs/resources/tms_resource_tags.md
+++ b/docs/resources/tms_resource_tags.md
@@ -70,3 +70,11 @@ The `resources` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/huaweicloud/services/acceptance/tms/resource_huaweicloud_tms_resource_tags_test.go
+++ b/huaweicloud/services/acceptance/tms/resource_huaweicloud_tms_resource_tags_test.go
@@ -175,3 +175,54 @@ resource "huaweicloud_tms_resource_tags" "test" {
 }
 `, basicCfg, acceptance.HW_PROJECT_ID)
 }
+
+// MRS service binding tags is an asynchronous operation, so a separate test case is provided.
+func TestAccResourceTags_mrs(t *testing.T) {
+	var (
+		tagsConfigured bool
+
+		rName = "huaweicloud_tms_resource_tags.test"
+		rc    = acceptance.InitResourceCheck(rName, &tagsConfigured, getResourceTagsFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckProjectID(t)
+			acceptance.TestAccPreCheckMrsClusterID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceTags_mrs(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(rName, "resources.0.resource_type", "clusters"),
+					resource.TestCheckResourceAttr(rName, "resources.0.resource_id", acceptance.HW_MRS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceTags_mrs() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_tms_resource_tags" "test" {
+  project_id = "%[1]s"
+
+  resources {
+    resource_type = "clusters"
+    resource_id   = "%[2]s"
+  }
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+`, acceptance.HW_PROJECT_ID, acceptance.HW_MRS_CLUSTER_ID)
+}

--- a/huaweicloud/services/tms/resource_huaweicloud_tms_resource_tags.go
+++ b/huaweicloud/services/tms/resource_huaweicloud_tms_resource_tags.go
@@ -2,11 +2,14 @@ package tms
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
@@ -26,6 +29,12 @@ func ResourceResourceTags() *schema.Resource {
 		ReadContext:   resourceResourceTagsRead,
 		UpdateContext: resourceResourceTagsUpdate,
 		DeleteContext: resourceResourceTagsDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"project_id": {
@@ -93,6 +102,38 @@ func expandResourceTags(tagsInput map[string]interface{}) []tags.ResourceTag {
 	return result
 }
 
+func waitingResourceTagsConfigCompleted(ctx context.Context, cfg *config.Config, d *schema.ResourceData,
+	timeout time.Duration) error {
+	client, err := cfg.TmsV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating TMS v2 client: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			// For some services, binding tags is an asynchronous operation, such as MRS.
+			resResult, err := GetResourceTags(client, d)
+			if err != nil {
+				if _, ok := err.(golangsdk.ErrDefault404); ok {
+					return "waiting config", "PENDING", nil
+				}
+
+				return nil, "ERROR", err
+			}
+
+			return resResult, "COMPLETED", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	return err
+}
+
 func resourceResourceTagsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
@@ -119,6 +160,10 @@ func resourceResourceTagsCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("unable to generate resource ID of the TMS tags management: %s", err)
 	}
 	d.SetId(randUUID)
+
+	if err := waitingResourceTagsConfigCompleted(ctx, cfg, d, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for TMS resource tags config to complete: %s", err)
+	}
 
 	return resourceResourceTagsRead(ctx, d, meta)
 }
@@ -159,14 +204,7 @@ func compareTwoTags(localTags, remoteTags map[string]interface{}) (same, diff ma
 	return
 }
 
-func resourceResourceTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.TmsV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating TMS v2 client: %s", err)
-	}
-
+func GetResourceTags(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
 	var (
 		projectId = d.Get("project_id").(string)
 		resources = d.Get("resources").([]interface{})
@@ -189,7 +227,7 @@ func resourceResourceTagsRead(_ context.Context, d *schema.ResourceData, meta in
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				continue
 			}
-			return diag.Errorf("error query resource (%s) tags: %s", resourceId, err)
+			return nil, fmt.Errorf("error query resource (%s) tags: %s", resourceId, err)
 		}
 		actualTags := FlattenTagsToMap(resp)
 		same, diff := compareTwoTags(tagsInput, actualTags)
@@ -204,10 +242,28 @@ func resourceResourceTagsRead(_ context.Context, d *schema.ResourceData, meta in
 			resResult = append(resResult, val)
 		}
 	}
+
 	// All tags set failed.
 	if len(resResult) < 1 {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "TMS tags management")
+		return nil, golangsdk.ErrDefault404{}
 	}
+
+	return resResult, nil
+}
+
+func resourceResourceTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.TmsV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating TMS v2 client: %s", err)
+	}
+
+	resResult, err := GetResourceTags(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error getting TMS resource tags")
+	}
+
 	mErr := multierror.Append(nil,
 		d.Set("resources", resResult),
 	)
@@ -257,10 +313,46 @@ func resourceResourceTagsUpdate(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("some tags were not set successfully: %#v", failResp)
 	}
 
+	if err := waitingResourceTagsConfigCompleted(ctx, cfg, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return diag.Errorf("error waiting for TMS resource tags config to complete: %s", err)
+	}
+
 	return resourceResourceTagsRead(ctx, d, meta)
 }
 
-func resourceResourceTagsDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func waitingResourceTagsDeleteCompleted(ctx context.Context, cfg *config.Config, d *schema.ResourceData,
+	timeout time.Duration) error {
+	client, err := cfg.TmsV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating TMS v2 client: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			// For some services, binding tags is an asynchronous operation, such as MRS.
+			resResult, err := GetResourceTags(client, d)
+			if err != nil {
+				if _, ok := err.(golangsdk.ErrDefault404); ok {
+					return "success deleted", "COMPLETED", nil
+				}
+
+				return nil, "ERROR", err
+			}
+
+			return resResult, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceResourceTagsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	client, err := cfg.TmsV1Client(region)
@@ -279,6 +371,10 @@ func resourceResourceTagsDelete(_ context.Context, d *schema.ResourceData, meta 
 	}
 	if len(failResp) > 0 {
 		return diag.Errorf("some tags were not successfully removed: %#v", failResp)
+	}
+
+	if err := waitingResourceTagsDeleteCompleted(ctx, cfg, d, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for TMS resource tags delete to complete: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix mrs binding resource tags error.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

For some services, adding or deleting tags is an asynchronous operation, such as MRS.
The following problem occurs when the current resource is tagged with MRS：
<img width="1520" height="296" alt="image" src="https://github.com/user-attachments/assets/2b1b2b30-886f-4c35-8b2b-2bdb7677011d" />

The PR fixed the issue.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o tms -f TestAccResourceTags_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/tms" -v -coverprofile="./huaweicloud/services/acceptance/tms/tms_coverage.cov" -coverpkg="./huaweicloud/services/tms" -run TestAccResourceTags_ -timeout 360m -parallel 10
=== RUN   TestAccResourceTags_basic
=== PAUSE TestAccResourceTags_basic
=== RUN   TestAccResourceTags_mrs
=== PAUSE TestAccResourceTags_mrs
=== CONT  TestAccResourceTags_basic
=== CONT  TestAccResourceTags_mrs
--- PASS: TestAccResourceTags_mrs (26.18s)
--- PASS: TestAccResourceTags_basic (67.85s)
PASS
coverage: 26.5% of statements in ./huaweicloud/services/tms
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/tms       67.958s coverage: 26.5% of statements in ./huaweicloud/services/tms
```
<img width="1251" height="78" alt="image" src="https://github.com/user-attachments/assets/054a4bcc-52f5-43cc-a8ea-69bf19232461" />


* [X] Documentation updated.
* [ ] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="824" height="199" alt="image" src="https://github.com/user-attachments/assets/739c0d97-8904-4aef-b300-16ccc7aa1558" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
