### PR TITLE
feat(DCS): dcs isntance support update az

### DIFF
--- a/docs/resources/dcs_instance.md
+++ b/docs/resources/dcs_instance.md
@@ -127,10 +127,10 @@ The following arguments are supported:
     in [DCS Instance Specifications](https://support.huaweicloud.com/intl/en-us/productdesc-dcs/dcs-pd-200713003.html)
   + Log in to the DCS console, click *Buy DCS Instance*, and find the corresponding instance specification.
 
-* `availability_zones` - (Required, List, ForceNew) The code of the AZ where the cache node resides.
+* `availability_zones` - (Required, List) The code of the AZ where the cache node resides.
   Master/Standby, Proxy Cluster, and Redis Cluster DCS instances support cross-AZ deployment.
   You can specify an AZ for the standby node. When specifying AZs for nodes, use commas (,) to separate AZs.
-  Changing this creates a new instance.
+  Supports changes from single-AZ to cross-AZ.
 
 * `vpc_id` - (Required, String, ForceNew) The ID of VPC which the instance belongs to.
   Changing this creates a new instance resource.

--- a/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
+++ b/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
@@ -1832,18 +1832,22 @@ data "huaweicloud_dcs_flavors" "test" {
 }
 
 resource "huaweicloud_dcs_instance" "test" {
-  name               = "%s"
-  engine_version     = "5.0"
-  password           = "Huawei_test"
-  engine             = "Redis"
-  port               = 6388
-  capacity           = 8
-  vpc_id             = data.huaweicloud_vpc.test.id
-  subnet_id          = data.huaweicloud_vpc_subnet.test.id
-  availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
-  flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
-  maintain_begin     = "06:00:00"
-  maintain_end       = "07:00:00"
+  name           = "%s"
+  engine_version = "5.0"
+  password       = "Huawei_test"
+  engine         = "Redis"
+  port           = 6388
+  capacity       = 8
+  vpc_id         = data.huaweicloud_vpc.test.id
+  subnet_id      = data.huaweicloud_vpc_subnet.test.id
+  flavor         = data.huaweicloud_dcs_flavors.test.flavors[0].name
+  maintain_begin = "06:00:00"
+  maintain_end   = "07:00:00"
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0],
+    data.huaweicloud_availability_zones.test.names[1]
+  ]
 }`, instanceName)
 }
 
@@ -1867,18 +1871,22 @@ data "huaweicloud_dcs_flavors" "test" {
 }
 
 resource "huaweicloud_dcs_instance" "test" {
-  name               = "%s"
-  engine_version     = "5.0"
-  password           = "Huawei_test"
-  engine             = "Redis"
-  port               = 6388
-  capacity           = 4
-  vpc_id             = data.huaweicloud_vpc.test.id
-  subnet_id          = data.huaweicloud_vpc_subnet.test.id
-  availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
-  flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
-  maintain_begin     = "06:00:00"
-  maintain_end       = "07:00:00"
+  name           = "%s"
+  engine_version = "5.0"
+  password       = "Huawei_test"
+  engine         = "Redis"
+  port           = 6388
+  capacity       = 4
+  vpc_id         = data.huaweicloud_vpc.test.id
+  subnet_id      = data.huaweicloud_vpc_subnet.test.id
+  flavor         = data.huaweicloud_dcs_flavors.test.flavors[0].name
+  maintain_begin = "06:00:00"
+  maintain_end   = "07:00:00"
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0],
+    data.huaweicloud_availability_zones.test.names[1]
+  ]
 }`, instanceName)
 }
 

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -40,6 +40,7 @@ var (
 // @API DCS POST /v2/{project_id}/instances
 // @API DCS GET /v2/{project_id}/instances/{instance_id}
 // @API DCS PUT /v2/{project_id}/instance/{instance_id}/whitelist
+// @API DCS GET /v2/{project_id}/instance/{instance_id}/groups
 // @API DCS GET /v2/{project_id}/instance/{instance_id}/whitelist
 // @API DCS PUT /v2/{project_id}/instances/{instance_id}/async-configs
 // @API DCS PUT /v2/{project_id}/{instance_id}/client-ip-transparent-transmission
@@ -127,7 +128,6 @@ func ResourceDcsInstance() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
-				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "schema: Required",
 			},
