### PR TITLE
feat(cfw): new resource to batch delete domain sets

### DIFF
--- a/docs/resources/cfw_batch_delete_domain_sets.md
+++ b/docs/resources/cfw_batch_delete_domain_sets.md
@@ -1,0 +1,75 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_batch_delete_domain_sets"
+description: |-
+  Manages a resource to batch delete domain sets within HuaweiCloud.
+---
+
+# huaweicloud_cfw_batch_delete_domain_sets
+
+Manages a resource to batch delete domain sets within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource used to batch delete domain sets. Deleting this resource will not clear
+  the corresponding request record, but will only remove the resource information from the tf state file.
+  <br/>2. After the successful execution of the resource, it is necessary to pay attention to the value of the `data`
+  attribute. If the value of `data` is empty, it means that the current operation has not taken effect.
+
+## Example Usage
+
+```hcl
+variable "object_id" {}
+variable "set_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_cfw_batch_delete_domain_sets" "test" {
+  object_id = var.object_id
+  set_ids   = var.set_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `object_id` - (Required, String, NonUpdatable) Specifies the protected object ID.
+
+* `set_ids` - (Required, List, NonUpdatable) Specifies the IDs of domain sets to be deleted.
+
+* `fw_instance_id` - (Optional, String, NonUpdatable) Specifies the firewall ID.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate on assets under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need to set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `object_id`.
+
+* `data` - The domain sets for batch deletion.
+
+  The [data](#Batch_Delete_Domain_Sets_Data) structure is documented below.
+
+<a name="Batch_Delete_Domain_Sets_Data"></a>
+The `data` block supports:
+
+* `response_data` - The domain sets for batch deletion.
+
+  The [response_data](#Batch_Delete_Domain_Sets_Response_Data) structure is documented below.
+
+<a name="Batch_Delete_Domain_Sets_Response_Data"></a>
+The `response_data` block supports:
+
+* `name` - The name of the domain set for batch deletion.
+
+* `id` - The ID of the domain set for batch deletion.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3012,6 +3012,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_acl_rule":                      cfw.ResourceAclRule(),
 			"huaweicloud_cfw_add_dns_server":                cfw.ResourceAddDNSServer(),
 			"huaweicloud_cfw_batch_delete_acl_rules":        cfw.ResourceBatchDeleteAclRules(),
+			"huaweicloud_cfw_batch_delete_domain_sets":      cfw.ResourceBatchDeleteDomainSets(),
 			"huaweicloud_cfw_batch_update_acl_rules_action": cfw.ResourceBatchUpdateAclRulesAction(),
 			"huaweicloud_cfw_address_group":                 cfw.ResourceAddressGroup(),
 			"huaweicloud_cfw_advanced_ips_rule":             cfw.ResourceAdvancedIpsRule(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -468,6 +468,7 @@ var (
 	HW_CFW_IPS_ADVANCED_RULE_ID      = os.Getenv("HW_CFW_IPS_ADVANCED_RULE_ID")
 	HW_CFW_IPS_CUSTOM_RULE           = os.Getenv("HW_CFW_IPS_CUSTOM_RULE")
 	HW_CFW_ACL_RULE_ID               = os.Getenv("HW_CFW_ACL_RULE_ID")
+	HW_CFW_DOMAIN_SET_ID             = os.Getenv("HW_CFW_DOMAIN_SET_ID")
 	HW_CFW_IP_BLACKLIST_NAME         = os.Getenv("HW_CFW_IP_BLACKLIST_NAME")
 
 	HW_CTS_START_TIME = os.Getenv("HW_CTS_START_TIME")
@@ -2890,6 +2891,13 @@ func TestAccPreCheckCfwIpsAdvancedRuleID(t *testing.T) {
 func TestAccPreCheckCfwIpsCustomRule(t *testing.T) {
 	if HW_CFW_IPS_CUSTOM_RULE == "" {
 		t.Skip("HW_CFW_IPS_CUSTOM_RULE must be set for CFW IPS acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCfwDomainSetId(t *testing.T) {
+	if HW_CFW_DOMAIN_SET_ID == "" {
+		t.Skip("HW_CFW_DOMAIN_SET_ID must be set for CFW acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_batch_delete_domain_sets_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_batch_delete_domain_sets_test.go
@@ -1,0 +1,52 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchDeleteDomainSets_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting the firewall ID, domain set ID, and enterprise project ID for CFW,
+			// and ensuring that they are all under the same enterprise project.
+			acceptance.TestAccPreCheckCfw(t)
+			acceptance.TestAccPreCheckCfwDomainSetId(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchDeleteDomainSets_basic(),
+			},
+		},
+	})
+}
+
+func testBatchDeleteDomainSets_base() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_firewalls" "test" {
+  fw_instance_id = "%s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}
+
+func testBatchDeleteDomainSets_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cfw_batch_delete_domain_sets" "test" {
+  object_id             = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+  set_ids               = ["%[2]s"]
+  fw_instance_id        = "%[3]s"
+  enterprise_project_id = "%[4]s"
+}
+`, testBatchDeleteDomainSets_base(), acceptance.HW_CFW_DOMAIN_SET_ID, acceptance.HW_CFW_INSTANCE_ID,
+		acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_batch_delete_domain_sets.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_batch_delete_domain_sets.go
@@ -1,0 +1,191 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var batchDeleteDomainSetsNonUpdatableParams = []string{"object_id", "set_ids", "fw_instance_id", "enterprise_project_id"}
+
+// @API CFW POST /v1/{project_id}/domain-sets/batch-delete
+func ResourceBatchDeleteDomainSets() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBatchDeleteDomainSetsCreate,
+		ReadContext:   resourceBatchDeleteDomainSetsRead,
+		UpdateContext: resourceBatchDeleteDomainSetsUpdate,
+		DeleteContext: resourceBatchDeleteDomainSetsDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(batchDeleteDomainSetsNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"object_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"set_ids": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Required: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"response_data": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildBatchDeleteDomainSetsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := ""
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("fw_instance_id"); ok {
+		queryParams = fmt.Sprintf("%s&fw_instance_id=%v", queryParams, v)
+	}
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func buildBatchDeleteDomainSetsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"object_id": d.Get("object_id"),
+		"set_ids":   utils.ExpandToStringList(d.Get("set_ids").([]interface{})),
+	}
+
+	return bodyParams
+}
+
+func resourceBatchDeleteDomainSetsCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		objectId = d.Get("object_id").(string)
+		epsId    = cfg.GetEnterpriseProjectID(d)
+		httpUrl  = "v1/{project_id}/domain-sets/batch-delete"
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildBatchDeleteDomainSetsQueryParams(d, epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildBatchDeleteDomainSetsBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch deleting CFW domain sets: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(objectId)
+
+	return diag.FromErr(d.Set("data", flattenBatchDeleteDomainSetsDataResp(respBody)))
+}
+
+func flattenBatchDeleteDomainSetsDataResp(respBody interface{}) []map[string]interface{} {
+	responseDataResp := utils.PathSearch("data.responseDatas", respBody, make([]interface{}, 0)).([]interface{})
+	if len(responseDataResp) == 0 {
+		return nil
+	}
+
+	responseData := make([]map[string]interface{}, 0)
+	for _, v := range responseDataResp {
+		responseData = append(responseData, map[string]interface{}{
+			"name": utils.PathSearch("name", v, nil),
+			"id":   utils.PathSearch("id", v, nil),
+		})
+	}
+
+	return []map[string]interface{}{
+		{
+			"response_data": responseData,
+		},
+	}
+}
+
+func resourceBatchDeleteDomainSetsRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Read()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchDeleteDomainSetsUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Update()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchDeleteDomainSetsDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch delete domain sets. Deleting this resource
+    will not clear the corresponding request record, but will only remove resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to batch delete domain sets

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccBatchDeleteDomainSets_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccBatchDeleteDomainSets_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchDeleteDomainSets_basic
=== PAUSE TestAccBatchDeleteDomainSets_basic
=== CONT  TestAccBatchDeleteDomainSets_basic
--- PASS: TestAccBatchDeleteDomainSets_basic (17.84s)
PASS
coverage: 4.9% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       18.033s coverage: 4.9% of statements in ./huaweicloud/services/cfw
```
<img width="1321" height="79" alt="image" src="https://github.com/user-attachments/assets/7a43fa14-f308-4f96-9073-08d4c92c45ae" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
