### PR TITLE
feat(elb): add new resource to manage domain resolution IP address

### DIFF
--- a/docs/resources/elb_domain_address.md
+++ b/docs/resources/elb_domain_address.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Dedicated Load Balance (Dedicated ELB)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_elb_domain_address"
+description: |-
+  Manages an ELB domain IP address resource within HuaweiCloud.
+---
+
+# huaweicloud_elb_domain_address
+
+Manages an ELB domain IP address resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "loadbalancer_id" {}
+variable "ip_address" {}
+
+resource "huaweicloud_elb_domain_address" "test" {
+  loadbalancer_id = var.loadbalancer_id
+  ip_address      = var.ip_address
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `loadbalancer_id` - (Required, String, NonUpdatable) Specifies the ID of the load balancer.
+
+* `ip_address` - (Required, String, NonUpdatable) Specifies the IP address.
+  It can be an IPv4 or IPv6 address.
+
+  -> The IP address must be a private or public IP address of the load balancer.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also is the load balancer ID and IP address.
+  e.g. **1cab5d49-fb3d-4b99-8b05-c27d661152fd/192.168.1.105**
+
+* `enable` - Whether domain resolution is enabled for the IP address.
+
+* `type` - The IP address type.
+  + **vip**: Indicates private IP address.
+  + **eip**: Indicates public IP address.
+
+* `domain_name` - The domain name associated with the IP address.
+
+* `created_at` - The create time.
+
+* `updated_at` - The update time.
+
+## Import
+
+The resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_elb_domain_address.test <id>
+```

--- a/docs/resources/elb_domain_address.md
+++ b/docs/resources/elb_domain_address.md
@@ -1,0 +1,83 @@
+---
+subcategory: "Dedicated Load Balance (Dedicated ELB)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_elb_domain_address"
+description: |-
+  Manages an ELB domain IP address resource within HuaweiCloud.
+---
+
+# huaweicloud_elb_domain_address
+
+Manages an ELB domain IP address resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "loadbalancer_id" {}
+variable "ip_address" {}
+
+resource "huaweicloud_elb_domain_address" "test" {
+  loadbalancer_id = var.loadbalancer_id
+  ip_address      = var.ip_address
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `loadbalancer_id` - (Required, String, NonUpdatable) Specifies the ID of the load balancer.
+
+* `ip_address` - (Required, String, NonUpdatable) Specifies the IP address.
+  It can be an IPv4 or IPv6 address.
+
+  -> The IP address must be a private or public IP address of the load balancer.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also is the load balancer ID.
+
+* `enable` - Whether domain resolution is enabled for the IP address.
+
+* `type` - The IP address type.
+  + **vip**: Indicates private IP address.
+  + **eip**: Indicates public IP address.
+
+* `domain_name` - The domain name associated with the IP address.
+
+* `created_at` - The create time.
+
+* `updated_at` - The update time.
+
+## Import
+
+The resource can be imported using the `id` and `ip_address`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_elb_domain_address.test <id>/<ip_address>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `loadbalancer_id`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the instance. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_elb_domain_address" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      loadbalancer_id,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3402,6 +3402,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_eg_event_subscription_target":       eg.ResourceEventSubscriptionTarget(),
 
 			"huaweicloud_elb_certificate":                      elb.ResourceCertificateV3(),
+			"huaweicloud_elb_domain_address":                   elb.ResourceDomainAddress(),
 			"huaweicloud_elb_certificate_private_key_echo":     elb.ResourceCertificatePrivateKeyEcho(),
 			"huaweicloud_elb_l7policy":                         elb.ResourceL7PolicyV3(),
 			"huaweicloud_elb_l7rule":                           elb.ResourceL7RuleV3(),

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_domain_address_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_domain_address_test.go
@@ -1,0 +1,102 @@
+package elb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
+)
+
+func getDomainAddressResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("elb", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ELB client: %s", err)
+	}
+
+	return elb.GetDomainAddressInfomation(client, state.Primary.ID, state.Primary.Attributes["ip_address"])
+}
+
+func TestAccDomainAddress_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_elb_domain_address.test"
+		obj          interface{}
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDomainAddressResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Beforce running test, prepare a loadbalancer and enable domain resolution (private and public).
+			acceptance.TestAccPreCheckElbLoadbalancerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainAddressConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "loadbalancer_id", acceptance.HW_ELB_LOADBALANCER_ID),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "enable"),
+					resource.TestCheckResourceAttrSet(resourceName, "type"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccDomainAddressImportStateFunc(resourceName),
+				ImportStateVerifyIgnore: []string{
+					"loadbalancer_id",
+				},
+			},
+		},
+	})
+}
+
+func testAccDomainAddressConfig_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_elb_loadbalancers" "test" {
+  loadbalancer_id = "%[1]s"
+}
+
+resource "huaweicloud_elb_domain_address" "test" {
+  loadbalancer_id = "%[1]s"
+  ip_address      = data.huaweicloud_elb_loadbalancers.test.loadbalancers[0].ipv4_address
+}
+`, acceptance.HW_ELB_LOADBALANCER_ID)
+}
+
+func testAccDomainAddressImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var loadbalancerId, ipAddress string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		ipAddress = rs.Primary.Attributes["ip_address"]
+		loadbalancerId = rs.Primary.ID
+
+		if loadbalancerId == "" || ipAddress == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<id>/<ip_address>', but got '%s/%s'",
+				loadbalancerId, ipAddress)
+		}
+
+		return fmt.Sprintf("%s/%s", loadbalancerId, ipAddress), nil
+	}
+}

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_domain_address_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_domain_address_test.go
@@ -1,0 +1,81 @@
+package elb
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
+)
+
+func getDomainAddressResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("elb", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ELB client: %s", err)
+	}
+
+	resourceId := strings.Split(state.Primary.ID, "/")
+
+	return elb.GetDomainAddressInfomation(client, resourceId[0], resourceId[1])
+}
+
+func TestAccDomainAddress_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_elb_domain_address.test"
+		obj          interface{}
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDomainAddressResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Beforce running test, prepare a loadbalancer and enable domain resolution (private and public).
+			acceptance.TestAccPreCheckElbLoadbalancerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainAddressConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "loadbalancer_id", acceptance.HW_ELB_LOADBALANCER_ID),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "enable"),
+					resource.TestCheckResourceAttrSet(resourceName, "type"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDomainAddressConfig_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_elb_loadbalancers" "test" {
+  loadbalancer_id = "%[1]s"
+}
+
+resource "huaweicloud_elb_domain_address" "test" {
+  loadbalancer_id = "%[1]s"
+  ip_address      = data.huaweicloud_elb_loadbalancers.test.loadbalancers[0].ipv4_address
+}
+`, acceptance.HW_ELB_LOADBALANCER_ID)
+}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_domain_address.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_domain_address.go
@@ -1,0 +1,259 @@
+package elb
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var domainAddressnNonUpdatableParams = []string{"loadbalancer_id", "ip_address"}
+
+// @API ELB POST /v3/{project_id}/elb/loadbalancers/{loadbalancer_id}/dns/ips/batch-enable
+// @API ELB POST /v3/{project_id}/elb/loadbalancers/{loadbalancer_id}/dns/ips/batch-disable
+// @API ELB GET /v3/{project_id}/elb/loadbalancers/{loadbalancer_id}/dns/ips
+func ResourceDomainAddress() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDomainAddressCreate,
+		ReadContext:   resourceDomainAddressRead,
+		UpdateContext: resourceDomainAddressUpdate,
+		DeleteContext: resourceDomainAddressDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDomainAddressImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(domainAddressnNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"loadbalancer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"enable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildDomainAddressBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"ips": []map[string]interface{}{
+			{
+				"ip_address": d.Get("ip_address"),
+			},
+		},
+	}
+
+	return params
+}
+
+func resourceDomainAddressCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		loadbalancerId = d.Get("loadbalancer_id").(string)
+		httpUrl        = "v3/{project_id}/elb/loadbalancers/{loadbalancer_id}/dns/ips/batch-enable"
+	)
+
+	client, err := cfg.NewServiceClient("elb", region)
+	if err != nil {
+		return diag.Errorf("error creating ELB client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{loadbalancer_id}", loadbalancerId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDomainAddressBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error adding IP address to domain resolution: %s", err)
+	}
+
+	d.SetId(loadbalancerId)
+
+	return resourceDomainAddressRead(ctx, d, meta)
+}
+
+func resourceDomainAddressRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		ipAddress = d.Get("ip_address").(string)
+	)
+
+	client, err := cfg.NewServiceClient("elb", region)
+	if err != nil {
+		return diag.Errorf("error creating ELB client: %s", err)
+	}
+
+	address, err := GetDomainAddressInfomation(client, d.Id(), ipAddress)
+	if err != nil {
+		// If the load balancer not exsit, the query API return code is `404`.
+		return common.CheckDeletedDiag(d, err, "error retrieving domain resolution IP address information")
+	}
+
+	ipEnable := utils.PathSearch("enable", address, nil).(bool)
+	if !ipEnable {
+		// If the IP address not add to the domain name, the query API return code is `200` and the attribute `enable` is false,
+		// this situation also need to CheckDeletedDiag
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving domain resolution IP address information")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("ip_address", utils.PathSearch("ip_address", address, nil)),
+		d.Set("enable", utils.PathSearch("enable", address, nil)),
+		d.Set("type", utils.PathSearch("type", address, nil)),
+		d.Set("domain_name", utils.PathSearch("domain_name", address, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", address, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", address, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func GetDomainAddressInfomation(client *golangsdk.ServiceClient, loadbalancerId, ipAddress string) (interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/elb/loadbalancers/{loadbalancer_id}/dns/ips?limit={limit}"
+		limit   = 1
+		marker  = ""
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{loadbalancer_id}", loadbalancerId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s&marker=%s", listPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", listPathWithMarker, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		addresses := utils.PathSearch("ips", respBody, make([]interface{}, 0)).([]interface{})
+		address := utils.PathSearch(fmt.Sprintf("[?ip_address=='%s']|[0]", ipAddress), addresses, nil)
+		if address != nil {
+			return address, nil
+		}
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func resourceDomainAddressUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDomainAddressDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/elb/loadbalancers/{loadbalancer_id}/dns/ips/batch-disable"
+	)
+
+	client, err := cfg.NewServiceClient("elb", region)
+	if err != nil {
+		return diag.Errorf("error creating ELB client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{loadbalancer_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDomainAddressBodyParams(d),
+	}
+
+	_, err = client.Request("POST", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error removing IP address from domain resolution")
+	}
+
+	return nil
+}
+
+func resourceDomainAddressImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<id>/<ip_address>', but got '%s'",
+			importedId)
+	}
+
+	d.SetId(parts[0])
+
+	mErr := multierror.Append(nil,
+		d.Set("ip_address", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_domain_address.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_domain_address.go
@@ -1,0 +1,253 @@
+package elb
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var domainAddressnNonUpdatableParams = []string{"loadbalancer_id", "ip_address"}
+
+// @API ELB POST /v3/{project_id}/elb/loadbalancers/{loadbalancer_id}/dns/ips/batch-enable
+// @API ELB POST /v3/{project_id}/elb/loadbalancers/{loadbalancer_id}/dns/ips/batch-disable
+// @API ELB GET /v3/{project_id}/elb/loadbalancers/{loadbalancer_id}/dns/ips
+func ResourceDomainAddress() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDomainAddressCreate,
+		ReadContext:   resourceDomainAddressRead,
+		UpdateContext: resourceDomainAddressUpdate,
+		DeleteContext: resourceDomainAddressDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(domainAddressnNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"loadbalancer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"enable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildDomainAddressBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"ips": []map[string]interface{}{
+			{
+				"ip_address": d.Get("ip_address"),
+			},
+		},
+	}
+
+	return params
+}
+
+func resourceDomainAddressCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		loadbalancerId = d.Get("loadbalancer_id").(string)
+		ipAddress      = d.Get("ip_address").(string)
+		httpUrl        = "v3/{project_id}/elb/loadbalancers/{loadbalancer_id}/dns/ips/batch-enable"
+	)
+
+	client, err := cfg.NewServiceClient("elb", region)
+	if err != nil {
+		return diag.Errorf("error creating ELB client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{loadbalancer_id}", loadbalancerId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+		JSONBody:         buildDomainAddressBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error adding IP address to domain resolution: %s", err)
+	}
+
+	resourceId := fmt.Sprintf("%s/%s", loadbalancerId, ipAddress)
+
+	d.SetId(resourceId)
+
+	return resourceDomainAddressRead(ctx, d, meta)
+}
+
+func resourceDomainAddressRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		resourceId    = strings.Split(d.Id(), "/")
+		addressEnable bool
+	)
+
+	client, err := cfg.NewServiceClient("elb", region)
+	if err != nil {
+		return diag.Errorf("error creating ELB client: %s", err)
+	}
+
+	address, err := GetDomainAddressInfomation(client, resourceId[0], resourceId[1])
+	if err != nil {
+		// If the load balancer not exsit, the query API return code is `404`.
+		return common.CheckDeletedDiag(d, err, "error retrieving domain resolution IP address information")
+	}
+
+	ipEnable := utils.PathSearch("enable", address, nil)
+	if ipEnable != nil {
+		addressEnable = ipEnable.(bool)
+	}
+	if !addressEnable {
+		// If the IP address not add to the domain name, the query API return code is `200` and the attribute `enable` is false,
+		// this situation also need to CheckDeletedDiag
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving domain resolution IP address information")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("loadbalancer_id", resourceId[0]),
+		d.Set("ip_address", utils.PathSearch("ip_address", address, nil)),
+		d.Set("enable", utils.PathSearch("enable", address, nil)),
+		d.Set("type", utils.PathSearch("type", address, nil)),
+		d.Set("domain_name", utils.PathSearch("domain_name", address, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", address, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", address, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func GetDomainAddressInfomation(client *golangsdk.ServiceClient, loadbalancerId, ipAddress string) (interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/elb/loadbalancers/{loadbalancer_id}/dns/ips?limit={limit}"
+		limit   = 2000
+		marker  = ""
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{loadbalancer_id}", loadbalancerId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s&marker=%s", listPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", listPathWithMarker, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		addresses := utils.PathSearch("ips", respBody, make([]interface{}, 0)).([]interface{})
+		address := utils.PathSearch(fmt.Sprintf("[?ip_address=='%s']|[0]", ipAddress), addresses, nil)
+		if address != nil {
+			return address, nil
+		}
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func resourceDomainAddressUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDomainAddressDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		resourceId = strings.Split(d.Id(), "/")
+		httpUrl    = "v3/{project_id}/elb/loadbalancers/{loadbalancer_id}/dns/ips/batch-disable"
+	)
+
+	client, err := cfg.NewServiceClient("elb", region)
+	if err != nil {
+		return diag.Errorf("error creating ELB client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{loadbalancer_id}", resourceId[0])
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+		JSONBody:         buildDomainAddressBodyParams(d),
+	}
+
+	_, err = client.Request("POST", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error removing IP address from domain resolution")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to manage domain resolution IP address.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new resource to manage  domain resolution IP address.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/elb" TESTARGS="-run TestAccDomainAddress_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run TestAccDomainAddress_basic -timeout 360m -parallel 4
=== RUN   TestAccDomainAddress_basic
=== PAUSE TestAccDomainAddress_basic
=== CONT  TestAccDomainAddress_basic
--- PASS: TestAccDomainAddress_basic (29.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       29.452s
```
<img width="1208" height="19" alt="image" src="https://github.com/user-attachments/assets/5480121d-1ce7-4b58-ace0-126172d4b665" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
<img width="746" height="208" alt="ppp" src="https://github.com/user-attachments/assets/e3bc44f1-1a12-4343-a920-6d7251f55496" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
