### PR TITLE
feat(rabbitmq): add new one-time resource to restore recycle bin instance

### DIFF
--- a/docs/resources/dms_rabbitmq_recycle_instance_restore.md
+++ b/docs/resources/dms_rabbitmq_recycle_instance_restore.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rabbitmq_recycle_instance_restore"
+description: |-
+  Use this resource to restore RabbitMQ instance from recycle bin within HuaweiCloud.
+---
+
+# huaweicloud_dms_rabbitmq_recycle_instance_restore
+
+Use this resource to restore RabbitMQ instance from recycle bin within HuaweiCloud.
+
+-> This resource is only a one-time action resource for restoring recycle bin instance. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_rabbitmq_recycle_instance_restore" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the instance is located to be restored.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the instance ID to be restored from recycle bin.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3329,14 +3329,15 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_volume_auto_expand_configuration":  kafka.ResourceVolumeAutoExpandConfiguration(),
 
 			"huaweicloud_dms_rabbitmq_background_task_delete":           rabbitmq.ResourceDmsRabbitMQBackgroundTaskDelete(),
+			"huaweicloud_dms_rabbitmq_exchange":                         rabbitmq.ResourceDmsRabbitmqExchange(),
+			"huaweicloud_dms_rabbitmq_exchange_associate":               rabbitmq.ResourceDmsRabbitmqExchangeAssociate(),
 			"huaweicloud_dms_rabbitmq_instance":                         rabbitmq.ResourceDmsRabbitmqInstance(),
 			"huaweicloud_dms_rabbitmq_plugin":                           rabbitmq.ResourceDmsRabbitmqPlugin(),
-			"huaweicloud_dms_rabbitmq_vhost":                            rabbitmq.ResourceDmsRabbitmqVhost(),
-			"huaweicloud_dms_rabbitmq_exchange":                         rabbitmq.ResourceDmsRabbitmqExchange(),
 			"huaweicloud_dms_rabbitmq_queue":                            rabbitmq.ResourceDmsRabbitmqQueue(),
 			"huaweicloud_dms_rabbitmq_queue_message_clear":              rabbitmq.ResourceDmsRabbitmqQueueMessageClear(),
-			"huaweicloud_dms_rabbitmq_exchange_associate":               rabbitmq.ResourceDmsRabbitmqExchangeAssociate(),
+			"huaweicloud_dms_rabbitmq_recycle_instance_restore":         rabbitmq.ResourceRecycleInstanceRestore(),
 			"huaweicloud_dms_rabbitmq_user":                             rabbitmq.ResourceDmsRabbitmqUser(),
+			"huaweicloud_dms_rabbitmq_vhost":                            rabbitmq.ResourceDmsRabbitmqVhost(),
 			"huaweicloud_dms_rabbitmq_volume_auto_expand_configuration": rabbitmq.ResourceVolumeAutoExpandConfiguration(),
 
 			"huaweicloud_dms_rocketmq_instance":             rocketmq.ResourceDmsRocketMQInstance(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -843,7 +843,8 @@ var (
 	HW_DMS_KAFKA_TOPIC_NAME          = os.Getenv("HW_DMS_KAFKA_TOPIC_NAME")
 	HW_DMS_KAFKA_CONSUMER_GROUP_NAME = os.Getenv("HW_DMS_KAFKA_CONSUMER_GROUP_NAME")
 
-	HW_DMS_RABBITMQ_INSTANCE_ID = os.Getenv("HW_DMS_RABBITMQ_INSTANCE_ID")
+	HW_DMS_RABBITMQ_INSTANCE_ID             = os.Getenv("HW_DMS_RABBITMQ_INSTANCE_ID")
+	HW_DMS_RABBITMQ_RECYCLE_BIN_INSTANCE_ID = os.Getenv("HW_DMS_RABBITMQ_RECYCLE_BIN_INSTANCE_ID")
 
 	HW_DMS_ROCKETMQ_INSTANCE_ID = os.Getenv("HW_DMS_ROCKETMQ_INSTANCE_ID")
 	HW_DMS_ROCKETMQ_TOPIC_NAME  = os.Getenv("HW_DMS_ROCKETMQ_TOPIC_NAME")
@@ -4618,6 +4619,13 @@ func TestAccPreCheckDMSKafkaConsumerGroupName(t *testing.T) {
 func TestAccPreCheckDMSRabbitMQInstanceId(t *testing.T) {
 	if HW_DMS_RABBITMQ_INSTANCE_ID == "" {
 		t.Skip("HW_DMS_RABBITMQ_INSTANCE_ID must be set for RabbitMQ acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDMSRocketMQRecycleBinInstanceId(t *testing.T) {
+	if HW_DMS_RABBITMQ_RECYCLE_BIN_INSTANCE_ID == "" {
+		t.Skip("HW_DMS_RABBITMQ_RECYCLE_BIN_INSTANCE_ID must be set for restoring RabbitMQ recycle bin instance acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/rabbitmq/resource_huaweicloud_dms_rabbitmq_recycle_instance_restore_test.go
+++ b/huaweicloud/services/acceptance/rabbitmq/resource_huaweicloud_dms_rabbitmq_recycle_instance_restore_test.go
@@ -1,0 +1,49 @@
+package rabbitmq
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRecycleInstanceRestore_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSRocketMQRecycleBinInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRecycleInstanceRestore_instanceNotFound(),
+				ExpectError: regexp.MustCompile("This DMS instance does not exist"),
+			},
+			{
+				Config: testAccRecycleInstanceRestore_basic(),
+			},
+		},
+	})
+}
+
+func testAccRecycleInstanceRestore_instanceNotFound() string {
+	randomUUID, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_rabbitmq_recycle_instance_restore" "test" {
+  instance_id = "%s"
+}
+`, randomUUID)
+}
+
+func testAccRecycleInstanceRestore_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_rabbitmq_recycle_instance_restore" "test" {
+  instance_id = "%s"
+}
+`, acceptance.HW_DMS_RABBITMQ_RECYCLE_BIN_INSTANCE_ID)
+}

--- a/huaweicloud/services/rabbitmq/common.go
+++ b/huaweicloud/services/rabbitmq/common.go
@@ -3,6 +3,7 @@ package rabbitmq
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/chnsz/golangsdk"
 
@@ -31,4 +32,25 @@ func handleMultiOperationsError(err error) (bool, error) {
 		}
 	}
 	return false, err
