### PR TITLE
feat(GA): add dataSource to get the list of GA BYOIP pools

### DIFF
--- a/docs/data-sources/ga_byoip_pools.md
+++ b/docs/data-sources/ga_byoip_pools.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Global Accelerator (GA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ga_byoip_pools"
+description: |-
+  Use this data source to get the list of GA BYOIP pools within HuaweiCloud.
+---
+
+# huaweicloud_ga_byoip_pools
+
+Use this data source to get the list of GA BYOIP pools within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_ga_byoip_pools" "test" {}
+```
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The data source ID.
+
+* `byoip_pools` - The list of BYOIP pools.
+
+  The [byoip_pools](#byoip_pools_struct) structure is documented below.
+
+<a name="byoip_pools_struct"></a>
+The `byoip_pools` block supports:
+
+* `id` - The ID of the BYOIP pool.
+
+* `cidr` - The CIDR block of the BYOIP pool.
+
+* `ip_type` - The IP address version. The value can be **IPV4** or **IPV6**.
+
+* `created_at` - The creation time of the BYOIP pool.
+
+* `updated_at` - The latest update time of the BYOIP pool.
+
+* `area` - The acceleration area. The value can be one of the following:
+  + **OUTOFCM**: Outside the Chinese mainland.
+  + **CM**: Chinese mainland.
+
+* `domain_id` - The domain ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1344,6 +1344,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ga_access_logs":        ga.DataSourceGaAccessLogs(),
 			"huaweicloud_ga_address_groups":     ga.DataSourceAddressGroups(),
 			"huaweicloud_ga_availability_zones": ga.DataSourceAvailabilityZones(),
+			"huaweicloud_ga_byoip_pools":        ga.DataSourceGaByoipPools(),
 			"huaweicloud_ga_endpoint_groups":    ga.DataSourceEndpointGroups(),
 			"huaweicloud_ga_endpoints":          ga.DataSourceEndpoints(),
 			"huaweicloud_ga_health_checks":      ga.DataSourceHealthChecks(),

--- a/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_byoip_pools_test.go
+++ b/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_byoip_pools_test.go
@@ -1,0 +1,36 @@
+package ga
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGaByoipPools_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_ga_byoip_pools.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceGaByoipPools_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "byoip_pools.#"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceGaByoipPools_basic = `
+data "huaweicloud_ga_byoip_pools" "test" {}
+`

--- a/huaweicloud/services/ga/data_source_huaweicloud_ga_byoip_pools.go
+++ b/huaweicloud/services/ga/data_source_huaweicloud_ga_byoip_pools.go
@@ -1,0 +1,158 @@
+package ga
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GA GET /v1/byoip-pools
+func DataSourceGaByoipPools() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGaByoipPoolsRead,
+
+		Schema: map[string]*schema.Schema{
+			"byoip_pools": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of BYOIP pools.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the BYOIP pool.`,
+						},
+						"cidr": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The CIDR block of the BYOIP pool.`,
+						},
+						"ip_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The IP address version.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the BYOIP pool.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The update time of the BYOIP pool.`,
+						},
+						"area": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The acceleration area.`,
+						},
+						"domain_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The domain ID.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listByoipPools(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/byoip-pools"
+		result  = make([]interface{}, 0)
+		limit   = 500
+		marker  = ""
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = fmt.Sprintf("%s?limit=%d", listPath, limit)
+	reqOpt := &golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s&marker=%s", listPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", listPathWithMarker, reqOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		byoipPools := utils.PathSearch("byoip_pools", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, byoipPools...)
+		if len(byoipPools) < limit {
+			break
+		}
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func dataSourceGaByoipPoolsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("ga", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating GA client: %s", err)
+	}
+
+	byoipPools, err := listByoipPools(client)
+	if err != nil {
+		return diag.Errorf("error listing GA BYOIP pools: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return diag.FromErr(d.Set("byoip_pools", flattenByoipPools(byoipPools)))
+}
+
+func flattenByoipPools(byoipPools []interface{}) []interface{} {
+	if len(byoipPools) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(byoipPools))
+	for _, pool := range byoipPools {
+		result = append(result, map[string]interface{}{
+			"id":         utils.PathSearch("id", pool, nil),
+			"cidr":       utils.PathSearch("cidr", pool, nil),
+			"ip_type":    utils.PathSearch("ip_type", pool, nil),
+			"created_at": utils.PathSearch("created_at", pool, nil),
+			"updated_at": utils.PathSearch("updated_at", pool, nil),
+			"area":       utils.PathSearch("area", pool, nil),
+			"domain_id":  utils.PathSearch("domain_id", pool, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `ga_byoip_pools` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `ga_byoip_pools` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccDataSourceGaByoipPools_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga-v -run TestAccDataSourceGaByoipPools_basic-timeout 360m -parallel 4
=== RUN   TestAccDataSourceGaByoipPools_basic
=== PAUSE TestAccDataSourceGaByoipPools_basic
=== CONT  TestAccDataSourceGaByoipPools_basic
--- PASS: TestAccDataSourceGaByoipPools_basic (12.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga       21.311s
```
<img width="539" height="20" alt="image" src="https://github.com/user-attachments/assets/c7a5b154-d94f-4cba-a1d0-b36cd04e12b7" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
