### PR TITLE
feat(dws): add new resource support for elb associate

### DIFF
--- a/docs/resources/dws_cluster_elb_associate.md
+++ b/docs/resources/dws_cluster_elb_associate.md
@@ -1,0 +1,53 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_elb_associate"
+description: |-
+  Use this resource to associate an ELB to a DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_elb_associate
+
+Use this resource to associate an ELB to a DWS cluster within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "dws_cluster_id" {}
+variable "elb_id" {}
+
+resource "huaweicloud_dws_cluster_elb_associate" "test" {
+  cluster_id = var.dws_cluster_id
+  elb_id     = var.elb_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the cluster (to which the ELB associated) is
+  located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster to which the ELB is associated.
+
+* `elb_id` - (Required, String, NonUpdatable) Specifies the ID of the ELB to be associated with the DWS cluster.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also `cluster_id`.
+
+* `public_ip` - The public IP address of the ELB loadbalancer.
+
+* `private_ip` - The private IP address of the ELB loadbalancer.
+
+## Import
+
+The resource can be imported using the `id` (also `cluster_id`), e.g.
+
+```bash
+$ terraform import huaweicloud_dws_cluster_elb_associate.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3328,6 +3328,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_alarm_subscription":              dws.ResourceDwsAlarmSubs(),
 			"huaweicloud_dws_cluster":                         dws.ResourceDwsCluster(),
 			"huaweicloud_dws_cluster_eip_associate":           dws.ResourceClusterEipAssociate(),
+			"huaweicloud_dws_cluster_elb_associate":           dws.ResourceClusterElbAssociate(),
 			"huaweicloud_dws_cluster_exception_rule":          dws.ResourceClusterExceptionRule(),
 			"huaweicloud_dws_cluster_public_domain_associate": dws.ResourceClusterPublicDomainAssociate(),
 			"huaweicloud_dws_cluster_restart":                 dws.ResourceClusterRestart(),

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_elb_associate_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_elb_associate_test.go
@@ -1,0 +1,146 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
+)
+
+func getClusterAssociatedElbFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DWS Client: %s", err)
+	}
+
+	return dws.GetClusterAssociatedElbById(client, state.Primary.ID, state.Primary.Attributes["elb_id"])
+}
+
+// Before testing, please ensure that the subnet of the DWS cluster is not the first IP address segment of 255.255.240.0.
+func TestAccClusterElbAssociate_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName = "huaweicloud_dws_cluster_elb_associate.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getClusterAssociatedElbFunc)
+
+		name          = acceptance.RandomAccResourceName()
+		randomUUID, _ = uuid.GenerateUUID()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testClusterElbAssociate_nonExistentElb(randomUUID),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`error associating ELB \(%s\) to the DWS cluster \(%s\)`,
+					randomUUID, acceptance.HW_DWS_CLUSTER_ID)),
+			},
+			{
+				Config: testClusterElbAssociate_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttrPair(rName, "elb_id", "huaweicloud_elb_loadbalancer.test", "id"),
+					resource.TestMatchResourceAttr(rName, "private_ip", regexp.MustCompile(`^\d{1,3}(\.\d{1,3}){3}$`)),
+					resource.TestMatchResourceAttr(rName, "public_ip", regexp.MustCompile(`^\d{1,3}(\.\d{1,3}){3}$`)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testClusterElbAssociate_nonExistentElb(randomUUID string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_cluster_elb_associate" "test" {
+  cluster_id = "%[1]s"
+  elb_id     = "%[2]s"
+}
+`, acceptance.HW_DWS_CLUSTER_ID, randomUUID)
+}
+
+func testClusterElbAssociate_basic(name string) string {
+	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
+data "huaweicloud_dws_clusters" "test" {}
+
+locals {
+  vpc_id = try([for v in data.huaweicloud_dws_clusters.test.clusters: v.vpc_id if v.id == "%[2]s"][0], "")
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpcs" "test" {
+  id = local.vpc_id
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[3]s"
+  vpc_id     = data.huaweicloud_vpcs.test.vpcs[0].id
+  cidr       = cidrsubnet(data.huaweicloud_vpcs.test.vpcs[0].cidr, 4, 0)
+  gateway_ip = cidrhost(cidrsubnet(data.huaweicloud_vpcs.test.vpcs[0].cidr, 4, 0), 1)
+}
+
+resource "huaweicloud_vpc_eip" "test" {
+  name                  = "%[3]s"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    name        = "%[3]s"
+    size        = 1
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_elb_loadbalancer" "test" {
+  name                  = "%[3]s"
+  vpc_id                = data.huaweicloud_vpcs.test.vpcs[0].id
+  ipv4_subnet_id        = huaweicloud_vpc_subnet.test.ipv4_subnet_id
+  # Bind EIP to ensure that the 'public_ip' field can be correctly obtained and verified after association.
+  ipv4_eip_id           = huaweicloud_vpc_eip.test.id
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
+  availability_zone = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      l4_flavor_id, l7_flavor_id
+    ]
+  }
+}
+
+resource "huaweicloud_dws_cluster_elb_associate" "test" {
+  cluster_id = "%[2]s"
+  elb_id     = huaweicloud_elb_loadbalancer.test.id
+}
+`, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST, acceptance.HW_DWS_CLUSTER_ID, name)
+}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_elb_associate.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_elb_associate.go
@@ -1,0 +1,358 @@
+package dws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	clusterElbAssociateNonUpdatableParams = []string{
+		"cluster_id",
+		"elb_id",
+	}
+	clusterElbAssociateExpected400ErrCodes = []string{
+		"DWS.0102",
+	}
+	clusterElbAssociateRetryableErrCodes = []string{
+		"DWS.7023",
+	}
+)
+
+// @API DWS POST /v2/{project_id}/clusters/{cluster_id}/elbs/{elb_id}
+// @API DWS GET /v1.0/{project_id}/clusters/{cluster_id}
+// @API DWS DELETE /v2/{project_id}/clusters/{cluster_id}/elbs/{elb_id}
+func ResourceClusterElbAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceClusterElbAssociateCreate,
+		ReadContext:   resourceClusterElbAssociateRead,
+		UpdateContext: resourceClusterElbAssociateUpdate,
+		DeleteContext: resourceClusterElbAssociateDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(clusterElbAssociateNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the cluster (to which the ELB associated) is located.`,
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster to which the ELB is associated.`,
+			},
+			"elb_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the ELB to be associated with the DWS cluster.`,
+			},
+
+			// Attributes.
+			"public_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The public IP address of the ELB loadbalancer.`,
+			},
+			"private_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The private IP address of the ELB loadbalancer.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
+			},
+		},
+	}
+}
+
+func refreshClusterElbAssociateFunc(client *golangsdk.ServiceClient, clusterId, elbId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		elb, err := GetClusterAssociatedElbById(client, clusterId, elbId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return "Resource Not Found", "PENDING", nil
+			}
+			return nil, "ERROR", err
+		}
+
+		return elb, "COMPLETED", nil
+	}
+}
+
+// An error will be returned if the cluster status is not allowed to operation.
+// Even if the cluster status is NORMAL, this error may be returned in a very short time after the last operation is completed.
+// The error information is as follows:
+//
+//	{
+//	 "externalMessage":"Cluster status is not allowed to operation.",
+//	 "errCode":"DWS.7023",
+//	 "error_code":"DWS.7023",
+//	 "error_msg":"Cluster status is not allowed to operation."
+//	}
+func isClusterElbAssociateRetryableError(err error) bool {
+	if apiErr, ok := err.(golangsdk.ErrDefault403); ok {
+		var respBody interface{}
+		if jsonErr := json.Unmarshal(apiErr.Body, &respBody); jsonErr != nil {
+			log.Printf("[WARN] failed to unmarshal the response body: %s", jsonErr)
+			return false
+		}
+		// AS.2033: "You are not allowed to perform the operation when the AS group is in current [xxx] status."
+		// AS.0003: "AS group lock conflict."
+		errCode := utils.PathSearch("error_code", respBody, "").(string)
+		if utils.StrSliceContains(clusterElbAssociateRetryableErrCodes, errCode) {
+			return true
+		}
+	}
+	return false
+}
+
+func associateClusterElb(ctx context.Context, client *golangsdk.ServiceClient, clusterId, elbId string, timeout time.Duration) error {
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/elbs/{elb_id}"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{cluster_id}", clusterId)
+	createPath = strings.ReplaceAll(createPath, "{elb_id}", elbId)
+
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	err := resource.RetryContext(ctx, timeout, func() *resource.RetryError {
+		_, reqErr := client.Request("POST", createPath, &createOpts)
+		if reqErr != nil {
+			if isClusterElbAssociateRetryableError(reqErr) {
+				// Wait for the update to take effect
+				// lintignore:R018
+				time.Sleep(10 * time.Second)
+				return resource.RetryableError(reqErr)
+			}
+			return resource.NonRetryableError(reqErr)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshClusterElbAssociateFunc(client, clusterId, elbId),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+// GetClusterAssociatedElbById queries the cluster ELB information and verifies whether the specified ELB is associated
+// with the DWS cluster if the elbId is provided, otherwise returns the current associated ELB.
+func GetClusterAssociatedElbById(client *golangsdk.ServiceClient, clusterId string, elbId ...string) (interface{}, error) {
+	clusterDetail, err := GetClusterInfoByClusterId(client, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	elb := utils.PathSearch("cluster.elb", clusterDetail, nil)
+	log.Printf("[Lance] the current associated ELB: %#v", elb)
+	if elb == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1.0/{project_id}/clusters/{cluster_id}",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the ELB is not associated with the DWS cluster (%s)", clusterId)),
+			},
+		}
+	}
+
+	currentElbId := utils.PathSearch("id", elb, "").(string)
+	if len(elbId) > 0 && elbId[0] != "" && (currentElbId == "" || currentElbId != elbId[0]) {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1.0/{project_id}/clusters/{cluster_id}",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the ELB (%s) is not associated with the DWS cluster (%s)", elbId, clusterId)),
+			},
+		}
+	}
+
+	return elb, nil
+}
+
+func resourceClusterElbAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+		elbId     = d.Get("elb_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	err = associateClusterElb(ctx, client, clusterId, elbId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error associating ELB (%s) to the DWS cluster (%s): %s", elbId, clusterId, err)
+	}
+
+	d.SetId(clusterId)
+	return resourceClusterElbAssociateRead(ctx, d, meta)
+}
+
+func resourceClusterElbAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Id()
+		elbId     = d.Get("elb_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	elb, err := GetClusterAssociatedElbById(client, clusterId, elbId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err,
+			fmt.Sprintf("error retrieving ELB association for the DWS cluster (%s)", clusterId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("cluster_id", clusterId),
+		d.Set("elb_id", utils.PathSearch("id", elb, nil)),
+		d.Set("public_ip", utils.PathSearch("public_ip", elb, nil)),
+		d.Set("private_ip", utils.PathSearch("private_ip", elb, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceClusterElbAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because all parameters are NonUpdatable.
+	return resourceClusterElbAssociateRead(ctx, d, meta)
+}
+
+func refreshClusterElbDisassociateFunc(client *golangsdk.ServiceClient, clusterId, elbId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		elb, err := GetClusterAssociatedElbById(client, clusterId, elbId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return "Resource Not Found", "COMPLETED", nil
+			}
+			return nil, "ERROR", err
+		}
+		return elb, "PENDING", nil
+	}
+}
+
+func disassociateClusterElb(ctx context.Context, client *golangsdk.ServiceClient, clusterId, elbId string, timeout time.Duration) error {
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/elbs/{elb_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", clusterId)
+	deletePath = strings.ReplaceAll(deletePath, "{elb_id}", elbId)
+
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	err := resource.RetryContext(ctx, timeout, func() *resource.RetryError {
+		_, reqErr := client.Request("DELETE", deletePath, &deleteOpts)
+		if reqErr != nil {
+			if isClusterElbAssociateRetryableError(reqErr) {
+				// Wait for the update to take effect
+				// lintignore:R018
+				time.Sleep(10 * time.Second)
+				return resource.RetryableError(reqErr)
+			}
+			return resource.NonRetryableError(reqErr)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshClusterElbDisassociateFunc(client, clusterId, elbId),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceClusterElbAssociateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Id()
+		elbId     = d.Get("elb_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	err = disassociateClusterElb(ctx, client, clusterId, elbId, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", clusterElbAssociateExpected400ErrCodes...),
+			fmt.Sprintf("error disassociating ELB (%s) from the DWS cluster (%s)", elbId, clusterId))
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource for cluster associate ELB loadbalancer.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of resource's acceptance test:
<img width="1018" height="431" alt="image" src="https://github.com/user-attachments/assets/cb4c6b9d-996a-4d19-ae36-180dbceffce5" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new resource for cluster associate ELB loadbalancer.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dws -f TestAccClusterElbAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccClusterElbAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccClusterElbAssociate_basic
=== PAUSE TestAccClusterElbAssociate_basic
=== CONT  TestAccClusterElbAssociate_basic
--- PASS: TestAccClusterElbAssociate_basic (122.00s)
PASS
coverage: 5.5% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       122.212s        coverage: 5.5% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1639" height="1119" alt="image" src="https://github.com/user-attachments/assets/42e7b299-9c7c-4b3e-b11c-6d38952a1e87" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1811" height="1035" alt="image" src="https://github.com/user-attachments/assets/cb065c35-7742-4999-8473-7920789a8204" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
