### PR TITLE
feat(organizations): add new resource attach entity to dry-run policy resource

### DIFF
--- a/docs/resources/organizations_dry_run_policy_entity_attach.md
+++ b/docs/resources/organizations_dry_run_policy_entity_attach.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Organizations"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_organizations_dry_run_policy_entity_attach"
+description: |-
+  Manages an Organizations dry-run policy attach to entity resource within HuaweiCloud.
+---
+
+# huaweicloud_organizations_dry_run_policy_entity_attach
+
+Manages an Organizations dry-run policy attach to entity resource within HuaweiCloud.
+
+-> Before using this resource, you must ensure that the policy dry-run feature is enabled.
+
+## Example Usage
+
+```hcl
+variable "policy_id" {}
+variable "entity_id" {}
+
+resource "huaweicloud_organizations_dry_run_policy_entity_attach" "test" {
+  policy_id = var.policy_id
+  entity_id = var.entity_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, String, NonUpdatable) Specifies the ID of the dry-run policy.
+
+* `entity_id` - (Required, String, NonUpdatable) Specifies the ID of the entity (root, OU, or account).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is formatted as `<policy_id>/<entity_id>`.
+
+* `entity_name` - The name of the entity.
+
+* `entity_type` - The type of the entity.
+
+## Import
+
+The dry-run policy entity attach can be imported using the `policy_id` and `entity_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_organizations_dry_run_policy_entity_attach.test <policy_id>/<entity_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4513,6 +4513,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_organizations_account_invite_decliner":      organizations.ResourceAccountInviteDecliner(),
 			"huaweicloud_organizations_delegated_administrator":      organizations.ResourceDelegatedAdministrator(),
 			"huaweicloud_organizations_dry_run_policy":               organizations.ResourceDryRunPolicy(),
