### PR TITLE
feat(cfw): support `cfw_enterprise_routers` data source

### DIFF
--- a/docs/data-sources/cfw_enterprise_routers.md
+++ b/docs/data-sources/cfw_enterprise_routers.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_enterprise_routers"
+description: |-
+  Use this data source to get the enterprise routers used by the CFW east-west firewall within HuaweiCloud.
+---
+
+# huaweicloud_cfw_enterprise_routers
+
+Use this data source to get the enterprise routers used by the CFW east-west firewall within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+
+data "huaweicloud_cfw_enterprise_routers" "test" {
+  fw_instance_id = var.fw_instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `fw_instance_id` - (Required, String) Specifies the firewall instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `er_list` - The enterprise router list.
+
+  The [er_list](#er_list_struct) structure is documented below.
+
+<a name="er_list_struct"></a>
+The `er_list` block supports:
+
+* `er_id` - The enterprise router ID.
+
+* `name` - The enterprise router name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -847,6 +847,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_domain_resolve_ip_list":        cfw.DataSourceCfwDomainResolveIpList(),
 			"huaweicloud_cfw_eip_auto_protect_status":       cfw.DataSourceEipAutoProtectStatus(),
 			"huaweicloud_cfw_eip_count":                     cfw.DataSourceEipCount(),
+			"huaweicloud_cfw_enterprise_routers":            cfw.DataSourceEnterpriseRouters(),
 			"huaweicloud_cfw_protection_rules":              cfw.DataSourceCfwProtectionRules(),
 			"huaweicloud_cfw_service_groups":                cfw.DataSourceCfwServiceGroups(),
 			"huaweicloud_cfw_service_group_members":         cfw.DataSourceCfwServiceGroupMembers(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_enterprise_routers_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_enterprise_routers_test.go
@@ -1,0 +1,45 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEnterpriseRouters_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cfw_enterprise_routers.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case requires setting a firewall instance ID.
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceEnterpriseRouters_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "er_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "er_list.0.er_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "er_list.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceEnterpriseRouters_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_enterprise_routers" "test" {
+  fw_instance_id = "%s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_enterprise_routers.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_enterprise_routers.go
@@ -1,0 +1,114 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/firewall/east-west/enterprise-router
+func DataSourceEnterpriseRouters() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEnterpriseRoutersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"er_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"er_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceEnterpriseRoutersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cfw"
+		httpUrl = "v1/{project_id}/firewall/east-west/enterprise-router"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?fw_instance_id=%s", d.Get("fw_instance_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW east-west firewall enterprise routers: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("er_list", flattenEnterpriseRouterErList(
+			utils.PathSearch("data.er_list", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenEnterpriseRouterErList(erListResp []interface{}) []interface{} {
+	if len(erListResp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(erListResp))
+	for _, raw := range erListResp {
+		result = append(result, map[string]interface{}{
+			"er_id": utils.PathSearch("er_id", raw, nil),
+			"name":  utils.PathSearch("name", raw, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_enterprise_routers` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_enterprise_routers` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceEnterpriseRouters_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccDataSourceEnterpriseRouters_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceEnterpriseRouters_basic
--- PASS: TestAccDataSourceEnterpriseRouters_basic (11.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       11.635s
```
<img width="875" height="37" alt="image" src="https://github.com/user-attachments/assets/d84d19ca-b15c-4260-aea4-d868c0aa55d3" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
