### PR TITLE
refactor(mrs): optimize codes and docs for query cluster versions and nodes

### DIFF
--- a/docs/data-sources/mapreduce_versions.md
+++ b/docs/data-sources/mapreduce_versions.md
@@ -2,25 +2,25 @@
 subcategory: "MapReduce Service (MRS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_mapreduce_versions"
-description: ""
+description: |-
+  Use this data source to get available cluster versions of MapReduce within HuaweiCloud.
 ---
 
 # huaweicloud_mapreduce_versions
 
-Use this data source to get available cluster versions of MapReduce.
+Use this data source to get available cluster versions of MapReduce within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
-data "huaweicloud_mapreduce_versions" "test" {
-}
+data "huaweicloud_mapreduce_versions" "test" {}
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the data source.
+* `region` - (Optional, String) Specifies the region where the cluster versions are located.  
   If omitted, the provider-level region will be used.
 
 ## Attribute Reference
@@ -29,4 +29,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `versions` - List of available cluster versions.
+* `versions` - The list of available cluster versions.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1904,7 +1904,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_mapreduce_cluster_synchronized_iam_objects": mrs.DataSourceClusterSynchronizedIamObjects(),
 			"huaweicloud_mapreduce_clusters":                         mrs.DataSourceMrsClusters(),
 			"huaweicloud_mapreduce_tags_quota":                       mrs.DataSourceTagsQuota(),
-			"huaweicloud_mapreduce_versions":                         mrs.DataSourceMrsVersions(),
+			"huaweicloud_mapreduce_versions":                         mrs.DataSourceVersions(),
 
 			"huaweicloud_obs_buckets":       obs.DataSourceObsBuckets(),
 			"huaweicloud_obs_bucket_object": obs.DataSourceObsBucketObject(),

--- a/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_versions_test.go
+++ b/huaweicloud/services/acceptance/mrs/data_source_huaweicloud_mapreduce_versions_test.go
@@ -1,6 +1,7 @@
 package mrs
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -8,27 +9,27 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourceMrsVersions_basic(t *testing.T) {
-	rName := "data.huaweicloud_mapreduce_versions.test"
-	dc := acceptance.InitDataSourceCheck(rName)
+func TestAccDataVersions_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_mapreduce_versions.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceMrsVersions_basic(),
+				Config: testAccDataVersions_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(rName, "versions.#"),
+					resource.TestMatchResourceAttr(all, "versions.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
 				),
 			},
 		},
 	})
 }
 
-func testAccDatasourceMrsVersions_basic() string {
-	return `
-data "huaweicloud_mapreduce_versions" "test" {
-}`
-}
+const testAccDataVersions_basic = `
+data "huaweicloud_mapreduce_versions" "test" {}
+`

--- a/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_cluster_nodes.go
+++ b/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_cluster_nodes.go
@@ -19,7 +19,7 @@ import (
 // @API MRS GET /v2/{project_id}/clusters/{cluster_id}/nodes
 func DataSourceClusterNodes() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: resourceClusterNodesRead,
+		ReadContext: dataSourceClusterNodesRead,
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -407,7 +407,7 @@ func buildListClusterNodesQueryParams(d *schema.ResourceData) string {
 	return res
 }
 
-func resourceClusterNodesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceClusterNodesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg       = meta.(*config.Config)
 		region    = cfg.GetRegion(d)

--- a/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_versions.go
+++ b/huaweicloud/services/mrs/data_source_huaweicloud_mapreduce_versions.go
@@ -1,8 +1,3 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product MRS
-// ---------------------------------------------------------------
-
 package mrs
 
 import (
@@ -16,61 +11,55 @@ import (
 
 	"github.com/chnsz/golangsdk"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API MRS GET /v2/{project_id}/metadata/versions
-func DataSourceMrsVersions() *schema.Resource {
+func DataSourceVersions() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: resourceMrsVersionsRead,
+		ReadContext: dataSourceVersionsRead,
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the cluster versions are located.`,
 			},
+			// Attributes.
 			"versions": {
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Computed:    true,
-				Description: "List of available cluster versions",
+				Description: `The list of available cluster versions.`,
 			},
 		},
 	}
 }
 
-func resourceMrsVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	var mErr *multierror.Error
-
+func dataSourceVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
+		cfg                = meta.(*config.Config)
+		region             = cfg.GetRegion(d)
 		getVersionsHttpUrl = "v2/{project_id}/metadata/versions"
-		getVersionsProduct = "mrs"
 	)
-	getVersionsClient, err := cfg.NewServiceClient(getVersionsProduct, region)
+
+	client, err := cfg.NewServiceClient("mrs", region)
 	if err != nil {
 		return diag.Errorf("error creating MRS client: %s", err)
 	}
 
-	getVersionsPath := getVersionsClient.Endpoint + getVersionsHttpUrl
-	getVersionsPath = strings.ReplaceAll(getVersionsPath, "{project_id}", getVersionsClient.ProjectID)
+	getVersionsPath := client.Endpoint + getVersionsHttpUrl
+	getVersionsPath = strings.ReplaceAll(getVersionsPath, "{project_id}", client.ProjectID)
 
 	getVersionsOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
 
-	getVersionsResp, err := getVersionsClient.Request("GET", getVersionsPath, &getVersionsOpt)
-
+	getVersionsResp, err := client.Request("GET", getVersionsPath, &getVersionsOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving MrsVersions")
+		return diag.Errorf("error retrieving cluster available versions: %s", err)
 	}
 
 	getVersionsRespBody, err := utils.FlattenResponse(getVersionsResp)
@@ -84,8 +73,7 @@ func resourceMrsVersionsRead(_ context.Context, d *schema.ResourceData, meta int
 	}
 	d.SetId(uuid)
 
-	mErr = multierror.Append(
-		mErr,
+	mErr := multierror.Append(
 		d.Set("region", region),
 		d.Set("versions", utils.PathSearch("cluster_versions", getVersionsRespBody, nil)),
 	)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Optimize redundant code, correct incorrect method names, and improve documentation.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. correcting incorrect method naming
2. improving documentation
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o mrs -f TestAccDataVersions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccDataVersions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataVersions_basic
=== PAUSE TestAccDataVersions_basic
=== CONT  TestAccDataVersions_basic
--- PASS: TestAccDataVersions_basic (18.47s)
PASS
coverage: 4.4% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       18.572s coverage: 4.4% of statements in ./huaweicloud/services/mrs
```
<img width="1126" height="35" alt="image" src="https://github.com/user-attachments/assets/ca5645a2-19f7-41d2-a660-fd26e925f278" />

```
 ./scripts/coverage.sh -o mrs -f TestAccDataClusterNodes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/mrs" -v -coverprofile="./huaweicloud/services/acceptance/mrs/mrs_coverage.cov" -coverpkg="./huaweicloud/services/mrs" -run TestAccDataClusterNodes_basic -timeout 360m -parallel 10
=== RUN   TestAccDataClusterNodes_basic
=== PAUSE TestAccDataClusterNodes_basic
=== CONT  TestAccDataClusterNodes_basic
--- PASS: TestAccDataClusterNodes_basic (17.67s)
PASS
coverage: 7.5% of statements in ./huaweicloud/services/mrs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       17.771s coverage: 7.5% of statements in ./huaweicloud/services/mrs
```
<img width="1074" height="63" alt="image" src="https://github.com/user-attachments/assets/6d950e67-853b-4ebc-9a3f-cc4c8231638b" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
