### PR TITLE
feat(cfw): new resource to manage advanced ips rule

### DIFF
--- a/docs/resources/cfw_advanced_ips_rule.md
+++ b/docs/resources/cfw_advanced_ips_rule.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_advanced_ips_rule"
+description: |-
+  Manages a resource to create advanced IPS rule within HuaweiCloud.
+---
+
+# huaweicloud_cfw_advanced_ips_rule
+
+Manages a resource to create advanced IPS rule within HuaweiCloud.
+
+-> This resource is a one-time action resource used to create advanced IPS rule. Deleting this resource will
+  not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "ips_rule_id" {}
+variable "object_id" {}
+variable "fw_instance_id" {}
+
+resource "huaweicloud_cfw_advanced_ips_rule" "test" {
+  ips_rule_id    = var.ips_rule_id
+  object_id      = var.object_id
+  fw_instance_id = var.fw_instance_id
+  param          = "{\"threshold\":11}"
+  action         = 0
+  ips_rule_type  = 1
+  status         = 0
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `action` - (Required, Int, NonUpdatable) Specifies the action type.  
+  The valid values are as follows:
+  + `0`: Record logs only.
+  + `1`: Block session.
+  + `2`: Block IP.
+
+* `ips_rule_id` - (Required, String, NonUpdatable) Specifies the advanced IPS rule ID.
+
+* `ips_rule_type` - (Required, Int, NonUpdatable) Specifies the IPS rule type.  
+  The valid values are as follows:
+  + `0`: Sensitive directory scanning.
+  + `1`: Reverse shell xshell.
+
+* `object_id` - (Required, String, NonUpdatable) Specifies the protection object ID.
+
+* `param` - (Required, String, NonUpdatable) Specifies the JSON string containing special parameters.
+
+* `status` - (Required, Int, NonUpdatable) Specifies the rule status.  
+  The valid values are as follows:
+  + `0`: Disabled.
+  + `1`: Enabled.
+
+* `fw_instance_id` - (Optional, String, NonUpdatable) Specifies the firewall instance ID.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  For enterprise users, if omitted, default enterprise project will be used.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3013,6 +3013,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_batch_delete_acl_rules":        cfw.ResourceBatchDeleteAclRules(),
 			"huaweicloud_cfw_batch_update_acl_rules_action": cfw.ResourceBatchUpdateAclRulesAction(),
 			"huaweicloud_cfw_address_group":                 cfw.ResourceAddressGroup(),
+			"huaweicloud_cfw_advanced_ips_rule":             cfw.ResourceAdvancedIpsRule(),
 			"huaweicloud_cfw_address_group_member":          cfw.ResourceAddressGroupMember(),
 			"huaweicloud_cfw_alarm_config":                  cfw.ResourceAlarmConfig(),
 			"huaweicloud_cfw_anti_virus":                    cfw.ResourceAntiVirus(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -465,6 +465,7 @@ var (
 	HW_CFW_PREDEFINED_SERVICE_GROUP2 = os.Getenv("HW_CFW_PREDEFINED_SERVICE_GROUP2")
 	HW_CFW_PREDEFINED_ADDRESS_GROUP1 = os.Getenv("HW_CFW_PREDEFINED_ADDRESS_GROUP1")
 	HW_CFW_PREDEFINED_ADDRESS_GROUP2 = os.Getenv("HW_CFW_PREDEFINED_ADDRESS_GROUP2")
+	HW_CFW_IPS_ADVANCED_RULE_ID      = os.Getenv("HW_CFW_IPS_ADVANCED_RULE_ID")
 	HW_CFW_IPS_CUSTOM_RULE           = os.Getenv("HW_CFW_IPS_CUSTOM_RULE")
 	HW_CFW_ACL_RULE_ID               = os.Getenv("HW_CFW_ACL_RULE_ID")
 	HW_CFW_IP_BLACKLIST_NAME         = os.Getenv("HW_CFW_IP_BLACKLIST_NAME")
@@ -2875,6 +2876,13 @@ func TestAccPreCheckCfwPredefinedServiceGroup(t *testing.T) {
 func TestAccPreCheckCfwPredefinedAddressGroup(t *testing.T) {
 	if HW_CFW_PREDEFINED_ADDRESS_GROUP1 == "" || HW_CFW_PREDEFINED_ADDRESS_GROUP2 == "" {
 		t.Skip("HW_CFW_PREDEFINED_ADDRESS_GROUP1 and HW_CFW_PREDEFINED_ADDRESS_GROUP2 must be set for CFW ACL rule acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCfwIpsAdvancedRuleID(t *testing.T) {
+	if HW_CFW_IPS_ADVANCED_RULE_ID == "" {
+		t.Skip("HW_CFW_IPS_ADVANCED_RULE_ID must be set for CFW IPS acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_advanced_ips_rule_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_advanced_ips_rule_test.go
@@ -1,0 +1,45 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAdvancedIpsRule_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+			acceptance.TestAccPreCheckCfwIpsAdvancedRuleID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAdvancedIpsRule_basic(),
+			},
+		},
+	})
+}
+
+func testAdvancedIpsRule_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_firewalls" "test" {
+  fw_instance_id = "%[1]s"
+}
+
+resource "huaweicloud_cfw_advanced_ips_rule" "test" {
+  fw_instance_id = "%[1]s"
+  ips_rule_id    = "%[2]s"
+  object_id      = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+  param          = "{\"threshold\":11}"
+  action         = 0
+  ips_rule_type  = 1
+  status         = 0
+}
+`, acceptance.HW_CFW_INSTANCE_ID, acceptance.HW_CFW_IPS_ADVANCED_RULE_ID)
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_advanced_ips_rule.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_advanced_ips_rule.go
@@ -1,0 +1,175 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW POST /v1/{project_id}/advanced-ips-rule
+func ResourceAdvancedIpsRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAdvancedIpsRuleCreate,
+		ReadContext:   resourceAdvancedIpsRuleRead,
+		UpdateContext: resourceAdvancedIpsRuleUpdate,
+		DeleteContext: resourceAdvancedIpsRuleDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"action",
+			"ips_rule_id",
+			"ips_rule_type",
+			"object_id",
+			"param",
+			"status",
+			"fw_instance_id",
+			"enterprise_project_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"action": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"ips_rule_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ips_rule_type": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"object_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"param": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"status": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildAdvancedIpsRuleQueryParams(d *schema.ResourceData) string {
+	rst := ""
+
+	if v, ok := d.GetOk("fw_instance_id"); ok {
+		rst += fmt.Sprintf("&fw_instance_id=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("enterprise_project_id"); ok {
+		rst += fmt.Sprintf("&enterprise_project_id=%s", v.(string))
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func buildAdvancedIpsRuleCreateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"action":        d.Get("action"),
+		"ips_rule_id":   d.Get("ips_rule_id"),
+		"ips_rule_type": d.Get("ips_rule_type"),
+		"object_id":     d.Get("object_id"),
+		"param":         d.Get("param"),
+		"status":        d.Get("status"),
+	}
+}
+
+func resourceAdvancedIpsRuleCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/advanced-ips-rule"
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAdvancedIpsRuleQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildAdvancedIpsRuleCreateBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating CFW advanced IPS rule: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error parsing response: %s", err)
+	}
+
+	id := utils.PathSearch("data.id", respBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating CFW advanced IPS rule: ID is not found in API response")
+	}
+	d.SetId(id)
+
+	return nil
+}
+
+func resourceAdvancedIpsRuleRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceAdvancedIpsRuleUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceAdvancedIpsRuleDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to create advanced IPS rule. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage advanced ips rule

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccAdvancedIpsRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccAdvancedIpsRule_basic -timeout 360m -parallel 10 
=== RUN   TestAccAdvancedIpsRule_basic
=== PAUSE TestAccAdvancedIpsRule_basic
=== CONT  TestAccAdvancedIpsRule_basic
--- PASS: TestAccAdvancedIpsRule_basic (14.44s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       14.561s coverage: 3.7% of statements in ./huaweicloud/services/cfw
```
<img width="1399" height="90" alt="image" src="https://github.com/user-attachments/assets/26fe5450-1cbc-4a53-8243-6045fa6b8f39" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
