### PR TITLE
feat(dataarts): add new data source to query factory resources

### DIFF
--- a/docs/data-sources/dataarts_factory_resources.md
+++ b/docs/data-sources/dataarts_factory_resources.md
@@ -1,0 +1,54 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_factory_resources"
+description: |-
+  Use this data source to get the list of DataArts Factory resources within HuaweiCloud.
+---
+# huaweicloud_dataarts_factory_resources
+
+Use this data source to get the list of DataArts Factory resources within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_factory_resources" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the resources are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Optional, String) Specifies the ID of the workspace to which the resources belong.  
+  If omitted, the default workspace will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resources` - The list of resources that match the filter parameters.  
+  The [resources](#factory_resources) structure is documented below.
+
+<a name="factory_resources"></a>
+The `resources` block supports:
+
+* `name` - The name of the resource.
+
+* `type` - The type of the resource.
+
+* `location` - The OBS path of the resource file.
+
+* `directory` - The directory where the resource is located.
+
+* `description` - The description of the resource.
+
+* `depend_files` - The list of dependent file paths.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1075,7 +1075,8 @@ func Provider() *schema.Provider {
 			// DataArts Quality
 			"huaweicloud_dataarts_quality_tasks": dataarts.DataSourceQualityTasks(),
 			// DataArts Factory
-			"huaweicloud_dataarts_factory_jobs": dataarts.DataSourceFactoryJobs(),
+			"huaweicloud_dataarts_factory_jobs":      dataarts.DataSourceFactoryJobs(),
+			"huaweicloud_dataarts_factory_resources": dataarts.DataSourceFactoryResources(),
 
 			"huaweicloud_dbss_audit_data_masking_rules":  dbss.DataSourceDbssAuditDataMaskingRules(),
 			"huaweicloud_dbss_audit_risk_rules":          dbss.DataSourceDbssAuditRiskRules(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_factory_resources_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_factory_resources_test.go
@@ -1,0 +1,109 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataFactoryResources_basic(t *testing.T) {
+	var (
+		rName      = acceptance.RandomAccResourceName()
+		dataSource = "data.huaweicloud_dataarts_factory_resources.all"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckOBSObjectStoragePath(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataFactoryResources_nonExistentWorkspace(),
+				ExpectError: regexp.MustCompile("Operation failed, detail msg Workspace does not exists."),
+			},
+			{
+				Config: testAccDataFactoryResources_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "resources.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckOutput("is_resource_queried", "true"),
+					resource.TestCheckOutput("is_resource_name_correct", "true"),
+					resource.TestCheckOutput("is_resource_type_correct", "true"),
+					resource.TestCheckOutput("is_resource_description_correct", "true"),
+					resource.TestCheckOutput("is_resource_directory_correct", "true"),
+					resource.TestCheckOutput("is_resource_location_correct", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataFactoryResources_nonExistentWorkspace() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_factory_resources" "test" {
+  workspace_id = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataFactoryResources_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_factory_resource" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  type         = "jar"
+  description  = "Created by terraform script"
+  directory    = "/"
+  location     = "%[3]s"
+}
+
+data "huaweicloud_dataarts_factory_resources" "all" {
+  depends_on = [
+    huaweicloud_dataarts_factory_resource.test,
+  ]
+
+  workspace_id = "%[1]s"
+}
+
+locals {
+  id_filter_result = [
+    for v in data.huaweicloud_dataarts_factory_resources.all.resources : v if v.name == huaweicloud_dataarts_factory_resource.test.name
+  ]
+}
+
+output "is_resource_queried" {
+  value = length(local.id_filter_result) > 0
+}
+
+output "is_resource_name_correct" {
+  value = local.id_filter_result[0].name == huaweicloud_dataarts_factory_resource.test.name
+}
+
+output "is_resource_type_correct" {
+  value = local.id_filter_result[0].type == huaweicloud_dataarts_factory_resource.test.type
+}
+
+output "is_resource_description_correct" {
+  value = local.id_filter_result[0].description == huaweicloud_dataarts_factory_resource.test.description
+}
+
+output "is_resource_directory_correct" {
+  value = local.id_filter_result[0].directory == huaweicloud_dataarts_factory_resource.test.directory
+}
+
+output "is_resource_location_correct" {
+  value = local.id_filter_result[0].location == huaweicloud_dataarts_factory_resource.test.location
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_OBS_OBJECT_STORAGE_PATH)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_factory_resources.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_factory_resources.go
@@ -1,0 +1,190 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/resources
+func DataSourceFactoryResources() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceFactoryResourcesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the resources are located.`,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the workspace to which the resources belong.`,
+			},
+
+			// Attributes.
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the resource.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the resource.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the resource.`,
+						},
+						"location": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The OBS path of the resource file.`,
+						},
+						"directory": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The directory where the resource is located.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the resource.`,
+						},
+						"depend_files": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of dependent file paths.`,
+						},
+					},
+				},
+				Description: `The list of resources that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildFactoryMoreHeaders(workspaceId string) map[string]string {
+	result := map[string]string{
+		"Content-Type": "application/json",
+		"Dlm-Type":     "EXCLUSIVE",
+	}
+
+	if workspaceId != "" {
+		result["workspace"] = workspaceId
+	}
+
+	return result
+}
+
+func listFactoryResources(client *golangsdk.ServiceClient, workspaceId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/resources?limit={limit}"
+		offset  = 0
+		limit   = 100
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildFactoryMoreHeaders(workspaceId),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		resources := utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, resources...)
+		if len(resources) < limit {
+			break
+		}
+		offset += len(resources)
+	}
+
+	return result, nil
+}
+
+func flattenFactoryResources(resources []interface{}) []map[string]interface{} {
+	if len(resources) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(resources))
+	for _, resource := range resources {
+		result = append(result, map[string]interface{}{
+			"id":           utils.PathSearch("resourceId", resource, nil),
+			"name":         utils.PathSearch("name", resource, nil),
+			"type":         utils.PathSearch("type", resource, nil),
+			"location":     utils.PathSearch("location", resource, nil),
+			"directory":    utils.PathSearch("directory", resource, nil),
+			"description":  utils.PathSearch("desc", resource, nil),
+			"depend_files": utils.PathSearch("dependFiles", resource, make([]interface{}, 0)).([]interface{}),
+		})
+	}
+
+	return result
+}
+
+func dataSourceFactoryResourcesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts-dlf", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	resources, err := listFactoryResources(client, workspaceId)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Factory resources: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("resources", flattenFactoryResources(resources)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_resource.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_resource.go
@@ -84,8 +84,11 @@ func ResourceFactoryResource() *schema.Resource {
 }
 
 func resourceFactoryResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
 
 	createResourceHttpUrl := "v1/{project_id}/resources"
 	createResourceProduct := "dataarts-dlf"
