### PR TITLE
feat(TaurusDB): add action resource to kill user session threads

### DIFF
--- a/docs/resources/taurusdb_node_sessions_kill.md
+++ b/docs/resources/taurusdb_node_sessions_kill.md
@@ -1,0 +1,53 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_node_sessions_kill"
+description: |-
+  Use this resource to terminate specified user session threads on a TaurusDB node within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_node_sessions_kill
+
+Use this resource to terminate specified user session threads on a TaurusDB node within HuaweiCloud.
+
+-> This resource is only a one-time action resource to kill user session threads. Deleting this resource
+will not clear the corresponding instance, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+variable "processes_ids" {
+  type = list(number)
+}
+
+resource "huaweicloud_taurusdb_node_sessions_kill" "test" {
+  instance_id = var.instance_id
+  node_id     = var.node_id
+  processes   = var.processes_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NoneUpdatable) Specifies the ID of the TaurusDB instance.
+
+* `node_id` - (Required, String, NoneUpdatable) Specifies the ID of the node in the TaurusDB instance.
+
+* `processes` - (Required, List, NoneUpdatable) Specifies the IDs of user session threads to be terminated.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `processes_killed` - The IDs of terminated user session threads in requested processes.
+
+* `processes_not_found` - The IDs of user session threads that were not found in requested processes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4261,6 +4261,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_scheduled_task_cancel":      taurusdb.ResourceTaurusDBScheduledTaskCancel(),
 			"huaweicloud_taurusdb_scheduled_task_delete":      taurusdb.ResourceTaurusDBScheduledTaskDelete(),
 			"huaweicloud_taurusdb_instant_task_delete":        taurusdb.ResourceTaurusDBInstantTaskDelete(),
