### PR TITLE
feat(CFW): add dataSource to get the resolve ip list

### DIFF
--- a/docs/data-sources/cfw_domain_resolve_ip_list.md
+++ b/docs/data-sources/cfw_domain_resolve_ip_list.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_domain_resolve_ip_list"
+description: |-
+  Use this data source to get the domain resolve IP list within HuaweiCloud.
+---
+
+# huaweicloud_cfw_domain_resolve_ip_list
+
+Use this data source to get the domain resolve IP list within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {} 
+variable "domain_address_id" {}
+
+data "huaweicloud_cfw_domain_resolve_ip_list" "test" { 
+  fw_instance_id    = var.fw_instance_id 
+  domain_address_id = var.domain_address_id 
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `fw_instance_id` - (Required, String) Specifies the firewall instance ID.
+
+* `domain_address_id` - (Required, String) Specifies the domain address ID.
+
+* `address_type` - (Optional, Int) Specifies the address type.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data` - The data of domain resolve IP list.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `excess_ip` - The list of excess IPs.
+
+* `parsed_success_ip` - The list of parsed success IPs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -838,6 +838,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_capture_task_results":          cfw.DataSourceCfwCaptureTaskResults(),
 			"huaweicloud_cfw_domain_name_groups":            cfw.DataSourceCfwDomainNameGroups(),
 			"huaweicloud_cfw_domain_name_parse_ip_list":     cfw.DataSourceCfwDomainNameParseIpList(),
+			"huaweicloud_cfw_domain_resolve_ip_list":        cfw.DataSourceCfwDomainResolveIpList(),
 			"huaweicloud_cfw_eip_auto_protect_status":       cfw.DataSourceEipAutoProtectStatus(),
 			"huaweicloud_cfw_eip_count":                     cfw.DataSourceEipCount(),
 			"huaweicloud_cfw_protection_rules":              cfw.DataSourceCfwProtectionRules(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_domain_resolve_ip_list_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_domain_resolve_ip_list_test.go
@@ -1,0 +1,54 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCfwDomainResolveIpList_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cfw_domain_resolve_ip_list.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCfwDomainResolveIpList_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.excess_ip.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.parsed_success_ip.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCfwDomainResolveIpList_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_firewalls" "test" {
+  fw_instance_id = "%s"
+}
+
+data "huaweicloud_cfw_domain_name_groups" "test" {
+  depends_on     = [data.huaweicloud_cfw_firewalls.test]
+  fw_instance_id = data.huaweicloud_cfw_firewalls.test.records[0].fw_instance_id
+  object_id      = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+}
+
+data "huaweicloud_cfw_domain_resolve_ip_list" "test" {
+  depends_on        = [data.huaweicloud_cfw_firewalls.test, data.huaweicloud_cfw_domain_name_groups.test]
+  fw_instance_id    = data.huaweicloud_cfw_firewalls.test.records[0].fw_instance_id
+  domain_address_id = data.huaweicloud_cfw_domain_name_groups.test.records[0].domain_names[0].domain_address_id
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_domain_resolve_ip_list.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_domain_resolve_ip_list.go
@@ -1,0 +1,144 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v2/{project_id}/rule/domain/resolve-ip-list/{domain_address_id}
+func DataSourceCfwDomainResolveIpList() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCfwDomainResolveIpListRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"fw_instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the firewall instance ID.`,
+			},
+			"domain_address_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the domain address ID.`,
+			},
+			"address_type": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the address type.`,
+			},
+			"data": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The data of domain resolve IP list.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"excess_ip": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of excess IPs.`,
+						},
+						"parsed_success_ip": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of parsed success IPs.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildDomainResolveIpListQueryParams(d *schema.ResourceData) string {
+	fwInstanceId := d.Get("fw_instance_id").(string)
+	queryParams := fmt.Sprintf("?fw_instance_id=%s", fwInstanceId)
+
+	addressType, ok := d.GetOk("address_type")
+	if ok {
+		queryParams += fmt.Sprintf("&address_type=%v", addressType)
+	}
+
+	return queryParams
+}
+
+func dataSourceCfwDomainResolveIpListRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		region          = cfg.GetRegion(d)
+		domainAddressId = d.Get("domain_address_id").(string)
+		httpUrl         = "v2/{project_id}/rule/domain/resolve-ip-list/{domain_address_id}"
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{domain_address_id}", domainAddressId)
+	requestPath += buildDomainResolveIpListQueryParams(d)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW domain resolve IP list: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenDomainResolveIpListData(utils.PathSearch("data", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDomainResolveIpListData(data interface{}) []interface{} {
+	if data == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"excess_ip":         utils.PathSearch("excess_ip", data, make([]interface{}, 0)),
+			"parsed_success_ip": utils.PathSearch("parsed_success_ip", data, make([]interface{}, 0)),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_domain_resolve_ip_list` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_domain_resolve_ip_list` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceCfwDomainResolveIpList_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw-v -run TestAccDataSourceCfwDomainResolveIpList_basic-timeout 360m -parallel 4
=== RUN   TestAccDataSourceCfwDomainResolveIpList_basic
=== PAUSE TestAccDataSourceCfwDomainResolveIpList_basic
=== CONT  TestAccDataSourceCfwDomainResolveIpList_basic
--- PASS: TestAccDataSourceCfwDomainResolveIpList_basic (15.06s)
PASS

ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       21.311s
```
<img width="616" height="31" alt="image" src="https://github.com/user-attachments/assets/80fb7f07-2c07-4c81-aa96-2479a3b2885a" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
