### PR TITLE
feat(rfs): support `rfs_stack_resources` data source

### DIFF
--- a/docs/data-sources/rfs_stack_resources.md
+++ b/docs/data-sources/rfs_stack_resources.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_stack_resources"
+description: |-
+  Use this datasource to get the list of resources managed by a resource stack.
+---
+
+# huaweicloud_rfs_stack_resources
+
+Use this datasource to get the list of resources managed by a resource stack.
+
+## Example Usage
+
+```hcl
+variable "stack_name" {}
+
+data "huaweicloud_rfs_stack_resources" "test" {
+  stack_name = var.stack_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `stack_name` - (Required, String) Specifies the name of the resource stack.
+
+* `stack_id` - (Optional, String) Specifies the unique ID of the resource stack for strong matching.
+  If it does not match the current stack, the API returns an error.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `stack_resources` - The list of resources managed by the stack.
+
+  The [stack_resources](#stack_resources_struct) structure is documented below.
+
+<a name="stack_resources_struct"></a>
+The `stack_resources` block supports:
+
+* `physical_resource_id` - The physical ID of the resource.
+
+* `physical_resource_name` - The physical name of the resource.
+
+* `logical_resource_name` - The logical name of the resource defined in the template.
+
+* `logical_resource_type` - The logical resource type defined in the template.
+
+* `index_key` - The index of the resource when **count** or **for_each** is used in the template.
+
+* `resource_status` - The status of the resource.
+
+* `status_message` - A brief error summary when the resource is in a failed state.
+
+* `resource_attributes` - The list of resource attributes. It is available when the stack is in a terminal state.
+
+  The [resource_attributes](#stack_resource_attributes_struct) structure is documented below.
+
+<a name="stack_resource_attributes_struct"></a>
+The `resource_attributes` block supports:
+
+* `key` - The attribute key.
+
+* `value` - The attribute value.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2022,6 +2022,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rfs_private_modules":              rfs.DataSourcePrivateModules(),
 			"huaweicloud_rfs_private_hook_versions":        rfs.DataSourcePrivateHookVersions(),
 			"huaweicloud_rfs_stack_instances":              rfs.DataSourceStackInstances(),
+			"huaweicloud_rfs_stack_resources":              rfs.DataSourceStackResources(),
 			"huaweicloud_rfs_stack_set_operation_metadata": rfs.DataSourceStackSetOperationMetadata(),
 			"huaweicloud_rfs_private_providers":            rfs.DataSourcePrivateProviders(),
 			"huaweicloud_rfs_templates":                    rfs.DataSourceRfsTemplates(),

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_stack_resources_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_stack_resources_test.go
@@ -1,0 +1,49 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceStackResources_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_stack_resources.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRfsStackName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceStackResources_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_resources.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_resources.0.physical_resource_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_resources.0.physical_resource_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_resources.0.logical_resource_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_resources.0.logical_resource_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_resources.0.resource_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_resources.0.resource_attributes.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_resources.0.resource_attributes.0.key"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_resources.0.resource_attributes.0.value"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceStackResources_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_rfs_stack_resources" "test" {
+  stack_name = "%[1]s"
+}
+`, acceptance.HW_RFS_STACK_NAME)
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_stack_resources.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_stack_resources.go
@@ -1,0 +1,211 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/{project_id}/stacks/{stack_name}/resources
+func DataSourceStackResources() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceStackResourcesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"stack_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"stack_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"stack_resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"physical_resource_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"physical_resource_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"logical_resource_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"logical_resource_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"index_key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status_message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_attributes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildListStackResourcesQueryParams(d *schema.ResourceData, marker string) string {
+	rst := ""
+
+	if v, ok := d.GetOk("stack_id"); ok {
+		rst += fmt.Sprintf("&stack_id=%s", v.(string))
+	}
+
+	if marker != "" {
+		rst += fmt.Sprintf("&marker=%s", marker)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourceStackResourcesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg               = meta.(*config.Config)
+		region            = cfg.GetRegion(d)
+		httpUrl           = "v1/{project_id}/stacks/{stack_name}/resources"
+		allStackResources = make([]interface{}, 0)
+		nextMarker        string
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	reqUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	stackName := d.Get("stack_name").(string)
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{stack_name}", stackName)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Client-Request-Id": reqUUID},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildListStackResourcesQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RFS stack resources: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		stackResources := utils.PathSearch("stack_resources", respBody, make([]interface{}, 0)).([]interface{})
+		if len(stackResources) == 0 {
+			break
+		}
+
+		allStackResources = append(allStackResources, stackResources...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	d.SetId(reqUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("stack_resources", flattenStackResources(allStackResources)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenStackResources(stackResources []interface{}) []interface{} {
+	if len(stackResources) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(stackResources))
+	for _, v := range stackResources {
+		rst = append(rst, map[string]interface{}{
+			"physical_resource_id":   utils.PathSearch("physical_resource_id", v, nil),
+			"physical_resource_name": utils.PathSearch("physical_resource_name", v, nil),
+			"logical_resource_name":  utils.PathSearch("logical_resource_name", v, nil),
+			"logical_resource_type":  utils.PathSearch("logical_resource_type", v, nil),
+			"index_key":              utils.PathSearch("index_key", v, nil),
+			"resource_status":        utils.PathSearch("resource_status", v, nil),
+			"status_message":         utils.PathSearch("status_message", v, nil),
+			"resource_attributes":    flattenStackResourceAttributes(v),
+		})
+	}
+	return rst
+}
+
+func flattenStackResourceAttributes(v interface{}) []interface{} {
+	attributesResp := utils.PathSearch("resource_attributes", v, make([]interface{}, 0)).([]interface{})
+	if len(attributesResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(attributesResp))
+	for _, v := range attributesResp {
+		rst = append(rst, map[string]interface{}{
+			"key":   utils.PathSearch("key", v, nil),
+			"value": utils.PathSearch("value", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_stack_resources` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_stack_resources` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccDataSourceStackResources_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs -v -run TestAccDataSourceStackResources_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceStackResources_basic
=== PAUSE TestAccDataSourceStackResources_basic
=== CONT  TestAccDataSourceStackResources_basic
--- PASS: TestAccDataSourceStackResources_basic (23.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       24.101s
```
<img width="873" height="32" alt="image" src="https://github.com/user-attachments/assets/6410f74c-0e0c-4004-92d5-b10438eaae4f" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
