### PR TITLE
feat(dws): add new data source for cluster exception rules query

### DIFF
--- a/docs/data-sources/dws_cluster_exception_rules.md
+++ b/docs/data-sources/dws_cluster_exception_rules.md
@@ -1,0 +1,61 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_exception_rules"
+description: |-
+  Use this data source to query the exception rules under the DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_exception_rules
+
+Use this data source to query the exception rules under the DWS cluster within HuaweiCloud.
+
+## Example Usage
+
+### Query all exception rules in the cluster
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_dws_cluster_exception_rules" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+### Query the exception rules with a fuzzy word in the cluster
+
+```hcl
+variable "cluster_id" {}
+variable "fuzzy_name_word" {}
+
+data "huaweicloud_dws_cluster_exception_rules" "test" {
+  cluster_id = var.cluster_id
+  rule_name  = var.fuzzy_name_word
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the exception rules are located.  
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of the cluster to which the exception rules belong.
+
+* `rule_name` - (Optional, String) Specifies the name of the exception rule to be queried, which is the fuzzy query.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `rules` - The list of the exception rules that matched filter parameters.  
+  The [rules](#dws_cluster_exception_rules) structure is documented below.
+
+<a name="dws_cluster_exception_rules"></a>
+The `rules` block supports:
+
+* `name` - The name of the exception rule.
+
+* `configurations` - The configuration items of the exception rule.  
+  The type of configuration attribute is `map`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2453,6 +2453,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_cluster_database_objects":        dws.DataSourceClusterDatabaseObjects(),
 			"huaweicloud_dws_cluster_database_schemas":        dws.DataSourceClusterDatabaseSchemas(),
 			"huaweicloud_dws_cluster_database_users":          dws.DataSourceClusterDatabaseUsers(),
+			"huaweicloud_dws_cluster_exception_rules":         dws.DataSourceClusterExceptionRules(),
 			"huaweicloud_dws_cluster_logs":                    dws.DataSourceDwsClusterLogs(),
 			"huaweicloud_dws_cluster_nodes":                   dws.DataSourceDwsClusterNodes(),
 			"huaweicloud_dws_cluster_parameters":              dws.DataSourceClusterParameters(),

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_exception_rules_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_exception_rules_test.go
@@ -1,0 +1,168 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataClusterExceptionRules_basic(t *testing.T) {
+	var (
+		all   = "data.huaweicloud_dws_cluster_exception_rules.all"
+		dcAll = acceptance.InitDataSourceCheck(all)
+
+		byNameForExactMatch   = "data.huaweicloud_dws_cluster_exception_rules.filter_by_rule_name_for_exact_match"
+		dcByNameForExactMatch = acceptance.InitDataSourceCheck(byNameForExactMatch)
+
+		byNameForFuzzyMatch   = "data.huaweicloud_dws_cluster_exception_rules.filter_by_rule_name_for_fuzzy_match"
+		dcByNameForFuzzyMatch = acceptance.InitDataSourceCheck(byNameForFuzzyMatch)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataClusterExceptionRules_nonExistentCluster(),
+				ExpectError: regexp.MustCompile(`error querying cluster exception rules`),
+			},
+			{
+				Config: testAccDataClusterExceptionRules_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// Without filter parameters.
+					dcAll.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "rules.#", regexp.MustCompile(`^[0-9]+$`)),
+					// Filter by rule name.
+					dcByNameForExactMatch.CheckResourceExists(),
+					resource.TestCheckOutput("is_rule_name_for_exact_match_filter_useful", "true"),
+					dcByNameForFuzzyMatch.CheckResourceExists(),
+					resource.TestCheckOutput("is_rule_name_for_fuzzy_match_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataClusterExceptionRules_nonExistentCluster() string {
+	randomUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_exception_rules" "nonexistent_cluster" {
+  cluster_id = "%[1]s"
+}
+`, randomUUID)
+}
+
+func testAccDataClusterExceptionRules_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+variable "exception_rule_configurations" {
+  description = "The configurations of the exception rule."
+  type        = list(object({
+    key   = string
+    value = string
+  }))
+
+  default = [
+    {
+      key   = "action"
+      value = "penalty"
+    },
+    {
+      key   = "blocktime"
+      value = "300"
+    },
+    {
+      key   = "elapsedtime"
+      value = "400"
+    },
+    {
+        key   = "allcputime"
+        value = "500"
+    },
+  ]
+}
+
+resource "huaweicloud_dws_cluster_exception_rule" "test" {
+  count = 2
+
+  cluster_id = "%[1]s"
+  name       = format("%[2]s_%%d", count.index)
+
+  dynamic "configurations" {
+    for_each = var.exception_rule_configurations
+
+    content {
+      key   = configurations.value.key
+      value = configurations.value.value
+    }
+  }
+}
+
+# Query all exception rules in the cluster
+data "huaweicloud_dws_cluster_exception_rules" "all" {
+  depends_on = [
+    huaweicloud_dws_cluster_exception_rule.test,
+  ]
+
+  cluster_id = "%[1]s"
+}
+
+# Filter the exception rules with a specified name in the cluster (fuzzy matching)
+locals {
+  rule_name_for_exact_match = huaweicloud_dws_cluster_exception_rule.test[0].name
+  rule_name_for_fuzzy_match = "%[2]s"
+}
+
+data "huaweicloud_dws_cluster_exception_rules" "filter_by_rule_name_for_exact_match" {
+  # The behavior of parameter 'rule_name' of the exception rule resource is 'Required', means this parameter does not
+  # have 'Know After Apply' behavior.
+  depends_on = [
+    huaweicloud_dws_cluster_exception_rule.test,
+  ]
+
+  cluster_id = "%[1]s"
+  rule_name  = local.rule_name_for_exact_match
+}
+
+locals {
+  rule_name_for_exact_match_filter_result = [
+    for v in data.huaweicloud_dws_cluster_exception_rules.filter_by_rule_name_for_exact_match.rules[*].name : v == local.rule_name_for_exact_match
+  ]
+}
+
+output "is_rule_name_for_exact_match_filter_useful" {
+  value = length(local.rule_name_for_exact_match_filter_result) > 0 && alltrue(local.rule_name_for_exact_match_filter_result)
+}
+
+data "huaweicloud_dws_cluster_exception_rules" "filter_by_rule_name_for_fuzzy_match" {
+  # The input value of parameter 'rule_name' is a fixed value, so we need to depend on the exception rule resource.
+  depends_on = [
+    huaweicloud_dws_cluster_exception_rule.test,
+  ]
+
+  cluster_id = "%[1]s"
+  rule_name  = local.rule_name_for_fuzzy_match
+}
+
+locals {
+  rule_name_for_fuzzy_match_filter_result = [
+    for v in data.huaweicloud_dws_cluster_exception_rules.filter_by_rule_name_for_fuzzy_match.rules[*].name :
+      length(regexall(format(".*%%s.*", local.rule_name_for_fuzzy_match), v)) > 0
+  ]
+}
+
+output "is_rule_name_for_fuzzy_match_filter_useful" {
+  value = length(local.rule_name_for_fuzzy_match_filter_result) > 0 && alltrue(local.rule_name_for_fuzzy_match_filter_result)
+}
+`, acceptance.HW_DWS_CLUSTER_ID, name)
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_exception_rules.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_exception_rules.go
@@ -1,0 +1,122 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v1/{project_id}/clusters/{cluster_id}/workload/rules
+func DataSourceClusterExceptionRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterExceptionRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the exception rules are located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster to which the exception rules belong.`,
+			},
+
+			// Optional parameters.
+			"rule_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the exception rule to be queried, which is the fuzzy query.`,
+			},
+
+			// Attributes.
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the exception rule.`,
+						},
+						"configurations": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The configuration items of the exception rule.`,
+						},
+					},
+				},
+				Description: `The list of the exception rules that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildClusterExceptionRulesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("rule_name"); ok {
+		res = fmt.Sprintf("%s&rule_name=%v", res, v)
+	}
+
+	return res
+}
+
+func flattenClusterExceptionRules(exceptionRules []interface{}) []map[string]interface{} {
+	if len(exceptionRules) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(exceptionRules))
+	for _, rule := range exceptionRules {
+		result = append(result, map[string]interface{}{
+			"name":           utils.PathSearch("name", rule, nil),
+			"configurations": utils.PathSearch("except_rules", rule, make(map[string]interface{})),
+		})
+	}
+
+	return result
+}
+
+func dataSourceClusterExceptionRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	items, err := listClusterExceptionRules(client, clusterId, buildClusterExceptionRulesQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error querying cluster exception rules: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("rules", flattenClusterExceptionRules(items)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source for cluster exception rules query.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of data source's acceptance test:
<img width="1101" height="692" alt="image" src="https://github.com/user-attachments/assets/15477fd0-56d3-4968-a9ac-6718b4986888" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source for cluster exception rules query
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dws -f TestAccDataClusterExceptionRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccDataClusterExceptionRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataClusterExceptionRules_basic
=== PAUSE TestAccDataClusterExceptionRules_basic
=== CONT  TestAccDataClusterExceptionRules_basic
--- PASS: TestAccDataClusterExceptionRules_basic (27.28s)
PASS
coverage: 5.4% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       27.383s coverage: 5.4% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
