### PR TITLE
feat(VPCEP): add action resource to add servers for vpcep service

### DIFF
--- a/docs/resources/vpcep_service_add_servers.md
+++ b/docs/resources/vpcep_service_add_servers.md
@@ -1,0 +1,60 @@
+---
+subcategory: "VPC Endpoint (VPCEP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpcep_service_add_servers"
+description: -|
+  Use this resource to add backend resources to a VPC endpoint service within HuaweiCloud.
+---
+
+# huaweicloud_vpcep_service_add_servers
+
+Use this resource to add backend resources to a VPC endpoint service within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "vpc_endpoint_service_id" {}
+variable "elb_instance_id_1" {}
+variable "elb_az_id_1" {}
+variable "elb_instance_id_2" {}
+variable "elb_az_id_2" {}
+
+resource "huaweicloud_vpcep_service_add_servers" "test" {
+  vpc_endpoint_service_id = var.vpc_endpoint_service_id
+  
+  server_resources {
+    resource_id          = var.elb_instance_id_1
+    availability_zone_id = var.elb_az_id_1
+  }
+
+  server_resources {
+    resource_id          = var.elb_instance_id_2
+    availability_zone_id = var.elb_az_id_2
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the VPC endpoint service.
+  If omitted, the provider-level region will be used. Changing this creates a new VPC endpoint service resource.
+
+* `vpc_endpoint_service_id` - (Required, String, NonUpdatable) Specifies the ID of the VPC endpoint service.
+
+* `server_resources` - (Required, List, NonUpdatable) Specifies the load balancer IDs and AZs.  
+  The [server_resources](#server_resources) structure is documented below.
+
+<a name="server_resources"></a>
+The `server_resources` block supports:
+
+* `resource_id` - (Required, String, NonUpdatable) Specifies the load balancer ID.
+
+* `availability_zone_id` - (Optional, String, NonUpdatable) Specifies the ID of the AZ where the load balancer is located.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique ID of the VPC endpoint service.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4194,6 +4194,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpcep_approval":                  vpcep.ResourceVPCEndpointApproval(),
 			"huaweicloud_vpcep_endpoint":                  vpcep.ResourceVPCEndpoint(),
 			"huaweicloud_vpcep_service":                   vpcep.ResourceVPCEndpointService(),
+			"huaweicloud_vpcep_service_add_servers":       vpcep.ResourceVPCEndpointServiceAddServers(),
 			"huaweicloud_vpcep_service_upgrade":           vpcep.ResourceVPCServiceUpgrade(),
 			"huaweicloud_vpcep_service_connection_update": vpcep.ResourceVPCEndpointServiceConnectionUpdate(),
 

--- a/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_add_servers_test.go
+++ b/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_add_servers_test.go
@@ -1,0 +1,78 @@
+package vpcep
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccVpcepServiceAddServers_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testVpcepServiceAddServers_basic(rName),
+			},
+		},
+	})
+}
+
+func testVpcepServiceAddServers_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_elb_flavors" "flavors" {
+  type = "L4"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_lb_loadbalancer" "test" {
+  vip_subnet_id = huaweicloud_vpc_subnet.test.ipv4_subnet_id
+}
+
+locals {
+  availability_zone_id = data.huaweicloud_availability_zones.test.names[0]
+}
+
+resource "huaweicloud_elb_loadbalancer" "test" {
+  name              = "%[2]s"
+  description       = "created by terraform acc test"
+  vpc_id            = huaweicloud_vpc.test.id
+  ipv4_subnet_id    = huaweicloud_vpc_subnet.test.ipv4_subnet_id
+  l4_flavor_id      = data.huaweicloud_elb_flavors.flavors.flavors[0].id
+  availability_zone = [local.availability_zone_id]
+}
+
+resource "huaweicloud_vpcep_service" "test" {
+  name        = "%[3]s"
+  server_type = "LB"
+  vpc_id      = huaweicloud_vpc.test.id
+  port_id     = huaweicloud_lb_loadbalancer.test.vip_port_id
+  approval    = true
+  port_mapping {
+    service_port  = 8080
+    terminal_port = 80
+  }
+}
+
+resource "huaweicloud_vpcep_service_add_servers" "test" {
+  vpc_endpoint_service_id = huaweicloud_vpcep_service.test.id
+
+  server_resources {
+    resource_id          = huaweicloud_elb_loadbalancer.test.id
+    availability_zone_id = local.availability_zone_id
+  }
+}
+`, common.TestVpc(rName), rName, rName)
+}

--- a/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service_add_servers.go
+++ b/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service_add_servers.go
@@ -1,0 +1,148 @@
+package vpcep
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var vpcepServiceAddServersNonUpdatableParams = []string{"vpc_endpoint_service_id", "server_resources",
+	"server_resources.*.resource_id", "server_resources.*.availability_zone_id",
+}
+
+// @API VPCEP POST /v2/{project_id}/vpc-endpoint-services/{vpc_endpoint_service_id}/add-server-resources
+func ResourceVPCEndpointServiceAddServers() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVPCEndpointServiceAddServersCreate,
+		ReadContext:   resourceVPCEndpointServiceAddServersRead,
+		UpdateContext: resourceVPCEndpointServiceAddServersUpdate,
+		DeleteContext: resourceVPCEndpointServiceAddServersDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(vpcepServiceAddServersNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"vpc_endpoint_service_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"server_resources": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"availability_zone_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceVPCEndpointServiceAddServersCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                  = meta.(*config.Config)
+		region               = cfg.GetRegion(d)
+		httpUrl              = "v2/{project_id}/vpc-endpoint-services/{vpc_endpoint_service_id}/add-server-resources"
+		vpcEndpointServiceId = d.Get("vpc_endpoint_service_id").(string)
+	)
+
+	client, err := cfg.VPCEPClient(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC endpoint client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{vpc_endpoint_service_id}", vpcEndpointServiceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildAddServersRequestBody(d),
+		OkCodes: []int{
+			204,
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error adding servers to VPC endpoint service: %s", err)
+	}
+
+	d.SetId(vpcEndpointServiceId)
+
+	return nil
+}
+
+func buildAddServersRequestBody(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"server_resources": buildAddServerResources(d.Get("server_resources")),
+	}
+	return bodyParams
+}
+
+func buildAddServerResources(rawParams interface{}) []map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+
+		rst := make([]map[string]interface{}, len(rawArray))
+		for i, v := range rawArray {
+			raw := v.(map[string]interface{})
+			rst[i] = map[string]interface{}{
+				"resource_id":          utils.ValueIgnoreEmpty(raw["resource_id"]),
+				"availability_zone_id": utils.ValueIgnoreEmpty(raw["availability_zone_id"]),
+			}
+		}
+		return rst
+	}
+	return nil
+}
+
+func resourceVPCEndpointServiceAddServersRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVPCEndpointServiceAddServersUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVPCEndpointServiceAddServersDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting VPCEP service add servers resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add action resource to add servers for vpcep service
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add action resource to add servers for vpcep service
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/vpcep" TESTARGS="-run TestAccVpcepServiceAddServers_basic"
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVpcepServiceAddServers_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcepServiceAddServers_basic
=== PAUSE TestAccVpcepServiceAddServers_basic
=== CONT  TestAccVpcepServiceAddServers_basic
--- PASS: TestAccVpcepServiceAddServers_basic (76.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     76.899s
```
<img width="754" height="119" alt="image" src="https://github.com/user-attachments/assets/b8f2889a-c7f1-41f0-bf7d-add062446997" />

<img width="1349" height="980" alt="image" src="https://github.com/user-attachments/assets/b06e09fe-4913-4910-b608-cef2a9f01ab6" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
