### PR TITLE
feat(dataarts): add new data source to query user roles

### DIFF
--- a/docs/data-sources/dataarts_studio_workspace_user_roles.md
+++ b/docs/data-sources/dataarts_studio_workspace_user_roles.md
@@ -1,0 +1,64 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_studio_workspace_user_roles"
+description: |-
+  Use this data source to query workspace roles of DataArts Studio within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_studio_workspace_user_roles
+
+Use this data source to query workspace user roles of DataArts Studio within HuaweiCloud.
+
+## Example Usage
+
+### Query the user roles under the full instance
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_dataarts_studio_workspace_user_roles" "test" {
+  instance_id = var.instance_id
+}
+```
+
+### Query the user roles under the specified workspace
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_studio_workspace_user_roles" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the workspace user roles are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Optional, String) Specifies the instance ID to query user roles.
+
+* `workspace_id` - (Optional, String) Specifies the workspace ID to query user roles.
+
+  -> At least one of `instance_id` and `workspace_id` must be set.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `roles` - The list of user roles that matched filter parameters.
+  The [roles](#dataarts_studio_workspace_user_roles_attr) structure is documented below.
+
+<a name="dataarts_studio_workspace_user_roles_attr"></a>
+The `roles` block supports:
+
+* `id` - The role ID.
+
+* `code` - The role code.
+
+* `name` - The role name.
+
+* `description` - The role description.

--- a/docs/data-sources/dataarts_studio_workspace_user_roles.md
+++ b/docs/data-sources/dataarts_studio_workspace_user_roles.md
@@ -1,0 +1,64 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_studio_workspace_user_roles"
+description: |-
+  Use this data source to query workspace roles of DataArts Studio within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_studio_workspace_user_roles
+
+Use this data source to query workspace user roles of DataArts Studio within HuaweiCloud.
+
+## Example Usage
+
+### Query the user roles under the full instance
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_dataarts_studio_workspace_user_roles" "test" {
+  instance_id = var.instance_id
+}
+```
+
+### Query the user roles under the specified workspace
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_studio_workspace_user_roles" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the workspace user roles are located.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Optional, String) Specifies the instance ID to query roles.
+
+* `workspace_id` - (Optional, String) Specifies the workspace ID to query roles.
+
+  -> At least one of `instance_id` and `workspace_id` must be set.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `roles` - The list of roles that matched filter parameters.
+  The [roles](#dataarts_studio_workspace_user_roles_attr) structure is documented below.
+
+<a name="dataarts_studio_workspace_user_roles_attr"></a>
+The `roles` block supports:
+
+* `id` - The role ID.
+
+* `code` - The role code.
+
+* `name` - The role name.
+
+* `description` - The role description.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1070,8 +1070,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_css_vpcep_connections":         css.DataSourceVpcepserviceConnections(),
 
 			// DataArts Studio Management Center
-			"huaweicloud_dataarts_studio_data_connections": dataarts.DataSourceStudioDataConnections(),
-			"huaweicloud_dataarts_studio_workspaces":       dataarts.DataSourceDataArtsStudioWorkspaces(),
+			"huaweicloud_dataarts_studio_data_connections":     dataarts.DataSourceStudioDataConnections(),
+			"huaweicloud_dataarts_studio_workspaces":           dataarts.DataSourceDataArtsStudioWorkspaces(),
+			"huaweicloud_dataarts_studio_workspace_user_roles": dataarts.DataSourceStudioWorkspaceUserRoles(),
 			// DataArts Architecture
 			"huaweicloud_dataarts_architecture_ds_template_optionals": dataarts.DataSourceTemplateOptionalFields(),
 			"huaweicloud_dataarts_architecture_model_statistic":       dataarts.DataSourceArchitectureModelStatistic(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1068,8 +1068,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_css_vpcep_connections":         css.DataSourceVpcepserviceConnections(),
 
 			// DataArts Studio Management Center
-			"huaweicloud_dataarts_studio_data_connections": dataarts.DataSourceStudioDataConnections(),
-			"huaweicloud_dataarts_studio_workspaces":       dataarts.DataSourceDataArtsStudioWorkspaces(),
+			"huaweicloud_dataarts_studio_data_connections":     dataarts.DataSourceStudioDataConnections(),
+			"huaweicloud_dataarts_studio_workspaces":           dataarts.DataSourceDataArtsStudioWorkspaces(),
+			"huaweicloud_dataarts_studio_workspace_user_roles": dataarts.DataSourceStudioWorkspaceUserRoles(),
 			// DataArts Architecture
 			"huaweicloud_dataarts_architecture_ds_template_optionals": dataarts.DataSourceTemplateOptionalFields(),
 			"huaweicloud_dataarts_architecture_model_statistic":       dataarts.DataSourceArchitectureModelStatistic(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -675,6 +675,7 @@ var (
 
 	// Common
 	HW_DATAARTS_WORKSPACE_ID                               = os.Getenv("HW_DATAARTS_WORKSPACE_ID")
+	HW_DATAARTS_INSTANCE_ID                                = os.Getenv("HW_DATAARTS_INSTANCE_ID")
 	HW_DATAARTS_CDM_NAME                                   = os.Getenv("HW_DATAARTS_CDM_NAME")
 	HW_DATAARTS_MANAGER_ID                                 = os.Getenv("HW_DATAARTS_MANAGER_ID")
 	HW_DATAARTS_BIZ_CATALOG_ID                             = os.Getenv("HW_DATAARTS_BIZ_CATALOG_ID")
@@ -3931,6 +3932,13 @@ func TestAccPreCheckASLifecycleHookName(t *testing.T) {
 func TestAccPreCheckDataArtsWorkSpaceID(t *testing.T) {
 	if HW_DATAARTS_WORKSPACE_ID == "" {
 		t.Skip("This environment does not support DataArts Studio tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDataArtsInstanceID(t *testing.T) {
+	if HW_DATAARTS_INSTANCE_ID == "" {
+		t.Skip("HW_DATAARTS_INSTANCE_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -673,6 +673,7 @@ var (
 
 	// Common
 	HW_DATAARTS_WORKSPACE_ID                               = os.Getenv("HW_DATAARTS_WORKSPACE_ID")
+	HW_DATAARTS_INSTANCE_ID                                = os.Getenv("HW_DATAARTS_INSTANCE_ID")
 	HW_DATAARTS_CDM_NAME                                   = os.Getenv("HW_DATAARTS_CDM_NAME")
 	HW_DATAARTS_MANAGER_ID                                 = os.Getenv("HW_DATAARTS_MANAGER_ID")
 	HW_DATAARTS_BIZ_CATALOG_ID                             = os.Getenv("HW_DATAARTS_BIZ_CATALOG_ID")
@@ -3905,6 +3906,13 @@ func TestAccPreCheckASLifecycleHookName(t *testing.T) {
 func TestAccPreCheckDataArtsWorkSpaceID(t *testing.T) {
 	if HW_DATAARTS_WORKSPACE_ID == "" {
 		t.Skip("This environment does not support DataArts Studio tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDataArtsInstanceID(t *testing.T) {
+	if HW_DATAARTS_INSTANCE_ID == "" {
+		t.Skip("HW_DATAARTS_INSTANCE_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_studio_workspace_user_roles_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_studio_workspace_user_roles_test.go
@@ -1,0 +1,73 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataStudioWorkspaceUserRoles_basic(t *testing.T) {
+	var (
+		allRolesUnderWorkspace   = "data.huaweicloud_dataarts_studio_workspace_user_roles.all_roles_under_workspace"
+		dcAllRolesUnderWorkspace = acceptance.InitDataSourceCheck(allRolesUnderWorkspace)
+		allRolesUnderInstance    = "data.huaweicloud_dataarts_studio_workspace_user_roles.all_roles_under_instance"
+		dcAllRolesUnderInstance  = acceptance.InitDataSourceCheck(allRolesUnderInstance)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataStudioWorkspaceUserRoles_nonExistentWorkspace(),
+				ExpectError: regexp.MustCompile("error querying DataArts Studio workspace user roles"),
+			},
+			{
+				Config: testAccDataStudioWorkspaceUserRoles_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dcAllRolesUnderWorkspace.CheckResourceExists(),
+					resource.TestMatchResourceAttr(allRolesUnderWorkspace, "roles.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(allRolesUnderWorkspace, "roles.0.id"),
+					resource.TestCheckResourceAttrSet(allRolesUnderWorkspace, "roles.0.name"),
+					resource.TestCheckResourceAttrSet(allRolesUnderWorkspace, "roles.0.code"),
+					dcAllRolesUnderInstance.CheckResourceExists(),
+					resource.TestMatchResourceAttr(allRolesUnderInstance, "roles.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(allRolesUnderInstance, "roles.0.id"),
+					resource.TestCheckResourceAttrSet(allRolesUnderInstance, "roles.0.name"),
+					resource.TestCheckResourceAttrSet(allRolesUnderInstance, "roles.0.code"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataStudioWorkspaceUserRoles_nonExistentWorkspace() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_studio_workspace_user_roles" "test" {
+  workspace_id = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataStudioWorkspaceUserRoles_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_studio_workspace_user_roles" "all_roles_under_workspace" {
+  workspace_id = "%[1]s"
+}
+
+data "huaweicloud_dataarts_studio_workspace_user_roles" "all_roles_under_instance" {
+  instance_id = "%[2]s"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_INSTANCE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_studio_workspace_user_roles.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_studio_workspace_user_roles.go
@@ -1,0 +1,160 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/users/role
+func DataSourceStudioWorkspaceUserRoles() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceStudioWorkspaceUserRolesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the workspace user roles are located.`,
+			},
+
+			// Optional parameters.
+			"instance_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				AtLeastOneOf: []string{"instance_id", "workspace_id"},
+				Description:  `The instance ID to query user roles.`,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The workspace ID to query user roles.`,
+			},
+
+			// Attributes.
+			"roles": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The role ID.`,
+						},
+						"code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The role code.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The role name.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The role description.`,
+						},
+					},
+				},
+				Description: `The list of user roles that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildStudioWorkspaceUserRolesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("instance_id"); ok {
+		res = fmt.Sprintf("%s&instance_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("workspace_id"); ok {
+		res = fmt.Sprintf("%s&workspace_id=%v", res, v)
+	}
+
+	if len(res) > 0 {
+		return fmt.Sprintf("?%s", res[1:])
+	}
+	return res
+}
+
+func getStudioWorkspaceUserRoles(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	httpUrl := "v2/{project_id}/users/role"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path += buildStudioWorkspaceUserRolesQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", path, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("[]", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenStudioWorkspaceUserRoles(roles []interface{}) []map[string]interface{} {
+	if len(roles) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(roles))
+	for _, role := range roles {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("role_id", role, nil),
+			"code":        utils.PathSearch("role_code", role, nil),
+			"name":        utils.PathSearch("role_name", role, nil),
+			"description": utils.PathSearch("description", role, nil),
+		})
+	}
+	return result
+}
+
+func dataSourceStudioWorkspaceUserRolesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	roles, err := getStudioWorkspaceUserRoles(client, d)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Studio workspace user roles: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("roles", flattenStudioWorkspaceUserRoles(roles)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_studio_workspace_user_roles.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_studio_workspace_user_roles.go
@@ -1,0 +1,160 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/users/role
+func DataSourceStudioWorkspaceUserRoles() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceStudioWorkspaceUserRolesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the workspace user roles are located.`,
+			},
+
+			// Optional parameters.
+			"instance_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				AtLeastOneOf: []string{"instance_id", "workspace_id"},
+				Description:  `The instance ID to query user roles.`,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The workspace ID to query user roles.`,
+			},
+
+			// Attributes.
+			"roles": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The role ID.`,
+						},
+						"code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The role code.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The role name.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The role description.`,
+						},
+					},
+				},
+				Description: `The list of roles that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildStudioWorkspaceUserRolesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("instance_id"); ok {
+		res = fmt.Sprintf("%s&instance_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("workspace_id"); ok {
+		res = fmt.Sprintf("%s&workspace_id=%v", res, v)
+	}
+
+	if len(res) > 0 {
+		return fmt.Sprintf("?%s", res[1:])
+	}
+	return res
+}
+
+func getStudioWorkspaceUserRoles(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	httpUrl := "v2/{project_id}/users/role"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path += buildStudioWorkspaceUserRolesQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", path, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("[]", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenStudioWorkspaceUserRoles(roles []interface{}) []map[string]interface{} {
+	if len(roles) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(roles))
+	for _, role := range roles {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("role_id", role, nil),
+			"code":        utils.PathSearch("role_code", role, nil),
+			"name":        utils.PathSearch("role_name", role, nil),
+			"description": utils.PathSearch("description", role, nil),
+		})
+	}
+	return result
+}
+
+func dataSourceStudioWorkspaceUserRolesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	roles, err := getStudioWorkspaceUserRoles(client, d)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Studio workspace user roles: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("roles", flattenStudioWorkspaceUserRoles(roles)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source for DataArts Studio Management Center: huaweicloud_dataarts_studio_workspace_user_roles

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The data source type `DLI` does not supported in the workspace user roles query parameters.

The coverage of acceptance test:
<img width="1028" height="90" alt="image" src="https://github.com/user-attachments/assets/fbd4d599-9309-4727-bac1-2cceb0b77762" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query user roles.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataStudioWorkspaceUserRoles_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataStudioWorkspaceUserRoles_basic -timeout 360m -parallel 10
=== RUN   TestAccDataStudioWorkspaceUserRoles_basic
=== PAUSE TestAccDataStudioWorkspaceUserRoles_basic
=== CONT  TestAccDataStudioWorkspaceUserRoles_basic
--- PASS: TestAccDataStudioWorkspaceUserRoles_basic (12.88s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  12.990s coverage: 4.1% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
