### PR TITLE
feat(cdn): Redirect rule supports new param and upgrade history param behavior

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -953,10 +953,18 @@ The `error_code_redirect_rules` block support:
 * `error_code` - (Required, Int) Specifies the redirect unique error code. Valid values are: **400**, **403**, **404**,
   **405**, **414**, **416**, **451**, **500**, **501**, **502**, **503**, and **504**.
 
-* `target_code` - (Required, Int) Specifies the redirect status code. The value can be **301** or **302**.
-
 * `target_link` - (Required, String) Specifies the destination URL. The value must start with **http://** or **https://**.
   For example: `http://www.example.com`.
+
+* `execution_mode` - (Required, String) Specifies the execution mode of the error code redirect rule.  
+  The valid values are as follows:
+  + **redirect**
+  + **break**
+
+* `target_code` - (Optional, Int) Specifies the redirect status code.  
+  The valid values are as follows:
+  + **301**
+  + **302**
 
 <a name="hsts_object"></a>
 The `hsts` block support:

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -586,7 +586,7 @@ func TestAccDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.type", "gzip"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.file_type", ".js,.html,.css,.xml,.json,.shtml,.htm"),
+					resource.TestCheckResourceAttrSet(resourceName, "configs.0.compress.0.file_type"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.referer.0.type", "white"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.referer.0.include_empty", "false"),
@@ -608,6 +608,17 @@ func TestAccDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.#", "2"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_redirect_rules.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "configs.0.error_code_redirect_rules.*", map[string]string{
+						"error_code":     "416",
+						"target_code":    "301",
+						"target_link":    "http://example.com",
+						"execution_mode": "redirect",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "configs.0.error_code_redirect_rules.*", map[string]string{
+						"error_code":     "502",
+						"target_link":    "/errorcode.html",
+						"execution_mode": "break",
+					}),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.access_area_filter.#", "2"),
 
@@ -736,6 +747,7 @@ func TestAccDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_redirect_rules.0.error_code", "416"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_redirect_rules.0.target_code", "301"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_redirect_rules.0.target_link", "http://example.com"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_redirect_rules.0.execution_mode", "redirect"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.access_area_filter.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.access_area_filter.0.area", "HK,TW,AE,LB"),
@@ -1020,15 +1032,16 @@ resource "huaweicloud_cdn_domain" "test" {
     }
 
     error_code_redirect_rules {
-      error_code  = 416
-      target_code = 301
-      target_link = "http://example.com"
+      error_code     = 416
+      target_code    = 301
+      target_link    = "http://example.com"
+      execution_mode = "redirect"
     }
 
     error_code_redirect_rules {
-      error_code  = 502
-      target_code = 302
-      target_link = "https://xxx.cn/"
+      error_code     = 502
+      target_link    = "/errorcode.html"
+      execution_mode = "break"
     }
 
     access_area_filter {
@@ -1277,9 +1290,10 @@ resource "huaweicloud_cdn_domain" "test" {
     }
 
     error_code_redirect_rules {
-      error_code  = 416
-      target_code = 301
-      target_link = "http://example.com"
+      error_code     = 416
+      target_code    = 301
+      target_link    = "http://example.com"
+      execution_mode = "redirect"
     }
 
     access_area_filter {

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -689,13 +689,25 @@ var errorCodeRedirectRules = schema.Schema{
 				Type:     schema.TypeInt,
 				Required: true,
 			},
-			"target_code": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
 			"target_link": {
 				Type:     schema.TypeString,
 				Required: true,
+			},
+			"execution_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The execution mode of the error code redirect rule.`,
+					utils.SchemaDescInput{
+						Required: true,
+					},
+				),
+			},
+			"target_code": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
 			},
 		},
 	},
@@ -1982,9 +1994,10 @@ func flattenErrorCodeRedirectRulesAttributes(configResp interface{}) []interface
 	for _, v := range curArray {
 		rawMap := v.(map[string]interface{})
 		rst = append(rst, map[string]interface{}{
-			"error_code":  rawMap["error_code"],
-			"target_code": rawMap["target_code"],
-			"target_link": rawMap["target_link"],
+			"error_code":     rawMap["error_code"],
+			"target_code":    rawMap["target_code"],
+			"target_link":    rawMap["target_link"],
+			"execution_mode": rawMap["execution_mode"],
 		})
 	}
 	return rst
@@ -2667,11 +2680,12 @@ func buildCdnDomainErrorCodeRedirectRules(errorCodeRedirectRules []interface{}) 
 	rst := make([]interface{}, 0, len(errorCodeRedirectRules))
 	for _, v := range errorCodeRedirectRules {
 		rawMap := v.(map[string]interface{})
-		rst = append(rst, map[string]interface{}{
-			"error_code":  rawMap["error_code"],
-			"target_code": rawMap["target_code"],
-			"target_link": rawMap["target_link"],
-		})
+		rst = append(rst, utils.RemoveNil(map[string]interface{}{
+			"error_code":     rawMap["error_code"],
+			"target_link":    rawMap["target_link"],
+			"target_code":    utils.ValueIgnoreEmpty(rawMap["target_code"]),
+			"execution_mode": utils.ValueIgnoreEmpty(rawMap["execution_mode"]),
+		}))
 	}
 	return rst
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new parameter `execution_mode` for `configs.0.error_code_redirect_rules`.
The behavior is set to with `Optional` and `Computed` to avoid incompatibility issues with historical scripts.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. error code redirect rule supports new parameter.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o cdn -f TestAccDomain_configs
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cdn" -v -coverprofile="./huaweicloud/services/acceptance/cdn/cdn_coverage.cov" -coverpkg="./huaweicloud/services/cdn" -run TestAccDomain_configs -timeout 360m -parallel 10
=== RUN   TestAccDomain_configs
=== PAUSE TestAccDomain_configs
=== CONT  TestAccDomain_configs
--- PASS: TestAccDomain_configs (1113.33s)
PASS
coverage: 25.4% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       1113.417s       coverage: 25.4% of statements in ./huaweicloud/services/cdn
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
