### PR TITLE
feat(organizations): add new data source to query dry run policy list

### DIFF
--- a/docs/data-sources/organizations_dry_run_policies.md
+++ b/docs/data-sources/organizations_dry_run_policies.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Organizations"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_organizations_dry_run_policies"
+description: |-
+  Use this data source to get the list of Organizations dry run policies within HuaweiCloud.
+---
+
+# huaweicloud_organizations_dry_run_policies
+
+Use this data source to get the list of Organizations dry run policies within HuaweiCloud.
+
+## Example Usage
+
+### Query all dry run policies
+
+```hcl
+data "huaweicloud_organizations_dry_run_policies" "test" {}
+```
+
+### Query dry run policies by attached entity ID
+
+```hcl
+variable "attached_entity_id" {}
+
+data "huaweicloud_organizations_dry_run_policies" "test" {
+  attached_entity_id = var.attached_entity_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_type` - (Optional, String) Specifies the type of the dry run policies to be queried.  
+  The valid values are as follows:
+  + **service_control_policy**: Service control policy.
+
+* `attached_entity_id` - (Optional, String) Specifies the ID of the entity associated with the dry run policy.  
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `policies` - The list of dry run policies that matched the filter parameters.  
+  The [policies](#dry_run_policies) structure is documented below.
+
+<a name="dry_run_policies"></a>
+The `policies` block supports:
+
+* `id` - The unique ID of the dry run policy.
+
+* `name` - The name of the dry run policy.
+
+* `type` - The type of the dry run policy.
+
+* `urn` - The uniform resource name of the dry run policy.
+
+* `description` - The description of the dry run policy.
+
+* `is_builtin` - Whether the dry run policy is a built-in policy.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2725,6 +2725,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_organizations_close_account_status":             organizations.DataSourceCloseAccountStatus(),
 			"huaweicloud_organizations_create_account_status":            organizations.DataSourceCreateAccountStatus(),
 			"huaweicloud_organizations_delegated_services":               organizations.DataSourceDelegatedServices(),
+			"huaweicloud_organizations_dry_run_policies":                 organizations.DataSourceDryRunPolicies(),
 			"huaweicloud_organizations_dry_run_policy_attached_entities": organizations.DataSourceDryRunPolicyAttachedEntities(),
 			"huaweicloud_organizations_effective_policies":               organizations.DataSourceEffectivePolicies(),
 			"huaweicloud_organizations_organization":                     organizations.DataSourceOrganization(),

--- a/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_dry_run_policies_test.go
+++ b/huaweicloud/services/acceptance/organizations/data_source_huaweicloud_organizations_dry_run_policies_test.go
@@ -1,0 +1,186 @@
+package organizations
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataDryRunPolicies_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		all = "data.huaweicloud_organizations_dry_run_policies.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byPolicyType   = "data.huaweicloud_organizations_dry_run_policies.filter_by_policy_type"
+		dcByPolicyType = acceptance.InitDataSourceCheck(byPolicyType)
+
+		byAttachedEntityId   = "data.huaweicloud_organizations_dry_run_policies.filter_by_attached_entity_id"
+		dcByAttachedEntityId = acceptance.InitDataSourceCheck(byAttachedEntityId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataDryRunPolicies_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "policies.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'policy_type' parameter.
+					dcByPolicyType.CheckResourceExists(),
+					resource.TestCheckOutput("is_policy_type_filter_useful", "true"),
+					// Filter by 'attached_entity_id' parameter.
+					dcByAttachedEntityId.CheckResourceExists(),
+					resource.TestCheckOutput("attached_entity_id_filter_result", "true"),
+					// Check attributes.
+					resource.TestCheckResourceAttrSet(all, "policies.0.id"),
+					resource.TestCheckResourceAttrSet(all, "policies.0.name"),
+					resource.TestCheckResourceAttrSet(all, "policies.0.type"),
+					resource.TestCheckResourceAttrSet(all, "policies.0.urn"),
+					resource.TestCheckResourceAttrSet(all, "policies.0.is_builtin"),
+					resource.TestCheckOutput("is_description_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataDryRunPolicies_base(name string) string {
+	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
+}
+
+data "huaweicloud_organizations_organization" "test" {}
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket                = "%[2]s"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+  force_destroy         = true
+}
+
+resource "huaweicloud_identity_trust_agency" "test" {
+  name         = "%[2]s"
+  policy_names = ["OBSFullAccessPolicy"]
+  trust_policy = jsonencode(
+    {
+      Version = "5.0"
+      Statement = [
+        {
+          Action = ["sts:agencies:assume"]
+          Effect = "Allow"
+          Principal = {
+            Service = ["service.Organizations"]
+          }
+        },
+      ]
+    }
+  )
+}
+
+resource "huaweicloud_organizations_policy_dry_run_configuration" "test" {
+  root_id     = data.huaweicloud_organizations_organization.test.root_id
+  policy_type = "service_control_policy"
+  status      = "enabled"
+  bucket_name = huaweicloud_obs_bucket.test.bucket
+  region_id   = huaweicloud_obs_bucket.test.region
+  agency_name = huaweicloud_identity_trust_agency.test.name
+}
+
+resource "huaweicloud_organizations_dry_run_policy" "test" {
+  name        = "%[2]s"
+  type        = "service_control_policy"
+  description = "Created by terraform script"
+  content = jsonencode({
+    Version = "5.0",
+
+    Statement = [
+      {
+        Effect = "Deny",
+        Action = []
+      }
+    ]
+  })
+}
+
+resource "huaweicloud_organizations_organizational_unit" "test" {
+  name      = "%[2]s"
+  parent_id = data.huaweicloud_organizations_organization.test.root_id
+}
+
+resource "huaweicloud_organizations_dry_run_policy_entity_attach" "test" {
+  policy_id = huaweicloud_organizations_dry_run_policy.test.id
+  entity_id = huaweicloud_organizations_organizational_unit.test.id
+
+  depends_on = [huaweicloud_organizations_policy_dry_run_configuration.test]
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+}
+
+func testAccDataDryRunPolicies_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_organizations_dry_run_policies" "test" {
+  depends_on = [huaweicloud_organizations_dry_run_policy_entity_attach.test]
+}
+
+# Filter by 'policy_type' parameter.
+locals {
+  policy_type = huaweicloud_organizations_dry_run_policy.test.type
+}
+
+data "huaweicloud_organizations_dry_run_policies" "filter_by_policy_type" {
+  policy_type = local.policy_type
+
+  depends_on = [huaweicloud_organizations_dry_run_policy.test]
+}
+
+locals {
+  policy_type_filter_result = [for v in data.huaweicloud_organizations_dry_run_policies.filter_by_policy_type.policies[*].type :
+  v == local.policy_type]
+}
+
+output "is_policy_type_filter_useful" {
+  value = length(local.policy_type_filter_result) > 0 && alltrue(local.policy_type_filter_result)
+}
+
+# Filter by 'attached_entity_id' parameter.
+locals {
+  policy_id = huaweicloud_organizations_dry_run_policy.test.id
+}
+
+data "huaweicloud_organizations_dry_run_policies" "filter_by_attached_entity_id" {
+  attached_entity_id = huaweicloud_organizations_organizational_unit.test.id
+
+  depends_on = [huaweicloud_organizations_dry_run_policy_entity_attach.test]
+}
+
+locals {
+  attached_entity_id_filter_result = [for v in data.huaweicloud_organizations_dry_run_policies.filter_by_attached_entity_id.policies :
+  v if v.id == local.policy_id]
+}
+
+output "attached_entity_id_filter_result" {
+  value = try(local.attached_entity_id_filter_result[0].id == local.policy_id, false)
+}
+
+output "is_description_set_and_valid" {
+  value = try(local.attached_entity_id_filter_result[0].description == huaweicloud_organizations_dry_run_policy.test.description, false)
+}
+`, testAccDataDryRunPolicies_base(name))
+}

--- a/huaweicloud/services/organizations/data_source_huaweicloud_organizations_dry_run_policies.go
+++ b/huaweicloud/services/organizations/data_source_huaweicloud_organizations_dry_run_policies.go
@@ -1,0 +1,181 @@
+package organizations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Organizations GET /v1/organizations/dry-run-policies
+func DataSourceDryRunPolicies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDryRunPoliciesRead,
+		Schema: map[string]*schema.Schema{
+			// Optional parameters.
+			"policy_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of the dry run policies to be queried.`,
+			},
+			"attached_entity_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the entity associated with the dry run policy.`,
+			},
+
+			// Attributes.
+			"policies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The unique ID of the dry run policy.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the dry run policy.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the dry run policy.`,
+						},
+						"urn": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The uniform resource name of the dry run policy.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the dry run policy.`,
+						},
+						"is_builtin": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the dry run policy is a built-in policy.`,
+						},
+					},
+				},
+				Description: `The list of dry run policies that matched the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildDryRunPoliciesBodyParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("policy_type"); ok {
+		res = fmt.Sprintf("&policy_type=%v", v)
+	}
+
+	if v, ok := d.GetOk("attached_entity_id"); ok {
+		res = fmt.Sprintf("%s&attached_entity_id=%v", res, v)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+
+	return res
+}
+
+func listDryRunPolicies(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/organizations/dry-run-policies"
+		marker  = ""
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath += buildDryRunPoliciesBodyParams(d)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		listPathWithMarker := listPath
+		if marker != "" {
+			listPathWithMarker = fmt.Sprintf("%s&marker=%s", listPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", listPathWithMarker, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		policies := utils.PathSearch("policies", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, policies...)
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func dataSourceDryRunPoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("organizations", region)
+	if err != nil {
+		return diag.Errorf("error creating Organizations client: %s", err)
+	}
+
+	policies, err := listDryRunPolicies(client, d)
+	if err != nil {
+		return diag.Errorf("error retrieving dry run policies: %s", err)
+	}
+
+	dataSourceID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceID)
+
+	return diag.FromErr(d.Set("policies", flattenDryRunPolicies(policies)))
+}
+
+func flattenDryRunPolicies(policies []interface{}) []interface{} {
+	if len(policies) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(policies))
+	for _, v := range policies {
+		rst = append(rst, map[string]interface{}{
+			"id":          utils.PathSearch("id", v, nil),
+			"name":        utils.PathSearch("name", v, nil),
+			"type":        utils.PathSearch("type", v, nil),
+			"urn":         utils.PathSearch("urn", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+			"is_builtin":  utils.PathSearch("is_builtin", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source(`huaweicloud_organizations_dry_run_policies`) to query dry run policy list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o organizations -f TestAccDataDryRunPolicies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/organizations" -v -coverprofile="./huaweicloud/services/acceptance/organizations/organizations_coverage.cov" -coverpkg="./huaweicloud/services/organizations" -run TestAccDataDryRunPolicies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDryRunPolicies_basic
=== PAUSE TestAccDataDryRunPolicies_basic
=== CONT  TestAccDataDryRunPolicies_basic
--- PASS: TestAccDataDryRunPolicies_basic (26.99s)
PASS
coverage: 18.6% of statements in ./huaweicloud/services/organizations
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/organizations     27.117s coverage: 18.6% of statements in ./huaweicloud/services/organizations
```
```
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/organizations/data_source_huaweicloud_organizations_dry_run_policies.go (85.1%)
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
