### PR TITLE
feat(cfw): new resource to add dns server to cfw

### DIFF
--- a/docs/resources/cfw_add_dns_server.md
+++ b/docs/resources/cfw_add_dns_server.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_add_dns_server"
+description: |-
+  Manages a resource to add DNS server within HuaweiCloud.
+---
+
+# huaweicloud_cfw_add_dns_server
+
+Manages a resource to add DNS server within HuaweiCloud.
+
+-> This resource is a one-time action resource used to add DNS server. Deleting this resource will
+  not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+variable "server_ip" {}
+
+resource "huaweicloud_cfw_add_dns_server" "test" {
+  fw_instance_id = var.fw_instance_id
+  server_ip      = var.server_ip
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `fw_instance_id` - (Required, String, NonUpdatable) Specifies the firewall instance ID.
+
+* `server_ip` - (Required, String, NonUpdatable) Specifies the DNS server IP address.
+  The DNS server IP can be obtained through the query DNS server list interface.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `fw_instance_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3009,6 +3009,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ces_resource_group_alarm_template_async_associate": ces.ResourceResourceGroupAlarmTemplateAsyncAssociate(),
 
 			"huaweicloud_cfw_acl_rule":                      cfw.ResourceAclRule(),
+			"huaweicloud_cfw_add_dns_server":                cfw.ResourceAddDNSServer(),
 			"huaweicloud_cfw_batch_delete_acl_rules":        cfw.ResourceBatchDeleteAclRules(),
 			"huaweicloud_cfw_batch_update_acl_rules_action": cfw.ResourceBatchUpdateAclRulesAction(),
 			"huaweicloud_cfw_address_group":                 cfw.ResourceAddressGroup(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -455,6 +455,7 @@ var (
 
 	// The CFW instance ID
 	HW_CFW_INSTANCE_ID               = os.Getenv("HW_CFW_INSTANCE_ID")
+	HW_CFW_SERVER_IP                 = os.Getenv("HW_CFW_SERVER_IP")
 	HW_CFW_REPORT_PROFILE_ID         = os.Getenv("HW_CFW_REPORT_PROFILE_ID")
 	HW_CFW_REPORT_ID                 = os.Getenv("HW_CFW_REPORT_ID")
 	HW_CFW_EAST_WEST_FIREWALL        = os.Getenv("HW_CFW_EAST_WEST_FIREWALL")
@@ -2825,6 +2826,13 @@ func TestAccPreCheckCesAlarmRuleWithTags(t *testing.T) {
 func TestAccPreCheckCfw(t *testing.T) {
 	if HW_CFW_INSTANCE_ID == "" {
 		t.Skip("HW_CFW_INSTANCE_ID must be set for CFW acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCfwServerIp(t *testing.T) {
+	if HW_CFW_SERVER_IP == "" {
+		t.Skip("HW_CFW_SERVER_IP must be set for CFW acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_add_dns_server_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_add_dns_server_test.go
@@ -1,0 +1,36 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAddDNSServer_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+			acceptance.TestAccPreCheckCfwServerIp(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAddDNSServer_basic(),
+			},
+		},
+	})
+}
+
+func testAddDNSServer_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cfw_add_dns_server" "test" {
+  fw_instance_id = "%[1]s"
+  server_ip      = "%[2]s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID, acceptance.HW_CFW_SERVER_IP)
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_add_dns_server.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_add_dns_server.go
@@ -1,0 +1,108 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW POST /v1/{project_id}/dns/server/{server_ip}/status
+func ResourceAddDNSServer() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAddDNSServerCreate,
+		ReadContext:   resourceAddDNSServerRead,
+		UpdateContext: resourceAddDNSServerUpdate,
+		DeleteContext: resourceAddDNSServerDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"fw_instance_id",
+			"server_ip",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"server_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceAddDNSServerCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v1/{project_id}/dns/server/{server_ip}/status"
+		fwInstanceId = d.Get("fw_instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{server_ip}", d.Get("server_ip").(string))
+	requestPath += fmt.Sprintf("?fw_instance_id=%s", fwInstanceId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error adding DNS server to CFW: %s", err)
+	}
+
+	d.SetId(fwInstanceId)
+
+	return nil
+}
+
+func resourceAddDNSServerRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceAddDNSServerUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceAddDNSServerDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to add DNS server. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to add dns server to cfw

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccAddDNSServer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccAddDNSServer_basic -timeout 360m -parallel 10
=== RUN   TestAccAddDNSServer_basic
=== PAUSE TestAccAddDNSServer_basic
=== CONT  TestAccAddDNSServer_basic
--- PASS: TestAccAddDNSServer_basic (14.68s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       14.809s coverage: 3.5% of statements in ./huaweicloud/services/cfw
```
<img width="1291" height="81" alt="image" src="https://github.com/user-attachments/assets/bfecc7b8-b39b-4f2e-8d03-05072de10281" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
