### PR TITLE
feat(cfw): support `cfw_eip_alarm_whitelist` resource

### DIFF
--- a/docs/resources/cfw_eip_alarm_whitelist.md
+++ b/docs/resources/cfw_eip_alarm_whitelist.md
@@ -1,0 +1,87 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_eip_alarm_whitelist"
+description: |-
+  Manages a CFW EIP alarm whitelist resource within HuaweiCloud.
+---
+
+# huaweicloud_cfw_eip_alarm_whitelist
+
+Manages a CFW EIP alarm whitelist resource within HuaweiCloud.
+
+-> Currently, this resource does not support the delete function. Deleting this resource will not clear the
+  corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+variable "eip_id" {}
+variable "public_ip" {}
+
+resource "huaweicloud_cfw_eip_alarm_whitelist" "test" {
+  fw_instance_id = var.fw_instance_id
+  eip_id         = var.eip_id
+  public_ip      = var.public_ip
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `fw_instance_id` - (Required, String, NonUpdatable) Specifies the firewall instance ID.
+
+* `eip_id` - (Required, String, NonUpdatable) Specifies the EIP ID.  
+
+* `public_ip` - (Required, String, NonUpdatable) Specifies the IPv4 address.  
+
+* `object_id` - (Optional, String, NonUpdatable) Specifies the protected object ID.
+
+* `public_ipv6` - (Optional, String, NonUpdatable) Specifies the IPv6 address.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  This parameter is valid only when the enterprise project is enabled.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `fw_instance_id`.
+
+* `device_name` - The device name.
+
+* `type` -  The EIP whitelist flag.  
+  The valid values are as follows:
+  + **1**: The EIP is in the whitelist.
+  + **0**: The EIP is not in the whitelist.
+
+## Import
+
+The EIP alarm whitelist resource can be imported using `id` and `public_ip`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_cfw_eip_alarm_whitelist.test <id>/<public_ip>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `object_id`, `enterprise_project_id`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition
+should be updated to align with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_cfw_eip_alarm_whitelist" "test" { 
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      object_id, enterprise_project_id,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3000,6 +3000,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_alarm_config":                  cfw.ResourceAlarmConfig(),
 			"huaweicloud_cfw_anti_virus":                    cfw.ResourceAntiVirus(),
 			"huaweicloud_cfw_black_white_list":              cfw.ResourceBlackWhiteList(),
+			"huaweicloud_cfw_eip_alarm_whitelist":           cfw.ResourceEipAlarmWhitelist(),
 			"huaweicloud_cfw_eip_auto_protection":           cfw.ResourceEipAutoProtection(),
 			"huaweicloud_cfw_eip_protection":                cfw.ResourceEipProtection(),
 			"huaweicloud_cfw_service_group":                 cfw.ResourceServiceGroup(),

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_eip_alarm_whitelist_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_eip_alarm_whitelist_test.go
@@ -1,0 +1,146 @@
+package cfw
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cfw"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getEipAlarmWhitelistResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		httpUrl  = "v1/{project_id}/eip/alarm-whitelist/{fw_instance_id}"
+		product  = "cfw"
+		publicIP = state.Primary.Attributes["public_ip"]
+		epsId    = state.Primary.Attributes["enterprise_project_id"]
+	)
+
+	client, err := cfg.NewServiceClient(product, acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{fw_instance_id}", state.Primary.ID)
+	requestPath += cfw.BuildEipAlarmWhitelistQueryParams(epsId, publicIP)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	listResp := utils.PathSearch("data.list", respBody, make([]interface{}, 0)).([]interface{})
+	if len(listResp) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	typeResp := utils.PathSearch("type", listResp[0], float64(0)).(float64)
+	if typeResp == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return listResp[0], nil
+}
+
+func TestAccEipAlarmWhitelist_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_cfw_eip_alarm_whitelist.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getEipAlarmWhitelistResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+			acceptance.TestAccPrecheckEipIDAndIP(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// Destroy does not remove the whitelist entry from the cloud (no delete API).
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testEipAlarmWhitelist_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "fw_instance_id", acceptance.HW_CFW_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "eip_id", acceptance.HW_EIP_ID),
+					resource.TestCheckResourceAttr(rName, "public_ip", acceptance.HW_EIP_ADDRESS),
+					resource.TestCheckResourceAttrSet(rName, "type"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"object_id", "enterprise_project_id"},
+				ImportStateIdFunc:       testEipAlarmWhitelistImportStateId(rName),
+			},
+		},
+	})
+}
+
+func testEipAlarmWhitelist_base() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_firewalls" "test" {
+  fw_instance_id = "%s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}
+
+func testEipAlarmWhitelist_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cfw_eip_alarm_whitelist" "test" {
+  fw_instance_id = "%[2]s"
+  eip_id         = "%[3]s"
+  public_ip      = "%[4]s"
+  object_id      = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+}
+`, testEipAlarmWhitelist_base(), acceptance.HW_CFW_INSTANCE_ID, acceptance.HW_EIP_ID, acceptance.HW_EIP_ADDRESS)
+}
+
+func testEipAlarmWhitelistImportStateId(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		resourceId := rs.Primary.ID
+		if resourceId == "" {
+			return "", fmt.Errorf("attribute (ID) of resource (%s) not found", name)
+		}
+
+		publicIP := rs.Primary.Attributes["public_ip"]
+		if publicIP == "" {
+			return "", fmt.Errorf("attribute (public_ip) of resource (%s) not found", name)
+		}
+
+		return fmt.Sprintf("%s/%s", resourceId, publicIP), nil
+	}
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_eip_alarm_whitelist.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_eip_alarm_whitelist.go
@@ -1,0 +1,241 @@
+package cfw
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var eipAlarmWhitelistNonUpdatableParams = []string{"fw_instance_id", "eip_id", "public_ip", "object_id", "public_ipv6",
+	"enterprise_project_id"}
+
+// @API CFW POST /v1/{project_id}/eip/alarm-whitelist
+// @API CFW GET /v1/{project_id}/eip/alarm-whitelist/{fw_instance_id}
+func ResourceEipAlarmWhitelist() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEipAlarmWhitelistCreate,
+		ReadContext:   resourceEipAlarmWhitelistRead,
+		UpdateContext: resourceEipAlarmWhitelistUpdate,
+		DeleteContext: resourceEipAlarmWhitelistDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceEipAlarmWhitelistImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(eipAlarmWhitelistNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"eip_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// The API does not return this field, so the `Computed` attribute is not added.
+			"object_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"public_ipv6": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// The API does not return this field, so the `Computed` attribute is not added.
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"device_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildAddEipAlarmWhitelistBodyParam(d *schema.ResourceData) map[string]interface{} {
+	eipInfo := utils.RemoveNil(map[string]interface{}{
+		"eip_id":         d.Get("eip_id"),
+		"public_ip":      d.Get("public_ip"),
+		"fw_instance_id": d.Get("fw_instance_id").(string),
+		"object_id":      utils.ValueIgnoreEmpty(d.Get("object_id")),
+		"public_ipv6":    utils.ValueIgnoreEmpty(d.Get("public_ipv6")),
+	})
+
+	return map[string]interface{}{
+		"fw_instance_id": d.Get("fw_instance_id"),
+		"eip_infos":      []interface{}{eipInfo},
+	}
+}
+
+func resourceEipAlarmWhitelistCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/eip/alarm-whitelist"
+		product = "cfw"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAddEipAlarmWhitelistBodyParam(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error adding CFW EIP alarm whitelist: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("data.id", respBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error adding CFW EIP alarm whitelist: ID is not found in API response")
+	}
+
+	d.SetId(id)
+
+	return resourceEipAlarmWhitelistRead(ctx, d, meta)
+}
+
+func BuildEipAlarmWhitelistQueryParams(epsId, publicIP string) string {
+	queryParams := fmt.Sprintf("?ip_address=%s", publicIP)
+	// This query does not require pagination, but the `limit` and `offset` parameters in the API are required.
+	queryParams += "&limit=1024&offset=0"
+	if epsId != "" {
+		queryParams += fmt.Sprintf("&eps_id=%s", epsId)
+	}
+
+	return queryParams
+}
+func resourceEipAlarmWhitelistRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v1/{project_id}/eip/alarm-whitelist/{fw_instance_id}"
+		product  = "cfw"
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		publicIP = d.Get("public_ip").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{fw_instance_id}", d.Id())
+	requestPath += BuildEipAlarmWhitelistQueryParams(epsId, publicIP)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW EIP alarm whitelist: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listResp := utils.PathSearch("data.list", respBody, make([]interface{}, 0)).([]interface{})
+	if len(listResp) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	typeResp := utils.PathSearch("type", listResp[0], float64(0)).(float64)
+	if typeResp == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("eip_id", utils.PathSearch("eip_id", listResp[0], nil)),
+		d.Set("public_ip", utils.PathSearch("public_ip", listResp[0], nil)),
+		d.Set("public_ipv6", utils.PathSearch("public_ipv6", listResp[0], nil)),
+		d.Set("device_name", utils.PathSearch("device_name", listResp[0], nil)),
+		d.Set("type", typeResp),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceEipAlarmWhitelistUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceEipAlarmWhitelistDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `Currently, this resource does not support the delete function. Deleting this resource will not clear
+    the corresponding request record, but will only remove the resource information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func resourceEipAlarmWhitelistImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
+	[]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, errors.New("invalid format specified for import ID, must be <id>/<public_ip>")
+	}
+
+	d.SetId(parts[0])
+
+	mErr := multierror.Append(nil,
+		d.Set("fw_instance_id", parts[0]),
+		d.Set("public_ip", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_eip_alarm_whitelist` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_eip_alarm_whitelist` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccEipAlarmWhitelist_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccEipAlarmWhitelist_basic -timeout 360m -parallel 4
=== RUN   TestAccEipAlarmWhitelist_basic
=== PAUSE TestAccEipAlarmWhitelist_basic
=== CONT  TestAccEipAlarmWhitelist_basic
--- PASS: TestAccEipAlarmWhitelist_basic (19.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       19.840s
```
<img width="880" height="41" alt="image" src="https://github.com/user-attachments/assets/1c91bd55-a902-4c26-9da5-5d5918fa2cfa" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
