### PR TITLE
feat(GA): add dataSource to get the list of GA resources by tags

### DIFF
--- a/docs/data-sources/ga_resources_by_tags.md
+++ b/docs/data-sources/ga_resources_by_tags.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Global Accelerator (GA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ga_resources_by_tags"
+description: |- 
+  Use this data source to get the list of GA resources by tags.
+---
+
+# huaweicloud_ga_resources_by_tags
+
+Use this data source to get the list of GA resources by tags.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_ga_resources_by_tags" "test" {
+  resource_type = "ga-accelerators"
+  
+  tags {
+    key    = "foo"
+    values = ["bar"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_type` - (Required, String) Specifies the resource type.
+  Valid values include **ga-accelerators** and **ga-listeners**.
+
+* `tags` - (Optional, List) Specifies the list of tags used for filtering resources.
+  The [tags](#tags_struct) structure is documented below.
+
+* `matches` - (Optional, List) Specifies the list of matches used for filtering resources.
+  The [matches](#matches_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - (Required, String) Specifies the key of the tag.
+
+* `values` - (Required, List) Specifies the list of the tag values.
+
+<a name="matches_struct"></a>
+The `matches` block supports:
+
+* `key` - (Required, String) Specifies the key for matching a resource instance. The value can be: **resource_name**.
+
+* `value` - (Required, String) Specifies the value for matching a resource instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resources` - The list of target resources that matched filter parameters.
+  The [resources](#resources_struct) structure is documented below.
+
+* `total_count` - The total count of the resources.
+
+<a name="resources_struct"></a>
+The `resources` block supports:
+
+* `resource_id` - The ID of the resource.
+
+* `resource_name` - The name of the resource.
+
+* `tags` - The list of tags associated with the resource.
+  The [tags](#tags_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `value` - The value of the tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1350,6 +1350,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ga_listeners":          ga.DataSourceListeners(),
 			"huaweicloud_ga_pops":               ga.DataSourceGaPops(),
 			"huaweicloud_ga_quotas":             ga.DataSourceGaQuotas(),
+			"huaweicloud_ga_resources_by_tags":  ga.DataSourceGaResourcesByTags(),
 			"huaweicloud_ga_tags":               ga.DataSourceGaTags(),
 
 			"huaweicloud_gaussdb_nosql_flavors":                geminidb.DataSourceGaussDBNoSQLFlavors(),

--- a/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_resources_by_tags_test.go
+++ b/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_resources_by_tags_test.go
@@ -1,0 +1,83 @@
+package ga
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGaResourcesByTags_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_ga_resources_by_tags.test"
+	rName := acceptance.RandomAccResourceNameWithDash()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceGaResourceByTags_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.tags.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "total_count"),
+
+					resource.TestCheckOutput("tags_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceGaResourceByTags_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_ga_resources_by_tags" "test" {
+  depends_on = [huaweicloud_ga_accelerator.test]
+
+  resource_type = "ga-accelerators"
+}
+
+data "huaweicloud_ga_resources_by_tags" "filter_by_tags" {
+  depends_on = [huaweicloud_ga_accelerator.test]
+
+  resource_type = "ga-accelerators"
+
+  tags {
+    key    = "foo"
+    values = ["bar1"]
+  }
+}
+
+output "tags_filter_is_useful" {
+  value = length(data.huaweicloud_ga_resources_by_tags.filter_by_tags.resources) > 0
+}
+`, testAccGaResourceByTags_base(name))
+}
+
+func testAccGaResourceByTags_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ga_accelerator" "test" {
+  name        = "%[1]s"
+  description = "terraform test"
+
+  ip_sets {
+    area = "CM"
+  }
+
+  tags = {
+    foo = "bar1"
+    key = "value1"
+  }
+}
+`, name)
+}

--- a/huaweicloud/services/ga/data_source_huaweicloud_ga_resources_by_tags.go
+++ b/huaweicloud/services/ga/data_source_huaweicloud_ga_resources_by_tags.go
@@ -1,0 +1,249 @@
+package ga
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GA POST /v1/{resource_type}/resource-instances/filter
+func DataSourceGaResourcesByTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGaResourceByTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"resource_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the resource type.`,
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Specifies the list of tags.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `Specifies the key of the tag.`,
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `Specifies the list of the tag values.`,
+						},
+					},
+				},
+			},
+			"matches": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Specifies the list of matches.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `Specifies the key for matching a resource instance.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `Specifies the value for matching a resource instance.`,
+						},
+					},
+				},
+			},
+			"resources": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of target resources that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the resource.`,
+						},
+						"resource_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the resource.`,
+						},
+						"tags": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of tags associated with the resource.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The key of the tag.`,
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The value of the tag.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"total_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The total count of the resources.`,
+			},
+		},
+	}
+}
+
+func dataSourceGaResourceByTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "ga"
+		httpUrl    = "v1/{resource_type}/resource-instances/filter"
+		result     = make([]interface{}, 0)
+		limit      = 1000
+		offset     = 0
+		totalCount = float64(0)
+		mErr       *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GA client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{resource_type}", d.Get("resource_type").(string))
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildGaResourceByTagsBodyParams(d)),
+	}
+
+	for {
+		currentListPath := listPath + fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
+		listResp, err := client.Request("POST", currentListPath, &reqOpt)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		listRespBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalCount = utils.PathSearch("total_count", listRespBody, float64(0)).(float64)
+		resources := utils.PathSearch("resources", listRespBody, make([]interface{}, 0)).([]interface{})
+		if len(resources) == 0 {
+			break
+		}
+
+		result = append(result, resources...)
+
+		offset += len(resources)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("resources", flattenGaResourceByTagsRespBody(result)),
+		d.Set("total_count", totalCount),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGaResourceByTagsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"tags":    buildGaResourceByTagsTagsBodyParams(d),
+		"matches": buildGaResourceByTagsMatchesBodyParams(d),
+	}
+
+	return bodyParams
+}
+
+func buildGaResourceByTagsTagsBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	tags, ok := d.GetOk("tags")
+	if !ok {
+		return nil
+	}
+
+	bodyParams := make([]map[string]interface{}, len(tags.([]interface{})))
+
+	for i, tag := range tags.([]interface{}) {
+		bodyParams[i] = map[string]interface{}{
+			"key":    utils.PathSearch("key", tag, nil),
+			"values": utils.PathSearch("values", tag, nil),
+		}
+	}
+
+	return bodyParams
+}
+
+func buildGaResourceByTagsMatchesBodyParams(d *schema.ResourceData) []map[string]interface{} {
+	matches, ok := d.GetOk("matches")
+	if !ok {
+		return nil
+	}
+
+	bodyParams := make([]map[string]interface{}, len(matches.([]interface{})))
+
+	for i, match := range matches.([]interface{}) {
+		bodyParams[i] = map[string]interface{}{
+			"key":    utils.PathSearch("key", match, nil),
+			"values": utils.PathSearch("values", match, nil),
+		}
+	}
+
+	return bodyParams
+}
+
+func flattenGaResourceByTagsRespBody(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	resources := make([]interface{}, len(resp))
+	for i, v := range resp {
+		tags := utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})
+		tagsList := make([]interface{}, 0, len(tags))
+		for _, tag := range tags {
+			tagsList = append(tagsList, map[string]interface{}{
+				"key":   utils.PathSearch("key", tag, nil),
+				"value": utils.PathSearch("value", tag, nil),
+			})
+		}
+		resources[i] = map[string]interface{}{
+			"resource_id":   utils.PathSearch("resource_id", v, nil),
+			"resource_name": utils.PathSearch("resource_name", v, nil),
+			"tags":          tagsList,
+		}
+	}
+	return resources
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `ga_resource_by_tags` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `ga_resource_by_tags` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccDataSourceGaResourceByTags_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga-v -run TestAccDataSourceGaResourceByTags_basic-timeout 360m -parallel 4
=== RUN   TestAccDataSourceGaResourceByTags_basic
=== PAUSE TestAccDataSourceGaResourceByTags_basic
=== CONT  TestAccDataSourceGaResourceByTags_basic
--- PASS: TestAccDataSourceGaResourceByTags_basic (69.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga       21.311s
```
<img width="870" height="21" alt="image" src="https://github.com/user-attachments/assets/3f251023-827b-45aa-8b64-5e717240a41c" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