+}
+
+func getInstanceTaskById(client *golangsdk.ServiceClient, instanceId, taskId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/instances/{instance_id}/tasks/{task_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath = strings.ReplaceAll(getPath, "{task_id}", taskId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
 }

--- a/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_recycle_instance_restore.go
+++ b/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_recycle_instance_restore.go
@@ -1,0 +1,171 @@
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var recycleInstanceRestoreNonUpdatableParams = []string{
+	"instance_id",
+}
+
+// @API RabbitMQ POST /v2/{project_id}/recycle
+// @API RabbitMQ GET /v2/{project_id}/instances/{instance_id}/tasks/{task_id}
+func ResourceRecycleInstanceRestore() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRecycleInstanceRestoreCreate,
+		ReadContext:   resourceRecycleInstanceRestoreRead,
+		UpdateContext: resourceRecycleInstanceRestoreUpdate,
+		DeleteContext: resourceRecycleInstanceRestoreDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(recycleInstanceRestoreNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the instance is located to be restored.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The instance ID to be restored from recycle bin.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func resourceRecycleInstanceRestoreCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/{project_id}/recycle"
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dms", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"instances": []interface{}{instanceId},
+		},
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("error restoring recycle bin instance (%s): %s", instanceId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch(fmt.Sprintf("results[?instance_id=='%s']|[0].job_id", instanceId), respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID for restoring instance (%s) from API response", instanceId)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      recycleInstanceRestoreTaskStatusRefreshFunc(client, instanceId, jobId),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		PollInterval: 20 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the instance (%s) to be restored from recycle bin: %s", instanceId, err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate resource ID: %s", err)
+	}
+
+	d.SetId(randUUID)
+
+	return nil
+}
+
+func recycleInstanceRestoreTaskStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId, taskId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := getInstanceTaskById(client, instanceId, taskId)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+
+		status := utils.PathSearch("tasks|[0].status", resp, "").(string)
+		if utils.StrSliceContains([]string{"FAILED", "DELETED"}, status) {
+			return resp, status, fmt.Errorf("unexpect status (%s)", status)
+		}
+
+		if status == "SUCCESS" {
+			return resp, "COMPLETED", nil
+		}
+
+		return resp, "PENDING", nil
+	}
+}
+
+func resourceRecycleInstanceRestoreRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRecycleInstanceRestoreUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRecycleInstanceRestoreDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for restoring recycle bin instance. Deleting this resource 
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new one-time resource(huaweicloud_dms_rabbitmq_recycle_instance_restore``) to restore recycle bin instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new one-time resource.
2. provided a new environment variable HW_DMS_RABBITMQ_RECYCLE_BIN_INSTANCE_ID.
3. Sort RabbitMQ resources in ascending alphabetical order.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o rabbitmq -f TestAccRecycleInstanceRestore_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rabbitmq" -v -coverprofile="./huaweicloud/services/acceptance/rabbitmq/rabbitmq_coverage.cov" -coverpkg="./huaweicloud/services/rabbitmq" -run TestAccRecycleInstanceRestore_basic -timeout 360m -parallel 10
=== RUN   TestAccRecycleInstanceRestore_basic
=== PAUSE TestAccRecycleInstanceRestore_basic
=== CONT  TestAccRecycleInstanceRestore_basic
--- PASS: TestAccRecycleInstanceRestore_basic (109.37s)
PASS
coverage: 4.8% of statements in ./huaweicloud/services/rabbitmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rabbitmq  109.462s        coverage: 4.8% of statements in ./huaweicloud/services/rabbitmq
```
<img width="1033" height="39" alt="image" src="https://github.com/user-attachments/assets/217bbf8c-eb26-4c70-864f-027fbadefb93" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
