### PR TITLE
chore(dataarts): optimize the permission set resource, test and document

### DIFF
--- a/docs/resources/dataarts_security_permission_set_privilege.md
+++ b/docs/resources/dataarts_security_permission_set_privilege.md
@@ -42,62 +42,61 @@ resource "huaweicloud_dataarts_security_permission_set_privilege" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
-  If omitted, the provider-level region will be used.
-  Changing this creates a new resource.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to the permission set to be granted privilege
+  is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
 
-* `workspace_id` - (Required, String, ForceNew) Specifies the ID of the workspace to which the permission set belongs.
-  Changing this creates a new resource.
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the ID of the workspace to which the permission set
+  belongs.
 
-* `permission_set_id` - (Required, String, ForceNew) Specifies the ID of the permission set to be granted.
-  Changing this creates a new resource.
+* `permission_set_id` - (Required, String, NonUpdatable) Specifies the ID of the permission set to be granted.
 
-* `datasource_type` - (Required, String, ForceNew) Specifies the type of granted data source.
-  The valid values are **HIVE**, **DWS** and **DLI**.
-  Changing this creates a new resource.
-  
-* `type` - (Required, String, ForceNew) Specifies the type of permission to be configured.
+* `datasource_type` - (Required, String, NonUpdatable) Specifies the type of granted data source.  
+  The valid values are as follows:
+  + **HIVE**
+  + **DWS**
+  + **DLI**
+
+* `type` - (Required, String, NonUpdatable) Specifies the type of permission to be configured.  
   Currently, only **ALLOW** is supported.
-  Changing this creates a new resource.
 
-* `actions` - (Required, List) Specifies the list of granted permissions. The valid length is limited from `1` to `32`,
+* `actions` - (Required, List) Specifies the list of granted permissions.  
+  The valid length is limited from `1` to `32`.  
   The valid [permissions](#permissions_for_permission_set) are documented below.
 
-* `cluster_name` - (Required, String, ForceNew) Specifies the cluster name corresponding to the granted data source.
-  The valid ranges from `1` to `128`.
-  Changing this creates a new resource.
-  If `datasource_type` is set to `DLI`, the parameter is set to `*`.
+* `cluster_name` - (Required, String, NonUpdatable) Specifies the cluster name corresponding to the granted data
+  source.  
+  The valid ranges from `1` to `128`.  
+  If `datasource_type` is set to **DLI**, the parameter is set to `*`.
 
-* `cluster_id` - (Optional, String, ForceNew) Specifies the cluster ID corresponding to the granted data source.
-  It is required when `datasource_type` is `HIVE` or `DWS`.
-  Changing this creates a new resource.
+* `cluster_id` - (Optional, String, NonUpdatable) Specifies the cluster ID corresponding to the granted data source.  
+  It is required when `datasource_type` is **HIVE** or **DWS**.
 
 * `connection_id` - (Optional, String) Specifies the data connection ID corresponding to the granted data source.
 
-* `database_url` - (Optional, String, ForceNew) Specifies the URL of the database corresponding to the granted data source.
-  Changing this creates a new resource.
-  This parameter is only valid when `datasource_type` is set to `HIVE`.
-  This parameter is conflict with `database_name`, `table_name` and `column_name`.
+* `database_url` - (Optional, String, NonUpdatable) Specifies the URL of the database corresponding to the granted  
+  data source.  
+  This parameter is only valid when `datasource_type` is set to **HIVE**.  
+  This parameter is conflict with **database_name**, **table_name** and **column_name**.
 
-* `database_name` - (Optional, String, ForceNew) Specifies the name of the database corresponding to the granted data source.
-  Changing this creates a new resource.
-  It is required when `datasource_type` is `DWS` or `DLI`.
+* `database_name` - (Optional, String, NonUpdatable) Specifies the name of the database corresponding to the granted  
+  data source.  
+  It is required when `datasource_type` is **DWS** or **DLI**.
 
-* `table_name` - (Optional, String, ForceNew) Specifies the name of the data table corresponding to the granted data source.
-  Changing this creates a new resource.
+* `table_name` - (Optional, String, NonUpdatable) Specifies the name of the data table corresponding to the granted  
+  data source.
 
-* `column_name` - (Optional, String, ForceNew) Specifies the name of column corresponding to the granted data source.
-  Changing this creates a new resource.
+* `column_name` - (Optional, String, NonUpdatable) Specifies the name of column corresponding to the granted data  
+  source.
 
   -> 1. For `database_name`, `table_name` and `column_name` parameters, the valid length is limited from `1` to `128`,
      only letters, digits, underscores (_) and asterisk (*) are allowed.<br/>2. The permissions of databases, tables,
      and columns are managed by layer.
      For example, a user who has been granted database permissions does not have the permissions of tables and columns.
      Table and column permissions must be granted separately.
-  
-* `schema_name` - (Optional, String, ForceNew) Specifies the schema name corresponding to the DWS data source.
-  Changing this creates a new resource.
-  This parameter is only valid when `datasource_type` is set to `DWS`.
+
+* `schema_name` - (Optional, String, NonUpdatable) Specifies the schema name corresponding to the DWS data source.  
+  This parameter is only valid when `datasource_type` is set to **DWS**.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege_test.go
@@ -17,16 +17,23 @@ func getSecurityPermissionSetPrivilegeFunc(cfg *config.Config, state *terraform.
 	if err != nil {
 		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
 	}
+
 	workspaceId := state.Primary.Attributes["workspace_id"]
 	permissionSetId := state.Primary.Attributes["permission_set_id"]
 	return dataarts.GetPrivilegeById(client, workspaceId, permissionSetId, state.Primary.ID)
 }
 
-func TestAccResourceSecurityPermissionSetPrivilege_basic(t *testing.T) {
-	var privliegeInfo interface{}
-	resourceName := "huaweicloud_dataarts_security_permission_set_privilege.test"
-	name := acceptance.RandomAccResourceName()
-	rc := acceptance.InitResourceCheck(resourceName, &privliegeInfo, getSecurityPermissionSetPrivilegeFunc)
+// Please setting HW_DATAARTS_CONNECTION_ID if a existing connection is prepared.
+func TestAccSecurityPermissionSetPrivilege_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_dataarts_security_permission_set_privilege.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getSecurityPermissionSetPrivilegeFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
@@ -37,7 +44,7 @@ func TestAccResourceSecurityPermissionSetPrivilege_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceSecurityPermissionSetPrivilege_basic_step1(name),
+				Config: testAccSecurityPermissionSetPrivilege_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
@@ -53,7 +60,7 @@ func TestAccResourceSecurityPermissionSetPrivilege_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceSecurityPermissionSetPrivilege_basic_step2(name),
+				Config: testAccSecurityPermissionSetPrivilege_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "2"),
@@ -87,20 +94,49 @@ func testAccSecurityPermissionSetPrivilegeImportFunc(n string) resource.ImportSt
 	}
 }
 