+			"huaweicloud_taurusdb_node_sessions_kill":         taurusdb.ResourceTaurusDBNodeSessionsKill(),
 
 			"huaweicloud_tms_resource_tags": tms.ResourceResourceTags(),
 			"huaweicloud_tms_tags":          tms.ResourceTmsTag(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -273,6 +273,7 @@ var (
 
 	HW_TAURUSDB_INSTANCE_ID               = os.Getenv("HW_TAURUSDB_INSTANCE_ID")
 	HW_TAURUSDB_NODE_ID                   = os.Getenv("HW_TAURUSDB_NODE_ID")
+	HW_TAURUSDB_NODE_SESSION_ID           = os.Getenv("HW_TAURUSDB_NODE_SESSION_ID")
 	HW_TAURUSDB_DATABASE_NAME             = os.Getenv("HW_TAURUSDB_DATABASE_NAME")
 	HW_TAURUSDB_TABLE_NAME                = os.Getenv("HW_TAURUSDB_TABLE_NAME")
 	HW_TAURUSDB_INSTANCE_CONFIGURATION_ID = os.Getenv("HW_TAURUSDB_INSTANCE_CONFIGURATION_ID")
@@ -2267,6 +2268,13 @@ func TestAccPreCheckTaurusDBInstanceId(t *testing.T) {
 func TestAccPreCheckTaurusDBNodeId(t *testing.T) {
 	if HW_TAURUSDB_NODE_ID == "" {
 		t.Skip("HW_TAURUSDB_NODE_ID must be set for TaurusDB acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckTaurusDBNodeSessionId(t *testing.T) {
+	if HW_TAURUSDB_NODE_SESSION_ID == "" {
+		t.Skip("HW_TAURUSDB_NODE_SESSION_ID must be set for TaurusDB acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_node_sessions_kill_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_node_sessions_kill_test.go
@@ -1,0 +1,55 @@
+package taurusdb
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTaurusDBNodeSessionsKill_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBInstanceId(t)
+			acceptance.TestAccPreCheckTaurusDBNodeId(t)
+			acceptance.TestAccPreCheckTaurusDBNodeSessionId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaurusDBNodeSessionsKill_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("huaweicloud_taurusdb_node_sessions_kill.test", "processes_killed.#"),
+					resource.TestCheckOutput("killed_process_id", acceptance.HW_TAURUSDB_NODE_SESSION_ID),
+					resource.TestCheckResourceAttrSet("huaweicloud_taurusdb_node_sessions_kill.test", "processes_not_found.#"),
+					resource.TestCheckOutput("not_found_process_id", "999999999"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTaurusDBNodeSessionsKill_basic() string {
+	processId, _ := strconv.Atoi(acceptance.HW_TAURUSDB_NODE_SESSION_ID)
+	return fmt.Sprintf(`
+resource "huaweicloud_taurusdb_node_sessions_kill" "test" {
+  instance_id = "%[1]s"
+  node_id     = "%[2]s"
+  processes   = [%[3]d, 999999999]
+}
+
+output killed_process_id {
+  value = huaweicloud_taurusdb_node_sessions_kill.test.processes_killed[0]
+}
+
+output not_found_process_id {
+  value = huaweicloud_taurusdb_node_sessions_kill.test.processes_not_found[0]
+}
+`, acceptance.HW_TAURUSDB_INSTANCE_ID, acceptance.HW_TAURUSDB_NODE_ID, processId)
+}

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_node_sessions_kill.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_node_sessions_kill.go
@@ -1,0 +1,181 @@
+package taurusdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	nodeSessionsNonUpdatableParams = []string{"instance_id", "node_id", "processes"}
+)
+
+// @API TaurusDB DELETE /v3/{project_id}/instances/{instance_id}/nodes/{node_id}/processes
+func ResourceTaurusDBNodeSessionsKill() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTaurusDBNodeSessionsKillCreate,
+		ReadContext:   resourceTaurusDBNodeSessionsKillRead,
+		UpdateContext: resourceTaurusDBNodeSessionsKillUpdate,
+		DeleteContext: resourceTaurusDBNodeSessionsKillDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nodeSessionsNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the TaurusDB instance.`,
+			},
+			"node_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the node in the TaurusDB instance.`,
+			},
+			"processes": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+				Description: `Specifies the IDs of user session threads to be terminated.`,
+			},
+			"processes_killed": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+				Description: `The IDs of terminated user session threads in requested processes.`,
+			},
+			"processes_not_found": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+				Description: `The IDs of user session threads that were not found in requested processes.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceTaurusDBNodeSessionsKillCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/nodes/{node_id}/processes"
+		product    = "gaussdb"
+		instanceId = d.Get("instance_id").(string)
+		nodeId     = d.Get("node_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", instanceId)
+	requestPath = strings.ReplaceAll(requestPath, "{node_id}", nodeId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildCreateTaurusDBNodeSessionsKillBodyParams(d),
+	}
+
+	resp, err := client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error killing TaurusDB node sessions: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error parsing response: %s", err)
+	}
+
+	processesKilled := utils.PathSearch("processes_killed", respBody, make([]interface{}, 0))
+	killedIntIds := make([]int, 0)
+	if killedList, ok := processesKilled.([]interface{}); ok {
+		killedIntIds = expandToIntList(killedList)
+	}
+
+	processesNotFound := utils.PathSearch("processes_not_found", respBody, make([]interface{}, 0))
+	notFoundIntIds := make([]int, 0)
+	if notFoundList, ok := processesNotFound.([]interface{}); ok {
+		notFoundIntIds = expandToIntList(notFoundList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("processes_killed", killedIntIds),
+		d.Set("processes_not_found", notFoundIntIds),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting TaurusDB node sessions delete state: %s", mErr)
+	}
+	return nil
+}
+
+func buildCreateTaurusDBNodeSessionsKillBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"processes": utils.ExpandToIntList(d.Get("processes").([]interface{})),
+	}
+	return bodyParams
+}
+
+func expandToIntList(v []interface{}) []int {
+	s := make([]int, 0, len(v))
+	for _, val := range v {
+		if intVal, ok := val.(int); ok {
+			s = append(s, intVal)
+		}
+		if fv, ok := val.(float64); ok {
+			s = append(s, int(fv))
+		}
+	}
+	return s
+}
+
+func resourceTaurusDBNodeSessionsKillRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+func resourceTaurusDBNodeSessionsKillUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+func resourceTaurusDBNodeSessionsKillDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting TaurusDB node processes delete resource is not supported. The TaurusDB node processes " +
+		"delete resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add action resource to kill user session threads

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add action resource to kill user session threads
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/taurusdb" TESTARGS="-run TestAccTaurusDBNodeSessionsKill_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/taurusdb -v -run TestAccTaurusDBNodeSessionsKill_basic -timeout 360m -parallel 4
=== RUN   TestAccTaurusDBNodeSessionsKill_basic
=== PAUSE TestAccTaurusDBNodeSessionsKill_basic
=== CONT  TestAccTaurusDBNodeSessionsKill_basic
--- PASS: TestAccTaurusDBNodeSessionsKill_basic (14.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb  15.003s
```
<img width="1253" height="48" alt="image" src="https://github.com/user-attachments/assets/d8bd0731-eec7-4c5c-a94b-6915053b9435" />

<img width="1850" height="971" alt="image" src="https://github.com/user-attachments/assets/1327685e-f0e6-4802-8cc2-23fdf6578b8b" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
