### PR TITLE
feat(CFW): add dataSource to get the enterprise router

### DIFF
--- a/docs/data-sources/cfw_firewall_router.md
+++ b/docs/data-sources/cfw_firewall_router.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_firewall_router"
+description: |-
+  Use this data source to get the enterprise router list associated with the CFW east-west firewall within HuaweiCloud.
+---
+
+# huaweicloud_cfw_firewall_router
+
+Use this data source to get the enterprise router list associated with the CFW east-west firewall within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+
+data "huaweicloud_cfw_firewall_router" "test" { 
+  fw_instance_id = var.fw_instance_id 
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `fw_instance_id` - (Required, String) Specifies the firewall instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `er_list` - The list of enterprise routers associated with the east-west firewall.
+
+  The [er_list](#er_list_struct) structure is documented below.
+
+<a name="er_list_struct"></a>
+The `er_list` block supports:
+
+* `er_id` - The enterprise router ID.
+
+* `name` - The enterprise router name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -845,6 +845,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_domain_name_parse_ip_list":     cfw.DataSourceCfwDomainNameParseIpList(),
 			"huaweicloud_cfw_domain_resolve_ip_list":        cfw.DataSourceCfwDomainResolveIpList(),
 			"huaweicloud_cfw_eip_auto_protect_status":       cfw.DataSourceEipAutoProtectStatus(),
+			"huaweicloud_cfw_firewall_router":               cfw.DataSourceCfwEastWestFirewallEr(),
 			"huaweicloud_cfw_eip_count":                     cfw.DataSourceEipCount(),
 			"huaweicloud_cfw_protection_rules":              cfw.DataSourceCfwProtectionRules(),
 			"huaweicloud_cfw_service_groups":                cfw.DataSourceCfwServiceGroups(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_firewall_router_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_firewall_router_test.go
@@ -1,0 +1,42 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCfwFirewallRouter_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cfw_firewall_router.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCfwFirewallRouter_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "er_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "er_list.0.er_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "er_list.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCfwFirewallRouter_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_firewall_router" "test" {
+  fw_instance_id = "%s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_firewall_router.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_firewall_router.go
@@ -1,0 +1,130 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/firewall/east-west/enterprise-router
+func DataSourceCfwEastWestFirewallEr() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCfwEastWestFirewallErRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"fw_instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the firewall instance ID.`,
+			},
+			"er_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of enterprise routers associated with the east-west firewall.`,
+				Elem:        eastWestFirewallErSchema(),
+			},
+		},
+	}
+}
+
+func eastWestFirewallErSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"er_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The enterprise router ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The enterprise router name.`,
+			},
+		},
+	}
+}
+
+func buildEastWestFirewallErQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?fw_instance_id=%s", d.Get("fw_instance_id").(string))
+}
+
+func dataSourceCfwEastWestFirewallErRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cfw"
+		httpUrl = "v1/{project_id}/firewall/east-west/enterprise-router"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildEastWestFirewallErQueryParams(d)
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", listPath, &reqOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW east-west firewall enterprise router: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("er_list", flattenEastWestFirewallErList(utils.PathSearch("data.er_list", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenEastWestFirewallErList(erList []interface{}) []interface{} {
+	if erList == nil {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(erList))
+	for _, er := range erList {
+		result = append(result, map[string]interface{}{
+			"er_id": utils.PathSearch("er_id", er, nil),
+			"name":  utils.PathSearch("name", er, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
…d with the CFW

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_firewall_router` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_firewall_router` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceCfwFirewallRouter_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw-v -run TestAccDataSourceCfwFirewallRouter_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCfwFirewallRouter_basic
=== PAUSE TestAccDataSourceCfwFirewallRouter_basic
=== CONT  TestAccDataSourceCfwFirewallRouter_basic
--- PASS: TestAccDataSourceCfwFirewallRouter_basic (11.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       21.311s
```
<img width="618" height="18" alt="image" src="https://github.com/user-attachments/assets/f307051f-13b2-4d5b-869a-b533fefbcb05" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
