### PR TITLE
feat(rfs): add dataSource to get the list of RFS templates

### DIFF
--- a/docs/data-sources/rfs_templates.md
+++ b/docs/data-sources/rfs_templates.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_templates"
+description: |-
+  Use this data source to get the list of RFS templates within HuaweiCloud.
+---
+
+# huaweicloud_rfs_templates
+
+Use this data source to get the list of RFS templates within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_rfs_templates" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `templates` - The list of RFS templates.
+
+  The [templates](#templates_struct) structure is documented below.
+
+<a name="templates_struct"></a>
+The `templates` block supports:
+
+* `template_id` - The unique ID of the template.
+
+* `template_name` - The name of the template.
+
+* `template_description` - The description of the template.
+
+* `create_time` - The time when the template was created, in RFC3339 format (yyyy-mm-ddTHH:MM:SSZ),
+  such as **1970-01-01T00:00:00Z**.
+
+* `update_time` - The time when the template was last updated, in RFC3339 format (yyyy-mm-ddTHH:MM:SSZ),
+  such as **1970-01-01T00:00:00Z**.
+
+* `latest_version_description` - The description of the latest template version.
+
+* `latest_version_id` - The ID of the latest template version.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2020,6 +2020,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rfs_private_modules":         rfs.DataSourcePrivateModules(),
 			"huaweicloud_rfs_stack_instances":         rfs.DataSourceStackInstances(),
 			"huaweicloud_rfs_private_providers":       rfs.DataSourcePrivateProviders(),
+			"huaweicloud_rfs_templates":               rfs.DataSourceRfsTemplates(),
 
 			"huaweicloud_rgc_home_region":                           rgc.DataSourceHomeRegion(),
 			"huaweicloud_rgc_pre_launch_check":                      rgc.DataSourcePreLaunchCheck(),

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_templates_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_templates_test.go
@@ -1,0 +1,48 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRfsTemplates_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_templates.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRfsTemplate_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "templates.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "templates.0.template_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "templates.0.template_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "templates.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "templates.0.update_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "templates.0.latest_version_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRfsTemplate_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rfs_templates" "test" {
+	depends_on = [huaweicloud_rfs_template.test]
+}
+`, testRfsTemplate_basic(name))
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_templates.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_templates.go
@@ -1,0 +1,159 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/{project_id}/templates
+func DataSourceRfsTemplates() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRfsTemplateRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"templates": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"template_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"template_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"template_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"latest_version_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"latest_version_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceRfsTemplateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		product      = "rfs"
+		httpUrl      = "v1/{project_id}/templates"
+		allTemplates = make([]interface{}, 0)
+		limit        = 1000
+		marker       = ""
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = fmt.Sprintf("%s?limit=%d", requestPath, limit)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": uuid,
+			"Content-Type":      "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithMarker := requestPath
+		if marker != "" {
+			requestPathWithMarker = fmt.Sprintf("%s&marker=%s", requestPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", requestPathWithMarker, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RFS templates: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		templates := utils.PathSearch("templates", respBody, make([]interface{}, 0)).([]interface{})
+		if len(templates) == 0 {
+			break
+		}
+
+		allTemplates = append(allTemplates, templates...)
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("templates", flattenRfsTemplates(allTemplates)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRfsTemplates(templates []interface{}) []interface{} {
+	if len(templates) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(templates))
+	for _, template := range templates {
+		rst = append(rst, map[string]interface{}{
+			"template_id":                utils.PathSearch("template_id", template, nil),
+			"template_name":              utils.PathSearch("template_name", template, nil),
+			"template_description":       utils.PathSearch("template_description", template, nil),
+			"create_time":                utils.PathSearch("create_time", template, nil),
+			"update_time":                utils.PathSearch("update_time", template, nil),
+			"latest_version_description": utils.PathSearch("latest_version_description", template, nil),
+			"latest_version_id":          utils.PathSearch("latest_version_id", template, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_templates` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_templates` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccDataSourceRfsTemplates_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs-v -run TestAccDataSourceRfsTemplates_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRfsTemplates_basic
=== PAUSE TestAccDataSourceRfsTemplates_basic
=== CONT  TestAccDataSourceRfsTemplates_basic
--- PASS: TestAccDataSourceRfsTemplates_basic (12.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       21.311s
```
<img width="686" height="25" alt="image" src="https://github.com/user-attachments/assets/791149f8-1a2e-4bb2-8283-745ec2c2e2d7" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
