### PR TITLE
feat(SWR): add data source swr_signed_image_attachments

### DIFF
--- a/docs/data-sources/swr_signed_image_attachments.md
+++ b/docs/data-sources/swr_signed_image_attachments.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_swr_signed_image_attachments"
+description: |-
+  Use this data source to list the attachments of a signed image within HuaweiCloud.
+---
+
+# huaweicloud_swr_signed_image_attachments
+
+Use this data source to list the attachments of a signed image within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "namespace" {}
+variable "repository" {}
+variable "tag" {}
+
+data "huaweicloud_swr_signed_image_attachments" "test" {
+  namespace  = var.namespace
+  repository = var.repository
+  tag        = var.tag
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `namespace` - (Required, String) Specifies the namespace (organization) name of the signed image belongs.
+
+* `repository` - (Required, String) Specifies the repository name of the signed image.
+
+* `tag` - (Required, String) Specifies the tag of the signed image.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `accessories` - All accessories that match the filter parameters.
+  The [accessories](#accessories) structure is documented below.
+
+<a name="accessories"></a>
+The `accessories` block supports:
+
+* `id` - The ID of the attachment.
+
+* `domain_id` - The ID of the tenant the attachment belongs to.
+
+* `namespace_name` - The name of the organization (namespace) the attachment belongs to.
+
+* `repo_name` - The name of the repository the attachment belongs to.
+
+* `sig_tag` - The signature tag of the attachment.
+
+* `sig_digest` - The hash value of the attachment.
+
+* `target_digest` - The hash value of the signed image associated with the attachment.
+
+* `size` - The size of the attachment.
+
+* `type` - The type of the attachment.
+
+* `created_at` - The creation time of the attachment.
+
+* `updated_at` - The update time of the attachment.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2221,6 +2221,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_swr_sync_regions":              swr.DataSourceSyncRegions(),
 			"huaweicloud_swr_organizations":             swr.DataSourceOrganizations(),
 			"huaweicloud_swr_repositories":              swr.DataSourceRepositories(),
+			"huaweicloud_swr_signed_image_attachments":  swr.DataSourceSwrSignedImageAttachments(),
 			"huaweicloud_swrv3_repositories":            swr.DataSourceSwrv3Repositories(),
 			"huaweicloud_swr_shared_repositories":       swr.DataSourceSharedRepositories(),
 			"huaweicloud_swrv3_shared_repositories":     swr.DataSourceSwrv3SharedRepositories(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -500,6 +500,7 @@ var (
 	HW_SWR_REPOSITORY = os.Getenv("HW_SWR_REPOSITORY")
 	// The signature task is sign with image exist
 	HW_SWR_SIGNATURE_WITH_IAMGE_ENABLED = os.Getenv("HW_SWR_SIGNATURE_WITH_IAMGE_ENABLED")
+	HW_SWR_TAG                          = os.Getenv("HW_SWR_TAG")
 
 	HW_SCM_CERTIFICATE_ID          = os.Getenv("HW_SCM_CERTIFICATE_ID")
 	HW_SCM_CERTIFICATE_DOMAIN_NAME = os.Getenv("HW_SCM_CERTIFICATE_DOMAIN_NAME")
@@ -1908,6 +1909,14 @@ func TestAccPreCheckSWRDomian(t *testing.T) {
 func TestAccPreCheckSWRUser(t *testing.T) {
 	if HW_SWR_USER == "" {
 		t.Skip("HW_SWR_USER must be set for CCE autopilot addon tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSWRSignedImageAttachments(t *testing.T) {
+	if HW_SWR_ORGANIZATION == "" || HW_SWR_REPOSITORY == "" || HW_SWR_TAG == "" {
+		t.Skip("HW_SWR_ORGANIZATION, HW_SWR_REPOSITORY and HW_SWR_TAG must be set for " +
+			"swr signed image attachments tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/swr/data_source_huaweicloud_swr_signed_image_attachments_test.go
+++ b/huaweicloud/services/acceptance/swr/data_source_huaweicloud_swr_signed_image_attachments_test.go
@@ -1,0 +1,53 @@
+package swr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSwrSignedImageAttachments_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_swr_signed_image_attachments.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSWRSignedImageAttachments(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSwrSignedImageAttachments_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "accessories.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "accessories.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "accessories.0.domain_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "accessories.0.namespace_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "accessories.0.repo_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "accessories.0.sig_tag"),
+					resource.TestCheckResourceAttrSet(dataSource, "accessories.0.sig_digest"),
+					resource.TestCheckResourceAttrSet(dataSource, "accessories.0.target_digest"),
+					resource.TestCheckResourceAttrSet(dataSource, "accessories.0.size"),
+					resource.TestCheckResourceAttrSet(dataSource, "accessories.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "accessories.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "accessories.0.updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceSwrSignedImageAttachments_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_swr_signed_image_attachments" "test" {
+  namespace  = "%s"
+  repository = "%s"
+  tag        = "%s"
+}
+`, acceptance.HW_SWR_ORGANIZATION, acceptance.HW_SWR_REPOSITORY, acceptance.HW_SWR_TAG)
+}

--- a/huaweicloud/services/swr/data_source_huaweicloud_swr_signed_image_attachments.go
+++ b/huaweicloud/services/swr/data_source_huaweicloud_swr_signed_image_attachments.go
@@ -1,0 +1,207 @@
+package swr
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SWR GET /v2/manage/namespaces/{namespace}/repos/{repository}/{tag}/accessories
+func DataSourceSwrSignedImageAttachments() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSwrSignedImageAttachmentsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the region in which to query the data source.",
+			},
+			"namespace": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the namespace (organization) name of the signed image belongs.",
+			},
+			"repository": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the repository name of the signed image.",
+			},
+			"tag": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the tag of the signed image.",
+			},
+			"accessories": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The list of attachments of the signed image.",
+				Elem:        repositoryAccessoriesSchema(),
+			},
+		},
+	}
+}
+
+func repositoryAccessoriesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The ID of the attachment.",
+			},
+			"domain_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the tenant the attachment belongs to.",
+			},
+			"namespace_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the organization (namespace) the attachment belongs to.",
+			},
+			"repo_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the repository the attachment belongs to.",
+			},
+			"sig_tag": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The signature tag of the attachment.",
+			},
+			"sig_digest": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The hash value of the attachment.",
+			},
+			"target_digest": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The hash value of the signed image associated with the attachment.",
+			},
+			"size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The size of the attachment.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the attachment.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the attachment.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The update time of the attachment.",
+			},
+		},
+	}
+}
+
+func dataSourceSwrSignedImageAttachmentsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+	accessories, err := queryAccessories(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("accessories", flattenAccessories(accessories)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func queryAccessories(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/manage/namespaces/{namespace}/repos/{repository}/{tag}/accessories"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{namespace}", d.Get("namespace").(string))
+	listPath = strings.ReplaceAll(listPath, "{repository}", d.Get("repository").(string))
+	listPath = strings.ReplaceAll(listPath, "{tag}", d.Get("tag").(string))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s?limit=100&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving SWR repository tag accessories: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		accessories := utils.PathSearch("accessories", respBody, make([]interface{}, 0)).([]interface{})
+		if len(accessories) < 1 {
+			break
+		}
+		result = append(result, accessories...)
+		offset += len(accessories)
+	}
+	return result, nil
+}
+
+func flattenAccessories(accessories []interface{}) []interface{} {
+	if len(accessories) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(accessories))
+	for _, v := range accessories {
+		result = append(result, map[string]interface{}{
+			"id":             utils.PathSearch("id", v, nil),
+			"domain_id":      utils.PathSearch("domain_id", v, nil),
+			"namespace_name": utils.PathSearch("namespace_name", v, nil),
+			"repo_name":      utils.PathSearch("repo_name", v, nil),
+			"sig_tag":        utils.PathSearch("sig_tag", v, nil),
+			"sig_digest":     utils.PathSearch("sig_digest", v, nil),
+			"target_digest":  utils.PathSearch("target_digest", v, nil),
+			"size":           utils.PathSearch("size", v, nil),
+			"type":           utils.PathSearch("type", v, nil),
+			"created_at":     utils.PathSearch("created_at", v, nil),
+			"updated_at":     utils.PathSearch("updated_at", v, nil),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source swr_signed_image_attachments
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data source swr_signed_image_attachments
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST='./huaweicloud/services/acceptance/swr' TESTARGS='-run=TestAccDataSourceSwrSignedImageAttachments_basic'

TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run=TestAccDataSourceSwrSignedImageAttachments_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSwrSignedImageAttachments_basic
=== PAUSE TestAccDataSourceSwrSignedImageAttachments_basic
=== CONT  TestAccDataSourceSwrSignedImageAttachments_basic
--- PASS: TestAccDataSourceSwrSignedImageAttachments_basic (17.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       17.463s
```
<img width="729" height="110" alt="image" src="https://github.com/user-attachments/assets/14804402-3edc-4c79-bb43-a6aaf58daacb" />

<img width="1308" height="841" alt="image" src="https://github.com/user-attachments/assets/8c7d9e5c-244b-4270-af50-fa6fc46a6c58" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