@@ -99,7 +102,7 @@ func resourceFactoryResourceCreate(ctx context.Context, d *schema.ResourceData, 
 
 	createResourceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		MoreHeaders:      buildFactoryMoreHeaders(workspaceId),
 	}
 	createResourceOpt.JSONBody = utils.RemoveNil(buildCreateOrUpdateResourceBodyParams(d))
 	createResourceResp, err := createResourceClient.Request("POST", createResourcePath, &createResourceOpt)
@@ -150,11 +153,12 @@ func buildDependPackagesParams(d *schema.ResourceData) []map[string]string {
 }
 
 func resourceFactoryResourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	workspaceID := d.Get("workspace_id").(string)
-
-	var mErr *multierror.Error
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		mErr        *multierror.Error
+	)
 
 	getResourceHttpUrl := "v1/{project_id}/resources/{resource_id}"
 	getResourceProduct := "dataarts-dlf"
@@ -169,7 +173,7 @@ func resourceFactoryResourceRead(_ context.Context, d *schema.ResourceData, meta
 
 	getResourceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"workspace": workspaceID},
+		MoreHeaders:      buildFactoryMoreHeaders(workspaceId),
 	}
 	getResourceResp, err := getResourceClient.Request("GET", getResourcePath, &getResourceOpt)
 	if err != nil {
@@ -184,7 +188,7 @@ func resourceFactoryResourceRead(_ context.Context, d *schema.ResourceData, meta
 	mErr = multierror.Append(
 		mErr,
 		d.Set("region", region),
-		d.Set("workspace_id", workspaceID),
+		d.Set("workspace_id", workspaceId),
 		d.Set("name", utils.PathSearch("name", getResourceRespBody, nil)),
 		d.Set("type", utils.PathSearch("type", getResourceRespBody, nil)),
 		d.Set("location", utils.PathSearch("location", getResourceRespBody, nil)),
@@ -215,8 +219,11 @@ func flattenDependPackagesInGetResourceResponseBody(getResourceRespBody interfac
 }
 
 func resourceFactoryResourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
 
 	updateResourceHttpUrl := "v1/{project_id}/resources/{resource_id}"
 	updateResourceProduct := "dataarts-dlf"
@@ -231,7 +238,7 @@ func resourceFactoryResourceUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	updateResourceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		MoreHeaders:      buildFactoryMoreHeaders(workspaceId),
 		OkCodes: []int{
 			204,
 		},
@@ -246,8 +253,11 @@ func resourceFactoryResourceUpdate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceFactoryResourceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
 
 	deleteResourceHttpUrl := "v1/{project_id}/resources/{resource_id}"
 	deleteResourceProduct := "dataarts-dlf"
@@ -262,7 +272,7 @@ func resourceFactoryResourceDelete(_ context.Context, d *schema.ResourceData, me
 
 	deleteResourceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		MoreHeaders:      buildFactoryMoreHeaders(workspaceId),
 	}
 	_, err = deleteResourceClient.Request("DELETE", deleteResourcePath, &deleteResourceOpt)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source that used to query factory resources.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance test:
<img width="1034" height="81" alt="image" src="https://github.com/user-attachments/assets/e797bdd6-ad46-45e3-8867-7c5c3a511b83" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query factory resources
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataFactoryResources_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataFactoryResources_basic -timeout 360m -parallel 10
=== RUN   TestAccDataFactoryResources_basic
=== PAUSE TestAccDataFactoryResources_basic
=== CONT  TestAccDataFactoryResources_basic
--- PASS: TestAccDataFactoryResources_basic (13.52s)
PASS
coverage: 5.7% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  13.608s coverage: 5.7% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
