### PR TITLE
feat(GA): add dataSource to get the list of access points

### DIFF
--- a/docs/data-sources/ga_pops.md
+++ b/docs/data-sources/ga_pops.md
@@ -1,0 +1,32 @@
+---
+subcategory: "Global Accelerator (GA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ga_pops"
+description: |-
+  Use this data source to get the list of access points within HuaweiCloud.
+---
+
+# huaweicloud_ga_pops
+
+Use this data source to get the list of access points within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_ga_pops" "test" {}
+```
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The data source ID.
+
+* `pops` - The list of access points.
+
+  The [pops](#pops_struct) structure is documented below.
+
+<a name="pops_struct"></a>
+The `pops` block supports:
+
+* `id` - The access point ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1348,6 +1348,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ga_endpoints":          ga.DataSourceEndpoints(),
 			"huaweicloud_ga_health_checks":      ga.DataSourceHealthChecks(),
 			"huaweicloud_ga_listeners":          ga.DataSourceListeners(),
+			"huaweicloud_ga_pops":               ga.DataSourceGaPops(),
 			"huaweicloud_ga_quotas":             ga.DataSourceGaQuotas(),
 			"huaweicloud_ga_tags":               ga.DataSourceGaTags(),
 

--- a/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_pops_test.go
+++ b/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_pops_test.go
@@ -1,0 +1,38 @@
+package ga
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGaPops_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_ga_pops.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceGaPops_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "pops.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "pops.0.id"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceGaPops_basic = `
+data "huaweicloud_ga_pops" "test" {}
+`

--- a/huaweicloud/services/ga/data_source_huaweicloud_ga_pops.go
+++ b/huaweicloud/services/ga/data_source_huaweicloud_ga_pops.go
@@ -1,0 +1,121 @@
+package ga
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GA GET /v1/pops
+func DataSourceGaPops() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGaPopsRead,
+
+		Schema: map[string]*schema.Schema{
+			"pops": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The access point ID.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listpops(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/pops"
+		result  = make([]interface{}, 0)
+		limit   = 500
+		marker  = ""
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = fmt.Sprintf("%s?limit=%d", listPath, limit)
+	reqOpt := &golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s&marker=%s", listPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", listPathWithMarker, reqOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		pops := utils.PathSearch("pops", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, pops...)
+		if len(pops) < limit {
+			break
+		}
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func dataSourceGaPopsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("ga", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating GA client: %s", err)
+	}
+
+	pops, err := listpops(client)
+	if err != nil {
+		return diag.Errorf("error listing GA Pops: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return diag.FromErr(d.Set("pops", flattenPops(pops)))
+}
+
+func flattenPops(pops []interface{}) []interface{} {
+	if len(pops) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(pops))
+	for _, pop := range pops {
+		result = append(result, map[string]interface{}{
+			"id": utils.PathSearch("id", pop, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `ga_pops` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `ga_pops` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccDataSourceGaPops_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga-v -run TestAccDataSourceGaPops_basic-timeout 360m -parallel 4
=== RUN   TestAccDataSourceGaPops_basic
=== PAUSE TestAccDataSourceGaPops_basic
=== CONT  TestAccDataSourceGaPops_basic
--- PASS: TestAccDataSourceGaPops_basic (33.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga       21.311s
```
<img width="875" height="20" alt="image" src="https://github.com/user-attachments/assets/cfba5a0b-a993-41a3-802d-0e94e2b33ac6" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
