### PR TITLE
feat(rfs): new datasource to query private modules

### DIFF
--- a/docs/data-sources/rfs_private_modules.md
+++ b/docs/data-sources/rfs_private_modules.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_private_modules"
+description: |-
+  Use this datasource to get the list of private modules.
+---
+
+# huaweicloud_rfs_private_modules
+
+Use this datasource to get the list of private modules.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_rfs_private_modules" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `sort_key` - (Optional, String) Specifies the sort field, only supports **create_time**.
+
+* `sort_dir` - (Optional, String) Specifies the ascending or descending order.
+  Valid values are **asc** and **desc**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `modules` - The list of private modules. By default, these modules are sorted in ascending order of the creation time.
+
+  The [modules](#modules_struct) structure is documented below.
+
+<a name="modules_struct"></a>
+The `modules` block supports:
+
+* `module_name` - The name of the private module.
+
+* `module_id` - The unique ID of the private module.
+
+* `module_description` - The description of the private module.
+
+* `create_time` - The creation time of a private module. It is represented in UTC format (YYYY-MM-DDTHH:mm:ss.SSSZ),
+  such as **1970-01-01T00:00:00.000Z**.
+
+* `update_time` - The update time of a private module. It is represented in UTC format (YYYY-MM-DDTHH:mm:ss.SSSZ),
+  such as **1970-01-01T00:00:00.000Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2015,6 +2015,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_intelligent_session_kill_history":   rds.DataSourceIntelligentSessionKillHistory(),
 			"huaweicloud_rds_intelligent_session_kill_statistic": rds.DataSourceIntelligentSessionKillStatistic(),
 
+			"huaweicloud_rfs_private_modules": rfs.DataSourcePrivateModules(),
+
 			"huaweicloud_rgc_home_region":                           rgc.DataSourceHomeRegion(),
 			"huaweicloud_rgc_pre_launch_check":                      rgc.DataSourcePreLaunchCheck(),
 			"huaweicloud_rgc_landing_zone_available_updates":        rgc.DataSourceLandingZoneAvailableUpdates(),

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_private_modules_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_private_modules_test.go
@@ -1,0 +1,48 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcePrivateModules_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_private_modules.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePrivateModules_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "modules.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "modules.0.module_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "modules.0.module_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "modules.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "modules.0.update_time"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePrivateModules_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rfs_private_modules" "test" {
+  sort_key = "create_time"
+  sort_dir = "desc"
+}
+`, testAccPrivateModule_basic(name))
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_private_modules.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_private_modules.go
@@ -1,0 +1,169 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/private-modules
+func DataSourcePrivateModules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePrivateModulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"modules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"module_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"module_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"module_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildListPrivateModulesQueryParams(d *schema.ResourceData, marker string) string {
+	rst := ""
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%s", v.(string))
+	}
+
+	if marker != "" {
+		rst += fmt.Sprintf("&marker=%s", marker)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourcePrivateModulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1/private-modules"
+		allModules = make([]interface{}, 0)
+		nextMarker string
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": uuid,
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildListPrivateModulesQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving private modules: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		modules := utils.PathSearch("modules", respBody, make([]interface{}, 0)).([]interface{})
+		if len(modules) == 0 {
+			break
+		}
+
+		allModules = append(allModules, modules...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("modules", flattenPrivateModules(allModules)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPrivateModules(modules []interface{}) []interface{} {
+	if len(modules) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(modules))
+	for _, v := range modules {
+		rst = append(rst, map[string]interface{}{
+			"module_name":        utils.PathSearch("module_name", v, nil),
+			"module_id":          utils.PathSearch("module_id", v, nil),
+			"module_description": utils.PathSearch("module_description", v, nil),
+			"create_time":        utils.PathSearch("create_time", v, nil),
+			"update_time":        utils.PathSearch("update_time", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query private modules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o rfs -f TestAccDataSourcePrivateModules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rfs" -v -coverprofile="./huaweicloud/services/acceptance/rfs/rfs_coverage.cov" -coverpkg="./huaweicloud/services/rfs" -run TestAccDataSourcePrivateModules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourcePrivateModules_basic
=== PAUSE TestAccDataSourcePrivateModules_basic
=== CONT  TestAccDataSourcePrivateModules_basic
--- PASS: TestAccDataSourcePrivateModules_basic (16.19s)
PASS
coverage: 18.5% of statements in ./huaweicloud/services/rfs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       16.304s coverage: 18.5% of statements in ./huaweicloud/services/rfs
```
<img width="1212" height="79" alt="image" src="https://github.com/user-attachments/assets/ba5b3946-f844-44f0-b031-783307ff5e7c" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
