### PR TITLE
feat(cfw): support `cfw_ip_blacklist_switch` resource

### DIFF
--- a/docs/resources/cfw_ip_blacklist_switch.md
+++ b/docs/resources/cfw_ip_blacklist_switch.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_ip_blacklist_switch"
+description: |-
+  Manages a resource to enable or disable the IP blacklist feature within HuaweiCloud.
+---
+
+# huaweicloud_cfw_ip_blacklist_switch
+
+Manages a resource to enable or disable the IP blacklist feature within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource used to enable or disable the IP blacklist feature for traffic
+  filtering. Deleting this resource will not restore the previous switch state on the cloud, but will only remove the
+  resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "fw_instance_id" {}
+
+resource "huaweicloud_cfw_ip_blacklist_switch" "test" {
+  fw_instance_id = var.fw_instance_id
+  status         = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `fw_instance_id` - (Required, String, NonUpdatable) Specifies the firewall instance ID.
+
+* `status` - (Required, Int, NonUpdatable) Specifies whether to enable the IP blacklist feature.  
+  The valid values are as follows:
+  + **0**: Disable.
+  + **1**: Enable.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `fw_instance_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3054,6 +3054,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_export_ip_blacklist":                cfw.ResourceExportIpBlacklist(),
 			"huaweicloud_cfw_eip_all_protection_switch":          cfw.ResourceEipAllProtectionSwitch(),
 			"huaweicloud_cfw_ip_blacklist_retry":                 cfw.ResourceIpBlacklistRetry(),
+			"huaweicloud_cfw_ip_blacklist_switch":                cfw.ResourceIpBlacklistSwitch(),
 
 			"huaweicloud_cloudtable_cluster": cloudtable.ResourceCloudTableCluster(),
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_ip_blacklist_switch_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_ip_blacklist_switch_test.go
@@ -1,0 +1,35 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccIpBlacklistSwitch_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testIpBlacklistSwitch_basic(),
+			},
+		},
+	})
+}
+
+func testIpBlacklistSwitch_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cfw_ip_blacklist_switch" "test" {
+  fw_instance_id = "%s"
+  status         = 1
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_ip_blacklist_switch.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_ip_blacklist_switch.go
@@ -1,0 +1,111 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var ipBlacklistSwitchNonUpdatableParams = []string{"fw_instance_id", "status"}
+
+// @API CFW POST /v1/{project_id}/ptf/ip-blacklist/switch
+func ResourceIpBlacklistSwitch() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIpBlacklistSwitchCreate,
+		ReadContext:   resourceIpBlacklistSwitchRead,
+		UpdateContext: resourceIpBlacklistSwitchUpdate,
+		DeleteContext: resourceIpBlacklistSwitchDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(ipBlacklistSwitchNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"fw_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"status": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildEnableIpBlacklistQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?fw_instance_id=%s", d.Get("fw_instance_id").(string))
+}
+
+func resourceIpBlacklistSwitchCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/ptf/ip-blacklist/switch"
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildEnableIpBlacklistQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"status": d.Get("status"),
+		},
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error updating CFW IP blacklist switch: %s", err)
+	}
+
+	d.SetId(d.Get("fw_instance_id").(string))
+
+	return nil
+}
+
+func resourceIpBlacklistSwitchRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceIpBlacklistSwitchUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceIpBlacklistSwitchDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to enable or disable the IP blacklist feature.
+    Deleting this resource will not restore the previous switch state on the cloud, but will only remove the resource
+    information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_ip_blacklist_switch` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_ip_blacklist_switch` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccIpBlacklistSwitch_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccIpBlacklistSwitch_basic -timeout 360m -parallel 4
=== RUN   TestAccIpBlacklistSwitch_basic
=== PAUSE TestAccIpBlacklistSwitch_basic
=== CONT  TestAccIpBlacklistSwitch_basic
--- PASS: TestAccIpBlacklistSwitch_basic (12.35s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       12.441s
```
<img width="859" height="33" alt="image" src="https://github.com/user-attachments/assets/e8ca83fa-ba12-4338-969f-6fd811318301" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
