### PR TITLE
feat(DCS): add dcs redis run log collect resource and redis run logs data source

### DIFF
--- a/docs/data-sources/dcs_redis_run_logs.md
+++ b/docs/data-sources/dcs_redis_run_logs.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Distributed Cache Service (DCS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dcs_redis_run_logs"
+description: |-
+  Use this data source to query the list of Redis running logs within HuaweiCloud.
+---
+
+# huaweicloud_dcs_redis_run_logs
+
+Use this data source to query the list of Redis running logs within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_dcs_redis_run_logs" "test" {
+  instance_id = var.instance_id
+  log_type    = "run"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the DCS instance is located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the DCS instance.
+
+* `log_type` - (Required, String) Specifies the type of log to query.
+  Currently, only **run** (Redis running log) is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `file_list` - The list of running log files.  
+  The [file_list](#dcs_redislogs_file) structure is documented below.
+
+<a name="dcs_redislogs_file"></a>
+The `file_list` block supports:
+
+* `id` - The unique identifier of the log.
+
+* `file_name` - The running log file name.
+
+* `group_name` - The shard name.
+
+* `replication_ip` - The IP address of the replica where the running log was collected.
+
+* `status` - The status of getting the running log. Valid values are:
+  + **succeed**: Success.
+  + **failed**: Failed.
+
+* `time` - The date when the running log was collected, in the format **yyyy-MM-dd**.
+
+* `backup_id` - The ID of the log file.

--- a/docs/resources/dcs_redis_run_log_collect.md
+++ b/docs/resources/dcs_redis_run_log_collect.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Distributed Cache Service (DCS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dcs_redis_run_log_collect"
+description: |-
+  Manages a DCS redis run log collect resource within HuaweiCloud.
+---
+
+# huaweicloud_dcs_redis_run_log_collect
+
+Manages a DCS redis run log collect resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dcs_redis_run_log_collect" "test" {
+  instance_id = var.instance_id
+  log_type    = "run"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the redis run log collect.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the DCS instance.
+
+* `log_type` - (Required, String, NonUpdatable) Specifies the type of log to collect.
+  Currently, only **run** (Redis running log) is supported.
+
+* `query_time` - (Optional, Int, NonUpdatable) Specifies the date offset, indicating to query logs from the past n
+  days. Valid values are **0**, **1**, **3**, and **7**.  
+  + **0**: Query today's logs (default).
+  + **1**: Query logs from the past 1 day.
+  + **3**: Query logs from the past 3 days.
+  + **7**: Query logs from the past 7 days.
+
+* `replication_id` - (Optional, String, NonUpdatable) Specifies the replica ID. This parameter is required when the
+  instance is not a single-node instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the instance ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1131,6 +1131,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dcs_migration_task_logs":                 dcs.DataSourceDcsMigrationTaskLogs(),
 			"huaweicloud_dcs_instance_expired_key_scan_histories": dcs.DataSourceDcsInstanceExpiredKeyScanHistories(),
 			"huaweicloud_dcs_center_tasks":                        dcs.DataSourceDcsCenterTasks(),
+			"huaweicloud_dcs_redis_run_logs":                      dcs.DataSourceDcsRedisRunLogs(),
 
 			"huaweicloud_dds_quotas":                                  dds.DataSourceDdsQuotas(),
 			"huaweicloud_dds_audit_logs":                              dds.DataSourceDdsAuditLogs(),
@@ -3230,6 +3231,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dcs_online_data_migration_task_restart": dcs.ResourceDcsOnlineDataMigrationTaskRestart(),
 			"huaweicloud_dcs_migration_task_exchange_ip":         dcs.ResourceDcsMigrationTaskExchangeIp(),
 			"huaweicloud_dcs_migration_task_rollback_ip":         dcs.ResourceDcsMigrationTaskRollbackIp(),
+			"huaweicloud_dcs_redis_run_log_collect":              dcs.ResourceDcsRedisRunLogCollect(),
 
 			"huaweicloud_dds_database_role":                 dds.ResourceDatabaseRole(),
 			"huaweicloud_dds_database_user":                 dds.ResourceDatabaseUser(),

--- a/huaweicloud/services/acceptance/dcs/data_source_huaweicloud_dcs_redis_run_logs_test.go
+++ b/huaweicloud/services/acceptance/dcs/data_source_huaweicloud_dcs_redis_run_logs_test.go
@@ -1,0 +1,52 @@
+package dcs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRedisRunLogs_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_dcs_redis_run_logs.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceRedisRunLogs_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "file_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "file_list.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "file_list.0.file_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "file_list.0.group_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "file_list.0.replication_ip"),
+					resource.TestCheckResourceAttrSet(dataSource, "file_list.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "file_list.0.time"),
+					resource.TestCheckResourceAttrSet(dataSource, "file_list.0.backup_id"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceRedisRunLogs_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_dcs_redis_run_logs" "test" {
+  depends_on = [huaweicloud_dcs_redis_run_log_collect.test]
+
+  instance_id = huaweicloud_dcs_instance.test.id
+  log_type    = "run"
+}
+`, testRedisRunLogCollect_basic(name))
+}

--- a/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_redis_run_log_collect_test.go
+++ b/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_redis_run_log_collect_test.go
@@ -1,0 +1,74 @@
+package dcs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRedisRunLogCollect_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testRedisRunLogCollect_basic(name),
+			},
+		},
+	})
+}
+
+func testRedisRunLogCollect_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_dcs_flavors" "test" {
+  cache_mode       = "ha"
+  capacity         = 1
+  cpu_architecture = "x86_64"
+}
+
+resource "huaweicloud_dcs_instance" "test" {
+  name               = "%[1]s"
+  engine_version     = "5.0"
+  password           = "Huawei_test"
+  engine             = "Redis"
+  capacity           = 1
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
+  availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
+  flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
+}
+
+data "huaweicloud_dcs_instance_nodes" "test" {
+  instance_id = huaweicloud_dcs_instance.test.id
+}
+`, name)
+}
+
+func testRedisRunLogCollect_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dcs_redis_run_log_collect" "test" {
+  instance_id    = huaweicloud_dcs_instance.test.id
+  log_type       = "run"
+  query_time     = "3"
+  replication_id = data.huaweicloud_dcs_instance_nodes.test.nodes[0].replication_id
+}
+`, testRedisRunLogCollect_base(name))
+}

--- a/huaweicloud/services/dcs/data_source_huaweicloud_dcs_redis_run_logs.go
+++ b/huaweicloud/services/dcs/data_source_huaweicloud_dcs_redis_run_logs.go
@@ -1,0 +1,164 @@
+package dcs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DCS GET /v2/{project_id}/instances/{instance_id}/redislog
+func DataSourceDcsRedisRunLogs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDcsRedisRunLogsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"log_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"file_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dcsRedisRunLogSchema(),
+			},
+		},
+	}
+}
+
+func dcsRedisRunLogSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"file_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"replication_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"backup_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDcsRedisRunLogsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("dcs", region)
+	if err != nil {
+		return diag.Errorf("error creating DCS client: %s", err)
+	}
+
+	httpUrl := "v2/{project_id}/instances/{instance_id}/redislog"
+	getBasePath := client.Endpoint + httpUrl
+	getBasePath = strings.ReplaceAll(getBasePath, "{project_id}", client.ProjectID)
+	getBasePath = strings.ReplaceAll(getBasePath, "{instance_id}", d.Get("instance_id").(string))
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes:          []int{200, 204},
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	offset := 1
+	res := make([]interface{}, 0)
+	for {
+		getPath := getBasePath + buildGetRedisRunLogsQueryParams(d, offset)
+		getResp, err := client.Request("GET", getPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DCS redis run logs: %s", err)
+		}
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		fileList := flattenListRedisRunLogsBody(getRespBody)
+		if len(fileList) == 0 {
+			break
+		}
+
+		res = append(res, fileList...)
+		offset += 2
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("file_list", res),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetRedisRunLogsQueryParams(d *schema.ResourceData, offset int) string {
+	res := fmt.Sprintf("?limit=2&offset=%v", offset)
+	if v, ok := d.GetOk("log_type"); ok {
+		res = fmt.Sprintf("%s&log_type=%v", res, v)
+	}
+
+	return res
+}
+
+func flattenListRedisRunLogsBody(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("file_list", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	res := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		res = append(res, map[string]interface{}{
+			"id":             utils.PathSearch("id", v, nil),
+			"file_name":      utils.PathSearch("file_name", v, nil),
+			"group_name":     utils.PathSearch("group_name", v, nil),
+			"replication_ip": utils.PathSearch("replication_ip", v, nil),
+			"status":         utils.PathSearch("status", v, nil),
+			"time":           utils.PathSearch("time", v, nil),
+			"backup_id":      utils.PathSearch("backup_id", v, nil),
+		})
+	}
+	return res
+}

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_redis_run_log_collect.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_redis_run_log_collect.go
@@ -1,0 +1,135 @@
+package dcs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+var redisRunLogCollectNonUpdatableParams = []string{
+	"instance_id",
+	"log_type",
+	"query_time",
+	"replication_id",
+}
+
+// @API DCS POST /v2/{project_id}/instances/{instance_id}/redislog
+func ResourceDcsRedisRunLogCollect() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDcsRedisRunLogCollectCreate,
+		ReadContext:   resourceDcsRedisRunLogCollectRead,
+		UpdateContext: resourceDcsRedisRunLogCollectUpdate,
+		DeleteContext: resourceDcsRedisRunLogCollectDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(redisRunLogCollectNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"log_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"query_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"replication_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceDcsRedisRunLogCollectCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v2/{project_id}/instances/{instance_id}/redislog"
+		product = "dcs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DCS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createPath = buildCreateRedisRunLogCollectQueryParams(createPath, d)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes:          []int{204},
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DCS redis run log collect: %s", err)
+	}
+
+	d.SetId(instanceId)
+
+	return nil
+}
+
+func buildCreateRedisRunLogCollectQueryParams(url string, d *schema.ResourceData) string {
+	queryParams := make([]string, 0)
+
+	if v, ok := d.GetOk("query_time"); ok {
+		queryParams = append(queryParams, fmt.Sprintf("query_time=%d", v.(int)))
+	}
+
+	if v, ok := d.GetOk("log_type"); ok {
+		queryParams = append(queryParams, fmt.Sprintf("log_type=%s", v.(string)))
+	}
+
+	if v, ok := d.GetOk("replication_id"); ok {
+		queryParams = append(queryParams, fmt.Sprintf("replication_id=%s", v.(string)))
+	}
+
+	if len(queryParams) > 0 {
+		url = url + "?" + strings.Join(queryParams, "&")
+	}
+
+	return url
+}
+
+func resourceDcsRedisRunLogCollectRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDcsRedisRunLogCollectUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDcsRedisRunLogCollectDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting DCS redis run log collect resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1.  add dcs redis run log collect resource
2. add dcs redis run logs data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add dcs redis run log collect resource and redis run logs data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run TestAccRedisRunLogCollect_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccRedisRunLogCollect_basic -timeout 360m -parallel 4
=== RUN   TestAccRedisRunLogCollect_basic
=== PAUSE TestAccRedisRunLogCollect_basic
=== CONT  TestAccRedisRunLogCollect_basic
--- PASS: TestAccRedisRunLogCollect_basic (210.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       210.848s

make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run TestAccDataSourceRedisRunLogs_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccDataSourceRedisRunLogs_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRedisRunLogs_basic
=== PAUSE TestAccDataSourceRedisRunLogs_basic
=== CONT  TestAccDataSourceRedisRunLogs_basic
--- PASS: TestAccDataSourceRedisRunLogs_basic (252.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       252.706s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
