### PR TITLE
feat(dws): add new resource for cluster exception rule

### DIFF
--- a/docs/resources/dws_cluster_exception_rule.md
+++ b/docs/resources/dws_cluster_exception_rule.md
@@ -1,0 +1,132 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_exception_rule"
+description: |-
+  Manages a exception rule under the DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_exception_rule
+
+Manages a exception rule under the DWS cluster within HuaweiCloud.
+
+~> Optional configurations removed during the update process will have their values ​​reset to the corresponding
+   unrestricted value (-1).
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "rule_name" {}
+variable "exception_rule_configurations" {
+  description = "The configurations of the exception rule."
+  type        = list(object({
+    key   = string
+    value = string
+  }))
+
+  default = [
+    {
+      key   = "action"
+      value = "penalty"
+    },
+    {
+      key   = "spillsize"
+      value = "300"
+    },
+    {
+      key   = "bandwidth"
+      value = "400"
+    },
+    {
+      key   = "memsize"
+      value = "500"
+    },
+    {
+      key   = "broadcastsize"
+      value = "600"
+    },
+  ]
+}
+
+resource "huaweicloud_dws_cluster_exception_rule" "test" {
+  cluster_id = var.cluster_id
+  name       = var.rule_name
+
+  dynamic "configurations" {
+    for_each = var.exception_rule_configurations
+
+    content {
+      key   = configurations.value.key
+      value = configurations.value.value
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the exception rule is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster to which the exception rule belongs.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the exception rule.  
+  The valid value is limited from `3` to `28` characters, and only lowercase letters, digits, underscores (_) are
+  allowed.
+
+* `configurations` - (Required, List) Specifies the list of exception rule configurations.
+  The [configurations](#dws_cluster_exception_rule_configurations) structure is documented below.
+
+<a name="dws_cluster_exception_rule_configurations"></a>
+The `configurations` block supports:
+
+* `key` - (Required, String) Specifies the key of the exception rule configuration.
+
+* `value` - (Required, String) Specifies the value of the exception rule configuration.  
+  The valid keys and corresponding values are as follows:
+  + **action** (Required configuration key): Operation upon exception.  
+    The valid values are **abort** and **penalty**.
+  + **blocktime**: Job blocking duration in seconds, which isthe total time consumed by the global andlocal concurrent
+    queuing duration. The valueis an integer ranging from `1` to `2,147,483,647`. The value `-1` indicates nolimit.
+  + **elapsedtime**: Job execution time in seconds. The value is an integer ranging from `1` to `2,147,483,647`.
+    The value `-1` indicates no limit.
+  + **allcputime**: Total CPU time spent in executing jobs on all DNs, in seconds.
+    The value is an integer ranging from `1` to `2,147,483,647`. The value `-1` indicates no limit.
+  + **cpuskewpercent**: Total CPU time skew rate on all DNs, in percentage (%).  
+    The calculation formula is as follows:  
+    **(Maximum CPU time of a statement across all DNs) × 100 / (Maximum CPU time of a statement across all DNs)**.  
+    To set this rule, you need to set Interval for Checking CPU Skew Rate. The value is an integer in the range `1` to
+    `100`. The value `-1` indicates no limit.
+  + **cpuavgpercent**: Average CPU usage per DN, in percentage (%).  
+    The calculation formula is as follows:  
+    <!-- markdownlint-disable MD013 -->
+    **(Total CPU time of a job on all DNs × 100) / (Job execution duration × Maximum CPUs on all DNs available to the resource pool associated with the job)**
+    <!-- markdownlint-enable MD013 -->
+    The value range is `1` to `100`. The value `-1` indicates no limit.
+  + **spillsize**: Maximum allowed data (in MB) spilled to disk on a DN. The value range is `1` to `2,147,483,647`.  
+    The value `-1` indicates no limit.
+  + **bandwidth**: Maximum network bandwidth (in MB) that can be used by a job on a single DN.
+    The value range is `1` to `2,147,483,647`. The value `-1` indicates no limit.
+  + **memsize**: Maximum memory size (in MB) that can be used by a job on a single DN.
+    The value range is `1` to `2,147,483,647`. The value `-1` indicates no limit.
+  + **broadcastsize**: Maximum amount of large table broadcast data of a job on a single DN, in MB.
+    The value is an integer ranging from `1` to `2,147,483,647`. The value `-1` indicates no limit.
+
+  -> Except for **action** key, at least one of the other configurations must be set.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in the format of `<cluster_id>/<name>`.
+
+## Import
+
+The resource can be imported using the `cluster_id` and `name`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dws_cluster_exception_rule.test <cluster_id>/<name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3242,6 +3242,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_cluster_restart":               dws.ResourceClusterRestart(),
 			"huaweicloud_dws_cluster_user":                  dws.ResourceClusterUser(),
 			"huaweicloud_dws_cluster":                       dws.ResourceDwsCluster(),
+			"huaweicloud_dws_cluster_exception_rule":        dws.ResourceClusterExceptionRule(),
 			"huaweicloud_dws_database_schema_adjust_action": dws.ResourceDatabaseSchemaAdjustAction(),
 			"huaweicloud_dws_disaster_recovery_task":        dws.ResourceDwsDisasterRecoveryTask(),
 			"huaweicloud_dws_event_subscription":            dws.ResourceDwsEventSubs(),

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_exception_rule_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_exception_rule_test.go
@@ -1,0 +1,264 @@
+package dws
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
+)
+
+func getClusterExceptionRuleFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DWS Client: %s", err)
+	}
+
+	return dws.GetClusterExceptionRuleConfigurations(client, state.Primary.Attributes["cluster_id"],
+		state.Primary.Attributes["name"], nil, false)
+}
+
+func TestAccClusterExceptionRule_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName = "huaweicloud_dws_cluster_exception_rule.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getClusterExceptionRuleFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterExceptionRule_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "configurations.#", "6"),
+					resource.TestCheckResourceAttr(rName, "configurations.0.key", "action"),
+					resource.TestCheckResourceAttr(rName, "configurations.0.value", "abort"),
+					resource.TestCheckResourceAttr(rName, "configurations.1.key", "blocktime"),
+					resource.TestCheckResourceAttr(rName, "configurations.1.value", "300"),
+					resource.TestCheckResourceAttr(rName, "configurations.2.key", "elapsedtime"),
+					resource.TestCheckResourceAttr(rName, "configurations.2.value", "400"),
+					resource.TestCheckResourceAttr(rName, "configurations.3.key", "allcputime"),
+					resource.TestCheckResourceAttr(rName, "configurations.3.value", "500"),
+					resource.TestCheckResourceAttr(rName, "configurations.4.key", "cpuskewpercent"),
+					resource.TestCheckResourceAttr(rName, "configurations.4.value", "60"),
+					resource.TestCheckResourceAttr(rName, "configurations.5.key", "cpuavgpercent"),
+					resource.TestCheckResourceAttr(rName, "configurations.5.value", "70"),
+				),
+			},
+			{
+				Config: testAccClusterExceptionRule_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "configurations.#", "5"),
+					resource.TestCheckResourceAttr(rName, "configurations.0.key", "action"),
+					resource.TestCheckResourceAttr(rName, "configurations.0.value", "penalty"),
+					resource.TestCheckResourceAttr(rName, "configurations.1.key", "spillsize"),
+					resource.TestCheckResourceAttr(rName, "configurations.1.value", "300"),
+					resource.TestCheckResourceAttr(rName, "configurations.2.key", "bandwidth"),
+					resource.TestCheckResourceAttr(rName, "configurations.2.value", "400"),
+					resource.TestCheckResourceAttr(rName, "configurations.3.key", "memsize"),
+					resource.TestCheckResourceAttr(rName, "configurations.3.value", "500"),
+					resource.TestCheckResourceAttr(rName, "configurations.4.key", "broadcastsize"),
+					resource.TestCheckResourceAttr(rName, "configurations.4.value", "600"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"configurations",
+					"configurations_origin",
+				},
+				ImportStateCheck: checkClusterExceptionRuleImportState,
+			},
+		},
+	})
+}
+
+// checkClusterExceptionRuleImportState Verifies the exception rule configuration after import
+// 1. The configuration in step two must exist and have the correct value
+// 2. The old configuration in step one must be -1
+func checkClusterExceptionRuleImportState(states []*terraform.InstanceState) error {
+	if len(states) == 0 {
+		return errors.New("no state after import")
+	}
+	is := states[0]
+
+	// The imported configurations must include the configuration from step 2.
+	expected := map[string]string{
+		"action":        "penalty",
+		"spillsize":     "300",
+		"bandwidth":     "400",
+		"memsize":       "500",
+		"broadcastsize": "600",
+	}
+
+	// For items not included in step 2 (configurations set in step 1 but reset in step 2), check if their values
+	// ​​have been reset to -1.
+	shouldMinusOne := map[string]bool{
+		"blocktime":      true,
+		"elapsedtime":    true,
+		"allcputime":     true,
+		"cpuskewpercent": true,
+		"cpuavgpercent":  true,
+	}
+
+	cfgMap := make(map[string]string)
+	for k, v := range is.Attributes {
+		if strings.HasPrefix(k, "configurations.") && strings.HasSuffix(k, ".key") {
+			parts := strings.Split(k, ".")
+			if len(parts) < 3 {
+				continue
+			}
+
+			valKey := fmt.Sprintf("configurations.%s.value", parts[1])
+			cfgMap[v] = is.Attributes[valKey]
+		}
+	}
+	for k, expectVal := range expected {
+		actualVal, ok := cfgMap[k]
+		if !ok {
+			return fmt.Errorf("import check failed: missing key %s", k)
+		}
+		if actualVal != expectVal {
+			return fmt.Errorf("import check failed: key %s expect %s, got %s", k, expectVal, actualVal)
+		}
+	}
+
+	for k := range shouldMinusOne {
+		actualVal, ok := cfgMap[k]
+		if !ok {
+			return fmt.Errorf("import check failed: missing old key %s (should be -1)", k)
+		}
+		if actualVal != "-1" {
+			return fmt.Errorf("import check failed: key %s should be -1, got %s", k, actualVal)
+		}
+	}
+
+	return nil
+}
+
+func testAccClusterExceptionRule_basic_step1(name string) string {
+	return fmt.Sprintf(`
+variable "exception_rule_configurations" {
+  description = "The configurations of the exception rule."
+  type        = list(object({
+    key   = string
+    value = string
+  }))
+
+  default = [
+    {
+      key   = "action"
+      value = "abort"
+    },
+    {
+      key   = "blocktime"
+      value = "300"
+    },
+    {
+      key   = "elapsedtime"
+      value = "400"
+    },
+    {
+      key   = "allcputime"
+      value = "500"
+    },
+    {
+      key   = "cpuskewpercent"
+      value = "60"
+    },
+    {
+      key   = "cpuavgpercent"
+      value = "70"
+    },
+  ]
+}
+
+resource "huaweicloud_dws_cluster_exception_rule" "test" {
+  cluster_id = "%[1]s"
+  name       = "%[2]s"
+
+  dynamic "configurations" {
+    for_each = var.exception_rule_configurations
+
+    content {
+      key   = configurations.value.key
+      value = configurations.value.value
+    }
+  }
+}
+`, acceptance.HW_DWS_CLUSTER_ID, name)
+}
+
+// Configuration values ​​configured in step 1 but not in step 2 will be reset to -1 (no limit).
+func testAccClusterExceptionRule_basic_step2(name string) string {
+	return fmt.Sprintf(`
+variable "exception_rule_configurations" {
+  description = "The configurations of the exception rule."
+  type        = list(object({
+    key   = string
+    value = string
+  }))
+
+  default = [
+    {
+      key   = "action"
+      value = "penalty"
+    },
+    {
+      key   = "spillsize"
+      value = "300"
+    },
+    {
+      key   = "bandwidth"
+      value = "400"
+    },
+    {
+      key   = "memsize"
+      value = "500"
+    },
+    {
+      key   = "broadcastsize"
+      value = "600"
+    },
+  ]
+}
+
+resource "huaweicloud_dws_cluster_exception_rule" "test" {
+  cluster_id = "%[1]s"
+  name       = "%[2]s"
+
+  dynamic "configurations" {
+    for_each = var.exception_rule_configurations
+
+    content {
+      key   = configurations.value.key
+      value = configurations.value.value
+    }
+  }
+}
+`, acceptance.HW_DWS_CLUSTER_ID, name)
+}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_exception_rule.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_exception_rule.go
@@ -1,0 +1,470 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	clusterExceptionRuleNonUpdatableParams = []string{
+		"cluster_id",
+		"name",
+	}
+	clusterExceptionRuleJSONParamKeys = []string{
+		"configurations",
+	}
+)
+
+// @API DWS POST /v1/{project_id}/clusters/{cluster_id}/workload/rules
+// @API DWS GET /v1/{project_id}/clusters/{cluster_id}/workload/rules
+// @API DWS PUT /v1/{project_id}/clusters/{cluster_id}/workload/rules/{rule_name}
+// @API DWS DELETE /v1/{project_id}/clusters/{cluster_id}/workload/rules/{rule_name}
+func ResourceClusterExceptionRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceClusterExceptionRuleCreate,
+		ReadContext:   resourceClusterExceptionRuleRead,
+		UpdateContext: resourceClusterExceptionRuleUpdate,
+		DeleteContext: resourceClusterExceptionRuleDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(clusterExceptionRuleNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceClusterExceptionRuleImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the exception rule is located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster to which the exception rule belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the exception rule.`,
+			},
+			"configurations": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The key of the exception rule configuration.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The value of the exception rule configuration.`,
+						},
+					},
+				},
+				DiffSuppressFunc: utils.SuppressObjectSliceDiffs(),
+				Description:      `The list of exception rule configurations.`,
+			},
+
+			// Internal parameters.
+			"configurations_origin": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The key of the exception rule configuration.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The value of the exception rule configuration.",
+						},
+					},
+				},
+				DiffSuppressFunc: utils.SuppressDiffAll,
+				Description: utils.SchemaDesc(
+					`The configuration value of this change is also the original value used for comparison with
+ the new value next time the change is made. The corresponding parameter name is 'configurations'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
+			},
+		},
+	}
+}
+
+func buildClusterExceptionRuleConfigurations(configurations []interface{}) []map[string]interface{} {
+	if len(configurations) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(configurations))
+	for _, v := range configurations {
+		result = append(result, map[string]interface{}{
+			"rule_key":   utils.PathSearch("key", v, nil),
+			"rule_value": utils.PathSearch("value", v, nil),
+		})
+	}
+	return result
+}
+
+func buildClusterExceptionRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"rule_name":    d.Get("name"),
+		"except_rules": buildClusterExceptionRuleConfigurations(d.Get("configurations").([]interface{})),
+	}
+}
+
+func createClusterExceptionRule(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/clusters/{cluster_id}/workload/rules"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{cluster_id}", d.Get("cluster_id").(string))
+
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      requestOpts.MoreHeaders,
+		JSONBody:         utils.RemoveNil(buildClusterExceptionRuleBodyParams(d)),
+		OkCodes:          []int{200},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpts)
+	return err
+}
+
+func resourceClusterExceptionRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+		ruleName  = d.Get("name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	err = createClusterExceptionRule(client, d)
+	if err != nil {
+		return diag.Errorf("error creating exception rule (%s): %s", ruleName, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", clusterId, ruleName))
+
+	// If the request is successful, obtain the values of all JSON parameters first and save them to the corresponding
+	// '_origin' attributes for subsequent determination and construction of the request body during next updates.
+	// And whether corresponding parameters are changed, the origin values must be refreshed.
+	err = utils.RefreshObjectParamOriginValues(d, clusterExceptionRuleJSONParamKeys)
+	if err != nil {
+		// Don't report an error if origin refresh fails
+		log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+	}
+
+	return resourceClusterExceptionRuleRead(ctx, d, meta)
+}
+
+func flattenClusterExceptionRuleConfigurations(configurations map[string]interface{}) []interface{} {
+	if len(configurations) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(configurations))
+	for k, v := range configurations {
+		result = append(result, map[string]interface{}{
+			"key":   k,
+			"value": fmt.Sprintf("%v", v), // Convert the value to a string to avoid the difference in the type of the value.
+		})
+	}
+
+	return result
+}
+
+func listClusterExceptionRules(client *golangsdk.ServiceClient, clusterId string, queryParams ...string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/clusters/{cluster_id}/workload/rules?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{cluster_id}", clusterId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	if len(queryParams) > 0 {
+		listPath += fmt.Sprintf("&%s", queryParams[0])
+	}
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		items := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, items...)
+		if len(items) < limit {
+			break
+		}
+		offset += len(items)
+	}
+
+	return result, nil
+}
+
+func getClusterExceptionRuleByName(client *golangsdk.ServiceClient, clusterId, ruleName string) (interface{}, error) {
+	// Reduce the number of queries by specifying query filter parameters (rule_name is a fuzzy query parameter).
+	queryParams := fmt.Sprintf("rule_name=%s", ruleName)
+
+	rules, err := listClusterExceptionRules(client, clusterId, queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	// Exception rules are matched precisely using JMES expressions and based on the rule_name.
+	result := utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0]", ruleName), rules, nil)
+	if result == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/clusters/{cluster_id}/workload/rules",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the exception rule (%s) is not found", ruleName)),
+			},
+		}
+	}
+
+	return result, nil
+}
+
+func GetClusterExceptionRuleConfigurations(client *golangsdk.ServiceClient, clusterId, ruleName string, configurationsOrigin []interface{},
+	keepRemoteState bool) (interface{}, error) {
+	rule, err := getClusterExceptionRuleByName(client, clusterId, ruleName)
+	if err != nil {
+		return nil, err
+	}
+
+	return orderExceptionRuleExceptionRulesByConfigurationsOrigin(
+		flattenClusterExceptionRuleConfigurations(utils.PathSearch("except_rules", rule, make(map[string]interface{})).(map[string]interface{})),
+		configurationsOrigin, keepRemoteState), nil
+}
+
+func orderExceptionRuleExceptionRulesByConfigurationsOrigin(rules, configurationsOrigin []interface{}, keepRemoteState bool) []interface{} {
+	if len(configurationsOrigin) < 1 {
+		return rules
+	}
+
+	sortedConfigurations := make([]interface{}, 0, len(rules))
+	rulesCopy := rules
+
+	for _, ruleOrigin := range configurationsOrigin {
+		ruleKeyOrigin := utils.PathSearch("key", ruleOrigin, "").(string)
+		for index, rule := range rulesCopy {
+			ruleKey := utils.PathSearch("key", rule, "").(string)
+			if ruleKey != ruleKeyOrigin {
+				continue
+			}
+			// Add the found rule to the sorted rules list.
+			sortedConfigurations = append(sortedConfigurations, rulesCopy[index])
+			// Remove the processed rule from the original array.
+			rulesCopy = append(rulesCopy[:index], rulesCopy[index+1:]...)
+			break
+		}
+	}
+
+	if keepRemoteState {
+		sortedConfigurations = append(sortedConfigurations, rulesCopy...)
+	}
+	return sortedConfigurations
+}
+
+func resourceClusterExceptionRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                  = meta.(*config.Config)
+		region               = cfg.GetRegion(d)
+		clusterId            = d.Get("cluster_id").(string)
+		ruleName             = d.Get("name").(string)
+		configurationsOrigin = d.Get("configurations_origin").([]interface{})
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	configurations, err := GetClusterExceptionRuleConfigurations(client, clusterId, ruleName, configurationsOrigin, false)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DWS exception rule configurations")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		// Attributes.
+		d.Set("configurations", configurations),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildClusterExceptionRuleUpdateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	var (
+		rawConfig      = d.GetRawConfig()
+		configurations = utils.GetNestedObjectFromRawConfig(rawConfig, "configurations").([]interface{})
+	)
+
+	return map[string]interface{}{
+		"rule_name":    d.Get("name"),
+		"except_rules": buildClusterExceptionRuleConfigurations(configurations),
+	}
+}
+
+func updateClusterExceptionRule(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		clusterId = d.Get("cluster_id").(string)
+		ruleName  = d.Get("name").(string)
+		httpUrl   = "v1/{project_id}/clusters/{cluster_id}/workload/rules/{rule_name}"
+	)
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", clusterId)
+	updatePath = strings.ReplaceAll(updatePath, "{rule_name}", ruleName)
+
+	updateOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      requestOpts.MoreHeaders,
+		JSONBody:         utils.RemoveNil(buildClusterExceptionRuleUpdateBodyParams(d)),
+		OkCodes:          []int{200},
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpts)
+	return err
+}
+
+func resourceClusterExceptionRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		ruleName = d.Get("name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	if d.HasChange("configurations") {
+		if err := updateClusterExceptionRule(client, d); err != nil {
+			return diag.Errorf("error updating DWS exception rule (%s): %s", ruleName, err)
+		}
+
+		// If the request is successful, obtain the values of all JSON parameters first and save them to the corresponding
+		// '_origin' attributes for subsequent determination and construction of the request body during next updates.
+		// And whether corresponding parameters are changed, the origin values must be refreshed.
+		err = utils.RefreshObjectParamOriginValues(d, clusterExceptionRuleJSONParamKeys)
+		if err != nil {
+			// Don't report an error if origin refresh fails
+			log.Printf("[WARN] Unable to refresh the origin values: %s", err)
+		}
+	}
+
+	return resourceClusterExceptionRuleRead(ctx, d, meta)
+}
+
+func deleteClusterExceptionRule(client *golangsdk.ServiceClient, clusterId, ruleName string) error {
+	httpUrl := "v1/{project_id}/clusters/{cluster_id}/workload/rules/{rule_name}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", clusterId)
+	deletePath = strings.ReplaceAll(deletePath, "{rule_name}", ruleName)
+
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      requestOpts.MoreHeaders,
+		OkCodes:          []int{200},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpts)
+	return err
+}
+
+func resourceClusterExceptionRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+		ruleName  = d.Get("name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	if err := deleteClusterExceptionRule(client, clusterId, ruleName); err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting DWS exception rule (%s)", ruleName))
+	}
+
+	return nil
+}
+
+func resourceClusterExceptionRuleImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<cluster_id>/<name>', but got '%s'", d.Id())
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("cluster_id", parts[0]),
+		d.Set("name", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource for DWS cluster exception rule

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of DWS cluster exception rule test:
<img width="1055" height="365" alt="image" src="https://github.com/user-attachments/assets/e857d853-088c-4795-afd8-334ae9d462ca" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new resource for cluster exception rule
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dws -f TestAccClusterExceptionRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccClusterExceptionRule_basic -timeout 360m -parallel 10
=== RUN   TestAccClusterExceptionRule_basic
=== PAUSE TestAccClusterExceptionRule_basic
=== CONT  TestAccClusterExceptionRule_basic
--- PASS: TestAccClusterExceptionRule_basic (46.03s)
PASS
coverage: 5.6% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       46.165s coverage: 5.6% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1781" height="1131" alt="image" src="https://github.com/user-attachments/assets/8928a3c9-9cd8-49fa-8186-ea094ed002c1" />

    ab. Related resources (parent resources) not found
    <img width="1790" height="1181" alt="image" src="https://github.com/user-attachments/assets/de4b8d18-c2f2-4e70-9902-05635406cd6c" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
