### PR TITLE
feat(rfs): new resource to analysis template variables

### DIFF
--- a/docs/resources/rfs_template_analysis_variables.md
+++ b/docs/resources/rfs_template_analysis_variables.md
@@ -1,0 +1,83 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_template_analysis_variables"
+description: |-
+  Manages a resource to analyze template variables within HuaweiCloud.
+---
+
+# huaweicloud_rfs_template_analysis_variables
+
+Manages a resource to analyze template variables within HuaweiCloud.
+
+-> This resource is a one-time action resource used to analyze template variables. Deleting this resource will
+  not cancel the analysis operation, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "template_body" {}
+
+resource "huaweicloud_rfs_template_analysis_variables" "test" {
+  template_body = var.template_body
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `template_body` - (Optional, String) Specifies the HCL template that describes the target state of resources.
+
+* `template_uri` - (Optional, String) Specifies the OBS address of the HCL template that describes the target state of
+  resources. Please ensure that the OBS address is in the same region as the RFS service.
+  The corresponding file should be a pure tf file or zip compressed package.
+  A pure .tf file must end with .tf or .tf.json and comply with the HCL syntax.
+  Currently, only the .zip package is supported. The file name extension must be .zip. The decompressed file cannot
+  contain the .tfvars file and must be encoded in UTF8 format (the .tf.json file cannot contain the BOM header).
+  The .zip package supports a maximum of `100` subfiles.
+
+-> Either `template_body` or `template_uri` must be specified.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `variables` - The list of variables parsed from the template.
+
+  The [variables](#variables_struct) structure is documented below.
+
+<a name="variables_struct"></a>
+The `variables` block supports:
+
+* `name` - The name of the variable.
+
+* `type` - The type of the variable.
+
+* `description` - The description of the variable.
+
+* `default` - The default value of the variable. The type of the return value is the same as that defined in the
+  `type` field.
+
+* `sensitive` - Whether the variable is a sensitive field.
+  If `sensitive` is not defined in the variable, **false** is returned by default.
+
+* `nullable` - Whether the variable can be set to null.
+  If `nullable` is not defined in the variable, **true** is returned by default.
+
+* `validations` - The validation rules of the variable.
+
+  The [validations](#validations_struct) structure is documented below.
+
+<a name="validations_struct"></a>
+The `validations` block supports:
+
+* `condition` - The validation expression.
+
+* `error_message` - The error message when validation fails.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2807,13 +2807,14 @@ func Provider() *schema.Provider {
 			// V4 AOM resources.
 			"huaweicloud_aomv4_alarm_rule": aom.ResourceAlarmRuleV4(),
 
-			"huaweicloud_rfs_execution_plan":   rfs.ResourceExecutionPlan(),
-			"huaweicloud_rfs_private_hook":     rfs.ResourcePrivateHook(),
-			"huaweicloud_rfs_private_module":   rfs.ResourcePrivateModule(),
-			"huaweicloud_rfs_stack":            rfs.ResourceStack(),
-			"huaweicloud_rfs_template":         rfs.ResourceRfsTemplate(),
-			"huaweicloud_rfs_private_provider": rfs.ResourcePrivateProvider(),
-			"huaweicloud_rfs_stack_rollback":   rfs.ResourceStackRollback(),
+			"huaweicloud_rfs_execution_plan":              rfs.ResourceExecutionPlan(),
+			"huaweicloud_rfs_private_hook":                rfs.ResourcePrivateHook(),
+			"huaweicloud_rfs_private_module":              rfs.ResourcePrivateModule(),
+			"huaweicloud_rfs_stack":                       rfs.ResourceStack(),
+			"huaweicloud_rfs_template_analysis_variables": rfs.ResourceTemplateAnalysisVariables(),
+			"huaweicloud_rfs_template":                    rfs.ResourceRfsTemplate(),
+			"huaweicloud_rfs_private_provider":            rfs.ResourcePrivateProvider(),
+			"huaweicloud_rfs_stack_rollback":              rfs.ResourceStackRollback(),
 
 			"huaweicloud_api_gateway_api":         apigateway.ResourceAPI(),
 			"huaweicloud_api_gateway_environment": apigateway.ResourceEnvironment(),

--- a/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_template_analysis_variables_test.go
+++ b/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_template_analysis_variables_test.go
@@ -1,0 +1,72 @@
+package rfs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTemplateAnalysisVariables_basic(t *testing.T) {
+	rName := "huaweicloud_rfs_template_analysis_variables.test"
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTemplateAnalysisVariables_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rName, "variables.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "variables.0.type"),
+					resource.TestCheckResourceAttrSet(rName, "variables.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "variables.0.default"),
+					resource.TestCheckResourceAttrSet(rName, "variables.0.sensitive"),
+					resource.TestCheckResourceAttrSet(rName, "variables.0.nullable"),
+				),
+			},
+		},
+	})
+}
+
+const testAccTemplateAnalysisVariables_basic = `
+resource "huaweicloud_rfs_template_analysis_variables" "test" {
+  template_body = <<EOT
+variable "instance_name" {
+  type        = string
+  description = "The name of the instance"
+  default     = "test-instance"
+}
+
+variable "instance_count" {
+  type        = number
+  description = "The number of instances to create"
+  default     = 1
+  validation {
+    condition     = var.instance_count > 0
+    error_message = "Instance count must be greater than 0."
+  }
+}
+
+variable "enable_monitoring" {
+  type        = bool
+  description = "Whether to enable monitoring"
+  default     = false
+  sensitive   = false
+  nullable    = false
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to the instances"
+  default     = {
+    Environment = "test"
+    Project     = "demo"
+  }
+}
+EOT
+}
+`

