### PR TITLE
feat(VPCEP): add action resource to upgrade vpc endpoint

### DIFF
--- a/docs/resources/vpcep_endpoint_upgrade.md
+++ b/docs/resources/vpcep_endpoint_upgrade.md
@@ -1,0 +1,39 @@
+---
+subcategory: "VPC Endpoint (VPCEP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpcep_endpoint_upgrade"
+description: -|
+  Use this resource to upgrade a basic VPC endpoint to a professional VPC endpoint within HuaweiCloud.
+---
+
+# huaweicloud_vpcep_endpoint_upgrade
+
+Use this resource to upgrade a basic VPC endpoint to a professional VPC endpoint within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "vpc_endpoint_id" {}
+
+resource "huaweicloud_vpcep_endpoint_upgrade" "test" {
+  vpc_endpoint_id = var.vpc_endpoint_id
+  action          = "start"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which the resource belongs to.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `vpc_endpoint_id` - (Required, String, NonUpdatable) Specifies the ID of the VPC endpoint.
+
+* `action` - (Required, String, NonUpdatable) Specifies the upgrade action. The default value is **start**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4194,6 +4194,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_vpcep_approval":                  vpcep.ResourceVPCEndpointApproval(),
 			"huaweicloud_vpcep_endpoint":                  vpcep.ResourceVPCEndpoint(),
+			"huaweicloud_vpcep_endpoint_upgrade":          vpcep.ResourceVPCEndpointUpgrade(),
 			"huaweicloud_vpcep_service":                   vpcep.ResourceVPCEndpointService(),
 			"huaweicloud_vpcep_service_upgrade":           vpcep.ResourceVPCServiceUpgrade(),
 			"huaweicloud_vpcep_service_connection_update": vpcep.ResourceVPCEndpointServiceConnectionUpdate(),

--- a/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_endpoint_upgrade_test.go
+++ b/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_endpoint_upgrade_test.go
@@ -1,0 +1,49 @@
+package vpcep
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccVpcepEndpointUpgrade_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testVpcepEndpointUpgrade_basic(rName),
+			},
+		},
+	})
+}
+
+func testVpcepEndpointUpgrade_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_vpcep_public_services" "test" {
+  service_name = "iam"
+}
+
+resource "huaweicloud_vpcep_endpoint" "test" {
+  service_id = data.huaweicloud_vpcep_public_services.test.services[0].id
+  vpc_id     = huaweicloud_vpc.test.id
+  network_id = huaweicloud_vpc_subnet.test.id
+}
+
+resource "huaweicloud_vpcep_endpoint_upgrade" "test" {
+  vpc_endpoint_id = huaweicloud_vpcep_endpoint.test.id
+  action          = "start"
+}
+`, common.TestVpc(name), name)
+}

--- a/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_endpoint_upgrade.go
+++ b/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_endpoint_upgrade.go
@@ -1,0 +1,114 @@
+package vpcep
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var vpcepEndpointUpgradeNonUpdatableParams = []string{
+	"vpc_endpoint_id", "action",
+}
+
+// @API VPCEP POST /v2/{project_id}/vpc-endpoints/{vpc_endpoint_id}/upgrade
+func ResourceVPCEndpointUpgrade() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVPCEndpointUpgradeCreate,
+		ReadContext:   resourceVPCEndpointUpgradeRead,
+		UpdateContext: resourceVPCEndpointUpgradeUpdate,
+		DeleteContext: resourceVPCEndpointUpgradeDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(vpcepEndpointUpgradeNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"vpc_endpoint_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceVPCEndpointUpgradeCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		httpUrl       = "v2/{project_id}/vpc-endpoints/{vpc_endpoint_id}/upgrade"
+		vpcEndpointId = d.Get("vpc_endpoint_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("vpcep", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC endpoint client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{vpc_endpoint_id}", vpcEndpointId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildUpgradeRequestBody(d),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error upgrading VPC endpoint: %s", err)
+	}
+
+	d.SetId(vpcEndpointId)
+
+	return nil
+}
+
+func buildUpgradeRequestBody(d *schema.ResourceData) map[string]interface{} {
+	requestBody := map[string]interface{}{
+		"action": d.Get("action").(string),
+	}
+	return requestBody
+}
+
+func resourceVPCEndpointUpgradeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVPCEndpointUpgradeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVPCEndpointUpgradeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting VPC endpoint upgrade resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add action resource to upgrade vpc endpoint
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add action resource to upgrade vpc endpoint
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/vpcep" TESTARGS="-run TestAccVpcepEndpointUpgrade_basic"
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVpcepEndpointUpgrade_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcepEndpointUpgrade_basic
=== PAUSE TestAccVpcepEndpointUpgrade_basic
=== CONT  TestAccVpcepEndpointUpgrade_basic
--- PASS: TestAccVpcepEndpointUpgrade_basic (68.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     69.099s
```

<img width="770" height="114" alt="image" src="https://github.com/user-attachments/assets/82aeba73-7d6e-49ab-a1aa-f8be8a722820" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
