### PR TITLE
feat(dataarts): add new data source to query permission set privileges

### DIFF
--- a/docs/data-sources/dataarts_security_permission_set_privileges.md
+++ b/docs/data-sources/dataarts_security_permission_set_privileges.md
@@ -1,0 +1,113 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_pemission_set_privileges"
+description: |-
+  Use this data source to query the privileges of a DataArts Security permission set within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_pemission_set_privileges
+
+Use this data source to query the privileges of a DataArts Security permission set within HuaweiCloud.
+
+## Example Usage
+
+### Query all privileges under a specified permission set
+
+```hcl
+variable "workspace_id" {}
+variable "permission_set_id" {}
+
+data "huaweicloud_dataarts_security_pemission_set_privileges" "test" {
+  workspace_id      = var.workspace_id
+  permission_set_id = var.permission_set_id
+}
+```
+
+### Query the privileges under a specified permission set and using the permission type filter
+
+```hcl
+variable "workspace_id" {}
+variable "permission_set_id" {}
+
+data "huaweicloud_dataarts_security_pemission_set_privileges" "test" {
+  workspace_id      = var.workspace_id
+  permission_set_id = var.permission_set_id
+  privilege_type    = "ALLOW"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the permission set privileges are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the permission set belongs.
+
+* `permission_set_id` - (Required, String) Specifies the ID of the permission set to which the granted privileges belong.
+
+* `privilege_type` - (Optional, String) Specifies the privilege type used to filter privileges.
+
+* `privilege_action` - (Optional, String) Specifies the privilege action used to filter privileges.
+
+* `cluster_id` - (Optional, String) Specifies the cluster ID used to filter privileges.
+
+* `cluster_name` - (Optional, String) Specifies the cluster name used to filter privileges.
+
+* `datasource_type` - (Optional, String) Specifies the data source type used to filter privileges.
+
+* `database_name` - (Optional, String) Specifies the database name used to filter privileges.
+
+* `table_name` - (Optional, String) Specifies the table name used to filter privileges.
+
+* `column_name` - (Optional, String) Specifies the column name used to filter privileges.
+
+* `sync_status` - (Optional, String) Specifies the synchronization status used to filter privileges.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `privileges` - The list of privileges that matched filter parameters.  
+  The [privileges](#dataarts_security_pemission_set_privileges_attr) structure is documented below.
+
+<a name="dataarts_security_pemission_set_privileges_attr"></a>
+The `privileges` block supports:
+
+* `id` - The ID of the granted privilege.
+
+* `permission_set_id` - The ID of the permission set to which the granted privilege belongs.
+
+* `instance_id` - TThe ID of the instance to which the granted privilege belongs.
+
+* `type` - The type of the permission to be configured.
+
+* `actions` - The list of granted privileges.
+
+* `cluster_id` - The ID of the cluster to which the granted privilege belongs.
+
+* `cluster_name` - The name of the cluster to which the granted privilege belongs.
+
+* `datasource_type` - The type of the granted data source.
+
+* `database_name` - The name of the database to which the granted privilege belongs.
+
+* `schema_name` - The name of the schema to which the granted privilege belongs.
+
+* `namespace` - The name of the namespace to which the granted privilege belongs.
+
+* `table_name` - The name of the table to which the granted privilege belongs.
+
+* `column_name` - The name of the column to which the granted privilege belongs.
+
+* `row_level_security` - The row level security of the granted privilege.
+
+* `sync_status` - The synchronization status of the granted privilege.
+
+* `sync_msg` - The synchronization message of the granted privilege.
+
+* `url` - The URL path name of the granted privilege.

--- a/docs/data-sources/dataarts_security_permission_set_privileges.md
+++ b/docs/data-sources/dataarts_security_permission_set_privileges.md
@@ -1,0 +1,113 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_pemission_set_privileges"
+description: |-
+  Use this data source to query the privileges of a DataArts Security permission set within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_pemission_set_privileges
+
+Use this data source to query the privileges of a DataArts Security permission set within HuaweiCloud.
+
+## Example Usage
+
+### Query all privileges under a specified permission set
+
+```hcl
+variable "workspace_id" {}
+variable "permission_set_id" {}
+
+data "huaweicloud_dataarts_security_pemission_set_privileges" "test" {
+  workspace_id      = var.workspace_id
+  permission_set_id = var.permission_set_id
+}
+```
+
+### Query the privileges under a specified permission set and using the permission type filter
+
+```hcl
+variable "workspace_id" {}
+variable "permission_set_id" {}
+
+data "huaweicloud_dataarts_security_pemission_set_privileges" "test" {
+  workspace_id      = var.workspace_id
+  permission_set_id = var.permission_set_id
+  privilege_type    = "ALLOW"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the permission set belongs.
+
+* `permission_set_id` - (Required, String) Specifies the ID of the permission set to which the granted privileges belong.
+
+* `privilege_type` - (Optional, String) Specifies the privilege type used to filter privileges.
+
+* `privilege_action` - (Optional, String) Specifies the privilege action used to filter privileges.
+
+* `cluster_id` - (Optional, String) Specifies the cluster ID used to filter privileges.
+
+* `cluster_name` - (Optional, String) Specifies the cluster name used to filter privileges.
+
+* `datasource_type` - (Optional, String) Specifies the data source type used to filter privileges.
+
+* `database_name` - (Optional, String) Specifies the database name used to filter privileges.
+
+* `table_name` - (Optional, String) Specifies the table name used to filter privileges.
+
+* `column_name` - (Optional, String) Specifies the column name used to filter privileges.
+
+* `sync_status` - (Optional, String) Specifies the synchronization status used to filter privileges.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `privileges` - The list of privileges that matched filter parameters.
+  The [privileges](#dataarts_security_pemission_set_privileges_privileges) structure is documented below.
+
+<a name="dataarts_security_pemission_set_privileges_privileges"></a>
+The `privileges` block supports:
+
+* `id` - The privilege ID.
+
+* `permission_set_id` - The ID of the permission set to which the granted privilege belongs.
+
+* `instance_id` - The instance ID.
+
+* `type` - The privilege type.
+
+* `actions` - The privilege action list.
+
+* `cluster_id` - The cluster ID.
+
+* `cluster_name` - The cluster name.
+
+* `datasource_type` - The data source type.
+
+* `database_name` - The database name.
+
+* `schema_name` - The schema name.
+
+* `namespace` - The namespace.
+
+* `table_name` - The table name.
+
+* `column_name` - The column name.
+
+* `row_level_security` - The row level security.
+
+* `sync_status` - The synchronization status.
+
+* `sync_msg` - The synchronization message.
+
+* `url` - The URL path name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1091,6 +1091,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_factory_resources": dataarts.DataSourceFactoryResources(),
 			"huaweicloud_dataarts_factory_scripts":   dataarts.DataSourceFactoryScripts(),
 			// DataArts Security
+			"huaweicloud_dataarts_security_permission_set_privileges":   dataarts.DataSourceSecurityPermissionSetPrivileges(),
 			"huaweicloud_dataarts_security_workspace_associated_queues": dataarts.DataSourceSecurityWorkspaceAssociatedQueues(),
 
 			"huaweicloud_dbss_audit_data_masking_rules":  dbss.DataSourceDbssAuditDataMaskingRules(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1082,6 +1082,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_dataservice_messages":        dataarts.DataSourceDataServiceMessages(),
 			// DataArts Quality
 			"huaweicloud_dataarts_quality_tasks": dataarts.DataSourceQualityTasks(),
+			// DataArts Security
+			"huaweicloud_dataarts_security_permission_set_privileges": dataarts.DataSourceSecurityPermissionSetPrivileges(),
 			// DataArts Factory
 			"huaweicloud_dataarts_factory_jobs":      dataarts.DataSourceFactoryJobs(),
 			"huaweicloud_dataarts_factory_resources": dataarts.DataSourceFactoryResources(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_permission_set_privileges_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_permission_set_privileges_test.go
@@ -1,0 +1,331 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSecurityPermissionSetPrivileges_basic(t *testing.T) {
+	var (
+		rName = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_security_permission_set_privileges.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byPrivilegeType   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_privilege_type"
+		dcByPrivilegeType = acceptance.InitDataSourceCheck(byPrivilegeType)
+
+		byPrivilegeAction   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_privilege_action"
+		dcByPrivilegeAction = acceptance.InitDataSourceCheck(byPrivilegeAction)
+
+		byClusterId   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_cluster_id"
+		dcByClusterId = acceptance.InitDataSourceCheck(byClusterId)
+
+		byClusterName   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_cluster_name"
+		dcByClusterName = acceptance.InitDataSourceCheck(byClusterName)
+
+		byDatabaseName   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_database_name"
+		dcByDatabaseName = acceptance.InitDataSourceCheck(byDatabaseName)
+
+		byTableName   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_table_name"
+		dcByTableName = acceptance.InitDataSourceCheck(byTableName)
+
+		byColumnName   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_column_name"
+		dcByColumnName = acceptance.InitDataSourceCheck(byColumnName)
+
+		bySyncStatus   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_sync_status"
+		dcBySyncStatus = acceptance.InitDataSourceCheck(bySyncStatus)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsManagerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSecurityPermissionSetPrivileges_nonExistentWorkspace(),
+				ExpectError: regexp.MustCompile("error querying DataArts Security permission set privileges"),
+			},
+			{
+				Config: testAccDataSecurityPermissionSetPrivileges_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "privileges.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByPrivilegeType.CheckResourceExists(),
+					resource.TestCheckOutput("privilege_type_filter_is_useful", "true"),
+					dcByPrivilegeAction.CheckResourceExists(),
+					resource.TestCheckOutput("privilege_action_filter_is_useful", "true"),
+					dcByClusterId.CheckResourceExists(),
+					resource.TestCheckOutput("cluster_id_filter_is_useful", "true"),
+					dcByClusterName.CheckResourceExists(),
+					resource.TestCheckOutput("cluster_name_filter_is_useful", "true"),
+					dcByDatabaseName.CheckResourceExists(),
+					resource.TestCheckOutput("database_name_filter_is_useful", "true"),
+					dcByTableName.CheckResourceExists(),
+					resource.TestCheckOutput("table_name_filter_is_useful", "true"),
+					dcByColumnName.CheckResourceExists(),
+					resource.TestCheckOutput("column_name_filter_is_useful", "true"),
+					dcBySyncStatus.CheckResourceExists(),
+					resource.TestCheckOutput("sync_status_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSecurityPermissionSetPrivileges_nonExistentWorkspace() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_security_permission_set_privileges" "test" {
+  workspace_id      = "%[1]s"
+  permission_set_id = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataSecurityPermissionSetPrivileges_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_security_permission_set_privilege" "test" {
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  datasource_type   = "DLI"
+  type              = "ALLOW"
+  actions           = ["SELECT"]
+  cluster_name      = "*"
+  database_name     = huaweicloud_dli_database.test.name
+  table_name        = huaweicloud_dli_table.test.name
+  column_name       = huaweicloud_dli_table.test.columns[0].name
+  connection_id     = var.data_connection_id != "" ? var.data_connection_id : huaweicloud_dataarts_studio_data_connection.test[0].id
+}
+
+# Query all privileges without any filters.
+data "huaweicloud_dataarts_security_permission_set_privileges" "all" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+}
+
+# Filter by permission type.
+locals {
+  privilege_type = huaweicloud_dataarts_security_permission_set_privilege.test.type
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_privilege_type" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  privilege_type    = local.privilege_type
+}
+
+locals {
+  privilege_type_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_privilege_type.privileges[*].type :
+      v == local.privilege_type
+  ]
+}
+
+output "privilege_type_filter_is_useful" {
+  value = length(local.privilege_type_filter_result) > 0 && alltrue(local.privilege_type_filter_result)
+}
+
+# Filter by permission action.
+locals {
+  privilege_action = try(tolist(huaweicloud_dataarts_security_permission_set_privilege.test.actions)[0], "NOT_FOUND")
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_privilege_action" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  privilege_action  = local.privilege_action
+}
+
+locals {
+  privilege_action_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_privilege_action.privileges[*].actions :
+      contains(v, local.privilege_action)
+  ]
+}
+
+output "privilege_action_filter_is_useful" {
+  value = length(local.privilege_action_filter_result) > 0 && alltrue(local.privilege_action_filter_result)
+}
+
+# Filter by cluster ID.
+locals {
+  cluster_id = huaweicloud_dataarts_security_permission_set_privilege.test.cluster_id
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_cluster_id" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  cluster_id        = local.cluster_id
+}
+
+locals {
+  cluster_id_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_cluster_id.privileges[*].cluster_id :
+      v == local.cluster_id
+  ]
+}
+
+output "cluster_id_filter_is_useful" {
+  value = length(local.cluster_id_filter_result) > 0 && alltrue(local.cluster_id_filter_result)
+}
+
+# Filter by cluster name.
+locals {
+  cluster_name = huaweicloud_dataarts_security_permission_set_privilege.test.cluster_name
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_cluster_name" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  cluster_name      = local.cluster_name
+}
+
+locals {
+  cluster_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_cluster_name.privileges[*].cluster_name :
+      v == local.cluster_name
+  ]
+}
+
+output "cluster_name_filter_is_useful" {
+  value = length(local.cluster_name_filter_result) > 0 && alltrue(local.cluster_name_filter_result)
+}
+
+# Filter by database name.
+locals {
+  database_name = huaweicloud_dataarts_security_permission_set_privilege.test.database_name
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_database_name" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  database_name     = local.database_name
+}
+
+locals {
+  database_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_database_name.privileges[*].database_name :
+      v == local.database_name
+  ]
+}
+
+output "database_name_filter_is_useful" {
+  value = length(local.database_name_filter_result) > 0 && alltrue(local.database_name_filter_result)
+}
+
+# Filter by table name.
+locals {
+  table_name = huaweicloud_dataarts_security_permission_set_privilege.test.table_name
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_table_name" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  table_name        = local.table_name
+}
+
+locals {
+  table_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_table_name.privileges[*].table_name :
+      v == local.table_name
+  ]
+}
+
+output "table_name_filter_is_useful" {
+  value = length(local.table_name_filter_result) > 0 && alltrue(local.table_name_filter_result)
+}
+
+# Filter by column name.
+locals {
+  column_name = huaweicloud_dataarts_security_permission_set_privilege.test.column_name
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_column_name" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  column_name       = local.column_name
+}
+
+locals {
+  column_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_column_name.privileges[*].column_name :
+      v == local.column_name
+  ]
+}
+
+output "column_name_filter_is_useful" {
+  value = length(local.column_name_filter_result) > 0 && alltrue(local.column_name_filter_result)
+}
+
+# Filter by sync status.
+locals {
+  sync_status = huaweicloud_dataarts_security_permission_set_privilege.test.status
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_sync_status" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  sync_status       = local.sync_status
+}
+
+locals {
+  sync_status_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_sync_status.privileges[*].sync_status :
+      v == local.sync_status
+  ]
+}
+
+output "sync_status_filter_is_useful" {
+  value = length(local.sync_status_filter_result) > 0 && alltrue(local.sync_status_filter_result)
+}
+`, testAccSecurityPermissionSetPrivilege_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_permission_set_privileges_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_permission_set_privileges_test.go
@@ -1,0 +1,332 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSecurityPermissionSetPrivileges_basic(t *testing.T) {
+	var (
+		rName = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_security_permission_set_privileges.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byPrivilegeType   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_privilege_type"
+		dcByPrivilegeType = acceptance.InitDataSourceCheck(byPrivilegeType)
+
+		byPrivilegeAction   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_privilege_action"
+		dcByPrivilegeAction = acceptance.InitDataSourceCheck(byPrivilegeAction)
+
+		byClusterId   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_cluster_id"
+		dcByClusterId = acceptance.InitDataSourceCheck(byClusterId)
+
+		byClusterName   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_cluster_name"
+		dcByClusterName = acceptance.InitDataSourceCheck(byClusterName)
+
+		byDatabaseName   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_database_name"
+		dcByDatabaseName = acceptance.InitDataSourceCheck(byDatabaseName)
+
+		byTableName   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_table_name"
+		dcByTableName = acceptance.InitDataSourceCheck(byTableName)
+
+		byColumnName   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_column_name"
+		dcByColumnName = acceptance.InitDataSourceCheck(byColumnName)
+
+		bySyncStatus   = "data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_sync_status"
+		dcBySyncStatus = acceptance.InitDataSourceCheck(bySyncStatus)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsManagerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSecurityPermissionSetPrivileges_nonExistentWorkspace(),
+				ExpectError: regexp.MustCompile("error querying DataArts Security permission set privileges"),
+			},
+			{
+				Config: testAccDataSecurityPermissionSetPrivileges_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "privileges.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByPrivilegeType.CheckResourceExists(),
+					resource.TestCheckOutput("privilege_type_filter_is_useful", "true"),
+					dcByPrivilegeAction.CheckResourceExists(),
+					resource.TestCheckOutput("privilege_action_filter_is_useful", "true"),
+					dcByClusterId.CheckResourceExists(),
+					resource.TestCheckOutput("cluster_id_filter_is_useful", "true"),
+					dcByClusterName.CheckResourceExists(),
+					resource.TestCheckOutput("cluster_name_filter_is_useful", "true"),
+					dcByDatabaseName.CheckResourceExists(),
+					resource.TestCheckOutput("database_name_filter_is_useful", "true"),
+					dcByTableName.CheckResourceExists(),
+					resource.TestCheckOutput("table_name_filter_is_useful", "true"),
+					dcByColumnName.CheckResourceExists(),
+					resource.TestCheckOutput("column_name_filter_is_useful", "true"),
+					dcBySyncStatus.CheckResourceExists(),
+					resource.TestCheckOutput("sync_status_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSecurityPermissionSetPrivileges_nonExistentWorkspace() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_security_permission_set_privileges" "test" {
+  workspace_id      = "%[1]s"
+  permission_set_id = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataSecurityPermissionSetPrivileges_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_security_permission_set_privilege" "test" {
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  datasource_type   = "DLI"
+  type              = "ALLOW"
+  actions           = ["SELECT"]
+  cluster_name      = "*"
+  database_name     = huaweicloud_dli_database.test.name
+  table_name        = huaweicloud_dli_table.test.name
+  column_name       = huaweicloud_dli_table.test.columns[0].name
+  connection_id     = var.data_connection_id != "" ? var.data_connection_id : huaweicloud_dataarts_studio_data_connection.test[0].id
+}
+
+
+# Query all privileges without any filters.
+data "huaweicloud_dataarts_security_permission_set_privileges" "all" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+}
+
+# Filter by permission type.
+locals {
+  privilege_type = huaweicloud_dataarts_security_permission_set_privilege.test.type
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_privilege_type" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  privilege_type    = local.privilege_type
+}
+
+locals {
+  privilege_type_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_privilege_type.privileges[*].type :
+      v == local.privilege_type
+  ]
+}
+
+output "privilege_type_filter_is_useful" {
+  value = length(local.privilege_type_filter_result) > 0 && alltrue(local.privilege_type_filter_result)
+}
+
+# Filter by permission action.
+locals {
+  privilege_action = try(tolist(huaweicloud_dataarts_security_permission_set_privilege.test.actions)[0], "NOT_FOUND")
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_privilege_action" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  privilege_action = local.privilege_action
+}
+
+locals {
+  privilege_action_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_privilege_action.privileges[*].actions :
+      contains(v, local.privilege_action)
+  ]
+}
+
+output "privilege_action_filter_is_useful" {
+  value = length(local.privilege_action_filter_result) > 0 && alltrue(local.privilege_action_filter_result)
+}
+
+# Filter by cluster ID.
+locals {
+  cluster_id = huaweicloud_dataarts_security_permission_set_privilege.test.cluster_id
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_cluster_id" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  cluster_id        = local.cluster_id
+}
+
+locals {
+  cluster_id_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_cluster_id.privileges[*].cluster_id :
+      v == local.cluster_id
+  ]
+}
+
+output "cluster_id_filter_is_useful" {
+  value = length(local.cluster_id_filter_result) > 0 && alltrue(local.cluster_id_filter_result)
+}
+
+# Filter by cluster name.
+locals {
+  cluster_name = huaweicloud_dataarts_security_permission_set_privilege.test.cluster_name
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_cluster_name" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  cluster_name      = local.cluster_name
+}
+
+locals {
+  cluster_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_cluster_name.privileges[*].cluster_name :
+      v == local.cluster_name
+  ]
+}
+
+output "cluster_name_filter_is_useful" {
+  value = length(local.cluster_name_filter_result) > 0 && alltrue(local.cluster_name_filter_result)
+}
+
+# Filter by database name.
+locals {
+  database_name = huaweicloud_dataarts_security_permission_set_privilege.test.database_name
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_database_name" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  database_name     = local.database_name
+}
+
+locals {
+  database_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_database_name.privileges[*].database_name :
+      v == local.database_name
+  ]
+}
+
+output "database_name_filter_is_useful" {
+  value = length(local.database_name_filter_result) > 0 && alltrue(local.database_name_filter_result)
+}
+
+# Filter by table name.
+locals {
+  table_name = huaweicloud_dataarts_security_permission_set_privilege.test.table_name
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_table_name" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  table_name        = local.table_name
+}
+
+locals {
+  table_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_table_name.privileges[*].table_name :
+      v == local.table_name
+  ]
+}
+
+output "table_name_filter_is_useful" {
+  value = length(local.table_name_filter_result) > 0 && alltrue(local.table_name_filter_result)
+}
+
+# Filter by column name.
+locals {
+  column_name = huaweicloud_dataarts_security_permission_set_privilege.test.column_name
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_column_name" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  column_name       = local.column_name
+}
+
+locals {
+  column_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_column_name.privileges[*].column_name :
+      v == local.column_name
+  ]
+}
+
+output "column_name_filter_is_useful" {
+  value = length(local.column_name_filter_result) > 0 && alltrue(local.column_name_filter_result)
+}
+
+# Filter by sync status.
+locals {
+  sync_status = huaweicloud_dataarts_security_permission_set_privilege.test.status
+}
+
+data "huaweicloud_dataarts_security_permission_set_privileges" "filter_by_sync_status" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_privilege.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  sync_status       = local.sync_status
+}
+
+locals {
+  sync_status_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_privileges.filter_by_sync_status.privileges[*].sync_status :
+      v == local.sync_status
+  ]
+}
+
+output "sync_status_filter_is_useful" {
+  value = length(local.sync_status_filter_result) > 0 && alltrue(local.sync_status_filter_result)
+}
+`, testAccSecurityPermissionSetPrivilege_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege_test.go
@@ -116,6 +116,12 @@ resource "huaweicloud_dataarts_studio_data_connection" "test" {
   config       = jsonencode({
     "cdm_property_enable": "false"
   })
+
+  lifecycle {
+    ignore_changes = [
+      config,
+    ]
+  }
 }
 
 resource "huaweicloud_dataarts_security_permission_set" "test" {

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_permission_set_privileges.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_permission_set_privileges.go
@@ -1,0 +1,285 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/security/permission-sets/{permission_set_id}/permissions
+func DataSourceSecurityPermissionSetPrivileges() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityPermissionSetPrivilegesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the permission set privileges are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the permission set belongs.`,
+			},
+			"permission_set_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the permission set to which the granted privileges belong.`,
+			},
+
+			// Optional parameters.
+			"privilege_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The privilege type used to filter privileges.`,
+			},
+			"privilege_action": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The privilege action used to filter privileges.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The cluster ID used to filter privileges.`,
+			},
+			"cluster_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The cluster name used to filter privileges.`,
+			},
+			"datasource_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The data source type used to filter privileges.`,
+			},
+			"database_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The database name used to filter privileges.`,
+			},
+			"table_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The table name used to filter privileges.`,
+			},
+			"column_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The column name used to filter privileges.`,
+			},
+			"sync_status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The synchronization status used to filter privileges.`,
+			},
+
+			// Attributes.
+			"privileges": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of privileges that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the granted privilege.`,
+						},
+						"permission_set_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the permission set to which the granted privilege belongs.`,
+						},
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the instance to which the granted privilege belongs.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the permission to be configured.`,
+						},
+						"actions": {
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Computed:    true,
+							Description: `The list of granted privileges.`,
+						},
+						"cluster_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the cluster to which the granted privilege belongs.`,
+						},
+						"cluster_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the cluster to which the granted privilege belongs.`,
+						},
+						"datasource_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the granted data source.`,
+						},
+						"database_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the database to which the granted privilege belongs.`,
+						},
+						"schema_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the schema to which the granted privilege belongs.`,
+						},
+						"namespace": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the namespace to which the granted privilege belongs.`,
+						},
+						"table_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the table to which the granted privilege belongs.`,
+						},
+						"column_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the column to which the granted privilege belongs.`,
+						},
+						"row_level_security": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The row level security of the granted privilege.`,
+						},
+						"sync_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The synchronization status of the granted privilege.`,
+						},
+						"sync_msg": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The synchronization message of the granted privilege.`,
+						},
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The URL path name of the granted privilege.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSecurityPermissionSetPrivilegesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("privilege_type"); ok {
+		res = fmt.Sprintf("%s&permission_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("privilege_action"); ok {
+		res = fmt.Sprintf("%s&permission_action=%v", res, v)
+	}
+	if v, ok := d.GetOk("cluster_id"); ok {
+		res = fmt.Sprintf("%s&cluster_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("cluster_name"); ok {
+		res = fmt.Sprintf("%s&cluster_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("datasource_type"); ok {
+		res = fmt.Sprintf("%s&datasource_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("database_name"); ok {
+		res = fmt.Sprintf("%s&database_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("table_name"); ok {
+		res = fmt.Sprintf("%s&table_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("column_name"); ok {
+		res = fmt.Sprintf("%s&column_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("sync_status"); ok {
+		res = fmt.Sprintf("%s&sync_status=%v", res, v)
+	}
+
+	if len(res) < 1 {
+		return res
+	}
+	return res[1:]
+}
+
+func flattenSecurityPermissionSetPrivileges(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(items))
+	for i, item := range items {
+		result[i] = map[string]interface{}{
+			"id":                 utils.PathSearch("id", item, nil),
+			"permission_set_id":  utils.PathSearch("permission_set_id", item, nil),
+			"instance_id":        utils.PathSearch("instance_id", item, nil),
+			"type":               utils.PathSearch("permission_type", item, nil),
+			"actions":            utils.PathSearch("permission_actions", item, nil),
+			"cluster_id":         utils.PathSearch("cluster_id", item, nil),
+			"cluster_name":       utils.PathSearch("cluster_name", item, nil),
+			"datasource_type":    utils.PathSearch("datasource_type", item, nil),
+			"database_name":      utils.PathSearch("database_name", item, nil),
+			"schema_name":        utils.PathSearch("schema_name", item, nil),
+			"namespace":          utils.PathSearch("namespace", item, nil),
+			"table_name":         utils.PathSearch("table_name", item, nil),
+			"column_name":        utils.PathSearch("column_name", item, nil),
+			"row_level_security": utils.PathSearch("row_level_security", item, nil),
+			"sync_status":        utils.PathSearch("sync_status", item, nil),
+			"sync_msg":           utils.PathSearch("sync_msg", item, nil),
+			"url":                utils.PathSearch("url", item, nil),
+		}
+	}
+	return result
+}
+
+func dataSourceSecurityPermissionSetPrivilegesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		region          = cfg.GetRegion(d)
+		workspaceId     = d.Get("workspace_id").(string)
+		permissionSetId = d.Get("permission_set_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	privileges, err := listPermissionSetAssociatedPrivileges(client, workspaceId, permissionSetId,
+		buildSecurityPermissionSetPrivilegesQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error querying DataArts Security permission set privileges: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("privileges", flattenSecurityPermissionSetPrivileges(privileges)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_permission_set_privileges.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_permission_set_privileges.go
@@ -1,0 +1,285 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/security/permission-sets/{permission_set_id}/permissions
+func DataSourceSecurityPermissionSetPrivileges() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityPermissionSetPrivilegesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the permission set privileges are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the permission set belongs.`,
+			},
+			"permission_set_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the permission set to which the granted privileges belong.`,
+			},
+
+			// Optional parameters.
+			"privilege_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The privilege type used to filter privileges.`,
+			},
+			"privilege_action": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The privilege action used to filter privileges.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The cluster ID used to filter privileges.`,
+			},
+			"cluster_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The cluster name used to filter privileges.`,
+			},
+			"datasource_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The data source type used to filter privileges.`,
+			},
+			"database_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The database name used to filter privileges.`,
+			},
+			"table_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The table name used to filter privileges.`,
+			},
+			"column_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The column name used to filter privileges.`,
+			},
+			"sync_status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The synchronization status used to filter privileges.`,
+			},
+
+			// Attributes.
+			"privileges": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of privileges that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The privilege ID.`,
+						},
+						"permission_set_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The permission set ID.`,
+						},
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The instance ID.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The privilege type.`,
+						},
+						"actions": {
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Computed:    true,
+							Description: `The privilege action list.`,
+						},
+						"cluster_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The cluster ID.`,
+						},
+						"cluster_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The cluster name.`,
+						},
+						"datasource_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The data source type.`,
+						},
+						"database_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The database name.`,
+						},
+						"schema_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The schema name.`,
+						},
+						"namespace": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The namespace.`,
+						},
+						"table_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The table name.`,
+						},
+						"column_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The column name.`,
+						},
+						"row_level_security": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The row level security.`,
+						},
+						"sync_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The synchronization status.`,
+						},
+						"sync_msg": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The synchronization message.`,
+						},
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The URL path name.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSecurityPermissionSetPrivilegesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("privilege_type"); ok {
+		res = fmt.Sprintf("%s&permission_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("privilege_action"); ok {
+		res = fmt.Sprintf("%s&permission_action=%v", res, v)
+	}
+	if v, ok := d.GetOk("cluster_id"); ok {
+		res = fmt.Sprintf("%s&cluster_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("cluster_name"); ok {
+		res = fmt.Sprintf("%s&cluster_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("datasource_type"); ok {
+		res = fmt.Sprintf("%s&datasource_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("database_name"); ok {
+		res = fmt.Sprintf("%s&database_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("table_name"); ok {
+		res = fmt.Sprintf("%s&table_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("column_name"); ok {
+		res = fmt.Sprintf("%s&column_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("sync_status"); ok {
+		res = fmt.Sprintf("%s&sync_status=%v", res, v)
+	}
+
+	if len(res) < 1 {
+		return res
+	}
+	return res[1:]
+}
+
+func flattenSecurityPermissionSetPrivileges(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(items))
+	for i, item := range items {
+		result[i] = map[string]interface{}{
+			"id":                 utils.PathSearch("id", item, nil),
+			"permission_set_id":  utils.PathSearch("permission_set_id", item, nil),
+			"instance_id":        utils.PathSearch("instance_id", item, nil),
+			"type":               utils.PathSearch("permission_type", item, nil),
+			"actions":            utils.PathSearch("permission_actions", item, nil),
+			"cluster_id":         utils.PathSearch("cluster_id", item, nil),
+			"cluster_name":       utils.PathSearch("cluster_name", item, nil),
+			"datasource_type":    utils.PathSearch("datasource_type", item, nil),
+			"database_name":      utils.PathSearch("database_name", item, nil),
+			"schema_name":        utils.PathSearch("schema_name", item, nil),
+			"namespace":          utils.PathSearch("namespace", item, nil),
+			"table_name":         utils.PathSearch("table_name", item, nil),
+			"column_name":        utils.PathSearch("column_name", item, nil),
+			"row_level_security": utils.PathSearch("row_level_security", item, nil),
+			"sync_status":        utils.PathSearch("sync_status", item, nil),
+			"sync_msg":           utils.PathSearch("sync_msg", item, nil),
+			"url":                utils.PathSearch("url", item, nil),
+		}
+	}
+	return result
+}
+
+func dataSourceSecurityPermissionSetPrivilegesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		region          = cfg.GetRegion(d)
+		workspaceId     = d.Get("workspace_id").(string)
+		permissionSetId = d.Get("permission_set_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	privileges, err := listPermissionSetAssociatedPrivileges(client, workspaceId, permissionSetId,
+		buildSecurityPermissionSetPrivilegesQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error querying DataArts Security permission set privileges: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("privileges", flattenSecurityPermissionSetPrivileges(privileges)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source for DataArts Studio Security: huaweicloud_dataarts_security_permission_set_privileges

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance test:
<img width="1065" height="49" alt="image" src="https://github.com/user-attachments/assets/62795f52-07d5-4f5c-89c7-b280eacfb41a" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source that used to query permission set privileges.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataSecurityPermissionSetPrivileges_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataSecurityPermissionSetPrivileges_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSecurityPermissionSetPrivileges_basic
=== PAUSE TestAccDataSecurityPermissionSetPrivileges_basic
=== CONT  TestAccDataSecurityPermissionSetPrivileges_basic
--- PASS: TestAccDataSecurityPermissionSetPrivileges_basic (754.55s)
PASS
coverage: 8.0% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  754.661s        coverage: 8.0% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
