### PR TITLE
chore(dataarts): optimize the data connection data source coding

### DIFF
--- a/docs/data-sources/dataarts_studio_data_connections.md
+++ b/docs/data-sources/dataarts_studio_data_connections.md
@@ -27,14 +27,14 @@ The following arguments are supported:
 * `region` - (Optional, String) Specifies the region in which to query the data source.
   If omitted, the provider-level region will be used.
 
-* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the data connection belongs.
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the data connections belong.
 
-* `connection_id` - (Optional, String) Specifies the ID of the data connection.
+* `connection_id` - (Optional, String) Specifies the ID of the data connection to be queried.
 
-* `name` - (Optional, String) Specifies the name of the data connection.
+* `name` - (Optional, String) Specifies the name of the data connection to be queried.  
   Supports fuzzy search.
 
-* `type` - (Optional, String) Specifies the type of the data connection.
+* `type` - (Optional, String) Specifies the type of the data connection to be queried.
 
 ## Attribute Reference
 
@@ -60,4 +60,6 @@ The `connections` block supports:
 
 * `created_by` - The creator of the data connection.
 
-* `created_at` - The creation time of the data connection.
+* `created_at` - The creation time of the data connection, in RFC3339 format.
+
+* `create_timestamp` - The creation timestamp of the data connection.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1067,7 +1067,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_css_snapshots":                 css.DataSourceCssSnapshots(),
 			"huaweicloud_css_vpcep_connections":         css.DataSourceVpcepserviceConnections(),
 
