### PR TITLE
fix(dns/endpoint_assignment): fix resource creation failures in some regions

### DIFF
--- a/docs/resources/dns_endpoint_assignment.md
+++ b/docs/resources/dns_endpoint_assignment.md
@@ -42,8 +42,9 @@ resource "huaweicloud_dns_endpoint_assignment" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
-  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+* `region` - (Optional, String, ForceNew) Specifies the region where the endpoint is located.  
+  If omitted, the provider-level region will be used, but for some regions, it must be specified, e.g. `sa-brazil-1`.
+  Changing this parameter will create a new resource.
 
 * `name` - (Required, String) Specifies the name of the endpoint.  
   The name valid length is limited from `1` to `64` characters. Only Chinese and English characters, digits and
@@ -100,4 +101,10 @@ The DNS endpoint resource can be imported using `id`, e.g.
 
 ```bash
 $ terraform import huaweicloud_dns_endpoint_assignment.test <id>
+```
+
+For `region` required endpoint, the resource can be imported using `<region>` and `<id>`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dns_endpoint_assignment.test <region>/<id>
 ```

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_endpoint_assignment_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_endpoint_assignment_test.go
@@ -14,7 +14,11 @@ import (
 )
 
 func getEndpointAssignmentResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.NewServiceClient("dns", acceptance.HW_REGION_NAME)
+	if state.Primary.Attributes["regional"] == "true" {
+		conf.RegionClient = true
+	}
+
+	client, err := conf.NewServiceClient("dns", state.Primary.Attributes["region"])
 	if err != nil {
 		return nil, fmt.Errorf("error creating DNS client: %s", err)
 	}
@@ -70,6 +74,8 @@ func TestAccEndpointAssignment_basic(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				// Only ignore regional in acceptance test, it will not be changed in actual use.
+				ImportStateVerifyIgnore: []string{"regional"},
 			},
 		},
 	})
@@ -139,4 +145,135 @@ resource "huaweicloud_dns_endpoint_assignment" "test" {
     ip_address = cidrhost(huaweicloud_vpc_subnet.test[1].cidr, 103)
   }
 }`, testEndpointAssignment_base(rName), updateName)
+}
+
+// Check that some regions require the region parameter to be specified, such as 'sa-brazil-1'.
+func TestAccEndpointAssignment_regional(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_dns_endpoint_assignment.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getEndpointAssignmentResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckCustomRegion(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointAssignment_regional_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "direction", "inbound"),
+					resource.TestCheckResourceAttr(rName, "assignments.#", "2"),
+					resource.TestCheckResourceAttrSet(rName, "assignments.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(rName, "assignments.0.ip_address"),
+					resource.TestCheckResourceAttrSet(rName, "assignments.0.ip_address_id"),
+					resource.TestCheckResourceAttrPair(rName, "vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttr(rName, "regional", "true"),
+				),
+			},
+			{
+				Config: testAccEndpointAssignment_regional_step2(name, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "assignments.#", "2"),
+					resource.TestCheckResourceAttr(rName, "regional", "true"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Only ignore regional in acceptance test, it will not be changed in actual use.
+				ImportStateVerifyIgnore: []string{"regional"},
+				ImportStateIdFunc:       testAccEndpointAssignmentImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccEndpointAssignmentImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		region := rs.Primary.Attributes["region"]
+		endpointId := rs.Primary.ID
+		if region == "" || endpointId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<region>/<id>', but got '%s/%s'", region, endpointId)
+		}
+
+		return fmt.Sprintf("%s/%s", region, endpointId), nil
+	}
+}
+
+func testEndpointAssignment_regional_base(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  region = "%[1]s"
+  name   = "%[2]s"
+  cidr   = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  region     = "%[1]s"
+  name       = "%[2]s"
+  vpc_id     = huaweicloud_vpc.test.id
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 0)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 0), 1)
+}`, acceptance.HW_CUSTOM_REGION_NAME, rName)
+}
+
+func testAccEndpointAssignment_regional_step1(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dns_endpoint_assignment" "test" {
+  region    = "%[2]s"
+  name      = "%[3]s"
+  direction = "inbound"
+
+  assignments {
+    subnet_id  = huaweicloud_vpc_subnet.test.id
+    ip_address = cidrhost(huaweicloud_vpc_subnet.test.cidr, 100)
+  }
+  assignments {
+    subnet_id  = huaweicloud_vpc_subnet.test.id
+    ip_address = cidrhost(huaweicloud_vpc_subnet.test.cidr, 101)
+  }
+}`, testEndpointAssignment_regional_base(rName), acceptance.HW_CUSTOM_REGION_NAME, rName)
+}
+
+func testAccEndpointAssignment_regional_step2(rName, updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dns_endpoint_assignment" "test" {
+  region    = "%[2]s"
+  name      = "%[3]s"
+  direction = "inbound"
+
+  assignments {
+    subnet_id  = huaweicloud_vpc_subnet.test.id
+    ip_address = cidrhost(huaweicloud_vpc_subnet.test.cidr, 102)
+  }
+  assignments {
+    subnet_id  = huaweicloud_vpc_subnet.test.id
+    ip_address = cidrhost(huaweicloud_vpc_subnet.test.cidr, 103)
+  }
+}`, testEndpointAssignment_regional_base(rName), acceptance.HW_CUSTOM_REGION_NAME, updateName)
 }

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_endpoint_assignment.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_endpoint_assignment.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -33,7 +34,7 @@ func ResourceEndpointAssignment() *schema.Resource {
 		UpdateContext: resourceEndpointAssignmentUpdate,
 		DeleteContext: resourceEndpointAssignmentDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceEndpointAssignmentImportState,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -44,10 +45,11 @@ func ResourceEndpointAssignment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the endpoint is located.`,
 			},
 			"name": {
 				Type:        schema.TypeString,
@@ -101,6 +103,17 @@ func ResourceEndpointAssignment() *schema.Resource {
 				Computed:    true,
 				Description: `The creation time of the endpoint, in RFC3339 format.`,
 			},
+			// Internal attribute(s).
+			"regional": {
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: utils.SuppressDiffAll,
+				Description: utils.SchemaDesc(`The regional is used to indicate whether the script region is configured.
+If the script region is configured, the region client will be used to create the endpoint.`,
+					utils.SchemaDescInput{Internal: true},
+				),
+			},
 		},
 	}
 }
