### PR TITLE
fix(cceautopilot): update resource cce_autopilot_release name

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2896,7 +2896,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cce_autopilot_cluster":         cceautopilot.ResourceAutopilotCluster(),
 			"huaweicloud_cce_autopilot_addon":           cceautopilot.ResourceAutopilotAddon(),
 			"huaweicloud_cce_autopilot_chart":           cceautopilot.ResourceAutopilotChart(),
-			"huaweicloud_cce_autopiot_release":          cceautopilot.ResourceAutopilotRelease(),
+			"huaweicloud_cce_autopilot_release":         cceautopilot.ResourceAutopilotRelease(),
 			"huaweicloud_cce_autopilot_cluster_upgrade": cceautopilot.ResourceAutopilotClusterUpgrade(),
 
 			"huaweicloud_cce_access_policy":                         cce.ResourceAccessPolicy(),
@@ -4331,6 +4331,8 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_projectman_project": codearts.ResourceProject(),
 			"huaweicloud_codehub_repository": codearts.ResourceRepository(),
+
+			"huaweicloud_cce_autopiot_release": cceautopilot.ResourceAutopilotRelease(),
 
 			"huaweicloud_compute_instance_v2":             ecs.ResourceComputeInstance(),
 			"huaweicloud_compute_interface_attach_v2":     ecs.ResourceComputeInterfaceAttach(),

--- a/huaweicloud/services/acceptance/cceautopilot/resource_huaweicloud_cce_autopilot_cluster_test.go
+++ b/huaweicloud/services/acceptance/cceautopilot/resource_huaweicloud_cce_autopilot_cluster_test.go
@@ -129,6 +129,12 @@ resource "huaweicloud_cce_autopilot_cluster" "test" {
     "foo" = "bar"
     "key" = "value"
   }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 `, common.TestVpc(rName), rName)
 }
@@ -161,6 +167,12 @@ resource "huaweicloud_cce_autopilot_cluster" "test" {
   tags = {
     "foo"        = "bar_update"
     "key_update" = "value_update"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
   }
 }
 `, common.TestVpc(rName), rName)

--- a/huaweicloud/services/acceptance/cceautopilot/resource_huaweicloud_cce_autopilot_release_test.go
+++ b/huaweicloud/services/acceptance/cceautopilot/resource_huaweicloud_cce_autopilot_release_test.go
@@ -47,7 +47,7 @@ func getAutopilotReleaseFunc(cfg *config.Config, state *terraform.ResourceState)
 func TestAccAutopilotRelease_basic(t *testing.T) {
 	var (
 		release      interface{}
-		resourceName = "huaweicloud_cce_autopiot_release.test"
+		resourceName = "huaweicloud_cce_autopilot_release.test"
 		name         = acceptance.RandomAccResourceNameWithDash()
 
 		rc = acceptance.InitResourceCheck(
@@ -117,7 +117,7 @@ func testAccAutopilotRelease_basic(name string) string {
 
 %[2]s
 
-resource "huaweicloud_cce_autopiot_release" "test" {
+resource "huaweicloud_cce_autopilot_release" "test" {
   cluster_id = huaweicloud_cce_autopilot_cluster.test.id
   chart_id   = huaweicloud_cce_autopilot_chart.test.id
   name       = "%[3]s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
update resource cce_autopilot_release name
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
update resource cce_autopilot_release name
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cceautopilot" TESTARGS="-run TestAccAutopilotRelease_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cceautopilot -v -run TestAccAutopilotRelease_basic -timeout 360m -parallel 4
=== RUN   TestAccAutopilotRelease_basic
=== PAUSE TestAccAutopilotRelease_basic
=== CONT  TestAccAutopilotRelease_basic
--- PASS: TestAccAutopilotRelease_basic (484.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cceautopilot      485.121s
```
<img width="1737" height="983" alt="image" src="https://github.com/user-attachments/assets/79e464a4-30c9-4d88-a82b-88ae85e9fe5c" />


* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