-func testAccResourceSecurityPermissionSetPrivilege_base(name string) string {
+func testAccSecurityPermissionSetPrivilege_base(name string) string {
 	return fmt.Sprintf(`
-%[1]s
+variable "data_connection_id" {
+  type    = string
+  default = "%[1]s"
+}
 
-%[2]s
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[2]s"
+}
+
+resource "huaweicloud_dataarts_studio_data_connection" "test" {
+  count = var.data_connection_id == "" ? 1 : 0
+
+  workspace_id = "%[3]s"
+  type         = "DLI"
+  name         = "%[4]s"
+  env_type     = 0
+  config       = jsonencode({
+    "cdm_property_enable": "false"
+  })
+}
+
+resource "huaweicloud_dataarts_security_permission_set" "test" {
+  workspace_id = "%[3]s"
+  name         = "%[4]s"
+  parent_id    = "0"
+  manager_id   = "%[5]s"
+}
 
 resource "huaweicloud_dli_database" "test" {
-  name                  = "%[3]s"
-  enterprise_project_id = "0"
+  name                  = "%[4]s"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
-  
+
 resource "huaweicloud_dli_table" "test" {
+  depends_on = [
+    huaweicloud_dli_database.test,
+  ]
+
   database_name = huaweicloud_dli_database.test.name
-  name          = "%[3]s"
+  name          = "%[4]s"
   data_location = "DLI"
 
   columns {
@@ -109,15 +145,20 @@ resource "huaweicloud_dli_table" "test" {
     description = "person name"
   }
 }
-`, testAccDataConnection_basic(name), testAccSecurityPermissionSet_basic(name), name, acceptance.HW_DATAARTS_WORKSPACE_ID)
+`, acceptance.HW_DATAARTS_CONNECTION_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, acceptance.HW_DATAARTS_WORKSPACE_ID,
+		name, acceptance.HW_DATAARTS_MANAGER_ID)
 }
 
-func testAccResourceSecurityPermissionSetPrivilege_basic_step1(name string) string {
+func testAccSecurityPermissionSetPrivilege_basic_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-  
+
 resource "huaweicloud_dataarts_security_permission_set_privilege" "test" {
-  workspace_id      = "%[3]s"
+  depends_on = [
+    huaweicloud_dli_table.test,
+  ]
+
+  workspace_id      = "%[2]s"
   permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
   datasource_type   = "DLI"
   type              = "ALLOW"
@@ -125,17 +166,21 @@ resource "huaweicloud_dataarts_security_permission_set_privilege" "test" {
   cluster_name      = "*"
   database_name     = huaweicloud_dli_database.test.name
   table_name        = huaweicloud_dli_table.test.name
-  connection_id     = huaweicloud_dataarts_studio_data_connection.test.id
+  connection_id     = var.data_connection_id != "" ? var.data_connection_id : huaweicloud_dataarts_studio_data_connection.test[0].id
 }
-`, testAccResourceSecurityPermissionSetPrivilege_base(name), name, acceptance.HW_DATAARTS_WORKSPACE_ID)
+`, testAccSecurityPermissionSetPrivilege_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
 }
 
-func testAccResourceSecurityPermissionSetPrivilege_basic_step2(name string) string {
+func testAccSecurityPermissionSetPrivilege_basic_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-  
+
 resource "huaweicloud_dataarts_security_permission_set_privilege" "test" {
-  workspace_id      = "%[3]s"
+  depends_on = [
+    huaweicloud_dli_table.test,
+  ]
+
+  workspace_id      = "%[2]s"
   permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
   datasource_type   = "DLI"
   type              = "ALLOW"
@@ -143,7 +188,7 @@ resource "huaweicloud_dataarts_security_permission_set_privilege" "test" {
   cluster_name      = "*"
   database_name     = huaweicloud_dli_database.test.name
   table_name        = huaweicloud_dli_table.test.name
-  connection_id     = huaweicloud_dataarts_studio_data_connection.test.id
+  connection_id     = var.data_connection_id != "" ? var.data_connection_id : huaweicloud_dataarts_studio_data_connection.test[0].id
 }
-`, testAccResourceSecurityPermissionSetPrivilege_base(name), name, acceptance.HW_DATAARTS_WORKSPACE_ID)
+`, testAccSecurityPermissionSetPrivilege_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege.go
@@ -3,11 +3,13 @@ package dataarts
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -16,10 +18,25 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var PermissionSetPrivilegeResourceNotFoundCodes = []string{
-	"DLS.6036",
-	"DLS.3027",
-}
+var (
+	permissionSetPrivilegeResourceNotFoundCodes = []string{
+		"DLS.6036",
+		"DLS.3027",
+	}
+	permissionSetPrivilegeNonUpdatableParams = []string{
+		"workspace_id",
+		"permission_set_id",
+		"datasource_type",
+		"type",
+		"cluster_name",
+		"cluster_id",
+		"database_url",
+		"database_name",
+		"table_name",
+		"column_name",
+		"schema_name",
+	}
+)
 
 // @API DataArtsStudio POST /v1/{project_id}/security/permission-sets/{permission_set_id}/permissions
 // @API DataArtsStudio GET /v1/{project_id}/security/permission-sets/{permission_set_id}/permissions
@@ -32,197 +49,264 @@ func ResourceSecurityPermissionSetPrivilege() *schema.Resource {
 		UpdateContext: resourceSecurityPermissionSetPrivilegeUpdate,
 		DeleteContext: resourceSecurityPermissionSetPrivilegeDelete,
 
+		CustomizeDiff: config.FlexibleForceNew(permissionSetPrivilegeNonUpdatableParams),
+
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityPermissionSetPrivilegeImportState,
 		},
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region in which to the permission set to be granted privilege is located.`,
 			},
