### PR TITLE
feat(WAF): add dataSource to get the tags of a WAF resource

### DIFF
--- a/docs/data-sources/waf_instance_tags.md
+++ b/docs/data-sources/waf_instance_tags.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_waf_instance_tags"
+description: |-
+  Use this data source to get the tags of a WAF resource within HuaweiCloud.
+---
+
+# huaweicloud_waf_instance_tags
+
+Use this data source to get the tags of a WAF resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "resource_type" {} 
+variable "resource_id" {}
+
+data "huaweicloud_waf_instance_tags" "test" { 
+  resource_type = var.resource_type 
+  resource_id   = var.resource_id 
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `resource_type` - (Required, String) Specifies the resource type.
+  The value can be **waf-instance** and **waf** .
+
+* `resource_id` - (Required, String) Specifies the resource ID.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of tags associated with the resource.
+  The [tags](#tags_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `value` - The value of the tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2409,6 +2409,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_events":                               waf.DataSourceWafAttackEvents(),
 			"huaweicloud_waf_geolocation_detail":                   waf.DataSourceGeolocationDetail(),
 			"huaweicloud_waf_instance_groups":                      waf.DataSourceWafInstanceGroups(),
+			"huaweicloud_waf_instance_tags":                        waf.DataSourceWafInstanceTags(),
 			"huaweicloud_waf_overviews_abnormal":                   waf.DataSourceWafOverviewsAbnormal(),
 			"huaweicloud_waf_overviews_attack_action_types":        waf.DataSourceOverviewsAttackActionTypes(),
 			"huaweicloud_waf_overviews_attack_ip":                  waf.DataSourceOverviewsAttackIp(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_instance_tags_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_instance_tags_test.go
@@ -1,0 +1,69 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataSourceWafInstanceTags_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_waf_instance_tags.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		rName          = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceWafInstanceTags_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tags.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tags.0.key"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tags.0.value"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceWafInstanceTags_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_waf_dedicated_instance" "test" {
+  name               = "%[2]s"
+  available_zone     = data.huaweicloud_availability_zones.test.names[1]
+  specification_code = "waf.instance.enterprise"
+  ecs_flavor         = data.huaweicloud_compute_flavors.test.ids[0]
+  vpc_id             = huaweicloud_vpc.test.id
+  subnet_id          = huaweicloud_vpc_subnet.test.id
+  res_tenant         = true
+  anti_affinity      = true
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+
+  security_group = [
+    huaweicloud_networking_secgroup.test.id
+  ]
+}
+
+data "huaweicloud_waf_instance_tags" "test" {
+  depends_on    = [huaweicloud_waf_dedicated_instance.test]
+  resource_type = "waf-instance"
+  resource_id   = huaweicloud_waf_dedicated_instance.test.id
+}
+`, common.TestBaseComputeResources(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_instance_tags.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_instance_tags.go
@@ -1,0 +1,138 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WAF GET /v1/{project_id}/waf/{resource_type}/{resourceid}/tags
+func DataSourceWafInstanceTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWafResourceTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"resource_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the resource type.`,
+			},
+			"resource_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the resource ID.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the enterprise project ID.`,
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of tags associated with the resource.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The key of the tag.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The value of the tag.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceWafResourceTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "waf"
+		httpUrl = "v1/{project_id}/waf/{resource_type}/{resourceid}/tags"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{resource_type}", d.Get("resource_type").(string))
+	listPath = strings.ReplaceAll(listPath, "{resourceid}", d.Get("resource_id").(string))
+
+	listPath += buildWafResourceTagsQueryParams(cfg, d)
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", listPath, &reqOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := d.Set("tags", flattenWafResourceTags(utils.PathSearch("tags", respBody, make([]interface{}, 0)).([]interface{})))
+
+	return diag.FromErr(mErr)
+}
+
+func buildWafResourceTagsQueryParams(cfg *config.Config, d *schema.ResourceData) string {
+	epsId := cfg.GetEnterpriseProjectID(d)
+	if epsId == "" {
+		return ""
+	}
+	return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+}
+
+func flattenWafResourceTags(tags []interface{}) []interface{} {
+	if len(tags) == 0 {
+		return make([]interface{}, 0)
+	}
+
+	result := make([]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.PathSearch("value", tag, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `waf_instance_tags` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `waf_instance_tags` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDataSourceWafInstanceTags_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw-v -run TestAccDataSourceWafInstanceTags_basic-timeout 360m -parallel 4
=== RUN   TestAccDataSourceWafInstanceTags_basic
=== PAUSE TestAccDataSourceWafInstanceTags_basic
=== CONT  TestAccDataSourceWafInstanceTags_basic
--- PASS: TestAccDataSourceWafInstanceTags_basic (489.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       21.311s
```
<img width="572" height="24" alt="image" src="https://github.com/user-attachments/assets/00f3e263-f0c3-489a-87fc-319b3ea3afa3" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
