### PR TITLE
feat(dws): add new resource support for operate cluster

### DIFF
--- a/docs/resources/dws_cluster_action.md
+++ b/docs/resources/dws_cluster_action.md
@@ -1,0 +1,52 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_action"
+description: |-
+  Use this resource to operate DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_action
+
+Use this resource to operate DWS cluster within HuaweiCloud.
+
+-> This resource is only a one-time action resource for operating the DWS cluster. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+resource "huaweicloud_dws_cluster_action" "restart" {
+  cluster_id = var.cluster_id
+  action     = "restart"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the cluster is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster to be operated.
+
+* `action` - (Required, String, NonUpdatable) Specifies the action type of the operation.  
+  The valid values are as follows:
+  + **start**
+  + **stop**
+  + **restart**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3329,6 +3329,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_dws_alarm_subscription":              dws.ResourceDwsAlarmSubs(),
 			"huaweicloud_dws_cluster":                         dws.ResourceDwsCluster(),
+			"huaweicloud_dws_cluster_action":                  dws.ResourceClusterAction(),
 			"huaweicloud_dws_cluster_eip_associate":           dws.ResourceClusterEipAssociate(),
 			"huaweicloud_dws_cluster_elb_associate":           dws.ResourceClusterElbAssociate(),
 			"huaweicloud_dws_cluster_exception_rule":          dws.ResourceClusterExceptionRule(),

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_action_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_action_test.go
@@ -1,0 +1,62 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccClusterAction_basic(t *testing.T) {
+	randUUID, _ := uuid.GenerateUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccClusterAction_nonExistentCluster(randUUID),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`error operating cluster \(%s\) with action \(restart\)`, randUUID)),
+			},
+			{
+				Config: testAccClusterAction_basic("stop"),
+			},
+			{
+				Config: testAccClusterAction_basic("start"),
+			},
+			{
+				Config: testAccClusterAction_basic("restart"),
+			},
+		},
+	})
+}
+
+func testAccClusterAction_nonExistentCluster(randUUID string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_cluster_action" "test" {
+  cluster_id = "%[1]s"
+  action     = "restart"
+}
+`, randUUID)
+}
+
+func testAccClusterAction_basic(action string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_cluster_action" "test" {
+  cluster_id = "%[1]s"
+  action     = "%[2]s"
+
+  enable_force_new  = "true"
+}
+`, acceptance.HW_DWS_CLUSTER_ID, action)
+}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_action.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_action.go
@@ -1,0 +1,193 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var clusterActionNonUpdatableParams = []string{
+	"cluster_id",
+	"action",
+}
+
+// @API DWS POST /v1.0/{project_id}/clusters/{cluster_id}/restart
+// @API DWS POST /v1/{project_id}/clusters/{cluster_id}/stop
+// @API DWS POST /v1/{project_id}/clusters/{cluster_id}/start
+// @API DWS GET /v1.0/{project_id}/clusters/{cluster_id}
+func ResourceClusterAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceClusterActionCreate,
+		ReadContext:   resourceClusterActionRead,
+		UpdateContext: resourceClusterActionUpdate,
+		DeleteContext: resourceClusterActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(clusterActionNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the cluster is located.",
+			},
+
+			// Required parameters.
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the cluster to be operated.",
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The action type of the operation.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
+			},
+		},
+	}
+}
+
+func doClusterAction(client *golangsdk.ServiceClient, clusterId, action string) error {
+	var httpUrl string
+
+	switch action {
+	case "restart":
+		httpUrl = "v1.0/{project_id}/clusters/{cluster_id}/restart"
+	case "stop":
+		httpUrl = "v1/{project_id}/clusters/{cluster_id}/stop"
+	case "start":
+		httpUrl = "v1/{project_id}/clusters/{cluster_id}/start"
+	default:
+		return fmt.Errorf("unsupported action: %s", action)
+	}
+	actionPath := client.Endpoint + httpUrl
+	actionPath = strings.ReplaceAll(actionPath, "{project_id}", client.ProjectID)
+	actionPath = strings.ReplaceAll(actionPath, "{cluster_id}", clusterId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("POST", actionPath, &opt)
+	return err
+}
+
+func refreshClusterActionStateFunc(client *golangsdk.ServiceClient, clusterId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetClusterInfoByClusterId(client, clusterId)
+		if err != nil {
+			return respBody, "ERROR", err
+		}
+
+		statusesInProgress := []string{"REBOOTING", "STARTING", "STOPPING"}
+		taskStatus := utils.PathSearch("cluster.task_status", respBody, "").(string)
+		if taskStatus == "" {
+			return "NOT_IN_PROGRESS", "COMPLETED", nil
+		}
+		if utils.StrSliceContains(statusesInProgress, taskStatus) {
+			return "IN_PROGRESS", "PENDING", nil
+		}
+
+		return respBody, "ERROR", fmt.Errorf("unexpected task status: %s", taskStatus)
+	}
+}
+
+func waitForClusterActionCompleted(ctx context.Context, client *golangsdk.ServiceClient, clusterId string, t time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshClusterActionStateFunc(client, clusterId),
+		Timeout:      t,
+		Delay:        10 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceClusterActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Get("cluster_id").(string)
+		action    = d.Get("action").(string)
+	)
+
+	// For the same DWS cluster, it is not supported to run multiple tasks at the same time.
+	config.MutexKV.Lock(clusterId)
+	defer config.MutexKV.Unlock(clusterId)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	err = doClusterAction(client, clusterId, action)
+	if err != nil {
+		return diag.Errorf("error operating cluster (%s) with action (%s): %s", clusterId, action, err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	err = waitForClusterActionCompleted(ctx, client, clusterId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for cluster (%s) to be available: %s", clusterId, err)
+	}
+
+	return resourceClusterActionRead(ctx, d, meta)
+}
+
+func resourceClusterActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceClusterActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceClusterActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for operating the DWS cluster. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource that used to operate cluster and provider these following action:
- start
- stop
- restart

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance test:
<img width="1002" height="231" alt="image" src="https://github.com/user-attachments/assets/26d25bae-74a6-4c58-9f32-d9017f11654e" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource support for operate cluster
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dws -f TestAccClusterAction_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccClusterAction_basic -timeout 360m -parallel 10
=== RUN   TestAccClusterAction_basic
=== PAUSE TestAccClusterAction_basic
=== CONT  TestAccClusterAction_basic
--- PASS: TestAccClusterAction_basic (411.98s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       412.146s        coverage: 3.8% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