@@ -452,7 +452,6 @@ func ResourceDcsInstance() *schema.Resource {
 			"available_zones": {
 				Type:         schema.TypeList,
 				Optional:     true,
-				ForceNew:     true,
 				Elem:         &schema.Schema{Type: schema.TypeString},
 				AtLeastOneOf: []string{"available_zones", "availability_zones"},
 				Deprecated:   "Deprecated, please use `availability_zones` instead",
@@ -977,7 +976,6 @@ func resourceDcsInstancesRead(ctx context.Context, d *schema.ResourceData, meta 
 		d.Set("engine", utils.PathSearch("engine", instance, nil)),
 		d.Set("engine_version", utils.PathSearch("engine_version", instance, nil)),
 		d.Set("flavor", utils.PathSearch("spec_code", instance, nil)),
-		d.Set("availability_zones", utils.PathSearch("az_codes", instance, nil)),
 		d.Set("vpc_id", utils.PathSearch("vpc_id", instance, nil)),
 		d.Set("vpc_name", utils.PathSearch("vpc_name", instance, nil)),
 		d.Set("subnet_id", utils.PathSearch("subnet_id", instance, nil)),
@@ -1016,6 +1014,7 @@ func resourceDcsInstancesRead(ctx context.Context, d *schema.ResourceData, meta 
 		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("tags", instance, make([]interface{}, 0)))),
 	)
 
+	mErr = multierror.Append(mErr, setDcsInstanceAzCodes(d, client))
 	mErr = multierror.Append(mErr, setDcsInstanceCapacity(d, instance))
 	mErr = multierror.Append(mErr, setDcsInstanceWhitelist(d, client)...)
 	mErr = multierror.Append(mErr, setDcsInstanceBigKeyAutoScan(d, client)...)
@@ -1233,6 +1232,30 @@ func setDcsInstanceAutoScaling(d *schema.ResourceData, client *golangsdk.Service
 	return d.Set("auto_scaling", autoScaling)
 }
 
+// the az codes order may be different from the input az codes order, so it is needed to get the az codes from groups
+func setDcsInstanceAzCodes(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	getRespBody, err := getInstanceField(client, getInstanceFieldParams{
+		httpUrl:    "v2/{project_id}/instance/{instance_id}/groups",
+		httpMethod: "GET",
+		pathParams: map[string]string{"instance_id": d.Id()},
+	})
+	if err != nil {
+		log.Printf("[WARN] error fetching DCS instance(%s) group replication: %s", d.Id(), err)
+		return nil
+	}
+
+	azCodeSearchPath := "group_list[0].replication_list[?replication_role=='%s']|[0].az_code"
+	masterAzCode := utils.PathSearch(fmt.Sprintf(azCodeSearchPath, "master"), getRespBody, "").(string)
+	slaveAzCode := utils.PathSearch(fmt.Sprintf(azCodeSearchPath, "slave"), getRespBody, "").(string)
+
+	azCodes := []string{masterAzCode}
+	if slaveAzCode != "" && masterAzCode != slaveAzCode {
+		azCodes = append(azCodes, slaveAzCode)
+	}
+
+	return d.Set("availability_zones", azCodes)
+}
+
 func setDcsInstanceParameters(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
 	instanceID string) diag.Diagnostics {
 	params, needStartParams, err := getParameters(client, instanceID, d.Get("parameters").(*schema.Set).List())
@@ -1384,6 +1407,13 @@ func resourceDcsInstancesUpdate(ctx context.Context, d *schema.ResourceData, met
 
 	if d.HasChange("auto_scaling") {
 		err = updateAutoScaling(ctx, d, client)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChanges("availability_zones", "available_zones") {
+		err = updateAvailabilityZones(ctx, d, client)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -1919,6 +1949,33 @@ func deleteAutoScaling(d *schema.ResourceData, client *golangsdk.ServiceClient) 
 	return nil
 }
 
+func updateAvailabilityZones(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	azIds, err := getAzId(d, client)
+	if err != nil {
+		return err
+	}
+	_, err = updateDcsInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:             "v2/{project_id}/instances/{instance_id}/available-zones",
+		httpMethod:          "PUT",
+		pathParams:          map[string]string{"instance_id": d.Id()},
+		updateBodyParams:    buildUpdateAvailabilityZonesBodyParams(azIds),
+		isRetry:             true,
+		isWaitInstanceReady: true,
+	})
+	if err != nil {
+		return fmt.Errorf("error updating instance availability zones: %s", err)
+	}
+	return nil
+}
+
+func buildUpdateAvailabilityZonesBodyParams(azIds []string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"new_available_zones": azIds,
+		"execute_immediately": true,
+	}
+	return bodyParams
+}
+
 func resourceDcsInstancesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
@@ -2017,12 +2074,80 @@ func getAzCode(d *schema.ResourceData, client *golangsdk.ServiceClient) ([]strin
 	return azCodes, nil
 }
 
+func getAzId(d *schema.ResourceData, client *golangsdk.ServiceClient) ([]string, error) {
+	var azIds []string
+	availabilityZones, ok := d.GetOk("availability_zones")
+	if ok {
+		availableZonesIds, err := getAvailableZoneIdByCode(client, availabilityZones.([]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		azIds = availableZonesIds
+	} else {
+		azIds = utils.ExpandToStringList(d.Get("available_zones").([]interface{}))
+	}
+	return azIds, nil
+}
+
+func getAvailableZoneIdByCode(client *golangsdk.ServiceClient, azCodes []interface{}) ([]string, error) {
+	azIds := make([]string, 0, len(azCodes))
+	if len(azCodes) == 0 {
+		return azIds, errors.New("availability_zones are required")
+	}
+
+	availableZones, err := getAvailableZone(client)
+	if err != nil {
+		return nil, err
+	}
+
+	mapping := make(map[string]string)
+	for _, v := range availableZones {
+		id := utils.PathSearch("id", v, "").(string)
+		code := utils.PathSearch("code", v, "").(string)
+		mapping[code] = id
+	}
+
+	for _, code := range azCodes {
+		azCode := code.(string)
+		if _, ok := mapping[azCode]; !ok {
+			return azIds, fmt.Errorf("invalid available zone code: %s", azCode)
+		}
+		azIds = append(azIds, mapping[azCode])
+	}
+
+	return azIds, nil
+}
+
 func getAvailableZoneCodeByID(client *golangsdk.ServiceClient, azIds []interface{}) ([]string, error) {
 	azCodes := make([]string, 0, len(azIds))
 	if len(azIds) == 0 {
-		return azCodes, fmt.Errorf("availability_zones are required")
+		return azCodes, errors.New("availability_zones are required")
 	}
 
+	availableZones, err := getAvailableZone(client)
+	if err != nil {
+		return nil, err
+	}
+
+	mapping := make(map[string]string)
+	for _, v := range availableZones {
+		id := utils.PathSearch("id", v, "").(string)
+		code := utils.PathSearch("code", v, "").(string)
+		mapping[id] = code
+	}
+
+	for _, id := range azIds {
+		azID := id.(string)
+		if _, ok := mapping[azID]; !ok {
+			return azCodes, fmt.Errorf("invalid available zone code: %s", azID)
+		}
+		azCodes = append(azCodes, mapping[azID])
+	}
+
+	return azCodes, nil
+}
+
+func getAvailableZone(client *golangsdk.ServiceClient) ([]interface{}, error) {
 	var (
 		httpUrl = "v2/available-zones"
 	)
@@ -2042,20 +2167,5 @@ func getAvailableZoneCodeByID(client *golangsdk.ServiceClient, azIds []interface
 	}
 
 	availableZones := utils.PathSearch("available_zones", getRespBody, make([]interface{}, 0)).([]interface{})
-	mapping := make(map[string]string)
-	for _, v := range availableZones {
-		id := utils.PathSearch("id", v, "").(string)
-		code := utils.PathSearch("code", v, "").(string)
-		mapping[id] = code
-	}
-
-	for _, id := range azIds {
-		azID := id.(string)
-		if _, ok := mapping[azID]; !ok {
-			return azCodes, fmt.Errorf("invalid available zone code: %s", azID)
-		}
-		azCodes = append(azCodes, mapping[azID])
-	}
-
-	return azCodes, nil
+	return availableZones, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  dcs isntance support update az
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run TestAccDcsInstances_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccDcsInstances_ -timeout 360m -parallel 4
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== RUN   TestAccDcsInstances_ha_change_capacity
=== PAUSE TestAccDcsInstances_ha_change_capacity
=== RUN   TestAccDcsInstances_ha_expand_replica
=== PAUSE TestAccDcsInstances_ha_expand_replica
=== RUN   TestAccDcsInstances_ha_to_proxy
=== PAUSE TestAccDcsInstances_ha_to_proxy
=== RUN   TestAccDcsInstances_rw_change_capacity
=== PAUSE TestAccDcsInstances_rw_change_capacity
=== RUN   TestAccDcsInstances_rw_expand_replica
=== PAUSE TestAccDcsInstances_rw_expand_replica
=== RUN   TestAccDcsInstances_rw_to_proxy
=== PAUSE TestAccDcsInstances_rw_to_proxy
=== RUN   TestAccDcsInstances_proxy_change_capacity
=== PAUSE TestAccDcsInstances_proxy_change_capacity
=== RUN   TestAccDcsInstances_proxy_to_ha
=== PAUSE TestAccDcsInstances_proxy_to_ha
=== RUN   TestAccDcsInstances_proxy_to_rw
=== PAUSE TestAccDcsInstances_proxy_to_rw
=== RUN   TestAccDcsInstances_cluster_change_capacity
=== PAUSE TestAccDcsInstances_cluster_change_capacity
=== RUN   TestAccDcsInstances_cluster_expand_replica
=== PAUSE TestAccDcsInstances_cluster_expand_replica
=== RUN   TestAccDcsInstances_whitelists
=== PAUSE TestAccDcsInstances_whitelists
=== RUN   TestAccDcsInstances_single
=== PAUSE TestAccDcsInstances_single
=== RUN   TestAccDcsInstances_prePaid
=== PAUSE TestAccDcsInstances_prePaid
=== RUN   TestAccDcsInstances_ssl
=== PAUSE TestAccDcsInstances_ssl
=== RUN   TestAccDcsInstances_auto_scaling
=== PAUSE TestAccDcsInstances_auto_scaling
=== CONT  TestAccDcsInstances_basic
=== CONT  TestAccDcsInstances_proxy_to_rw
=== CONT  TestAccDcsInstances_rw_expand_replica
=== CONT  TestAccDcsInstances_ha_to_proxy
--- PASS: TestAccDcsInstances_rw_expand_replica (421.88s)
=== CONT  TestAccDcsInstances_rw_change_capacity
--- PASS: TestAccDcsInstances_basic (589.12s)
=== CONT  TestAccDcsInstances_ha_expand_replica
--- PASS: TestAccDcsInstances_ha_to_proxy (810.23s)
=== CONT  TestAccDcsInstances_single
--- PASS: TestAccDcsInstances_proxy_to_rw (909.49s)
=== CONT  TestAccDcsInstances_auto_scaling
--- PASS: TestAccDcsInstances_single (164.06s)
=== CONT  TestAccDcsInstances_ha_change_capacity
--- PASS: TestAccDcsInstances_ha_expand_replica (418.49s)
=== CONT  TestAccDcsInstances_ssl
--- PASS: TestAccDcsInstances_rw_change_capacity (646.80s)
=== CONT  TestAccDcsInstances_proxy_change_capacity
--- PASS: TestAccDcsInstances_auto_scaling (401.67s)
=== CONT  TestAccDcsInstances_proxy_to_ha
--- PASS: TestAccDcsInstances_ssl (329.71s)
=== CONT  TestAccDcsInstances_prePaid
--- PASS: TestAccDcsInstances_ha_change_capacity (515.31s)
=== CONT  TestAccDcsInstances_rw_to_proxy
--- PASS: TestAccDcsInstances_prePaid (610.10s)
=== CONT  TestAccDcsInstances_cluster_change_capacity
--- PASS: TestAccDcsInstances_proxy_to_ha (938.58s)
=== CONT  TestAccDcsInstances_cluster_expand_replica
--- PASS: TestAccDcsInstances_rw_to_proxy (807.79s)
=== CONT  TestAccDcsInstances_whitelists
--- PASS: TestAccDcsInstances_whitelists (249.71s)
--- PASS: TestAccDcsInstances_cluster_expand_replica (543.49s)
--- PASS: TestAccDcsInstances_proxy_change_capacity (2262.53s)
--- PASS: TestAccDcsInstances_cluster_change_capacity (1696.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       3643.565s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