--- a/huaweicloud/services/rfs/resource_huaweicloud_rfs_template_analysis_variables.go
+++ b/huaweicloud/services/rfs/resource_huaweicloud_rfs_template_analysis_variables.go
@@ -1,0 +1,238 @@
+package rfs
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var templateAnalysisVariablesNonUpdatableParams = []string{
+	"template_body",
+	"template_uri",
+}
+
+// @API RFS POST /v1/{project_id}/template-analyses/variables
+func ResourceTemplateAnalysisVariables() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTemplateAnalysisVariablesCreate,
+		ReadContext:   resourceTemplateAnalysisVariablesRead,
+		UpdateContext: resourceTemplateAnalysisVariablesUpdate,
+		DeleteContext: resourceTemplateAnalysisVariablesDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(templateAnalysisVariablesNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"template_body": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"template_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"variables": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataVariablesSchema(),
+			},
+		},
+	}
+}
+
+func dataVariablesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			// Field `default` is object type in API response, but we need to convert it to string.
+			"default": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sensitive": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"nullable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"validations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"condition": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildTemplateAnalysisVariablesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"template_body": utils.ValueIgnoreEmpty(d.Get("template_body")),
+		"template_uri":  utils.ValueIgnoreEmpty(d.Get("template_uri")),
+	}
+}
+
+func resourceTemplateAnalysisVariablesCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/template-analyses/variables"
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate UUID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": requestId,
+		},
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildTemplateAnalysisVariablesBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error analyzing RFS template variables: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(requestId)
+
+	variables := utils.PathSearch("variables", respBody, make([]interface{}, 0)).([]interface{})
+	if err := d.Set("variables", flattenVariablesAttributes(variables)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func flattenVariablesAttributes(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"name":        utils.PathSearch("name", v, nil),
+			"type":        utils.PathSearch("type", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+			"default":     flattenVariablesDefaultAttributes(utils.PathSearch("default", v, nil)),
+			"sensitive":   utils.PathSearch("sensitive", v, nil),
+			"nullable":    utils.PathSearch("nullable", v, nil),
+			"validations": flattenVariablesValidationsAttributes(utils.PathSearch("validations", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenVariablesValidationsAttributes(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"condition":     utils.PathSearch("condition", v, nil),
+			"error_message": utils.PathSearch("error_message", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenVariablesDefaultAttributes(respValue interface{}) string {
+	if respValue == nil {
+		return ""
+	}
+
+	b, err := json.Marshal(respValue)
+	if err != nil {
+		log.Printf("[ERROR] failed to marshal RFS template analysis variables default value: %v", err)
+		return ""
+	}
+
+	return string(b)
+}
+
+func resourceTemplateAnalysisVariablesRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Read()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceTemplateAnalysisVariablesUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Update()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceTemplateAnalysisVariablesDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to analyze template variables. Deleting this resource
+    will not cancel the analysis operation, but will only remove resource information from
+    tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to analysis template variables

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o rfs -f TestAccTemplateAnalysisVariables_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rfs" -v -coverprofile="./huaweicloud/services/acceptance/rfs/rfs_coverage.cov" -coverpkg="./huaweicloud/services/rfs" -run TestAccTemplateAnalysisVariables_basic -timeout 360m -parallel 10
=== RUN   TestAccTemplateAnalysisVariables_basic
=== PAUSE TestAccTemplateAnalysisVariables_basic
=== CONT  TestAccTemplateAnalysisVariables_basic
--- PASS: TestAccTemplateAnalysisVariables_basic (13.89s)
PASS
coverage: 5.7% of statements in ./huaweicloud/services/rfs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       13.989s coverage: 5.7% of statements in ./huaweicloud/services/rfs
```
<img width="1243" height="68" alt="image" src="https://github.com/user-attachments/assets/d66d29cd-0039-4ddc-9613-67326c3eb130" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
