### PR TITLE
feat(dataarts/factory): add new data source to query scripts

### DIFF
--- a/docs/data-sources/dataarts_factory_scripts.md
+++ b/docs/data-sources/dataarts_factory_scripts.md
@@ -1,0 +1,68 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_factory_scripts"
+description: |-
+  Use this data source to query DataArts Factory scripts within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_factory_scripts
+
+Use this data source to query DataArts Factory scripts within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_factory_scripts" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the scripts are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the scripts belong.
+
+* `script_name` - (Optional, String) Specifies the name of script to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `scripts` - The list of scripts that matched filter parameters.  
+  The [scripts](#dataarts_factory_scripts) structure is documented below.
+
+<a name="dataarts_factory_scripts"></a>
+The `scripts` block supports:
+
+* `id` - The script ID.
+
+* `name` - The script name.
+
+* `type` - The script type.
+
+* `directory` - The directory path where the script is located.
+
+* `create_user` - The user who created the script.
+
+* `connection_name` - The connection name associated with the script.
+
+* `database` - The database associated with the script.
+
+* `queue_name` - The DLI queue name associated with the script.
+
+* `configuration` - The user-defined configuration parameters associated with the script.
+
+* `description` - The description of the script.
+
+* `modify_time` - The last modification time of the script, in RFC3339 format.
+
+* `owner` - The owner of the script.
+
+* `version` - The version number of the script.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1081,6 +1081,7 @@ func Provider() *schema.Provider {
 			// DataArts Factory
 			"huaweicloud_dataarts_factory_jobs":      dataarts.DataSourceFactoryJobs(),
 			"huaweicloud_dataarts_factory_resources": dataarts.DataSourceFactoryResources(),
+			"huaweicloud_dataarts_factory_scripts":   dataarts.DataSourceFactoryScripts(),
 
 			"huaweicloud_dbss_audit_data_masking_rules":  dbss.DataSourceDbssAuditDataMaskingRules(),
 			"huaweicloud_dbss_audit_risk_rules":          dbss.DataSourceDbssAuditRiskRules(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_factory_scripts_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_factory_scripts_test.go
@@ -1,0 +1,156 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataFactoryScripts_basic(t *testing.T) {
+	var (
+		rName = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_factory_scripts.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		filterByName   = "data.huaweicloud_dataarts_factory_scripts.filter_by_name"
+		dcFilterByName = acceptance.InitDataSourceCheck(filterByName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsConnectionName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataFactoryScripts_nonExistentWorkspace(),
+				ExpectError: regexp.MustCompile("Workspace does not exists"),
+			},
+			{
+				Config: testAccDataFactoryScripts_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "scripts.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcFilterByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_script_name_filter_useful", "true"),
+					resource.TestCheckResourceAttrSet(filterByName, "scripts.0.id"),
+					resource.TestCheckResourceAttrPair(filterByName, "scripts.0.name",
+						"huaweicloud_dataarts_factory_script.test", "name"),
+					resource.TestCheckResourceAttrPair(filterByName, "scripts.0.type",
+						"huaweicloud_dataarts_factory_script.test", "type"),
+					resource.TestCheckResourceAttrPair(filterByName, "scripts.0.directory",
+						"huaweicloud_dataarts_factory_script.test", "directory"),
+					resource.TestCheckResourceAttrPair(filterByName, "scripts.0.create_user",
+						"huaweicloud_dataarts_factory_script.test", "created_by"),
+					resource.TestCheckResourceAttrPair(filterByName, "scripts.0.connection_name",
+						"huaweicloud_dataarts_factory_script.test", "connection_name"),
+					resource.TestCheckResourceAttrPair(filterByName, "scripts.0.database",
+						"huaweicloud_dataarts_factory_script.test", "database"),
+					resource.TestCheckResourceAttrPair(filterByName, "scripts.0.queue_name",
+						"huaweicloud_dataarts_factory_script.test", "queue_name"),
+					resource.TestCheckResourceAttrPair(filterByName, "scripts.0.configuration",
+						"huaweicloud_dataarts_factory_script.test", "configuration"),
+					resource.TestCheckResourceAttrPair(filterByName, "scripts.0.description",
+						"huaweicloud_dataarts_factory_script.test", "description"),
+					resource.TestCheckResourceAttrSet(filterByName, "scripts.0.modify_time"),
+					resource.TestCheckResourceAttrSet(filterByName, "scripts.0.owner"),
+					resource.TestCheckResourceAttrSet(filterByName, "scripts.0.version"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataFactoryScripts_nonExistentWorkspace() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_factory_scripts" "test" {
+  workspace_id = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataFactoryScripts_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_database" "test" {
+  name        = "%[1]s"
+  description = "Created by Terraform Script"
+}
+
+resource "huaweicloud_dli_table" "test" {
+  database_name = huaweicloud_dli_database.test.name
+  name          = "%[1]s"
+  data_location = "DLI"
+  description   = "Created by Terraform Script"
+
+  columns {
+    name = "name"
+    type = "string"
+  }
+
+  columns {
+    name = "age"
+    type = "int"
+  }
+}
+
+resource "huaweicloud_dataarts_factory_script" "test" {
+  depends_on = [
+    huaweicloud_dli_database.test,
+    huaweicloud_dli_table.test,
+  ]
+
+  workspace_id    = "%[2]s"
+  name            = "%[1]s"
+  type            = "DLISQL"
+  content         = "SELECT * FROM ${huaweicloud_dli_database.test.name}.${huaweicloud_dli_table.test.name}"
+  connection_name = "%[3]s"
+  directory       = "/basic"
+  database        = huaweicloud_dli_database.test.name
+  queue_name      = "default"
+  description     = "Created by Terraform Script"
+}
+
+data "huaweicloud_dataarts_factory_scripts" "all" {
+  depends_on = [
+    huaweicloud_dataarts_factory_script.test,
+  ]
+
+  workspace_id = "%[2]s"
+}
+
+locals {
+  script_name = huaweicloud_dataarts_factory_script.test.name
+}
+
+data "huaweicloud_dataarts_factory_scripts" "filter_by_name" {
+  # The behavior of parameter 'name' of the resource is 'Required', means this parameter does not 
+  # have 'Know After Apply' behavior.
+  depends_on = [
+    huaweicloud_dataarts_factory_script.test,
+  ]
+
+  workspace_id = "%[2]s"
+  script_name  = local.script_name
+}
+
+locals {
+  script_name_filter_result = [
+    for v in data.huaweicloud_dataarts_factory_scripts.filter_by_name.scripts : v.name == local.script_name
+  ]
+}
+
+output "is_script_name_filter_useful" {
+  value = length(local.script_name_filter_result) > 0 && alltrue(local.script_name_filter_result)
+}
+`, name, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_CONNECTION_NAME)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_factory_resources.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_factory_resources.go
@@ -85,10 +85,16 @@ func DataSourceFactoryResources() *schema.Resource {
 	}
 }
 
-func buildFactoryMoreHeaders(workspaceId string) map[string]string {
+func buildFactoryMoreHeaders(workspaceId string, isExclusive ...bool) map[string]string {
 	result := map[string]string{
 		"Content-Type": "application/json",
 		"Dlm-Type":     "EXCLUSIVE",
+	}
+
+	// By default, the DLM type is set to 'EXCLUSIVE'. If the isExclusive parameter is set to 'false', the DLM type is
+	// not set.
+	if len(isExclusive) > 0 && !isExclusive[0] {
+		delete(result, "Dlm-Type")
 	}
 
 	if workspaceId != "" {

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_factory_scripts.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_factory_scripts.go
@@ -1,0 +1,231 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/factory/scripts
+func DataSourceFactoryScripts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceFactoryScriptsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the scripts are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the scripts belong.`,
+			},
+
+			// Optional parameters.
+			"script_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of script to be queried.`,
+			},
+
+			// Attributes.
+			"scripts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The script ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The script name.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The script type.`,
+						},
+						"directory": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The directory path where the script is located.`,
+						},
+						"create_user": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The user who created the script.`,
+						},
+						"connection_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The connection name associated with the script.`,
+						},
+						"database": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The database associated with the script.`,
+						},
+						"queue_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The DLI queue name associated with the script.`,
+						},
+						"configuration": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The user-defined configuration parameters associated with the script.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the script.`,
+						},
+						"modify_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The last modification time of the script, in RFC3339 format.`,
+						},
+						"owner": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The owner of the script.`,
+						},
+						"version": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The version number of the script.`,
+						},
+					},
+				},
+				Description: `The list of scripts that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildFactoryScriptsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("script_name"); ok {
+		res = fmt.Sprintf("%s&script_name=%v", res, v)
+	}
+
+	return res
+}
+
+func listFactoryScripts(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/factory/scripts?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildFactoryScriptsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildFactoryMoreHeaders(d.Get("workspace_id").(string), false),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		scripts := utils.PathSearch("scripts", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, scripts...)
+
+		if len(scripts) < limit {
+			break
+		}
+		offset += len(scripts)
+	}
+
+	return result, nil
+}
+
+func flattenFactoryScripts(scripts []interface{}) []map[string]interface{} {
+	if len(scripts) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(scripts))
+	for _, script := range scripts {
+		result = append(result, map[string]interface{}{
+			"id":              utils.PathSearch("id", script, nil),
+			"name":            utils.PathSearch("name", script, nil),
+			"type":            utils.PathSearch("type", script, nil),
+			"directory":       utils.PathSearch("directory", script, nil),
+			"create_user":     utils.PathSearch("create_user", script, nil),
+			"connection_name": utils.PathSearch("connection_name", script, nil),
+			"database":        utils.PathSearch("database", script, nil),
+			"queue_name":      utils.PathSearch("queue_name", script, nil),
+			"configuration":   utils.PathSearch("configuration", script, nil),
+			"description":     utils.PathSearch("description", script, nil),
+			"modify_time":     utils.FormatTimeStampRFC3339(int64(utils.PathSearch("modify_time", script, float64(0)).(float64))/1000, false),
+			"owner":           utils.PathSearch("owner", script, nil),
+			"version":         int(utils.PathSearch("version", script, float64(0)).(float64)),
+		})
+	}
+	return result
+}
+
+func dataSourceFactoryScriptsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	items, err := listFactoryScripts(client, d)
+	if err != nil {
+		return diag.Errorf("error querying DataArts factory scripts: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("scripts", flattenFactoryScripts(items)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source that used to query Factory scripts

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance test:
<img width="1035" height="80" alt="image" src="https://github.com/user-attachments/assets/dd58ba53-fa38-4556-ad2f-b9cdaf6146f7" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source for Factory scripts query
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataFactoryScripts_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataFactoryScripts_basic -timeout 360m -parallel 10
=== RUN   TestAccDataFactoryScripts_basic
=== PAUSE TestAccDataFactoryScripts_basic
=== CONT  TestAccDataFactoryScripts_basic
--- PASS: TestAccDataFactoryScripts_basic (23.90s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  24.028s coverage: 5.3% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