-			"huaweicloud_dataarts_studio_data_connections": dataarts.DataSourceDataConnections(),
+			// DataArts Studio Management Center
+			"huaweicloud_dataarts_studio_data_connections": dataarts.DataSourceStudioDataConnections(),
 			"huaweicloud_dataarts_studio_workspaces":       dataarts.DataSourceDataArtsStudioWorkspaces(),
 			// DataArts Architecture
 			"huaweicloud_dataarts_architecture_ds_template_optionals": dataarts.DataSourceTemplateOptionalFields(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_studio_data_connections_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_studio_data_connections_test.go
@@ -2,6 +2,7 @@ package dataarts
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,11 +10,19 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourceDataConnections_basic(t *testing.T) {
+func TestAccDataStudioDataConnections_basic(t *testing.T) {
 	var (
-		name             = acceptance.RandomAccResourceName()
-		byConnectionId   = "data.huaweicloud_dataarts_studio_data_connections.by_connection_id"
+		all = "data.huaweicloud_dataarts_studio_data_connections.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byConnectionId   = "data.huaweicloud_dataarts_studio_data_connections.filter_by_connection_id"
 		dcByConnectionId = acceptance.InitDataSourceCheck(byConnectionId)
+
+		byName   = "data.huaweicloud_dataarts_studio_data_connections.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byType   = "data.huaweicloud_dataarts_studio_data_connections.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -24,56 +33,129 @@ func TestAccDatasourceDataConnections_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceDataConnections_basic(name),
+				Config: testAccDataStudioDataConnections_basic(),
 				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "connections.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
 					dcByConnectionId.CheckResourceExists(),
+					resource.TestCheckOutput("is_connection_id_filter_useful", "true"),
 					resource.TestCheckResourceAttr(byConnectionId, "connections.#", "1"),
+					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.id"),
+					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.name"),
+					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.type"),
 					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.qualified_name"),
 					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.created_by"),
 					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.created_at"),
-					resource.TestCheckOutput("name_filter_is_useful", "true"),
-					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.create_timestamp"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDatasourceDataConnections_basic(name string) string {
+func testAccDataStudioDataConnections_basic() string {
+	name := acceptance.RandomAccResourceName()
+
 	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_dataarts_studio_data_connections" "by_connection_id" {
-  workspace_id  = "%[2]s"
-  connection_id = huaweicloud_dataarts_studio_data_connection.test.id
+variable "data_connection_id" {
+  type    = string
+  default = "%[1]s"
 }
 
-data "huaweicloud_dataarts_studio_data_connections" "by_name_filter" {
-  depends_on   = [huaweicloud_dataarts_studio_data_connection.test]
-
-  workspace_id = "%[2]s"
-  name         = "%[3]s"
-}
-
-output "name_filter_is_useful" {
-  value = length(data.huaweicloud_dataarts_studio_data_connections.by_name_filter.connections) > 0 && alltrue(
-    [for v in data.huaweicloud_dataarts_studio_data_connections.by_name_filter.connections[*].name : 
-    v == "%[3]s"]
-  )  
-}
-
-data "huaweicloud_dataarts_studio_data_connections" "by_type_filter" {
-  depends_on   = [huaweicloud_dataarts_studio_data_connection.test]
+resource "huaweicloud_dataarts_studio_data_connection" "test" {
+  count = var.data_connection_id == "" ? 1 : 0
 
   workspace_id = "%[2]s"
   type         = "DLI"
+  name         = "%[3]s"
+  env_type     = 0
+  config       = jsonencode({
+    "cdm_property_enable": "false"
+  })
+
+  lifecycle {
+    ignore_changes = [
+      config,
+    ]
+  }
 }
 
-output "type_filter_is_useful" {
-  value = length(data.huaweicloud_dataarts_studio_data_connections.by_type_filter.connections) > 0 && alltrue(
-    [for v in data.huaweicloud_dataarts_studio_data_connections.by_type_filter.connections[*].type : 
-    v == "DLI"]
-  )  
+# Query all data connections without any filter.
+data "huaweicloud_dataarts_studio_data_connections" "all" {
+  depends_on = [huaweicloud_dataarts_studio_data_connection.test]
+
+  workspace_id = "%[2]s"
 }
-`, testAccDataConnection_basic(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+
+# Filter by connection ID.
+locals {
+  data_connection_id = var.data_connection_id != "" ? var.data_connection_id : huaweicloud_dataarts_studio_data_connection.test[0].id
+}
+
+data "huaweicloud_dataarts_studio_data_connections" "filter_by_connection_id" {
+  workspace_id  = "%[2]s"
+  connection_id = local.data_connection_id
+}
+
+locals {
+  connection_id_filter_result = [
+    for v in data.huaweicloud_dataarts_studio_data_connections.filter_by_connection_id.connections[*].id : v == local.data_connection_id
+  ]
+}
+
+output "is_connection_id_filter_useful" {
+  value = length(local.connection_id_filter_result) > 0 && alltrue(local.connection_id_filter_result)
+}
+
+# Filter by name.
+locals {
+  data_connection_name = var.data_connection_id != "" ? try(data.huaweicloud_dataarts_studio_data_connections.all.connections[0].name,
+    "NOT_FOUND") : "%[3]s"
+}
+
+data "huaweicloud_dataarts_studio_data_connections" "filter_by_name" {
+  depends_on   = [huaweicloud_dataarts_studio_data_connection.test]
+
+  workspace_id = "%[2]s"
+  name         = local.data_connection_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dataarts_studio_data_connections.filter_by_name.connections[*].name : strcontains(v, local.data_connection_name)
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+
+# Filter by type.
+locals {
+  data_connection_type = var.data_connection_id != "" ? try(data.huaweicloud_dataarts_studio_data_connections.all.connections[0].type,
+    "NOT_FOUND") : huaweicloud_dataarts_studio_data_connection.test[0].type
+}
+
+data "huaweicloud_dataarts_studio_data_connections" "filter_by_type" {
+  depends_on   = [huaweicloud_dataarts_studio_data_connection.test]
+
+  workspace_id = "%[2]s"
+  type         = local.data_connection_type
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_dataarts_studio_data_connections.filter_by_type.connections[*].type : v == local.data_connection_type
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+`, acceptance.HW_DATAARTS_CONNECTION_ID, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
 }

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_studio_data_connections.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_studio_data_connections.go
@@ -3,52 +3,63 @@ package dataarts
 import (
 	"context"
 	"fmt"
+	"log"
+	"strconv"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/chnsz/golangsdk/openstack/dayu/v1/connections"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API DataArtsStudio GET /v1/{project_id}/data-connections
-func DataSourceDataConnections() *schema.Resource {
+func DataSourceStudioDataConnections() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: resourceDataConnectionsRead,
+		ReadContext: resourceStudioDataConnectionsRead,
+
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the data connections are located.`,
 			},
+
+			// Required parameters.
 			"workspace_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `Specifies the ID of the workspace to which the data connection belongs.`,
+				Description: `The ID of the workspace to which the data connections belong.`,
 			},
+
+			// Optional parameters.
 			"connection_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: `Specifies the ID of the data connection.`,
+				Description: `The ID of the data connection to be queried.`,
 			},
 			"name": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: `Specifies the name of the data connection.`,
+				Description: `The name of the data connection to be queried.`,
 			},
 			"type": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: `Specifies the type of the data connection.`,
+				Description: `The type of the data connection to be queried.`,
 			},
+
+			// Attributes.
 			"connections": {
 				Type:        schema.TypeList,
 				Computed:    true,
-				Description: `The list of the data connections.`,
+				Description: `The list of the data connections that matched filter parameters.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -84,7 +95,12 @@ func DataSourceDataConnections() *schema.Resource {
 						"created_at": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `The creation time of the data connection.`,
+							Description: `The creation time of the data connection, in RFC3339 format.`,
+						},
+						"create_timestamp": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The creation timestamp of the data connection.`,
 						},
 					},
 				},
@@ -93,26 +109,123 @@ func DataSourceDataConnections() *schema.Resource {
 	}
 }
 
-func resourceDataConnectionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.DataArtsV1Client(region)
+func buildStudioDataConnectionsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("type"); ok {
+		res = fmt.Sprintf("%s&type=%v", res, v)
+	}
+
+	if res != "" {
+		return res[1:]
+	}
+	return res
+}
+
+func buildStudioMoreHeaders(workspaceId string) map[string]string {
+	result := map[string]string{
+		"Content-Type": "application/json",
+	}
+
+	if workspaceId != "" {
+		result["workspace"] = workspaceId
+	}
+
+	return result
+}
+
+func listStudioDataConnections(client *golangsdk.ServiceClient, workspaceId string, queryParams ...string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/data-connections?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	if len(queryParams) > 0 {
+		listPath = fmt.Sprintf("%s&%s", listPath, queryParams[0])
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildStudioMoreHeaders(workspaceId),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		connections := utils.PathSearch("data_connection_lists", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, connections...)
+		if len(connections) < limit {
+			break
+		}
+		offset += len(connections)
+	}
+
+	return result, nil
+}
+
+func filterByConnectionId(connections []interface{}, connectionId string) []interface{} {
+	if connectionId == "" {
+		return connections
+	}
+
+	return utils.PathSearch(fmt.Sprintf("[?dw_id == '%s']", connectionId), connections, make([]interface{}, 0)).([]interface{})
+}
+
+func flattenConnections(connections []interface{}) []map[string]interface{} {
+	if len(connections) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(connections))
+	for _, connection := range connections {
+		result = append(result, map[string]interface{}{
+			"id":               utils.PathSearch("dw_id", connection, nil),
+			"name":             utils.PathSearch("dw_name", connection, nil),
+			"type":             utils.PathSearch("dw_type", connection, nil),
+			"agent_id":         utils.PathSearch("agent_id", connection, nil),
+			"qualified_name":   utils.PathSearch("qualified_name", connection, nil),
+			"created_by":       utils.PathSearch("create_user", connection, nil),
+			"created_at":       utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", connection, float64(0)).(float64))/1000, false),
+			"create_timestamp": int(utils.PathSearch("create_time", connection, float64(0)).(float64)),
+		})
+	}
+
+	return result
+}
+
+func resourceStudioDataConnectionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		workspaceId  = d.Get("workspace_id").(string)
+		connectionId = d.Get("connection_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
 	if err != nil {
-		return diag.Errorf("error creating DataArts Studio v1 client: %s", err)
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
 	}
 
-	// When limit and offset are used together, limit cannot be equal to the total number of connections.
-	// If limit is not specified, all connections are queried by default. A maximum of 200 data connections can be created.
-	opts := connections.ListOpts{
-		WorkspaceId: d.Get("workspace_id").(string),
-		Name:        d.Get("name").(string),
-		Type:        d.Get("type").(string),
-	}
-
-	resp, err := connections.List(client, opts)
+	connections, err := listStudioDataConnections(client, workspaceId, buildStudioDataConnectionsQueryParams(d))
 	if err != nil {
 		return diag.Errorf("error retrieving data connections: %s", err)
 	}
+	log.Printf("[Lance] The list response is: %v", connections)
 
 	randUUID, err := uuid.GenerateUUID()
 	if err != nil {
@@ -120,46 +233,10 @@ func resourceDataConnectionsRead(_ context.Context, d *schema.ResourceData, meta
 	}
 	d.SetId(randUUID)
 
-	mErr := multierror.Append(
-		nil,
+	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("connections", filterByConnectionId(flattenConnections(resp), d.Get("connection_id").(string))),
+		d.Set("connections", flattenConnections(filterByConnectionId(connections, connectionId))),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
-}
-
-func flattenConnections(resp []connections.Connection) []map[string]interface{} {
-	if len(resp) == 0 {
-		return nil
-	}
-
-	result := make([]map[string]interface{}, len(resp))
-	for i, connection := range resp {
-		result[i] = map[string]interface{}{
-			"id":             connection.DwId,
-			"name":           connection.DwName,
-			"type":           connection.DwType,
-			"agent_id":       connection.AgentId,
-			"qualified_name": connection.QualifiedName,
-			"created_by":     connection.CreateUser,
-			"created_at":     utils.FormatTimeStampRFC3339(int64(connection.CreateTime), false),
-		}
-	}
-	return result
-}
-
-func filterByConnectionId(all []map[string]interface{}, connectionId string) []map[string]interface{} {
-	if connectionId == "" {
-		return all
-	}
-
-	rst := make([]map[string]interface{}, 0, len(all))
-	for _, v := range all {
-		if connectionId == fmt.Sprint(utils.PathSearch("id", v, nil)) {
-			rst = append(rst, v)
-			return rst
-		}
-	}
-	return rst
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Optimize the data connection data source coding and ajust something:
- deprecate the data connection sdk usage
- repair the time format of attribute `created_at` (should using microsecond unit to calculate)
- refactor the acceptance test and supports using environment variable to specify data connection only

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of accetpance test:
<img width="1037" height="69" alt="image" src="https://github.com/user-attachments/assets/71614c0e-60b4-4963-8ac3-66b662329459" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. optimize the data connection data source coding.
2. optimize the corresponding acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

Using environment variable (HW_DATAARTS_CONNECTION_ID) to specify the existing data connection.
```
./scripts/coverage.sh -o dataarts -f TestAccDataStudioDataConnections_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataStudioDataConnections_basic -timeout 360m -parallel 10
=== RUN   TestAccDataStudioDataConnections_basic
=== PAUSE TestAccDataStudioDataConnections_basic
=== CONT  TestAccDataStudioDataConnections_basic
--- PASS: TestAccDataStudioDataConnections_basic (13.33s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  13.437s coverage: 4.6% of statements in ./huaweicloud/services/dataarts
```

Without using environment variable (HW_DATAARTS_CONNECTION_ID) and using resource to manage data connection.
```
./scripts/coverage.sh -o dataarts -f TestAccDataStudioDataConnections_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataStudioDataConnections_basic -timeout 360m -parallel 10
=== RUN   TestAccDataStudioDataConnections_basic
=== PAUSE TestAccDataStudioDataConnections_basic
=== CONT  TestAccDataStudioDataConnections_basic
--- PASS: TestAccDataStudioDataConnections_basic (15.88s)
PASS
coverage: 5.7% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  16.001s coverage: 5.7% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