@@ -131,6 +144,11 @@ func resourceEndpointAssignmentCreate(ctx context.Context, d *schema.ResourceDat
 		region  = conf.GetRegion(d)
 		httpUrl = "v2.1/endpoints"
 	)
+
+	scriptRegion := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "region")
+	if scriptRegion != nil && scriptRegion.(string) != "" {
+		conf.RegionClient = true
+	}
 
 	client, err := conf.NewServiceClient("dns", region)
 	if err != nil {
@@ -169,6 +187,13 @@ func resourceEndpointAssignmentCreate(ctx context.Context, d *schema.ResourceDat
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return diag.Errorf("error waiting for DNS endpoint (%s) creation to completed: %s", endpointId, err)
+	}
+
+	// In the ReadContext stage, the region parameter configured in the script cannot be obtained, so it needs to be set in the Create stage,
+	// for subsequent API client building to distinguish between using the global service endpoint or the specified regional client.
+	err = d.Set("regional", conf.RegionClient)
+	if err != nil {
+		log.Printf("[WARN] Unable to set regional attribute: %s", err)
 	}
 
 	return resourceEndpointAssignmentRead(ctx, d, meta)
@@ -212,6 +237,11 @@ func resourceEndpointAssignmentRead(_ context.Context, d *schema.ResourceData, m
 		region     = conf.GetRegion(d)
 		endpointId = d.Id()
 	)
+
+	if d.Get("regional").(bool) {
+		conf.RegionClient = true
+	}
+
 	client, err := conf.NewServiceClient("dns", region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
@@ -335,6 +365,11 @@ func resourceEndpointAssignmentUpdate(ctx context.Context, d *schema.ResourceDat
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	endpointId := d.Id()
+
+	if d.Get("regional").(bool) {
+		conf.RegionClient = true
+	}
+
 	client, err := conf.NewServiceClient("dns", region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
@@ -463,6 +498,11 @@ func resourceEndpointAssignmentDelete(ctx context.Context, d *schema.ResourceDat
 		httplUr    = "v2.1/endpoints/{endpoint_id}"
 		endpointId = d.Id()
 	)
+
+	if d.Get("regional").(bool) {
+		conf.RegionClient = true
+	}
+
 	client, err := conf.NewServiceClient("dns", region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
@@ -493,4 +533,24 @@ func resourceEndpointAssignmentDelete(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error waiting for DNS endpoint (%s) deletion to completed: %s", d.Id(), err)
 	}
 	return nil
+}
+
+func resourceEndpointAssignmentImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	switch len(parts) {
+	case 1:
+		d.SetId(parts[0])
+		return []*schema.ResourceData{d}, nil
+	case 2:
+		mErr := multierror.Append(
+			d.Set("region", parts[0]),
+			// When using region import, it means using the specified regional client.
+			d.Set("regional", true),
+		)
+
+		d.SetId(parts[1])
+		return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+	}
+
+	return nil, fmt.Errorf("invalid format for import ID, want '<id>' or '<region>/<id>', but got '%s'", d.Id())
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Issue: Resource creation fails on some regions, such as 'sa-brazil-1'.
Reason: On some regions, the API requires the endpoint to specify a local location.
Resolve: add an internal attribute 'regional' to record whether the region parameter is specified in the script. If specified, use the specified region to construct the client. If not specified, use the global region to construct the client.

Why add the regional attribute?
If the region is not specified, the region will be set to the provider level region when executing terraform plan next time. Then the region value in the resource will always be set, and it will not be possible to distinguish between global and specified regions.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

<img width="1467" height="295" alt="image" src="https://github.com/user-attachments/assets/fc70c0d6-e785-4d1a-bfbb-7bb6a1ef228e" />

<img width="1010" height="58" alt="image" src="https://github.com/user-attachments/assets/49aa86ab-7f41-4182-87e8-3f5dfaf2c18b" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
