### PR TITLE
feat(cfw): add dataSource to get the ACL rule import status

### DIFF
--- a/docs/data-sources/cfw_acl_rule_import_status.md
+++ b/docs/data-sources/cfw_acl_rule_import_status.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_acl_rule_import_status"
+description: |-
+  Use this data source to get the ACL rule import status within HuaweiCloud.
+---
+
+# huaweicloud_cfw_acl_rule_import_status
+
+Use this data source to get the ACL rule import status within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "object_id" {}
+
+data "huaweicloud_cfw_acl_rule_import_status" "test" {
+  object_id = var.object_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `object_id` - (Required, String) Specifies the protected object ID.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data` - The ACL rule import status data.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `id` - The import task ID.
+
+* `status` - The import status.  
+  The valid values are as follows:
+  + `0`: No task.
+  + `1`: Task waiting.
+  + `2`: Task executing.
+  + `3`: Task success.
+  + `4`: Task failed.
+  + `5`: Task partially successful.
+  + `6`: Task completely failed.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -873,6 +873,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_tags":                          cfw.DataSourceCfwTags(),
 			"huaweicloud_cfw_acl_rule_export_status":        cfw.DataSourceAclRuleExportStatus(),
 			"huaweicloud_cfw_acl_rule_hit_info":             cfw.DataSourceAclRuleHitInfo(),
+			"huaweicloud_cfw_acl_rule_import_status":        cfw.DataSourceAclRuleImportStatus(),
 			"huaweicloud_cfw_acl_rule_tags":                 cfw.DataSourceAclRuleTags(),
 			"huaweicloud_cfw_ip_blacklist":                  cfw.DataSourceIpBlacklist(),
 			"huaweicloud_cfw_ip_blacklist_switch":           cfw.DataSourceIpBlacklistSwitch(),

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_acl_rule_import_status_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_acl_rule_import_status_test.go
@@ -1,0 +1,49 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAclRuleImportStatus_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_cfw_acl_rule_import_status.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAclRuleImportStatus_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.status"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAclRuleImportStatus_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_firewalls" "test" {
+  fw_instance_id = "%s"
+}
+
+data "huaweicloud_cfw_acl_rule_import_status" "test" {
+  depends_on = [data.huaweicloud_cfw_firewalls.test]
+  object_id  = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_acl_rule_import_status.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_acl_rule_import_status.go
@@ -1,0 +1,128 @@
+package cfw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW GET /v1/{project_id}/acl-rule/import-status
+func DataSourceAclRuleImportStatus() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DataSourceAclRuleImportStatusRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"object_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAclRuleImportStatusQueryParams(objectID string, cfg *config.Config, d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("?object_id=%s", objectID)
+
+	epsId := cfg.GetEnterpriseProjectID(d)
+	if epsId != "" {
+		queryParams += fmt.Sprintf("&enterprise_project_id=%s", epsId)
+	}
+
+	return queryParams
+}
+
+func DataSourceAclRuleImportStatusRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		objectID = d.Get("object_id").(string)
+		httpUrl  = "v1/{project_id}/acl-rule/import-status"
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAclRuleImportStatusQueryParams(objectID, cfg, d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CFW ACL rule import status: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenAclRuleImportStatusData(utils.PathSearch("data", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAclRuleImportStatusData(data interface{}) []interface{} {
+	if data == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"id":     utils.PathSearch("id", data, nil),
+			"status": utils.PathSearch("status", data, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `cfw_acl_rule_import_status` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `cfw_acl_rule_import_status` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceAclRuleImportStatus_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw-v -run TestAccDataSourceAclRuleImportStatus_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAclRuleImportStatus_basic
=== PAUSE TestAccDataSourceAclRuleImportStatus_basic
=== CONT  TestAccDataSourceAclRuleImportStatus_basic
--- PASS: TestAccDataSourceAclRuleImportStatus_basic (12.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       21.311s
```
<img width="652" height="26" alt="image" src="https://github.com/user-attachments/assets/eef97930-35c8-4c07-981c-2df2b4aea889" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
