### PR TITLE
feat(CFW): add dataSource to get the VPC protection information

### DIFF
--- a/docs/data-sources/cfw_vpcs_protection.md
+++ b/docs/data-sources/cfw_vpcs_protection.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_vpcs_protection"
+description: |-
+  Use this data source to get the VPC protection information within HuaweiCloud.
+---
+
+# huaweicloud_cfw_vpcs_protection
+
+Use this data source to get the VPC protection information within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "object_id" {}
+
+data "huaweicloud_cfw_vpcs_protection" "test" { 
+  object_id = var.object_id 
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `object_id` - (Required, String) Specifies the protected object ID.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+
+* `fw_instance_id` - (Optional, String) Specifies the firewall instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data` - The data of VPC protection information.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `other_protect_vpcs` - The list of other protected VPCs.
+
+  The [other_protect_vpcs](#other_protect_vpcs_struct) structure is documented below.
+
+* `other_total` - The total number of other protected VPCs.
+
+* `protect_vpcs` - The list of protected VPCs.
+
+  The [protect_vpcs](#protect_vpcs_struct) structure is documented below.
+
+* `self_protect_vpcs` - The list of self-protected VPCs.
+
+  The [self_protect_vpcs](#self_protect_vpcs_struct) structure is documented below.
+
+* `self_total` - The total number of self-protected VPCs.
+
+* `total` - The total number of protected VPCs.
+
+* `total_assets` - The total number of assets.
+
+<a name="other_protect_vpcs_struct"></a>
+The `other_protect_vpcs` block supports:
+
+* `vpc_id` - The VPC ID.
+
+<a name="protect_vpcs_struct"></a>
+The `protect_vpcs` block supports:
+
+* `vpc_id` - The VPC ID.
+
+<a name="self_protect_vpcs_struct"></a>
+The `self_protect_vpcs` block supports:
+
+* `vpc_id` - The VPC ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -867,6 +867,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_ip_blacklist":                  cfw.DataSourceIpBlacklist(),
 			"huaweicloud_cfw_ip_blacklist_switch":           cfw.DataSourceIpBlacklistSwitch(),
 			"huaweicloud_cfw_report_profiles":               cfw.DataSourceReportProfiles(),
+			"huaweicloud_cfw_vpcs_protection":               cfw.DataSourceCfwVpcsProtection(),
 
 			"huaweicloud_cnad_advanced_instances":           cnad.DataSourceInstances(),
 			"huaweicloud_cnad_advanced_alarm_notifications": cnad.DataSourceAlarmNotifications(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_vpcs_protection_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_vpcs_protection_test.go
@@ -1,0 +1,56 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCfwVpcsProtection_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cfw_vpcs_protection.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCfwVpcsProtection_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.total"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.total_assets"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.self_total"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.other_total"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCfwVpcsProtection_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_firewalls" "test" {
+  fw_instance_id = "%s"
+}
+
+locals {
+  protect_objects = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects
+  object_id       = try([for obj in local.protect_objects : obj.object_id if obj.type == 1][0], "")
+}
+
+
+data "huaweicloud_cfw_vpcs_protection" "test" {
+  depends_on     = [data.huaweicloud_cfw_firewalls.test]
+  object_id      = local.object_id
+  fw_instance_id = data.huaweicloud_cfw_firewalls.test.records[0].fw_instance_id
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_vpcs_protection.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_vpcs_protection.go
@@ -1,0 +1,205 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/vpcs/protection
+func DataSourceCfwVpcsProtection() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCfwVpcsProtectionRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"object_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the protected object ID.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the enterprise project ID.`,
+			},
+			"fw_instance_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the firewall instance ID.`,
+			},
+			"data": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The data of VPC protection information.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"other_protect_vpcs": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of other protected VPCs.`,
+							Elem:        vpcIdSchema(),
+						},
+						"other_total": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The total number of other protected VPCs.`,
+						},
+						"protect_vpcs": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of protected VPCs.`,
+							Elem:        vpcIdSchema(),
+						},
+						"self_protect_vpcs": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of self-protected VPCs.`,
+							Elem:        vpcIdSchema(),
+						},
+						"self_total": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The total number of self-protected VPCs.`,
+						},
+						"total": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The total number of protected VPCs.`,
+						},
+						"total_assets": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The total number of assets.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func vpcIdSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The VPC ID.`,
+			},
+		},
+	}
+}
+
+func buildVpcsProtectionQueryParams(cfg *config.Config, d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("?object_id=%s", d.Get("object_id").(string))
+
+	if v, ok := d.GetOk("fw_instance_id"); ok {
+		queryParams = fmt.Sprintf("%s&fw_instance_id=%s", queryParams, v.(string))
+	}
+
+	if v := cfg.GetEnterpriseProjectID(d); v != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%s", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceCfwVpcsProtectionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cfw"
+		httpUrl = "v1/{project_id}/vpcs/protection"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildVpcsProtectionQueryParams(cfg, d)
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", listPath, &reqOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW VPCs protection: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenVpcsProtectionData(utils.PathSearch("data", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenVpcsProtectionData(dataResp interface{}) []interface{} {
+	if dataResp == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"other_protect_vpcs": flattenVpcIds(
+			utils.PathSearch("other_protect_vpcs", dataResp, make([]interface{}, 0)).([]interface{})),
+		"other_total":  utils.PathSearch("other_total", dataResp, nil),
+		"protect_vpcs": flattenVpcIds(utils.PathSearch("protect_vpcs", dataResp, make([]interface{}, 0)).([]interface{})),
+		"self_protect_vpcs": flattenVpcIds(
+			utils.PathSearch("self_protect_vpcs", dataResp, make([]interface{}, 0)).([]interface{})),
+		"self_total":   utils.PathSearch("self_total", dataResp, nil),
+		"total":        utils.PathSearch("total", dataResp, nil),
+		"total_assets": utils.PathSearch("total_assets", dataResp, nil),
+	}
+
+	return []interface{}{result}
+}
+
+func flattenVpcIds(vpcList []interface{}) []interface{} {
+	if len(vpcList) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(vpcList))
+	for _, v := range vpcList {
+		result = append(result, map[string]interface{}{
+			"vpc_id": utils.PathSearch("vpc_id", v, ""),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_vpcs_protection` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_vpcs_protection` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceCfwVpcsProtection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw-v -run TestAccDataSourceCfwVpcsProtection_basic-timeout 360m -parallel 4
=== RUN   TestAccDataSourceCfwVpcsProtection_basic
=== PAUSE TestAccDataSourceCfwVpcsProtection_basic
=== CONT  TestAccDataSourceCfwVpcsProtection_basic
--- PASS: TestAccDataSourceCfwVpcsProtection_basic (14.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       21.311s
```
<img width="617" height="23" alt="image" src="https://github.com/user-attachments/assets/c08707f3-ebb6-48b1-ae5f-d56b5478e2d2" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
