### PR TITLE
feat(rfs): support `rfs_private_hook_versions` data source

### DIFF
--- a/docs/data-sources/rfs_private_hook_versions.md
+++ b/docs/data-sources/rfs_private_hook_versions.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_private_hook_versions"
+description: |-
+  Use this datasource to get the list of private hook versions.
+---
+
+# huaweicloud_rfs_private_hook_versions
+
+Use this datasource to get the list of private hook versions.
+
+## Example Usage
+
+```hcl
+variable "hook_name" {}
+
+data "huaweicloud_rfs_private_hook_versions" "test" {
+  hook_name = var.hook_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `hook_name` - (Required, String) Specifies the name of the private hook.
+
+* `hook_id` - (Optional, String) Specifies the unique ID of the private hook for strong matching.
+  If it does not match the current hook, the API returns an error.
+
+* `sort_key` - (Optional, String) Specifies the sort field, only supports **create_time**.
+
+* `sort_dir` - (Optional, String) Specifies the ascending or descending order.
+  Valid values are **asc** and **desc**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `versions` - The list of private hook versions. By default, these versions are sorted in descending order of the
+  creation time.
+
+  The [versions](#versions_struct) structure is documented below.
+
+<a name="versions_struct"></a>
+The `versions` block supports:
+
+* `hook_name` - The name of the private hook.
+
+* `hook_id` - The unique ID of the private hook.
+
+* `hook_version` - The version number of the private hook.
+
+* `hook_version_description` - The description of the private hook version.
+
+* `create_time` - The creation time of a private hook version. It is represented in UTC
+  format (YYYY-MM-DDTHH:mm:ss.SSSZ), such as **1970-01-01T00:00:00.000Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2018,6 +2018,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_rfs_private_module_versions": rfs.DataSourcePrivateModuleVersions(),
 			"huaweicloud_rfs_private_modules":         rfs.DataSourcePrivateModules(),
+			"huaweicloud_rfs_private_hook_versions":   rfs.DataSourcePrivateHookVersions(),
 			"huaweicloud_rfs_stack_instances":         rfs.DataSourceStackInstances(),
 			"huaweicloud_rfs_private_providers":       rfs.DataSourcePrivateProviders(),
 

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_private_hook_versions_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_private_hook_versions_test.go
@@ -1,0 +1,74 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcePrivateHookVersions_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_private_hook_versions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourcePrivateHookVersions_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.hook_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.hook_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.hook_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.create_time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourcePrivateHookVersions_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rfs_private_hook" "test" {
+  name                = "%[1]s"
+  version             = "1.0.0"
+  version_description = "acc test hook version"
+  policy_body         = <<EOT
+package policy
+
+import rego.v1
+
+hook_result := {
+  "is_passed": true,
+  "err_msg":   "",
+}
+EOT
+
+  configuration {
+    failure_mode  = "WARN"
+    target_stacks = "ALL"
+  }
+}
+`, name)
+}
+
+func testDataSourcePrivateHookVersions_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rfs_private_hook_versions" "test" {
+  hook_name = huaweicloud_rfs_private_hook.test.name
+  sort_key  = "create_time"
+  sort_dir  = "desc"
+}
+`, testDataSourcePrivateHookVersions_base(name))
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_private_hook_versions.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_private_hook_versions.go
@@ -1,0 +1,183 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/private-hooks/{hook_name}/versions
+func DataSourcePrivateHookVersions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePrivateHookVersionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"hook_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"hook_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"hook_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hook_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hook_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hook_version_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildListPrivateHookVersionsQueryParams(d *schema.ResourceData, marker string) string {
+	rst := ""
+
+	if v, ok := d.GetOk("hook_id"); ok {
+		rst += fmt.Sprintf("&hook_id=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%s", v.(string))
+	}
+
+	if marker != "" {
+		rst += fmt.Sprintf("&marker=%s", marker)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourcePrivateHookVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v1/private-hooks/{hook_name}/versions"
+		allVersions = make([]interface{}, 0)
+		nextMarker  string
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	reqUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request UUID: %s", err)
+	}
+
+	hookName := d.Get("hook_name").(string)
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{hook_name}", hookName)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Client-Request-Id": reqUUID},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildListPrivateHookVersionsQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RFS private hook versions: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		versions := utils.PathSearch("versions", respBody, make([]interface{}, 0)).([]interface{})
+		if len(versions) == 0 {
+			break
+		}
+
+		allVersions = append(allVersions, versions...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	d.SetId(reqUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("versions", flattenPrivateHookVersions(allVersions)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPrivateHookVersions(versions []interface{}) []interface{} {
+	if len(versions) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(versions))
+	for _, v := range versions {
+		rst = append(rst, map[string]interface{}{
+			"hook_name":                utils.PathSearch("hook_name", v, nil),
+			"hook_id":                  utils.PathSearch("hook_id", v, nil),
+			"hook_version":             utils.PathSearch("hook_version", v, nil),
+			"hook_version_description": utils.PathSearch("hook_version_description", v, nil),
+			"create_time":              utils.PathSearch("create_time", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_private_hook_versions` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_private_hook_versions` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccDataSourcePrivateHookVersions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs -v -run TestAccDataSourcePrivateHookVersions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePrivateHookVersions_basic
=== PAUSE TestAccDataSourcePrivateHookVersions_basic
=== CONT  TestAccDataSourcePrivateHookVersions_basic
--- PASS: TestAccDataSourcePrivateHookVersions_basic (25.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       26.565s
```
<img width="908" height="33" alt="image" src="https://github.com/user-attachments/assets/54e9baba-aa78-4ae9-b5b3-fcb9689539c8" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
