### PR TITLE
feat(cfw): new resource to batch delete service group members

### DIFF
--- a/docs/resources/cfw_batch_delete_service_group_members.md
+++ b/docs/resources/cfw_batch_delete_service_group_members.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_batch_delete_service_group_members"
+description: |-
+  Manages a resource to batch delete service group members within HuaweiCloud.
+---
+
+# huaweicloud_cfw_batch_delete_service_group_members
+
+Manages a resource to batch delete service group members within HuaweiCloud.
+
+-> This resource is a one-time action resource used to batch delete service group members. Deleting this resource will
+  not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "set_id" {}
+variable "service_item_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_cfw_batch_delete_service_group_members" "test" {
+  set_id           = var.set_id
+  service_item_ids = var.service_item_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `set_id` - (Required, String, NonUpdatable) Specifies the service group ID.
+
+* `service_item_ids` - (Required, List, NonUpdatable) Specifies the IDs of service group members to be deleted.
+
+* `fw_instance_id` - (Optional, String, NonUpdatable) Specifies the firewall ID.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.  
+  This parameter is valid only when the enterprise project is enabled.
+  The default value is **0**, indicating the default enterprise project.
+  If it is necessary to operate on assets under all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need to set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `set_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3021,6 +3021,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_batch_delete_acl_rules":             cfw.ResourceBatchDeleteAclRules(),
 			"huaweicloud_cfw_batch_delete_address_group_members": cfw.ResourceBatchDeleteAddressGroupMembers(),
 			"huaweicloud_cfw_batch_delete_domain_sets":           cfw.ResourceBatchDeleteDomainSets(),
+			"huaweicloud_cfw_batch_delete_service_group_members": cfw.ResourceBatchDeleteServiceGroupMembers(),
 			"huaweicloud_cfw_batch_update_acl_rules_action":      cfw.ResourceBatchUpdateAclRulesAction(),
 			"huaweicloud_cfw_address_group":                      cfw.ResourceAddressGroup(),
 			"huaweicloud_cfw_advanced_ips_rule":                  cfw.ResourceAdvancedIpsRule(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -472,6 +472,8 @@ var (
 	HW_CFW_IP_BLACKLIST_NAME         = os.Getenv("HW_CFW_IP_BLACKLIST_NAME")
 	HW_CFW_ADDRESS_GROUP_ID          = os.Getenv("HW_CFW_ADDRESS_GROUP_ID")
 	HW_CFW_ADDRESS_GROUP_MEMBER_ID   = os.Getenv("HW_CFW_ADDRESS_GROUP_MEMBER_ID")
+	HW_CFW_SERVICE_GROUP_ID          = os.Getenv("HW_CFW_SERVICE_GROUP_ID")
+	HW_CFW_SERVICE_GROUP_MEMBER_ID   = os.Getenv("HW_CFW_SERVICE_GROUP_MEMBER_ID")
 
 	HW_CTS_START_TIME = os.Getenv("HW_CTS_START_TIME")
 	HW_CTS_END_TIME   = os.Getenv("HW_CTS_END_TIME")
@@ -2929,6 +2931,20 @@ func TestAccPreCheckCfwAddressGroupId(t *testing.T) {
 func TestAccPreCheckCfwAddressGroupMemberId(t *testing.T) {
 	if HW_CFW_ADDRESS_GROUP_MEMBER_ID == "" {
 		t.Skip("HW_CFW_ADDRESS_GROUP_MEMBER_ID must be set for CFW acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCfwServiceGroupId(t *testing.T) {
+	if HW_CFW_SERVICE_GROUP_ID == "" {
+		t.Skip("HW_CFW_SERVICE_GROUP_ID must be set for CFW acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCfwServiceGroupMemberId(t *testing.T) {
+	if HW_CFW_SERVICE_GROUP_MEMBER_ID == "" {
+		t.Skip("HW_CFW_SERVICE_GROUP_MEMBER_ID must be set for CFW acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_batch_delete_service_group_members_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_batch_delete_service_group_members_test.go
@@ -1,0 +1,36 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchDeleteServiceGroupMembers_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfwServiceGroupId(t)
+			acceptance.TestAccPreCheckCfwServiceGroupMemberId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchDeleteServiceGroupMembers_basic(),
+			},
+		},
+	})
+}
+
+func testBatchDeleteServiceGroupMembers_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cfw_batch_delete_service_group_members" "test" {
+  set_id           = "%[1]s"
+  service_item_ids = ["%[2]s"]
+}
+`, acceptance.HW_CFW_SERVICE_GROUP_ID, acceptance.HW_CFW_SERVICE_GROUP_MEMBER_ID)
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_batch_delete_service_group_members.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_batch_delete_service_group_members.go
@@ -1,0 +1,146 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var batchDeleteServiceGroupMembersNonUpdatableParams = []string{
+	"set_id",
+	"service_item_ids",
+	"fw_instance_id",
+	"enterprise_project_id",
+}
+
+// @API CFW DELETE /v1/{project_id}/service-items
+func ResourceBatchDeleteServiceGroupMembers() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBatchDeleteServiceGroupMembersCreate,
+		ReadContext:   resourceBatchDeleteServiceGroupMembersRead,
+		UpdateContext: resourceBatchDeleteServiceGroupMembersUpdate,
+		DeleteContext: resourceBatchDeleteServiceGroupMembersDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(batchDeleteServiceGroupMembersNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"set_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"service_item_ids": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Required: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildBatchDeleteServiceGroupMembersQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := ""
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("fw_instance_id"); ok {
+		queryParams = fmt.Sprintf("%s&fw_instance_id=%v", queryParams, v)
+	}
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func buildBatchDeleteServiceGroupMembersBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"set_id":           d.Get("set_id"),
+		"service_item_ids": utils.ExpandToStringList(d.Get("service_item_ids").([]interface{})),
+	}
+
+	return bodyParams
+}
+
+func resourceBatchDeleteServiceGroupMembersCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		setId   = d.Get("set_id").(string)
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v1/{project_id}/service-items"
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildBatchDeleteServiceGroupMembersQueryParams(d, epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildBatchDeleteServiceGroupMembersBodyParams(d),
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch deleting CFW service group members: %s", err)
+	}
+
+	d.SetId(setId)
+
+	return nil
+}
+
+func resourceBatchDeleteServiceGroupMembersRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Read()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchDeleteServiceGroupMembersUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Update()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchDeleteServiceGroupMembersDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch delete service group members. Deleting this resource
+    will not clear of corresponding request record, but will only remove resource information from
+    tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to batch delete service group members.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o cfw -f TestAccBatchDeleteServiceGroupMembers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccBatchDeleteServiceGroupMembers_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchDeleteServiceGroupMembers_basic
=== PAUSE TestAccBatchDeleteServiceGroupMembers_basic
=== CONT  TestAccBatchDeleteServiceGroupMembers_basic
--- PASS: TestAccBatchDeleteServiceGroupMembers_basic (15.57s)
PASS
coverage: 3.6% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       15.716s coverage: 3.6% of statements in ./huaweicloud/services/cfw
```
<img width="1367" height="80" alt="image" src="https://github.com/user-attachments/assets/ffb4a6f8-ee43-469d-9ecf-e8dba0542e77" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
