### PR TITLE
feat(dws): add new resource support for eip associate

### DIFF
--- a/docs/resources/dws_cluster_eip_associate.md
+++ b/docs/resources/dws_cluster_eip_associate.md
@@ -1,0 +1,53 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_eip_associate"
+description: |-
+  Manages an EIP association for the DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_eip_associate
+
+Use this resource to associate an EIP to a DWS cluster within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "dws_cluster_id" {}
+variable "eip_id" {}
+
+resource "huaweicloud_dws_cluster_eip_associate" "test" {
+  cluster_id = var.dws_cluster_id
+  eip_id     = var.eip_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the cluster (to which the EIP associated) is
+  located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster to which the EIP is associated.
+
+* `eip_id` - (Required, String, NonUpdatable) Specifies the ID of the EIP to be associated with the DWS cluster.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also `cluster_id`.
+
+* `public_ip` - The public IP address of the cluster endpoint.
+
+* `public_port` - The public port of the cluster endpoint.
+
+## Import
+
+The resource can be imported using the `id` (also `cluster_id`), e.g.
+
+```bash
+$ terraform import huaweicloud_dws_cluster_eip_associate.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3321,6 +3321,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_dws_alarm_subscription":              dws.ResourceDwsAlarmSubs(),
 			"huaweicloud_dws_cluster":                         dws.ResourceDwsCluster(),
+			"huaweicloud_dws_cluster_eip_associate":           dws.ResourceClusterEipAssociate(),
 			"huaweicloud_dws_cluster_exception_rule":          dws.ResourceClusterExceptionRule(),
 			"huaweicloud_dws_cluster_public_domain_associate": dws.ResourceClusterPublicDomainAssociate(),
 			"huaweicloud_dws_cluster_restart":                 dws.ResourceClusterRestart(),

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_eip_associate_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_eip_associate_test.go
@@ -1,0 +1,106 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
+)
+
+func getClusterAssociatedEipFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DWS Client: %s", err)
+	}
+
+	return dws.GetClusterAssociatedEipById(client, state.Primary.ID)
+}
+
+// Provide enterprise project ID to test if the DWS cluster is in the enterprise project.
+func TestAccClusterEipAssociate_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName = "huaweicloud_dws_cluster_eip_associate.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getClusterAssociatedEipFunc)
+
+		name          = acceptance.RandomAccResourceName()
+		randomUUID, _ = uuid.GenerateUUID()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testClusterEipAssociate_nonExistentEip(randomUUID),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`error associating EIP \(%s\) to the DWS cluster \(%s\)`,
+					randomUUID, acceptance.HW_DWS_CLUSTER_ID)),
+			},
+			{
+				Config: testClusterEipAssociate_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttrPair(rName, "eip_id", "huaweicloud_vpc_eip.test", "id"),
+					resource.TestMatchResourceAttr(rName, "public_ip", regexp.MustCompile(`^\d{1,3}(\.\d{1,3}){3}$`)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testClusterEipAssociate_nonExistentEip(randomUUID string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_cluster_eip_associate" "test" {
+  cluster_id = "%[1]s"
+  eip_id     = "%[2]s"
+}
+`, acceptance.HW_DWS_CLUSTER_ID, randomUUID)
+}
+
+func testClusterEipAssociate_basic(name string) string {
+	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  default = "%[1]s"
+}
+
+resource "huaweicloud_vpc_eip" "test" {
+  name                  = "%[2]s"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    name        = "%[2]s"
+    size        = 1
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_dws_cluster_eip_associate" "test" {
+  cluster_id = "%[3]s"
+  eip_id     = huaweicloud_vpc_eip.test.id
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name, acceptance.HW_DWS_CLUSTER_ID)
+}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_eip_associate.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_eip_associate.go
@@ -1,0 +1,223 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var clusterEipAssociateNonUpdatableParams = []string{
+	"cluster_id",
+	"eip_id",
+}
+
+// @API DWS POST /v2/{project_id}/clusters/{cluster_id}/eips/{eip_id}
+// @API DWS GET /v1/{project_id}/clusters/{cluster_id}/endpoints
+// @API DWS DELETE /v2/{project_id}/clusters/{cluster_id}/eips/{eip_id}
+func ResourceClusterEipAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceClusterEipAssociateCreate,
+		ReadContext:   resourceClusterEipAssociateRead,
+		UpdateContext: resourceClusterEipAssociateUpdate,
+		DeleteContext: resourceClusterEipAssociateDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(clusterEipAssociateNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the cluster (to which the EIP associated) is located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster to which the EIP is associated.`,
+			},
+			"eip_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the EIP to be associated with the DWS cluster.`,
+			},
+
+			// Attributes.
+			"public_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The public IP address of the cluster endpoint.`,
+			},
+			"public_port": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The public port of the cluster endpoint.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
+			},
+		},
+	}
+}
+
+func associateClusterEip(client *golangsdk.ServiceClient, clusterId, eipId string) error {
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/eips/{eip_id}"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{cluster_id}", clusterId)
+	createPath = strings.ReplaceAll(createPath, "{eip_id}", eipId)
+
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("POST", createPath, &createOpts)
+	return err
+}
+
+func disassociateClusterEip(client *golangsdk.ServiceClient, clusterId, eipId string) error {
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/eips/{eip_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", clusterId)
+	deletePath = strings.ReplaceAll(deletePath, "{eip_id}", eipId)
+
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpts)
+	return err
+}
+
+// GetClusterAssociatedEipById is a method used to query the public endpoint and verify whether the EIP is associated.
+func GetClusterAssociatedEipById(client *golangsdk.ServiceClient, clusterId string) (interface{}, error) {
+	endpoints, err := getClusterEndpointsById(client, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	publicEndpoints := utils.PathSearch("public_endpoints", endpoints, nil)
+	currentEipId := utils.PathSearch("ip_id", publicEndpoints, "").(string)
+	if currentEipId != "" {
+		return publicEndpoints, nil
+	}
+
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/v1/{project_id}/clusters/{cluster_id}/endpoints",
+			RequestId: "NONE",
+			Body:      []byte(fmt.Sprintf("the EIP is not associated with the DWS cluster (%s)", clusterId)),
+		},
+	}
+}
+
+func resourceClusterEipAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+		eipId     = d.Get("eip_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	err = associateClusterEip(client, clusterId, eipId)
+	if err != nil {
+		return diag.Errorf("error associating EIP (%s) to the DWS cluster (%s): %s", eipId, clusterId, err)
+	}
+
+	d.SetId(clusterId)
+	return resourceClusterEipAssociateRead(ctx, d, meta)
+}
+
+func resourceClusterEipAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	respBody, err := GetClusterAssociatedEipById(client, clusterId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err,
+			fmt.Sprintf("error retrieving EIP association for the DWS cluster (%s)", clusterId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("cluster_id", clusterId),
+		d.Set("eip_id", utils.PathSearch("ip_id", respBody, nil)),
+		d.Set("public_ip", utils.PathSearch("ip", respBody, nil)),
+		d.Set("public_port", utils.PathSearch("port", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceClusterEipAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because all parameters are NonUpdatable.
+	return resourceClusterEipAssociateRead(ctx, d, meta)
+}
+
+func resourceClusterEipAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Id()
+		eipId     = d.Get("eip_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	err = disassociateClusterEip(client, clusterId, eipId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err,
+			fmt.Sprintf("error disassociating EIP (%s) from the DWS cluster (%s)", eipId, clusterId))
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource for EIP associate to the DWS cluster.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of resource's acceptance test:
<img width="1045" height="364" alt="image" src="https://github.com/user-attachments/assets/5422d3a7-b727-40f6-8479-5bcd79da5a88" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new resource for EIP associate to the DWS cluster.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dws -f TestAccClusterEipAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccClusterEipAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccClusterEipAssociate_basic
=== PAUSE TestAccClusterEipAssociate_basic
=== CONT  TestAccClusterEipAssociate_basic
--- PASS: TestAccClusterEipAssociate_basic (47.40s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       47.533s coverage: 4.0% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1639" height="1269" alt="image" src="https://github.com/user-attachments/assets/19d8281c-dc64-42af-85af-9d2e0f52666f" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1155" height="770" alt="image" src="https://github.com/user-attachments/assets/89aefeb4-7377-47b2-afba-40c3a6d9d6b3" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