+			"huaweicloud_organizations_dry_run_policy_entity_attach": organizations.ResourceDryRunPolicyEntityAttach(),
 			"huaweicloud_organizations_organization":                 organizations.ResourceOrganization(),
 			"huaweicloud_organizations_organizational_unit":          organizations.ResourceOrganizationalUnit(),
 			"huaweicloud_organizations_policy":                       organizations.ResourcePolicy(),

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_dry_run_policy_entity_attach_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_dry_run_policy_entity_attach_test.go
@@ -1,0 +1,135 @@
+package organizations
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations"
+)
+
+func getDryRunPolicyEntityAttachResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("organizations", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Organizations client: %s", err)
+	}
+
+	return organizations.GetAttachedEntityForDryRunPolicy(client, state.Primary.Attributes["policy_id"],
+		state.Primary.Attributes["entity_id"])
+}
+
+func TestAccDryRunPolicyEntityAttach_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		obj   interface{}
+		rName = "huaweicloud_organizations_dry_run_policy_entity_attach.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getDryRunPolicyEntityAttachResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDryRunPolicyEntityAttach_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "policy_id",
+						"huaweicloud_organizations_dry_run_policy.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "entity_id",
+						"data.huaweicloud_organizations_organization.test", "root_id"),
+					resource.TestCheckResourceAttrSet(rName, "entity_name"),
+					resource.TestCheckResourceAttrSet(rName, "entity_type"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDryRunPolicyEntityAttach_base(name string) string {
+	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
+data "huaweicloud_organizations_organization" "test" {}
+
+resource "huaweicloud_organizations_dry_run_policy" "test" {
+  name    = "%[2]s"
+  type    = "service_control_policy"
+  content = jsonencode({
+    Version = "5.0",
+
+    Statement = [
+      {
+        Effect = "Deny",
+        Action = []
+      }
+    ]
+  })
+}
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket                = "%[2]s"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+  force_destroy         = true
+}
+
+resource "huaweicloud_identity_trust_agency" "test" {
+  name         = "%[2]s"
+  policy_names = ["OBSFullAccessPolicy"]
+  trust_policy = jsonencode(
+    {
+      Version = "5.0"
+      Statement = [
+        {
+          Action    = ["sts:agencies:assume"]
+          Effect    = "Allow"
+          Principal = {
+            Service = ["service.Organizations"]
+          }
+        },
+      ]
+    }
+  )
+}
+
+resource "huaweicloud_organizations_policy_dry_run_configuration" "test" {
+  root_id     = data.huaweicloud_organizations_organization.test.root_id
+  policy_type = "service_control_policy"
+  status      = "enabled"
+  bucket_name = huaweicloud_obs_bucket.test.bucket
+  region_id   = huaweicloud_obs_bucket.test.region
+  agency_name = huaweicloud_identity_trust_agency.test.name
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+}
+
+func testAccDryRunPolicyEntityAttach_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_organizations_dry_run_policy_entity_attach" "test" {
+  policy_id = huaweicloud_organizations_dry_run_policy.test.id
+  entity_id = data.huaweicloud_organizations_organization.test.root_id
+
+  depends_on = [huaweicloud_organizations_policy_dry_run_configuration.test]
+}
+`, testAccDryRunPolicyEntityAttach_base(name))
+}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_dry_run_policy_entity_attach.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_dry_run_policy_entity_attach.go
@@ -1,0 +1,243 @@
+package organizations
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var dryRunPolicyEntityAttachNonUpdatableParams = []string{"policy_id", "entity_id"}
+
+// @API Organizations POST /v1/organizations/dry-run-policies/{policy_id}/attach
+// @API Organizations GET /v1/organizations/dry-run-policies/{policy_id}/attached-entities
+// @API Organizations POST /v1/organizations/dry-run-policies/{policy_id}/detach
+func ResourceDryRunPolicyEntityAttach() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDryRunPolicyEntityAttachCreate,
+		ReadContext:   resourceDryRunPolicyEntityAttachRead,
+		UpdateContext: resourceDryRunPolicyEntityAttachUpdate,
+		DeleteContext: resourceDryRunPolicyEntityAttachDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDryRunPolicyEntityAttachImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(dryRunPolicyEntityAttachNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			// Required parameters.
+			"policy_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dry-run policy.`,
+			},
+			"entity_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the entity (root, OU, or account).`,
+			},
+			// Attributes.
+			"entity_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the entity.`,
+			},
+			"entity_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the entity.`,
+			},
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func resourceDryRunPolicyEntityAttachCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		httpUrl  = "v1/organizations/dry-run-policies/{policy_id}/attach"
+		policyId = d.Get("policy_id").(string)
+		entityId = d.Get("entity_id").(string)
+	)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Organizations client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{policy_id}", policyId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"entity_id": entityId,
+		},
+	}
+	if _, err = client.Request("POST", createPath, &createOpt); err != nil {
+		return diag.Errorf("error attaching entity (%s) to dry-run policy (%s): %s", entityId, policyId, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", policyId, entityId))
+
+	return resourceDryRunPolicyEntityAttachRead(ctx, d, meta)
+}
+
+func listAttachedEntitiesForDryRunPolicy(client *golangsdk.ServiceClient, policyId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/organizations/dry-run-policies/{policy_id}/attached-entities"
+		marker  = ""
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{policy_id}", policyId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s?marker=%s", listPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", listPathWithMarker, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		attachedEntities := utils.PathSearch("attached_entities", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, attachedEntities...)
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+// GetAttachedEntityForDryRunPolicy is a method used to query the attached entity for a dry-run policy.
+func GetAttachedEntityForDryRunPolicy(client *golangsdk.ServiceClient, policyId string, entityId string) (interface{}, error) {
+	attachedEntities, err := listAttachedEntitiesForDryRunPolicy(client, policyId)
+	if err != nil {
+		return nil, err
+	}
+
+	attachedEntity := utils.PathSearch(fmt.Sprintf("[?id=='%s']|[0]", entityId), attachedEntities, nil)
+	if attachedEntity != nil {
+		return attachedEntity, nil
+	}
+
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Method:    "GET",
+			URL:       "/v1/organizations/dry-run-policies/{policy_id}/attached-entities",
+			RequestId: "NONE",
+			Body:      []byte(fmt.Sprintf("the attached entity (%s) for dry-run policy (%s) does not exist", entityId, policyId)),
+		},
+	}
+}
+
+func resourceDryRunPolicyEntityAttachRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Organizations client: %s", err)
+	}
+
+	policyId := d.Get("policy_id").(string)
+	entityId := d.Get("entity_id").(string)
+	attachedEntity, err := GetAttachedEntityForDryRunPolicy(client, policyId, entityId)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+			fmt.Sprintf("error retrieving attached entity (%s) for dry-run policy (%s)", entityId, policyId),
+		)
+	}
+
+	mErr := multierror.Append(
+		d.Set("policy_id", policyId),
+		d.Set("entity_id", utils.PathSearch("id", attachedEntity, nil)),
+		d.Set("entity_name", utils.PathSearch("name", attachedEntity, nil)),
+		d.Set("entity_type", utils.PathSearch("type", attachedEntity, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDryRunPolicyEntityAttachUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDryRunPolicyEntityAttachDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		httpUrl  = "v1/organizations/dry-run-policies/{policy_id}/detach"
+		policyId = d.Get("policy_id").(string)
+		entityId = d.Get("entity_id").(string)
+	)
+	client, err := cfg.NewServiceClient("organizations", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Organizations client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{policy_id}", policyId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"entity_id": entityId,
+		},
+	}
+	if _, err = client.Request("POST", deletePath, &deleteOpt); err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", organizationNotFoundErrCodes...),
+			fmt.Sprintf("error detaching entity (%s) from dry-run policy (%s)", entityId, policyId),
+		)
+	}
+
+	return nil
+}
+
+func resourceDryRunPolicyEntityAttachImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<policy_id>/<entity_id>', but got '%s'", importedId)
+	}
+
+	mErr := multierror.Append(
+		d.Set("policy_id", parts[0]),
+		d.Set("entity_id", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add a new resource (`huaweicloud_organizations_dry_run_policy_entity_attach`) to associate the policy with the entity.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new resource.
2. add corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o organizations -f TestAccDryRunPolicyEntityAttach_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDryRunPolicyEntityAttach_basic -timeout 360m -parallel 10
=== RUN   TestAccDryRunPolicyEntityAttach_basic
=== PAUSE TestAccDryRunPolicyEntityAttach_basic
=== CONT  TestAccDryRunPolicyEntityAttach_basic
--- PASS: TestAccDryRunPolicyEntityAttach_basic (27.99s)
PASS
coverage: 14.3% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     28.105s coverage: 14.3% of statements in ./huaweicloud/services/organizations
```
```
githum/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations/resource_huaweicloud_organizations_dry_run_policy_entity_attach.go (83.6%)
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
