### PR TITLE
chore(kafka/volume_auto_expand_configuration): modify API supports 204 status code

### DIFF
--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_volume_auto_expand_configuration.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_volume_auto_expand_configuration.go
@@ -103,7 +103,10 @@ func resourceVolumeAutoExpandConfigurationCreate(_ context.Context, d *schema.Re
 
 	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildVolumeAutoExpandConfigurationBodyParams(d)),
+		// Currently, the API returns 204 status code, but to ensure that some regions have not updated the status code,
+		// so we add other status codes.
+		OkCodes:  []int{200, 201, 202, 204},
+		JSONBody: utils.RemoveNil(buildVolumeAutoExpandConfigurationBodyParams(d)),
 	}
 
 	_, err = client.Request("PUT", updatePath, &opt)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adapt the `204` status code for the API that modifies the disk automatic expansion configiguration.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccVolumeAutoExpandConfiguration_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccVolumeAutoExpandConfiguration_basic -timeout 360m -parallel 10
=== RUN   TestAccVolumeAutoExpandConfiguration_basic
=== PAUSE TestAccVolumeAutoExpandConfiguration_basic
=== CONT  TestAccVolumeAutoExpandConfiguration_basic
--- PASS: TestAccVolumeAutoExpandConfiguration_basic (37.93s)
PASS
coverage: 4.8% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     38.030s coverage: 4.8% of statements in ./huaweicloud/services/kafka
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
