### PR TITLE
feat(GA): add dataSource to query ga quotas

### DIFF
--- a/docs/data-sources/ga_quotas.md
+++ b/docs/data-sources/ga_quotas.md
@@ -1,0 +1,38 @@
+---
+subcategory: "Global Accelerator (GA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ga_quotas"
+description: |-
+Use this data source to get the list of GA quotas within HuaweiCloud.
+---
+
+# huaweicloud_ga_quotas
+
+Use this data source to get the list of GA quotas within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_ga_quotas" "test" {}
+```
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The data source ID.
+
+* `quotas` - All quotas that match the filter parameters.
+
+  The [quotas](#quotas_struct) structure is documented below.
+
+<a name="quotas_struct"></a>
+The `quotas` block supports:
+
+* `type` - The quota mark.
+
+* `min` - The minimum quota threshold.
+
+* `max` - The maximum quota threshold.
+
+* `quota` - The quota size.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1348,6 +1348,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ga_endpoints":          ga.DataSourceEndpoints(),
 			"huaweicloud_ga_health_checks":      ga.DataSourceHealthChecks(),
 			"huaweicloud_ga_listeners":          ga.DataSourceListeners(),
+			"huaweicloud_ga_quotas":             ga.DataSourceGaQuotas(),
 			"huaweicloud_ga_tags":               ga.DataSourceGaTags(),
 
 			"huaweicloud_gaussdb_nosql_flavors":                geminidb.DataSourceGaussDBNoSQLFlavors(),

--- a/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_quotas_test.go
+++ b/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_quotas_test.go
@@ -1,0 +1,40 @@
+package ga
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGaQuotas_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_ga_quotas.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceGaQuotas_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.min"),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.max"),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.quota"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceGaQuotas_basic = `
+data "huaweicloud_ga_quotas" "test" {}
+`

--- a/huaweicloud/services/ga/data_source_huaweicloud_ga_quotas.go
+++ b/huaweicloud/services/ga/data_source_huaweicloud_ga_quotas.go
@@ -1,0 +1,121 @@
+package ga
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GA GET /v1/{domain_id}/ga/quotas
+func DataSourceGaQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGaQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"quotas": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of quotas.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The quota mark.`,
+						},
+						"min": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The minimum quota threshold.`,
+						},
+						"max": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The maximum quota threshold.`,
+						},
+						"quota": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The quota size.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGaQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ga"
+		httpUrl = "v1/{domain_id}/ga/quotas"
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GA client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{domain_id}", cfg.DomainID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving GA quotas: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(nil,
+		d.Set("quotas", flattenQuotas(getRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenQuotas(quotasResp interface{}) []interface{} {
+	if quotasResp == nil {
+		return make([]interface{}, 0)
+	}
+
+	resources := utils.PathSearch("quotas.resources", quotasResp, make([]interface{}, 0)).([]interface{})
+	rst := make([]interface{}, 0, len(resources))
+	for _, v := range resources {
+		resource := v.(map[string]interface{})
+		rst = append(rst, map[string]interface{}{
+			"type":  utils.PathSearch("type", resource, nil),
+			"min":   utils.PathSearch("min", resource, nil),
+			"max":   utils.PathSearch("max", resource, nil),
+			"quota": utils.PathSearch("quota", resource, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `ga_quotas` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `ga_quotas` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccDataSourceGaQuotas_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga-v -run TestAccDataSourceGaQuotas_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceGaQuotas_basic
=== PAUSE TestAccDataSourceGaQuotas_basic
=== CONT  TestAccDataSourceGaQuotas_basic
--- PASS: TestAccDataSourceGaQuotas_basic (26.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga       21.311s
```
<img width="844" height="27" alt="image" src="https://github.com/user-attachments/assets/ffe55e17-7be7-4137-9012-071ae6586024" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
