### PR TITLE
feat(organizations): add new resource to manage dry-run policy

### DIFF
--- a/docs/resources/organizations_dry_run_policy.md
+++ b/docs/resources/organizations_dry_run_policy.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Organizations"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_organizations_dry_run_policy"
+description: |-
+  Manages an Organizations dry-run policy resource within HuaweiCloud.
+---
+
+# huaweicloud_organizations_dry_run_policy
+
+Manages an Organizations dry-run policy resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "policy_name" {}
+
+resource "huaweicloud_organizations_dry_run_policy" "test" {
+  name    = var.policy_name
+  type    = "service_control_policy"
+  content = jsonencode({
+    Version = "5.0",
+
+    Statement = [
+      {
+        Effect = "Deny",
+        Action = []
+      }
+    ]
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) Specifies the name of the dry-run policy.  
+  The name can contain `1` to `64` characters, only Chinese characters, letters, digits, underscore (_), hyphens (-)
+  and spaces are allowed and the first and last characters cannot be spaces.
+
+* `content` - (Required, String) Specifies the content of the dry-run policy, in JSON format.
+
+* `type` - (Required, String, NonUpdatable) Specifies the type of the dry-run policy.  
+  The valid values are as follows:
+  + **service_control_policy**: Service control policy.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs associated with the dry-run policy.
+
+* `description` - (Optional, String) Specifies the description of the dry-run policy.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `urn` - The uniform resource name of the dry-run policy.
+
+* `is_builtin` - Whether the dry-run policy is a built-in policy.
+
+## Import
+
+The dry-run policy can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_organizations_dry_run_policy.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4466,6 +4466,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_organizations_account_invite_accepter": organizations.ResourceAccountInviteAccepter(),
 			"huaweicloud_organizations_account_invite_decliner": organizations.ResourceAccountInviteDecliner(),
 			"huaweicloud_organizations_delegated_administrator": organizations.ResourceDelegatedAdministrator(),
+			"huaweicloud_organizations_dry_run_policy":          organizations.ResourceDryRunPolicy(),
 			"huaweicloud_organizations_organization":            organizations.ResourceOrganization(),
 			"huaweicloud_organizations_organizational_unit":     organizations.ResourceOrganizationalUnit(),
 			"huaweicloud_organizations_policy":                  organizations.ResourcePolicy(),

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_dry_run_policy_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_dry_run_policy_test.go
@@ -1,0 +1,130 @@
+package organizations
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations"
+)
+
+func getDryRunPolicyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("organizations", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Organizations client: %s", err)
+	}
+
+	return organizations.GetDryRunPolicyById(client, state.Primary.ID)
+}
+
+func TestAccDryRunPolicy_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_organizations_dry_run_policy.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getDryRunPolicyResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDryRunPolicy_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrWith(rName, "content",
+						checkPolicyContent("{\"Version\":\"5.0\",\"Statement\":[{\"Effect\":\"Deny\","+
+							"\"Action\":[]}]}")),
+					resource.TestCheckResourceAttr(rName, "type", "service_control_policy"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(rName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttrSet(rName, "urn"),
+					resource.TestCheckResourceAttr(rName, "is_builtin", "false"),
+				),
+			},
+			{
+				Config: testAccDryRunPolicy_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttrWith(rName, "content",
+						checkPolicyContent("{\"Version\":\"5.0\",\"Statement\":[{\"Sid\":\"Statement1\","+
+							"\"Effect\":\"Deny\",\"Action\":[\"vpc:subnets:delete\"]}]}")),
+					resource.TestCheckResourceAttr(rName, "type", "service_control_policy"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(rName, "tags.foo1", "bar_update"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDryRunPolicy_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_organizations_dry_run_policy" "test" {
+  name        = "%s"
+  type        = "service_control_policy"
+  description = "Created by terraform script"
+  content     = jsonencode({
+    Version = "5.0",
+
+    Statement = [
+      {
+        Effect = "Deny",
+        Action = []
+      }
+    ]
+  })
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+`, name)
+}
+
+func testAccDryRunPolicy_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_organizations_dry_run_policy" "test" {
+  name    = "%s"
+  type    = "service_control_policy"
+  content = jsonencode({
+    Version = "5.0",
+
+    Statement = [
+      {
+        Sid = "Statement1",
+        Effect = "Deny",
+        Action = ["vpc:subnets:delete"]
+      }
+    ]
+  })
+
+  tags = {
+    foo1 = "bar_update"
+  }
+}
+`, name)
+}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_dry_run_policy.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_dry_run_policy.go
@@ -1,0 +1,271 @@
+package organizations
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var dryRunPolicyNonUpdatableParams = []string{"type"}
+
+// @API Organizations POST /v1/organizations/dry-run-policies
+// @API Organizations GET /v1/organizations/dry-run-policies/{policy_id}
+// @API Organizations GET /v1/organizations/{resource_type}/{resource_id}/tags
+// @API Organizations PATCH /v1/organizations/dry-run-policies/{policy_id}
+// @API Organizations POST /v1/organizations/{resource_type}/{resource_id}/tags/create
+// @API Organizations POST /v1/organizations/{resource_type}/{resource_id}/tags/delete
+// @API Organizations DELETE /v1/organizations/dry-run-policies/{policy_id}
+func ResourceDryRunPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDryRunPolicyCreate,
+		ReadContext:   resourceDryRunPolicyRead,
+		UpdateContext: resourceDryRunPolicyUpdate,
+		DeleteContext: resourceDryRunPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: customdiff.All(
+			config.FlexibleForceNew(dryRunPolicyNonUpdatableParams),
+			config.MergeDefaultTags(),
+		),
+
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the dry-run policy.`,
+			},
+			"content": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  `The content of the dry-run policy, in JSON format.`,
+				ValidateFunc: validation.StringIsJSON,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the dry-run policy.`,
+			},
+			// Optional parameters.
+			"tags": common.TagsSchema(`The key/value pairs associated with the dry-run policy.`),
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the dry-run policy.`,
+			},
+			// Attributes.
+			"urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The uniform resource name of the dry-run policy.`,
+			},
+			"is_builtin": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the dry-run policy is a built-in policy.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceDryRunPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/organizations/dry-run-policies"
+	)
+	client, err := cfg.NewServiceClient("organizations", region)
+	if err != nil {
+		return diag.Errorf("error creating Organizations client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildCreateDryRunPolicyBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating dry-run policy: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error flattening dry-run policy create response: %s", err)
+	}
+
+	policyId := utils.PathSearch("policy.policy_summary.id", respBody, "").(string)
+	if policyId == "" {
+		return diag.Errorf("unable to find the dry-run policy ID from the API response")
+	}
+
+	d.SetId(policyId)
+
+	return resourceDryRunPolicyRead(ctx, d, meta)
+}
+
+func buildCreateDryRunPolicyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":    d.Get("name"),
+		"content": d.Get("content"),
+		"type":    d.Get("type"),
+		// The API requires description to be specified, so when not specified, pass through as empty string.
+		"description": d.Get("description"),
+		"tags":        utils.ValueIgnoreEmpty(utils.ExpandResourceTags(d.Get("tags").(map[string]interface{}))),
+	}
+}
+
+// GetDryRunPolicyById queries a dry-run policy by ID.
+func GetDryRunPolicyById(client *golangsdk.ServiceClient, policyId string) (interface{}, error) {
+	httpUrl := "v1/organizations/dry-run-policies/{policy_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{policy_id}", policyId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceDryRunPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		policyId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("organizations", region)
+	if err != nil {
+		return diag.Errorf("error creating Organizations client: %s", err)
+	}
+
+	respBody, err := GetDryRunPolicyById(client, policyId)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+			fmt.Sprintf("error retrieving dry-run policy (%s)", policyId),
+		)
+	}
+
+	mErr := multierror.Append(
+		d.Set("name", utils.PathSearch("policy.policy_summary.name", respBody, nil)),
+		d.Set("content", utils.PathSearch("policy.content", respBody, nil)),
+		d.Set("type", utils.PathSearch("policy.policy_summary.type", respBody, nil)),
+		d.Set("description", utils.PathSearch("policy.policy_summary.description", respBody, nil)),
+		d.Set("urn", utils.PathSearch("policy.policy_summary.urn", respBody, nil)),
+		d.Set("is_builtin", utils.PathSearch("policy.policy_summary.is_builtin", respBody, nil)),
+	)
+
+	tags, err := getTags(client, policiesType, policyId)
+	if err != nil {
+		log.Printf("[WARN] error getting tags of dry-run policy (%s): %s", policyId, err)
+	} else {
+		mErr = multierror.Append(mErr, d.Set("tags", tags))
+	}
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateDryRunPolicyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"content":     d.Get("content"),
+		"description": d.Get("description"),
+	}
+}
+
+func updateDryRunPolicy(client *golangsdk.ServiceClient, policyId string, d *schema.ResourceData) error {
+	httpUrl := "v1/organizations/dry-run-policies/{policy_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{policy_id}", policyId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildUpdateDryRunPolicyBodyParams(d)),
+	}
+
+	_, err := client.Request("PATCH", updatePath, &updateOpt)
+	return err
+}
+
+func resourceDryRunPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		policyId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Organizations client: %s", err)
+	}
+
+	if d.HasChanges("name", "content", "description") {
+		if err = updateDryRunPolicy(client, policyId, d); err != nil {
+			return diag.Errorf("error updating dry-run policy (%s): %s", policyId, err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		err = updateTags(d, client, policiesType, policyId, "tags")
+		if err != nil {
+			return diag.Errorf("error updating tags of dry-run policy (%s): %s", policyId, err)
+		}
+	}
+
+	return resourceDryRunPolicyRead(ctx, d, meta)
+}
+
+func resourceDryRunPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		httpUrl  = "v1/organizations/dry-run-policies/{policy_id}"
+		policyId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Organizations client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{policy_id}", policyId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+			fmt.Sprintf("error deleting dry-run policy (%s)", policyId),
+		)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource (`huaweicloud_organizations_dry_run_policy`) to manage dry-run policy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new resource.
2. add corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o organizations -f TestAccDryRunPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDryRunPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccDryRunPolicy_basic
=== PAUSE TestAccDryRunPolicy_basic
=== CONT  TestAccDryRunPolicy_basic
--- PASS: TestAccDryRunPolicy_basic (30.85s)
PASS
coverage: 10.1% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     30.945s coverage: 10.1% of statements in ./huaweicloud/services/organizations
```
```
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations/resource_huaweicloud_organizations_dry_run_policy.go (82.9%)
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
