### PR TITLE
fix(dns): fix errors for some regions

### DIFF
--- a/docs/data-sources/dns_floating_ptrrecords.md
+++ b/docs/data-sources/dns_floating_ptrrecords.md
@@ -15,7 +15,7 @@ Use this data source to get the list of DNS PTR records.
 ```hcl
 variable "domain_name" {}
 
-data "huaweicloud_dns_floating_ptrrecords" "test"{
+data "huaweicloud_dns_floating_ptrrecords" "test" {
   domain_name = var.domain_name
 }
 ```
@@ -23,9 +23,6 @@ data "huaweicloud_dns_floating_ptrrecords" "test"{
 ## Argument Reference
 
 The following arguments are supported:
-
-* `region` - (Optional, String) Specifies the region in which to query the resource.
-  If omitted, the provider-level region will be used.
 
 * `record_id` - (Optional, String) Specifies the ID of the PTR record.
   The format is `{region}:{floatingip_id}`, `floatingip_id` indicates the EIP ID corresponding to the PTR record.

--- a/docs/data-sources/dns_line_groups.md
+++ b/docs/data-sources/dns_line_groups.md
@@ -24,9 +24,6 @@ data "huaweicloud_dns_line_groups" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the resource.
-  If omitted, the provider-level region will be used.
-
 * `line_id` - (Optional, String) Specifies the ID of the line group. Fuzzy search is supported.
 
 * `name` - (Optional, String) Specifies the name of the line group. Fuzzy search is supported.

--- a/docs/data-sources/dnsv21_ptrrecords.md
+++ b/docs/data-sources/dnsv21_ptrrecords.md
@@ -20,9 +20,6 @@ data "huaweicloud_dnsv21_ptrrecords" "test"{}
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the data source.
-  If omitted, the provider-level region will be used.
-
 * `enterprise_project_id` - (Optional, String) The enterprise project ID corresponding to the PTR record.
 
 * `resource_type` - (Optional, String) The resource type.

--- a/docs/resources/dns_custom_line.md
+++ b/docs/resources/dns_custom_line.md
@@ -30,6 +30,10 @@ resource "huaweicloud_dns_custom_line" "test" {
 
 The following arguments are supported:
 
+* `region` - (Optional, String, ForceNew) Specifies the region where the custom line is located.  
+  If omitted, the provider-level region will be used, but for some special regions, the parameter must be specified.
+  Changing this creates a new resource.
+
 * `name` - (Required, String) Specifies the custom line name.  
   The value consists of `1` to `80` characters including Chinese characters, English letters, digits, hyphens (-),
   underscores (_) and dots (.). The name of each resolution line set by one account must be unique.
@@ -64,4 +68,10 @@ The DNS custom line can be imported using the `id`, e.g.
 
 ```bash
 $ terraform import huaweicloud_dns_custom_line.test <id>
+```
+
+If `region` is specified, the resource can be imported using `<region>` and `<id>`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dns_custom_line.test <region>/<id>
 ```

--- a/docs/resources/dnsv21_ptrrecord.md
+++ b/docs/resources/dnsv21_ptrrecord.md
@@ -26,8 +26,8 @@ resource "huaweicloud_dns_ptrrecord" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
-  If omitted, the provider-level region will be used.
+* `region` - (Optional, String, ForceNew) Specifies the region where the PTR record is located.  
+  If omitted, the provider-level region will be used, but for some special regions, the parameter must be specified.
   Changing this creates a new resource.
 
 * `names` - (Required, List) Specifies the domain names of the PTR record.

--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dnsv21_ptrrecords_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dnsv21_ptrrecords_test.go
@@ -94,5 +94,5 @@ locals {
 output "is_tags_filter_useful" {
   value = length(local.filter_result_by_tags) > 0 && alltrue(local.filter_result_by_tags)
 }
-`, testAccDNSV21PtrRecord_basic(name))
+`, testAccV21PtrRecord_basic(name))
 }

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_custom_line_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_custom_line_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -13,7 +14,11 @@ import (
 )
 
 func getCustomLine(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	getDNSCustomLineClient, err := cfg.NewServiceClient("dns", acceptance.HW_REGION_NAME)
+	if state.Primary.Attributes["regional"] == "true" {
+		cfg.RegionClient = true
+	}
+
+	getDNSCustomLineClient, err := cfg.NewServiceClient("dns", state.Primary.Attributes["region"])
 	if err != nil {
 		return nil, fmt.Errorf("error creating DNS Client: %s", err)
 	}
@@ -58,6 +63,8 @@ func TestAccCustomLine_basic(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				// Only ignore regional in acceptance test, it will not be changed in actual use.
+				ImportStateVerifyIgnore: []string{"regional"},
 			},
 		},
 	})
@@ -80,4 +87,93 @@ resource "huaweicloud_dns_custom_line" "test" {
   ip_segments = ["100.100.100.102-100.100.100.102", "100.100.100.101-100.100.100.101"]
 }
 `, name)
