### PR TITLE
feat(CFW): add dataSource to get the organization tree

### DIFF
--- a/docs/data-sources/cfw_organization_tree.md
+++ b/docs/data-sources/cfw_organization_tree.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_organization_tree"
+description: |-
+  Use this data source to get the organization tree within HuaweiCloud.
+---
+
+# huaweicloud_cfw_organization_tree
+
+Use this data source to get the organization tree within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+
+data "huaweicloud_cfw_organization_tree" "test" { 
+  fw_instance_id = var.fw_instance_id 
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `fw_instance_id` - (Required, String) Specifies the firewall instance ID.
+
+* `parent_id` - (Optional, String) Specifies the parent organization unit ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data` - The list of organization tree nodes.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `delegated` - The indication of whether the organization unit is delegated.
+
+* `id` - The organization unit ID.
+
+* `name` - The organization unit name.
+
+* `org_type` - The organization unit type.
+
+* `parent_id` - The parent organization unit ID.
+
+* `urn` - The uniform resource name of the organization unit.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -866,6 +866,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_acl_rule_tags":                 cfw.DataSourceAclRuleTags(),
 			"huaweicloud_cfw_ip_blacklist":                  cfw.DataSourceIpBlacklist(),
 			"huaweicloud_cfw_ip_blacklist_switch":           cfw.DataSourceIpBlacklistSwitch(),
+			"huaweicloud_cfw_organization_tree":             cfw.DataSourceCfwOrganizationTree(),
 			"huaweicloud_cfw_report_profiles":               cfw.DataSourceReportProfiles(),
 
 			"huaweicloud_cnad_advanced_instances":           cnad.DataSourceInstances(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_organization_tree_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_organization_tree_test.go
@@ -1,0 +1,41 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCfwOrganizationTree_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cfw_organization_tree.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCfwOrganizationTree_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCfwOrganizationTree_basic() string {
+	return fmt.Sprintf(`
+
+data "huaweicloud_cfw_organization_tree" "test" {
+  fw_instance_id = "%s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_organization_tree.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_organization_tree.go
@@ -1,0 +1,167 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/system/multi-account/organization-tree
+
+func DataSourceCfwOrganizationTree() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCfwOrganizationTreeRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"fw_instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the firewall instance ID.`,
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the parent organization unit ID.`,
+			},
+			"data": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of organization tree nodes.`,
+				Elem:        organizationTreeNodeSchema(),
+			},
+		},
+	}
+}
+
+func organizationTreeNodeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"delegated": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `The indication of whether the organization unit is delegated.`,
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The organization unit ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The organization unit name.`,
+			},
+			"org_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The organization unit type.`,
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The parent organization unit ID.`,
+			},
+			"urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The uniform resource name of the organization unit.`,
+			},
+		},
+	}
+}
+
+func buildOrganizationTreeQueryParams(d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("?fw_instance_id=%s&limit=2000", d.Get("fw_instance_id").(string))
+
+	if v, ok := d.GetOk("parent_id"); ok {
+		queryParams = fmt.Sprintf("%s&parent_id=%s", queryParams, v.(string))
+	}
+
+	return queryParams
+}
+
+func dataSourceCfwOrganizationTreeRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cfw"
+		httpUrl = "v1/{project_id}/system/multi-account/organization-tree"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	listPath += buildOrganizationTreeQueryParams(d)
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", listPath, &reqOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW organization tree: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenOrganizationTreeData(utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenOrganizationTreeData(dataResp []interface{}) []interface{} {
+	if len(dataResp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(dataResp))
+	for _, node := range dataResp {
+		result = append(result, map[string]interface{}{
+			"delegated": utils.PathSearch("delegated", node, false),
+			"id":        utils.PathSearch("id", node, nil),
+			"name":      utils.PathSearch("name", node, nil),
+			"org_type":  utils.PathSearch("org_type", node, nil),
+			"parent_id": utils.PathSearch("parent_id", node, nil),
+			"urn":       utils.PathSearch("urn", node, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_organization_tree` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_organization_tree` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceCfwOrganizationTree_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw-v -run TestAccDataSourceCfwOrganizationTree_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCfwOrganizationTree_basic
=== PAUSE TestAccDataSourceCfwOrganizationTree_basic
=== CONT  TestAccDataSourceCfwOrganizationTree_basic
--- PASS: TestAccDataSourceCfwOrganizationTree_basic (12.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       21.311s
```
<img width="605" height="23" alt="image" src="https://github.com/user-attachments/assets/5b1c10b3-f71c-401c-b714-ef4af72bc56e" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
