### PR TITLE
feat(rfs): support `rfs_private_providers` data source

### DIFF
--- a/docs/data-sources/rfs_private_providers.md
+++ b/docs/data-sources/rfs_private_providers.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_private_providers"
+description: |-
+  Use this datasource to get the list of private providers.
+---
+
+# huaweicloud_rfs_private_providers
+
+Use this datasource to get the list of private providers.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_rfs_private_providers" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `sort_key` - (Optional, String) Specifies the sort field, only supports **create_time**.
+
+* `sort_dir` - (Optional, String) Specifies the ascending or descending order.
+  Valid values are **asc** and **desc**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `providers` - The list of private providers.
+
+  The [providers](#providers_struct) structure is documented below.
+
+<a name="providers_struct"></a>
+The `providers` block supports:
+
+* `provider_id` - The unique ID of the private provider.
+
+* `provider_name` - The name of the private provider.
+
+* `provider_description` - The description of the private provider.
+
+* `provider_source` - The source parameter that users need to specify when defining the required providers information
+  in Terraform templates using private providers.
+
+* `provider_agency_urn` - The IAM agency URN bound to the custom provider.
+
+* `provider_agency_name` - The IAM agency name bound to the custom provider.
+
+* `create_time` - The creation time of a private provider. It is represented in UTC format (YYYY-MM-DDTHH:mm:ss.SSSZ),
+  such as **1970-01-01T00:00:00.000Z**.
+
+* `update_time` - The update time of a private provider. It is represented in UTC format (YYYY-MM-DDTHH:mm:ss.SSSZ),
+  such as **1970-01-01T00:00:00.000Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2016,8 +2016,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_intelligent_session_kill_history":   rds.DataSourceIntelligentSessionKillHistory(),
 			"huaweicloud_rds_intelligent_session_kill_statistic": rds.DataSourceIntelligentSessionKillStatistic(),
 
-			"huaweicloud_rfs_private_modules": rfs.DataSourcePrivateModules(),
-			"huaweicloud_rfs_stack_instances": rfs.DataSourceStackInstances(),
+			"huaweicloud_rfs_private_modules":   rfs.DataSourcePrivateModules(),
+			"huaweicloud_rfs_stack_instances":   rfs.DataSourceStackInstances(),
+			"huaweicloud_rfs_private_providers": rfs.DataSourcePrivateProviders(),
 
 			"huaweicloud_rgc_home_region":                           rgc.DataSourceHomeRegion(),
 			"huaweicloud_rgc_pre_launch_check":                      rgc.DataSourcePreLaunchCheck(),

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_private_providers_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_private_providers_test.go
@@ -1,0 +1,94 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcePrivateProviders_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_private_providers.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceNameWithDash()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePrivateProviders_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "providers.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "providers.0.provider_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "providers.0.provider_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "providers.0.provider_description"),
+					resource.TestCheckResourceAttrSet(dataSource, "providers.0.provider_source"),
+					resource.TestCheckResourceAttrSet(dataSource, "providers.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "providers.0.update_time"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePrivateProviders_base(name string) string {
+	return fmt.Sprintf(`
+variable "request_resp_print_script_content" {
+  default = <<EOT
+exports.handler = async (event, context) => {
+    const result =
+    {
+        'repsonse_code': 200,
+        'headers':
+        {
+            'Content-Type': 'application/json'
+        },
+        'isBase64Encoded': false,
+        'body': JSON.stringify(event)
+    }
+    return result
+}
+EOT
+}
+
+resource "huaweicloud_fgs_function" "test" {
+  name        = "%[1]s"
+  app         = "default"
+  agency      = "function_all_trust"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  code_type   = "inline"
+  runtime     = "Node.js12.13"
+  func_code   = base64encode(var.request_resp_print_script_content)
+}
+
+resource "huaweicloud_rfs_private_provider" "test" {
+  provider_name        = "%[1]s"
+  function_graph_urn   = huaweicloud_fgs_function.test.urn
+  provider_description = "provider description test"
+  provider_version     = "1.1.1"
+  version_description  = "version description test"
+}
+`, name)
+}
+
+func testAccDataSourcePrivateProviders_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rfs_private_providers" "test" {
+  depends_on = [huaweicloud_rfs_private_provider.test]
+
+  sort_key = "create_time"
+  sort_dir = "desc"
+}
+`, testAccDataSourcePrivateProviders_base(name))
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_private_providers.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_private_providers.go
@@ -1,0 +1,183 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/private-providers
+func DataSourcePrivateProviders() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePrivateProvidersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"providers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"provider_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"provider_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"provider_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"provider_source": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"provider_agency_urn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"provider_agency_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildListPrivateProvidersQueryParams(d *schema.ResourceData, marker string) string {
+	rst := ""
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%s", v.(string))
+	}
+
+	if marker != "" {
+		rst += fmt.Sprintf("&marker=%s", marker)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourcePrivateProvidersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v1/private-providers"
+		allProviders = make([]interface{}, 0)
+		nextMarker   string
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	reqUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request UUID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Client-Request-Id": reqUUID},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildListPrivateProvidersQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RFS private providers: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		providers := utils.PathSearch("providers", respBody, make([]interface{}, 0)).([]interface{})
+		if len(providers) == 0 {
+			break
+		}
+
+		allProviders = append(allProviders, providers...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	d.SetId(reqUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("providers", flattenPrivateProviders(allProviders)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPrivateProviders(providers []interface{}) []interface{} {
+	if len(providers) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(providers))
+	for _, v := range providers {
+		rst = append(rst, map[string]interface{}{
+			"provider_id":          utils.PathSearch("provider_id", v, nil),
+			"provider_name":        utils.PathSearch("provider_name", v, nil),
+			"provider_description": utils.PathSearch("provider_description", v, nil),
+			"provider_source":      utils.PathSearch("provider_source", v, nil),
+			"provider_agency_urn":  utils.PathSearch("provider_agency_urn", v, nil),
+			"provider_agency_name": utils.PathSearch("provider_agency_name", v, nil),
+			"create_time":          utils.PathSearch("create_time", v, nil),
+			"update_time":          utils.PathSearch("update_time", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_private_providers` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_private_providers` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccDataSourcePrivateProviders_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs -v -run TestAccDataSourcePrivateProviders_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePrivateProviders_basic
=== PAUSE TestAccDataSourcePrivateProviders_basic
=== CONT  TestAccDataSourcePrivateProviders_basic
--- PASS: TestAccDataSourcePrivateProviders_basic (19.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       19.896s
```
<img width="860" height="29" alt="image" src="https://github.com/user-attachments/assets/d6f36306-29cd-4b25-8e84-617b4c028aa5" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