+}
+
+func TestAccCustomLine_regional(t *testing.T) {
+	var (
+		name    = acceptance.RandomAccResourceName()
+		randInt = acctest.RandIntRange(50, 100)
+
+		obj   interface{}
+		rName = "huaweicloud_dns_custom_line.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getCustomLine)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckCustomRegion(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomLine_regional_step1(name, randInt),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "ip_segments.#", "1"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+				),
+			},
+			{
+				Config: testAccCustomLine_regional_step2(name, randInt),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "ip_segments.#", "1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Only ignore regional in acceptance test, it will not be changed in actual use.
+				ImportStateVerifyIgnore: []string{"regional"},
+				ImportStateIdFunc:       testAccCustomLineImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccCustomLineImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		region := rs.Primary.Attributes["region"]
+		customLineId := rs.Primary.ID
+		if region == "" || customLineId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<region>/<id>', but got '%s/%s'", region, customLineId)
+		}
+
+		return fmt.Sprintf("%s/%s", region, customLineId), nil
+	}
+}
+
+func testAccCustomLine_regional_step1(name string, randInt int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dns_custom_line" "test" {
+  region      = "%[1]s"
+
+  name        = "%[2]s"
+  description = "test description"
+  ip_segments = ["100.100.100.%[3]v-100.100.100.%[3]v"]
+}
+`, acceptance.HW_CUSTOM_REGION_NAME, name, randInt)
+}
+
+func testAccCustomLine_regional_step2(name string, randInt int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dns_custom_line" "test" {
+  region      = "%[1]s"
+
+  name        = "%[2]s_update"
+  ip_segments = ["100.100.100.%[3]v-100.100.100.%[3]v"]
+}
+`, acceptance.HW_CUSTOM_REGION_NAME, name, randInt+1)
 }

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dnsv21_ptrrecord_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dnsv21_ptrrecord_test.go
@@ -13,22 +13,27 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dns"
 )
 
-func getDNSV21PtrRecord(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := c.NewServiceClient("dns_region", acceptance.HW_REGION_NAME)
+func getV21PtrRecord(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	if state.Primary.Attributes["regional"] == "true" {
+		c.RegionClient = true
+	}
+
+	client, err := c.NewServiceClient("dns", state.Primary.Attributes["region"])
 	if err != nil {
 		return nil, fmt.Errorf("error creating DNS client : %s", err)
 	}
 	return dns.GetDNSV21PtrRecord(client, state.Primary.ID)
 }
 
-func TestAccDNSV21PtrRecord_basic(t *testing.T) {
+// Some regions require the region parameter can not be specified, such as 'sa-brazil-1'.
+func TestAccV21PtrRecord_basic(t *testing.T) {
 	var (
 		obj          interface{}
 		resourceName = "huaweicloud_dnsv21_ptrrecord.test"
 		rc           = acceptance.InitResourceCheck(
 			resourceName,
 			&obj,
-			getDNSV21PtrRecord,
+			getV21PtrRecord,
 		)
 
 		name = fmt.Sprintf("acpttest-ptr-%s.com", acctest.RandString(5))
@@ -40,7 +45,7 @@ func TestAccDNSV21PtrRecord_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV21PtrRecord_basic(name),
+				Config: testAccV21PtrRecord_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(resourceName, "names.#"),
@@ -54,7 +59,7 @@ func TestAccDNSV21PtrRecord_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDNSV21PtrRecord_update(name),
+				Config: testAccV21PtrRecord_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(resourceName, "names.#"),
@@ -70,12 +75,14 @@ func TestAccDNSV21PtrRecord_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				// Only ignore regional in acceptance test, it will not be changed in actual use.
+				ImportStateVerifyIgnore: []string{"regional"},
 			},
 		},
 	})
 }
 