+
+			// Required parameters.
 			"workspace_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the permission set belongs.`,
 			},
 			"permission_set_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the permission set to be granted.`,
 			},
 			"datasource_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the granted data source.`,
 			},
 			"type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of the permission to be configured.`,
 			},
 			"actions": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of granted permissions.`,
 			},
 			"cluster_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The cluster name corresponding to the granted data source.`,
 			},
+
+			// Optional parameters.
 			"cluster_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The cluster ID corresponding to the granted data source.`,
 			},
 			"connection_id": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The data connection ID corresponding to the granted data source.`,
 			},
 			"database_url": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"database_name", "table_name", "column_name"},
+				Description:   `The URL of the database corresponding to the granted data source.`,
 			},
 			"database_name": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"database_url"},
+				Description:   `The name of the database corresponding to the granted data source.`,
 			},
 			"table_name": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"database_url"},
+				Description:   `The name of the data table corresponding to the granted data source.`,
 			},
 			"column_name": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"database_url"},
+				Description:   `The name of the column corresponding to the granted data source.`,
 			},
 			"schema_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The schema name corresponding to the DWS data source.`,
 			},
 			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current synchronization status of the resource.`,
 			},
 			"sync_msg": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status information of the resource.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
 			},
 		},
 	}
 }
 
+func buildSecurityMoreHeaders(workspaceId string) map[string]string {
+	moreHeaders := map[string]string{
+		"Content-Type": "application/json",
+	}
+
+	if workspaceId != "" {
+		moreHeaders["workspace"] = workspaceId
+	}
+
+	return moreHeaders
+}
+
+func associatePrivilegeToPermissionSet(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	httpUrl := "v1/{project_id}/security/permission-sets/{permission_set_id}/permissions"
+	associatePath := client.Endpoint + httpUrl
+	associatePath = strings.ReplaceAll(associatePath, "{project_id}", client.ProjectID)
+	associatePath = strings.ReplaceAll(associatePath, "{permission_set_id}", d.Get("permission_set_id").(string))
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(d.Get("workspace_id").(string)),
+		JSONBody:         utils.RemoveNil(buildCreatePermissionSetPrivilegeBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", associatePath, &opts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
 func resourceSecurityPermissionSetPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		httpUrl = "v1/{project_id}/security/permission-sets/{permission_set_id}/permissions"
-		product = "dataarts"
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
 	)
-	client, err := cfg.NewServiceClient(product, region)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
 	if err != nil {
 		return diag.Errorf("error creating DataArts Studio client: %s", err)
 	}
 
-	creatPath := client.Endpoint + httpUrl
-	creatPath = strings.ReplaceAll(creatPath, "{project_id}", client.ProjectID)
-	creatPath = strings.ReplaceAll(creatPath, "{permission_set_id}", d.Get("permission_set_id").(string))
-	opts := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
-		JSONBody:         utils.RemoveNil(buildCreatePermissionSetPrivilegeBodyParams(d)),
-	}
-	resp, err := client.Request("POST", creatPath, &opts)
+	respBody, err := associatePrivilegeToPermissionSet(client, d)
 	if err != nil {
 		return diag.Errorf("error creating DataArts Security permission set privilege: %s", err)
 	}
-
-	respBody, err := utils.FlattenResponse(resp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
 	privilegeId := utils.PathSearch("id", respBody, "").(string)
 	if privilegeId == "" {
 		return diag.Errorf("unable to find the privilege ID of the DataArts Security permission set from the API response")
 	}
-
 	d.SetId(privilegeId)
+
 	return resourceSecurityPermissionSetPrivilegeRead(ctx, d, meta)
 }
 
 func buildCreatePermissionSetPrivilegeBodyParams(d *schema.ResourceData) map[string]interface{} {
-	bodyParams := map[string]interface{}{
+	return map[string]interface{}{
+		// Required parameters.
 		"datasource_type":    d.Get("datasource_type"),
 		"permission_type":    d.Get("type"),
-		"permission_actions": utils.ExpandToStringList(d.Get("actions").(*schema.Set).List()),
+		"permission_actions": d.Get("actions").(*schema.Set).List(),
 		"cluster_name":       d.Get("cluster_name"),
-		"cluster_id":         utils.ValueIgnoreEmpty(d.Get("cluster_id")),
-		"dw_id":              utils.ValueIgnoreEmpty(d.Get("connection_id")),
-		"url":                utils.ValueIgnoreEmpty(d.Get("database_url")),
-		"database_name":      utils.ValueIgnoreEmpty(d.Get("database_name")),
-		"table_name":         utils.ValueIgnoreEmpty(d.Get("table_name")),
-		"column_name":        utils.ValueIgnoreEmpty(d.Get("column_name")),
-		"schema_name":        utils.ValueIgnoreEmpty(d.Get("schema_name")),
+		// Optional parameters.
+		"cluster_id":    utils.ValueIgnoreEmpty(d.Get("cluster_id")),
+		"dw_id":         utils.ValueIgnoreEmpty(d.Get("connection_id")),
+		"url":           utils.ValueIgnoreEmpty(d.Get("database_url")),
+		"database_name": utils.ValueIgnoreEmpty(d.Get("database_name")),
+		"table_name":    utils.ValueIgnoreEmpty(d.Get("table_name")),
+		"column_name":   utils.ValueIgnoreEmpty(d.Get("column_name")),
+		"schema_name":   utils.ValueIgnoreEmpty(d.Get("schema_name")),
 	}
-	return bodyParams
 }
 
-// GetPrivilegeById is a method used to query permission configuration using a specified ID.
-func GetPrivilegeById(client *golangsdk.ServiceClient, workspaceId, permissionSetId, id string) (interface{}, error) {
-	httpUrl := "v1/{project_id}/security/permission-sets/{permission_set_id}/permissions?limit=100"
-	getPath := client.Endpoint + httpUrl
-	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
-	getPath = strings.ReplaceAll(getPath, "{permission_set_id}", permissionSetId)
-	opts := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"workspace": workspaceId},
+func listPermissionSetAssociatedPrivileges(client *golangsdk.ServiceClient, workspaceId, permissionSetId string,
+	queryParams ...string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/security/permission-sets/{permission_set_id}/permissions?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{permission_set_id}", permissionSetId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	if len(queryParams) > 0 {
+		listPath = fmt.Sprintf("%s&%s", listPath, queryParams[0])
 	}
 
-	var currentTotal int
-	for {
-		path := fmt.Sprintf("%s&offset=%v", getPath, currentTotal)
-		resp, err := client.Request("GET", path, &opts)
-		if err != nil {
-			return nil, common.ConvertExpected400ErrInto404Err(err, "error_code", PermissionSetPrivilegeResourceNotFoundCodes...)
-		}
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+	}
 
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &opts)
+		if err != nil {
+			return nil, err
+		}
 		respBody, err := utils.FlattenResponse(resp)
 		if err != nil {
 			return nil, err
 		}
-
-		totalNum := utils.PathSearch("total", respBody, 0)
-		if privilegeInfo := utils.PathSearch(fmt.Sprintf("permissions|[?id=='%s']|[0]", id), respBody, nil); privilegeInfo != nil {
-			return privilegeInfo, nil
-		}
-
 		privileges := utils.PathSearch("permissions", respBody, make([]interface{}, 0)).([]interface{})
-		currentTotal += len(privileges)
-		// The type of `total` is float64.
-		if float64(currentTotal) == totalNum {
+		result = append(result, privileges...)
+		if len(privileges) < limit {
 			break
 		}
+		offset += len(privileges)
+	}
+	return result, nil
+}
+
+// GetPrivilegeById is a method used to query permission configuration using a specified ID.
+func GetPrivilegeById(client *golangsdk.ServiceClient, workspaceId, permissionSetId, privilegeId string) (interface{}, error) {
+	privileges, err := listPermissionSetAssociatedPrivileges(client, workspaceId, permissionSetId)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, golangsdk.ErrDefault404{}
+	privilege := utils.PathSearch(fmt.Sprintf("[?id=='%s']|[0]", privilegeId), privileges, nil)
+	if privilege == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/security/permission-sets/{permission_set_id}/permissions",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the privilege (%s) does not exist", privilegeId)),
+			},
+		}
+	}
+	return privilege, nil
 }
 
 func resourceSecurityPermissionSetPrivilegeRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
 	client, err := cfg.NewServiceClient("dataarts", region)
 	if err != nil {
 		return diag.Errorf("error creating DataArts Studio client: %s", err)
@@ -230,7 +314,7 @@ func resourceSecurityPermissionSetPrivilegeRead(_ context.Context, d *schema.Res
 
 	respBody, err := GetPrivilegeById(client, d.Get("workspace_id").(string), d.Get("permission_set_id").(string), d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", PermissionSetPrivilegeResourceNotFoundCodes...),
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", permissionSetPrivilegeResourceNotFoundCodes...),
 			"DataArts Security permission set privilege")
 	}
 
@@ -253,27 +337,54 @@ func resourceSecurityPermissionSetPrivilegeRead(_ context.Context, d *schema.Res
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
+func buildUpdatePermissionSetPrivilegeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		// Required parameters.
+		"permission_actions": utils.ExpandToStringList(d.Get("actions").(*schema.Set).List()),
+		// Optional parameters.
+		"dw_id": utils.ValueIgnoreEmpty(d.Get("connection_id")),
+	}
+	return bodyParams
+}
+
+func updatePermissionSetPrivilege(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl         = "v1/{project_id}/security/permission-sets/{permission_set_id}/permissions/{permission_id}"
+		permissionSetId = d.Get("permission_set_id").(string)
+		privilegeId     = d.Id()
+		workspaceId     = d.Get("workspace_id").(string)
+	)
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{permission_set_id}", permissionSetId)
+	updatePath = strings.ReplaceAll(updatePath, "{permission_id}", privilegeId)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+		JSONBody:         utils.RemoveNil(buildUpdatePermissionSetPrivilegeBodyParams(d)),
+	}
+
+	resp, err := client.Request("PUT", updatePath, &opts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(resp)
+}
+
 func resourceSecurityPermissionSetPrivilegeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	httpUrl := "v1/{project_id}/security/permission-sets/{permission_set_id}/permissions/{permission_id}"
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
 	client, err := cfg.NewServiceClient("dataarts", region)
 	if err != nil {
 		return diag.Errorf("error creating DataArts Studio client: %s", err)
 	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{permission_set_id}", d.Get("permission_set_id").(string))
-	updatePath = strings.ReplaceAll(updatePath, "{permission_id}", d.Id())
-
-	opts := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
-		JSONBody:         utils.RemoveNil(buildUpdatePermissionSetPrivilegeBodyParams(d)),
-	}
-
-	_, err = client.Request("PUT", updatePath, &opts)
+	_, err = updatePermissionSetPrivilege(client, d)
 	if err != nil {
 		return diag.Errorf("error updating DataArts Security permission set privilege: %s", err)
 	}
@@ -281,39 +392,43 @@ func resourceSecurityPermissionSetPrivilegeUpdate(ctx context.Context, d *schema
 	return resourceSecurityPermissionSetPrivilegeRead(ctx, d, meta)
 }
 
-func buildUpdatePermissionSetPrivilegeBodyParams(d *schema.ResourceData) map[string]interface{} {
-	bodyParams := map[string]interface{}{
-		"dw_id":              utils.ValueIgnoreEmpty(d.Get("connection_id")),
-		"permission_actions": utils.ExpandToStringList(d.Get("actions").(*schema.Set).List()),
+func deletePermissionSetPrivilege(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl         = "v1/{project_id}/security/permission-sets/{permission_set_id}/permissions/batch-delete"
+		permissionSetId = d.Get("permission_set_id").(string)
+		privilegeId     = d.Id()
+		workspaceId     = d.Get("workspace_id").(string)
+	)
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{permission_set_id}", permissionSetId)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+		JSONBody: map[string]interface{}{
+			"ids": []string{privilegeId},
+		},
+		OkCodes: []int{200, 204},
 	}
-	return bodyParams
+
+	_, err := client.Request("POST", deletePath, &opts)
+	return err
 }
 
 func resourceSecurityPermissionSetPrivilegeDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		httpUrl = "v1/{project_id}/security/permission-sets/{permission_set_id}/permissions/batch-delete"
-		product = "dataarts"
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
 	)
-	client, err := cfg.NewServiceClient(product, region)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
 	if err != nil {
 		return diag.Errorf("error creating DataArts Studio client: %s", err)
 	}
 
-	deletePath := client.Endpoint + httpUrl
-	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
-	deletePath = strings.ReplaceAll(deletePath, "{permission_set_id}", d.Get("permission_set_id").(string))
-	opts := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
-		JSONBody: map[string]interface{}{
-			"ids": []string{d.Id()},
-		},
-		OkCodes: []int{204},
-	}
-
-	_, err = client.Request("POST", deletePath, &opts)
+	err = deletePermissionSetPrivilege(client, d)
 	if err != nil {
 		return diag.Errorf("error deleting DataArts Security permission set privilege: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor the permission set resource, acceptance test and corresponding documentation.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. optimize the permission set resource, test and document.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccResourceSecurityPermissionSet_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccResourceSecurityPermissionSet_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceSecurityPermissionSet_basic
=== PAUSE TestAccResourceSecurityPermissionSet_basic
=== CONT  TestAccResourceSecurityPermissionSet_basic
--- PASS: TestAccResourceSecurityPermissionSet_basic (25.02s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  25.114s coverage: 5.1% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