-func testAccDNSV21PtrRecord_basic(ptrName string) string {
+func testAccV21PtrRecord_basic(ptrName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -92,7 +99,7 @@ resource "huaweicloud_dnsv21_ptrrecord" "test" {
 `, testAccPtrRecord_base(), ptrName)
 }
 
-func testAccDNSV21PtrRecord_update(ptrName string) string {
+func testAccV21PtrRecord_update(ptrName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -106,4 +113,137 @@ resource "huaweicloud_dnsv21_ptrrecord" "test" {
   }
 }
 `, testAccPtrRecord_base(), ptrName)
+}
+
+// In Chinese website, the region can be specified or not, such as: `cn-north-4`
+func TestAccV21PtrRecord_regional(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceNameWithDash()
+		randString = acctest.RandString(5)
+
+		obj   interface{}
+		rName = "huaweicloud_dnsv21_ptrrecord.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getV21PtrRecord)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckCustomRegion(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV21PtrRecord_regional_step1(name, randString),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "names.#", "1"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(rName, "ttl", "6000"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttrPair(rName, "publicip_id", "huaweicloud_vpc_eip.test", "id"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(rName, "address"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+				),
+			},
+			{
+				Config: testAccV21PtrRecord_regional_step2(name, randString),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "names.#"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "ttl", "7000"),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttrSet(rName, "address"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Only ignore regional in acceptance test, it will not be changed in actual use.
+				ImportStateVerifyIgnore: []string{"regional"},
+				ImportStateIdFunc:       testAccV21PtrRecordImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccV21PtrRecordImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		region := rs.Primary.Attributes["region"]
+		ptrRecordId := rs.Primary.ID
+		if region == "" || ptrRecordId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<region>/<id>', but got '%s/%s'", region, ptrRecordId)
+		}
+
+		return fmt.Sprintf("%s/%s", region, ptrRecordId), nil
+	}
+}
+
+func testAccV21PtrRecord_regional_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_eip" "test" {
+  region = "%[1]s"
+
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "%[2]s"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+`, acceptance.HW_CUSTOM_REGION_NAME, name)
+}
+
+func testAccV21PtrRecord_regional_step1(name, randString string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dnsv21_ptrrecord" "test" {
+  region = "%[2]s"
+
+  names                 = ["%[3]s-%[4]s.com"]
+  description           = "Created by terraform script"
+  publicip_id           = huaweicloud_vpc_eip.test.id
+  ttl                   = 6000
+  enterprise_project_id = "%[5]s"
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, testAccV21PtrRecord_regional_base(name), acceptance.HW_CUSTOM_REGION_NAME, name, randString, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccV21PtrRecord_regional_step2(name, randString string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dnsv21_ptrrecord" "test" {
+  region = "%[2]s"
+
+  names                 = ["%[3]s-%[4]s-update.com"]
+  publicip_id           = huaweicloud_vpc_eip.test.id
+  ttl                   = 7000
+  enterprise_project_id = "%[5]s"
+
+  tags = {
+    owner = "terraform"
+  }
+}
+`, testAccV21PtrRecord_regional_base(name), acceptance.HW_CUSTOM_REGION_NAME, name, randString, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_floating_ptrrecords.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_floating_ptrrecords.go
@@ -24,10 +24,15 @@ func DataSourceFloatingPtrRecords() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: `The region in which to query the resource.`,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The region where the PTR records are located`,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					},
+				),
 			},
 			"record_id": {
 				Type:        schema.TypeString,
@@ -149,7 +154,10 @@ func dataSourceFloatingPtrRecordsRead(_ context.Context, d *schema.ResourceData,
 
 // @API DNS GET /v2/reverse/floatingips
 func (w *FloatingPtrrecordsDSWrapper) ListPtrRecords() (*gjson.Result, error) {
-	client, err := w.NewClient(w.Config, "dns_region")
+	_, regional := w.GetOk("region")
+	w.Config.RegionClient = regional
+
+	client, err := w.NewClient(w.Config, "dns")
 	if err != nil {
 		return nil, err
 	}

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_line_groups.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_line_groups.go
@@ -22,10 +22,15 @@ func DataSourceLineGroups() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: `The region in which to query the resource. If omitted, the provider-level region will be used.`,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The region where the line groups are located`,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					},
+				),
 			},
 			"line_id": {
 				Type:        schema.TypeString,
@@ -121,7 +126,10 @@ func dataSourceLineGroupsRead(_ context.Context, d *schema.ResourceData, meta in
 
 // @API DNS GET /v2.1/linegroups
 func (w *LineGroupsDSWrapper) ListLineGroups() (*gjson.Result, error) {
-	client, err := w.NewClient(w.Config, "dns_region")
+	_, regional := w.GetOk("region")
+	w.Config.RegionClient = regional
+
+	client, err := w.NewClient(w.Config, "dns")
 	if err != nil {
 		return nil, err
 	}

--- a/huaweicloud/services/dns/data_source_huaweicloud_dnsv21_ptrrecords.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dnsv21_ptrrecords.go
@@ -27,6 +27,12 @@ func DataSourceDNSV21PtrRecords() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				Description: utils.SchemaDesc(
+					`The region where the line groups are located`,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					},
+				),
 			},
 			"enterprise_project_id": {
 				Type:        schema.TypeString,
@@ -107,7 +113,11 @@ func DataSourceDNSV21PtrRecords() *schema.Resource {
 func dataSourceDNSV21PtrRecordsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	client, err := cfg.NewServiceClient("dns_region", region)
+
+	_, regional := d.GetOk("region")
+	cfg.RegionClient = regional
+
+	client, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_custom_line.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_custom_line.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -30,7 +31,7 @@ func ResourceCustomLine() *schema.Resource {
 		DeleteContext: resourceCustomLineDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceCustomLineImportState,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -41,16 +42,11 @@ func ResourceCustomLine() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Description: utils.SchemaDesc(
-					`The region where the custom line is located`,
-					utils.SchemaDescInput{
-						Deprecated: true,
-					},
-				),
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the custom line is located.`,
 			},
 			"name": {
 				Type:        schema.TypeString,
@@ -75,6 +71,17 @@ func ResourceCustomLine() *schema.Resource {
 				Computed:    true,
 				Description: `The resource status.`,
 			},
+			// Internal attribute(s).
+			"regional": {
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: utils.SuppressDiffAll,
+				Description: utils.SchemaDesc(`The regional is used to indicate whether the script region is configured.
+If the script region is configured, the region client will be used to create the endpoint.`,
+					utils.SchemaDescInput{Internal: true},
+				),
+			},
 		},
 	}
 }
@@ -82,14 +89,18 @@ func ResourceCustomLine() *schema.Resource {
 func resourceCustomLineCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	if _, ok := d.GetOk("region"); ok {
-		cfg.RegionClient = true
-	}
+
+	scriptRegion := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "region")
+	isRegion := scriptRegion != nil && scriptRegion.(string) != ""
+	// When creating multiple resources in parallel, `conf.RegionClient` will be overwritten, so a temporary variable is needed to store it.
+	cfg.RegionClient = isRegion
 
 	createCustomLineClient, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
 		return diag.Errorf("error creating DNS Client: %s", err)
 	}
+
+	log.Printf("[DEBUG] customLineClient.Endpoint: %#v", createCustomLineClient.Endpoint)
 
 	if err := createCustomLine(createCustomLineClient, d); err != nil {
 		return diag.FromErr(err)
@@ -98,6 +109,13 @@ func resourceCustomLineCreate(ctx context.Context, d *schema.ResourceData, meta 
 	err = waitForCustomLineCreateOrUpdate(ctx, createCustomLineClient, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	// In the ReadContext stage, the region parameter configured in the script cannot be obtained, so it needs to be set in the Create stage,
+	// for subsequent API client building to distinguish between using the global service endpoint or the specified regional client.
+	err = d.Set("regional", isRegion)
+	if err != nil {
+		log.Printf("[WARN] Unable to set regional attribute: %s", err)
 	}
 
 	return resourceCustomLineRead(ctx, d, meta)
@@ -185,9 +203,8 @@ func GetCustomLineById(client *golangsdk.ServiceClient, customLineId string) (in
 func resourceCustomLineRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	if _, ok := d.GetOk("region"); ok {
-		cfg.RegionClient = true
-	}
+
+	cfg.RegionClient = d.Get("regional").(bool)
 
 	getCustomLineClient, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
@@ -213,9 +230,8 @@ func resourceCustomLineRead(_ context.Context, d *schema.ResourceData, meta inte
 func resourceCustomLineUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	if _, ok := d.GetOk("region"); ok {
-		cfg.RegionClient = true
-	}
+
+	cfg.RegionClient = d.Get("regional").(bool)
 
 	updateCustomLineClient, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
@@ -230,6 +246,7 @@ func resourceCustomLineUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
 	return resourceCustomLineRead(ctx, d, meta)
 }
 
@@ -256,9 +273,8 @@ func resourceCustomLineDelete(ctx context.Context, d *schema.ResourceData, meta 
 		customLineId            = d.Id()
 		region                  = cfg.GetRegion(d)
 	)
-	if _, ok := d.GetOk("region"); ok {
-		cfg.RegionClient = true
-	}
+
+	cfg.RegionClient = d.Get("regional").(bool)
 
 	deleteCustomLineClient, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
@@ -312,4 +328,24 @@ func customLineStatusRefreshFunc(client *golangsdk.ServiceClient, customLineId s
 
 		return customLine, parseStatus(utils.PathSearch("status", customLine, "").(string)), nil
 	}
+}
+
+func resourceCustomLineImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	switch len(parts) {
+	case 1:
+		d.SetId(parts[0])
+		return []*schema.ResourceData{d}, nil
+	case 2:
+		// If the region is specified, it means using the specified regional client, formatted as '<region>/<id>'.
+		mErr := multierror.Append(
+			d.Set("region", parts[0]),
+			d.Set("regional", true),
+		)
+
+		d.SetId(parts[1])
+		return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+	}
+
+	return nil, fmt.Errorf("invalid format for import ID, want '<id>' or '<region>/<id>', but got '%s'", d.Id())
 }

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_endpoint_assignment.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_endpoint_assignment.go
@@ -146,9 +146,9 @@ func resourceEndpointAssignmentCreate(ctx context.Context, d *schema.ResourceDat
 	)
 
 	scriptRegion := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "region")
-	if scriptRegion != nil && scriptRegion.(string) != "" {
-		conf.RegionClient = true
-	}
+	isRegion := scriptRegion != nil && scriptRegion.(string) != ""
+	// When creating multiple resources in parallel, `conf.RegionClient` will be overwritten, so a temporary variable is needed to store it.
+	conf.RegionClient = isRegion
 
 	client, err := conf.NewServiceClient("dns", region)
 	if err != nil {
@@ -191,7 +191,7 @@ func resourceEndpointAssignmentCreate(ctx context.Context, d *schema.ResourceDat
 
 	// In the ReadContext stage, the region parameter configured in the script cannot be obtained, so it needs to be set in the Create stage,
 	// for subsequent API client building to distinguish between using the global service endpoint or the specified regional client.
-	err = d.Set("regional", conf.RegionClient)
+	err = d.Set("regional", isRegion)
 	if err != nil {
 		log.Printf("[WARN] Unable to set regional attribute: %s", err)
 	}
@@ -238,9 +238,7 @@ func resourceEndpointAssignmentRead(_ context.Context, d *schema.ResourceData, m
 		endpointId = d.Id()
 	)
 
-	if d.Get("regional").(bool) {
-		conf.RegionClient = true
-	}
+	conf.RegionClient = d.Get("regional").(bool)
 
 	client, err := conf.NewServiceClient("dns", region)
 	if err != nil {
@@ -366,9 +364,7 @@ func resourceEndpointAssignmentUpdate(ctx context.Context, d *schema.ResourceDat
 	region := conf.GetRegion(d)
 	endpointId := d.Id()
 
-	if d.Get("regional").(bool) {
-		conf.RegionClient = true
-	}
+	conf.RegionClient = d.Get("regional").(bool)
 
 	client, err := conf.NewServiceClient("dns", region)
 	if err != nil {
@@ -499,9 +495,7 @@ func resourceEndpointAssignmentDelete(ctx context.Context, d *schema.ResourceDat
 		endpointId = d.Id()
 	)
 
-	if d.Get("regional").(bool) {
-		conf.RegionClient = true
-	}
+	conf.RegionClient = d.Get("regional").(bool)
 
 	client, err := conf.NewServiceClient("dns", region)
 	if err != nil {

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_ptrrecord.go
@@ -44,10 +44,11 @@ func ResourcePtrRecord() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the PTR record is located.`,
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/dns/resource_huaweicloud_dnsv21_ptrrecord.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dnsv21_ptrrecord.go
@@ -2,6 +2,8 @@ package dns
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"reflect"
 	"sort"
 	"strings"
@@ -39,7 +41,7 @@ func ResourceDNSV21PtrRecord() *schema.Resource {
 		DeleteContext: resourceDNSV21PtrRecordDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceV21PtrRecordImportState,
 		},
 
 		CustomizeDiff: customdiff.All(
@@ -49,10 +51,11 @@ func ResourceDNSV21PtrRecord() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the PTR record is located.`,
 			},
 			"names": {
 				Type:     schema.TypeSet,
@@ -115,6 +118,17 @@ func ResourceDNSV21PtrRecord() *schema.Resource {
 				Computed:    true,
 				Description: `The status of the PTR record.`,
 			},
+			// Internal attribute(s).
+			"regional": {
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: utils.SuppressDiffAll,
+				Description: utils.SchemaDesc(`The regional is used to indicate whether the script region is configured.
+If the script region is configured, the region client will be used to create the endpoint.`,
+					utils.SchemaDescInput{Internal: true},
+				),
+			},
 		},
 	}
 }
@@ -122,7 +136,13 @@ func ResourceDNSV21PtrRecord() *schema.Resource {
 func resourceDNSV21PtrRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	client, err := cfg.NewServiceClient("dns_region", region)
+
+	scriptRegion := utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "region")
+	isRegion := scriptRegion != nil && scriptRegion.(string) != ""
+	// When creating multiple resources in parallel, `conf.RegionClient` will be overwritten, so a temporary variable is needed to store it.
+	cfg.RegionClient = isRegion
+
+	client, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
@@ -153,6 +173,13 @@ func resourceDNSV21PtrRecordCreate(ctx context.Context, d *schema.ResourceData, 
 	err = waitForDNSV21PtrRecordToBeActive(ctx, client, id, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("error waiting for PTR record (%s) to be active: %s", id, err)
+	}
+
+	// In the ReadContext stage, the region parameter configured in the script cannot be obtained, so it needs to be set in the Create stage,
+	// for subsequent API client building to distinguish between using the global service endpoint or the specified regional client.
+	err = d.Set("regional", isRegion)
+	if err != nil {
+		log.Printf("[WARN] Unable to set regional attribute: %s", err)
 	}
 
 	return resourceDNSV21PtrRecordRead(ctx, d, meta)
@@ -203,7 +230,10 @@ func waitForDNSV21PtrRecordToBeActive(ctx context.Context, client *golangsdk.Ser
 func resourceDNSV21PtrRecordRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	client, err := cfg.NewServiceClient("dns_region", region)
+
+	cfg.RegionClient = d.Get("regional").(bool)
+
+	client, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
@@ -254,7 +284,10 @@ func GetDNSV21PtrRecord(client *golangsdk.ServiceClient, id string) (interface{}
 func resourceDNSV21PtrRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	client, err := cfg.NewServiceClient("dns_region", region)
+
+	cfg.RegionClient = d.Get("regional").(bool)
+
+	client, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
@@ -302,7 +335,10 @@ func buildUpdateDNSV21PtrRecordBodyParams(d *schema.ResourceData) map[string]int
 func resourceDNSV21PtrRecordDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	client, err := cfg.NewServiceClient("dns_region", region)
+
+	cfg.RegionClient = d.Get("regional").(bool)
+
+	client, err := cfg.NewServiceClient("dns", region)
 	if err != nil {
 		return diag.Errorf("error creating DNS client: %s", err)
 	}
@@ -320,4 +356,24 @@ func resourceDNSV21PtrRecordDelete(_ context.Context, d *schema.ResourceData, me
 	}
 
 	return nil
+}
+
+func resourceV21PtrRecordImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	switch len(parts) {
+	case 1:
+		d.SetId(parts[0])
+		return []*schema.ResourceData{d}, nil
+	case 2:
+		mErr := multierror.Append(
+			d.Set("region", parts[0]),
+			// When using region import, it means using the specified regional client.
+			d.Set("regional", true),
+		)
+
+		d.SetId(parts[1])
+		return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+	}
+
+	return nil, fmt.Errorf("invalid format for import ID, want '<id>' or '<region>/<id>', but got '%s'", d.Id())
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Deprecating region parameter for some data datasources
+ data.huaweicloud_dns_floating_ptrrecords
+ data.huaweicloud_dns_line_groups
+ data.huaweicloud_dnsv21_ptrrecords
2. Adapt the `region` parameter of some resources so that they can be normally used in different regions.
+ huaweicloud_dns_custom_line
+huaweicloud_dnsv21_ptrrecord.go

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

fixes https://github.com/huaweicloud/terraform-provider-huaweicloud/issues/9236


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o dns -f TestAccCustomLine_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccCustomLine_ -timeout 360m -parallel 10
=== RUN   TestAccCustomLine_basic
=== PAUSE TestAccCustomLine_basic
=== RUN   TestAccCustomLine_regional
=== PAUSE TestAccCustomLine_regional
=== CONT  TestAccCustomLine_basic
=== CONT  TestAccCustomLine_regional
--- PASS: TestAccCustomLine_basic (106.29s)
--- PASS: TestAccCustomLine_regional (108.12s)
PASS
coverage: 5.6% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       108.227s        coverage: 5.6% of statements in ./huaweicloud/services/dns
```

```
./scripts/coverage.sh -o dns -f TestAccCustomLine_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dns" -v -coverprofile="./huaweicloud/services/acceptance/dns/dns_coverage.cov" -coverpkg="./huaweicloud/services/dns" -run TestAccCustomLine_ -timeout 360m -parallel 10
=== RUN   TestAccCustomLine_basic
=== PAUSE TestAccCustomLine_basic
=== RUN   TestAccCustomLine_regional
=== PAUSE TestAccCustomLine_regional
=== CONT  TestAccCustomLine_basic
=== CONT  TestAccCustomLine_regional
--- PASS: TestAccCustomLine_basic (106.29s)
--- PASS: TestAccCustomLine_regional (108.12s)
PASS
coverage: 5.6% of statements in ./huaweicloud/services/dns
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       108.227s        coverage: 5.6% of statements in ./huaweicloud/services/dns
```


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
