### PR TITLE
refactor(dws): support querying volume usage information for logical cluster

### DIFF
--- a/docs/resources/dws_logical_cluster.md
+++ b/docs/resources/dws_logical_cluster.md
@@ -102,6 +102,18 @@ In addition to all arguments above, the following attributes are exported:
 
 * `delete_enable` - Whether deletion is allowed.
 
+* `volume_usage` - The volume usage information of the logical cluster.
+The [volume_usage](#dws_logical_cluster_volume_usage) structure is documented below.
+
+<a name="dws_logical_cluster_volume_usage"></a>
+The `volume_usage` block supports:
+
+* `usage` - The disk usage of the logical cluster.
+
+* `total` - The total disk capacity of the logical cluster.
+
+* `percent` - The disk usage percentage of the logical cluster.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_logical_cluster_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_logical_cluster_test.go
@@ -59,13 +59,11 @@ func getLogicalClusterResourceFunc(cfg *config.Config, state *terraform.Resource
 	return cluster, nil
 }
 
-// Two logical clusters are created to test concurrent creation and deletion scenarios.
 func TestAccLogicalCluster_basic(t *testing.T) {
 	var obj interface{}
 
 	name := acceptance.RandomAccResourceName()
 	rName := "huaweicloud_dws_logical_cluster.test"
-	rName2 := "huaweicloud_dws_logical_cluster.test2"
 
 	rc := acceptance.InitResourceCheck(
 		rName,
@@ -82,11 +80,8 @@ func TestAccLogicalCluster_basic(t *testing.T) {
 				Config: testLogicalCluster_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(rName, "cluster_id",
-						"huaweicloud_dws_cluster.test", "id"),
 					resource.TestCheckResourceAttr(rName, "logical_cluster_name", name),
-					resource.TestCheckResourceAttr(rName, "cluster_rings.#", "2"),
-					resource.TestCheckResourceAttr(rName2, "cluster_rings.#", "1"),
+					resource.TestCheckResourceAttr(rName, "cluster_rings.#", "1"),
 					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.host_name"),
 					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.back_ip"),
 					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.cpu_cores"),
@@ -108,6 +103,11 @@ func TestAccLogicalCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "edit_enable"),
 					resource.TestCheckResourceAttrSet(rName, "restart_enable"),
 					resource.TestCheckResourceAttrSet(rName, "delete_enable"),
+
+					resource.TestCheckResourceAttr(rName, "volume_usage.#", "1"),
+					resource.TestCheckResourceAttrSet(rName, "volume_usage.0.usage"),
+					resource.TestCheckResourceAttrSet(rName, "volume_usage.0.total"),
+					resource.TestCheckResourceAttrSet(rName, "volume_usage.0.percent"),
 				),
 			},
 			{
@@ -124,40 +124,27 @@ func TestAccLogicalCluster_basic(t *testing.T) {
 }
 
 func testLogicalCluster_base(name string) string {
-	clusterBasic := testAccDwsCluster_basic_step1(name, 10, dws.PublicBindTypeAuto, "cluster123@!")
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 data "huaweicloud_dws_logical_cluster_rings" "test" {
   cluster_id = huaweicloud_dws_cluster.test.id
 }
-`, clusterBasic)
+`, testAccDwsCluster_basic_step1(name, 7, dws.PublicBindTypeAuto, "cluster123@!"))
 }
 
 func testLogicalCluster_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_dws_logical_cluster" "test" {
   cluster_id           = huaweicloud_dws_cluster.test.id
-  logical_cluster_name = "%s"
+  logical_cluster_name = "%[2]s"
 
   cluster_rings {
     dynamic "ring_hosts" {
       for_each = data.huaweicloud_dws_logical_cluster_rings.test.cluster_rings.0.ring_hosts[*]
-      content {
-        host_name = ring_hosts.value.host_name
-        back_ip   = ring_hosts.value.back_ip
-        cpu_cores = ring_hosts.value.cpu_cores
-        memory    = ring_hosts.value.memory
-        disk_size = ring_hosts.value.disk_size
-      }
-    }
-  }
 
-  cluster_rings {
-    dynamic "ring_hosts" {
-      for_each = data.huaweicloud_dws_logical_cluster_rings.test.cluster_rings.1.ring_hosts[*]
       content {
         host_name = ring_hosts.value.host_name
         back_ip   = ring_hosts.value.back_ip
@@ -168,25 +155,7 @@ resource "huaweicloud_dws_logical_cluster" "test" {
     }
   }
 }
-
-resource "huaweicloud_dws_logical_cluster" "test2" {
-  cluster_id           = huaweicloud_dws_cluster.test.id
-  logical_cluster_name = "%s_test2"
-
-  cluster_rings {
-    dynamic "ring_hosts" {
-      for_each = data.huaweicloud_dws_logical_cluster_rings.test.cluster_rings.2.ring_hosts[*]
-      content {
-        host_name = ring_hosts.value.host_name
-        back_ip   = ring_hosts.value.back_ip
-        cpu_cores = ring_hosts.value.cpu_cores
-        memory    = ring_hosts.value.memory
-        disk_size = ring_hosts.value.disk_size
-      }
-    }
-  }
-}
-`, testLogicalCluster_base(name), name, name)
+`, testLogicalCluster_base(name), name)
 }
 
 func testLogicalCluster_basic_step1(name string) string {
@@ -195,18 +164,13 @@ func testLogicalCluster_basic_step1(name string) string {
 
 func testLogicalCluster_basic_step2(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_dws_logical_cluster_restart" "test" {
   cluster_id         = huaweicloud_dws_cluster.test.id
   logical_cluster_id = huaweicloud_dws_logical_cluster.test.id
 }
-
-resource "huaweicloud_dws_logical_cluster_restart" "test2" {
-  cluster_id         = huaweicloud_dws_cluster.test.id
-  logical_cluster_id = huaweicloud_dws_logical_cluster.test2.id
-}
-`, testLogicalCluster_basic(name))
+`, testLogicalCluster_basic_step1(name))
 }
 
 // testLogicalClusterImportState use to return an ID with format <cluster_id>/<id>

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
@@ -8,6 +8,8 @@ package dws
 import (
 	"context"
 	"fmt"
+	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,6 +37,7 @@ var requestOpts = golangsdk.RequestOpts{
 
 // @API DWS POST /v2/{project_id}/clusters/{cluster_id}/logical-clusters
 // @API DWS GET /v2/{project_id}/clusters/{cluster_id}/logical-clusters
+// @API DWS GET /v2/{project_id}/clusters/{cluster_id}/logical-clusters/volumes
 // @API DWS DELETE /v2/{project_id}/clusters/{cluster_id}/logical-clusters/{logical_cluster_id}
 func ResourceLogicalCluster() *schema.Resource {
 	return &schema.Resource{
@@ -100,6 +103,12 @@ func ResourceLogicalCluster() *schema.Resource {
 				Computed:    true,
 				Description: `Whether deletion is allowed.`,
 			},
+			"volume_usage": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        logicalClusterVolumeUsageSchema(),
+				Description: `The volume usage information of the logical cluster.`,
+			},
 		},
 	}
 }
@@ -155,6 +164,28 @@ func logicalRingHostsSchema() *schema.Resource {
 		},
 	}
 	return &sc
+}
+
+func logicalClusterVolumeUsageSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"usage": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The disk usage of the logical cluster.`,
+			},
+			"total": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The total disk capacity of the logical cluster.`,
+			},
+			"percent": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The disk usage percentage of the logical cluster.`,
+			},
+		},
+	}
 }
 
 func buildLogicalRingHostsRequestBody(rawParams interface{}) []map[string]interface{} {
@@ -344,14 +375,70 @@ func flattenResponseBodyClusterRings(resp interface{}) []interface{} {
 	return rst
 }
 
+func listLogicalClusterVolumes(client *golangsdk.ServiceClient, clusterId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/clusters/{cluster_id}/logical-clusters/volumes?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{cluster_id}", clusterId)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+
+	listOpts := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := listPathWithLimit + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpts)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		volumes := utils.PathSearch("volumes", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, volumes...)
+		if len(volumes) < limit {
+			break
+		}
+		offset += len(volumes)
+	}
+
+	return result, nil
+}
+
+func flattenVolumeUsage(volume interface{}) []map[string]interface{} {
+	if volume == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"usage":   utils.PathSearch("usage", volume, nil),
+			"total":   utils.PathSearch("total", volume, nil),
+			"percent": utils.PathSearch("percent", volume, nil),
+		},
+	}
+}
+
 func resourceLogicalClusterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		mErr                     *multierror.Error
-		cfg                      = meta.(*config.Config)
-		region                   = cfg.GetRegion(d)
-		getLogicalClusterProduct = "dws"
+		mErr               *multierror.Error
+		cfg                = meta.(*config.Config)
+		region             = cfg.GetRegion(d)
+		clusterId          = d.Get("cluster_id").(string)
+		logicalClusterName = d.Get("logical_cluster_name").(string)
 	)
-	client, err := cfg.NewServiceClient(getLogicalClusterProduct, region)
+	client, err := cfg.NewServiceClient("dws", region)
 	if err != nil {
 		return diag.Errorf("error creating DWS client: %s", err)
 	}
@@ -370,16 +457,27 @@ func resourceLogicalClusterRead(_ context.Context, d *schema.ResourceData, meta 
 		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 	}
 
+	if logicalClusterName == "" {
+		logicalClusterName = utils.PathSearch("logical_cluster_name", cluster, "").(string)
+	}
+
+	volumes, err := listLogicalClusterVolumes(client, clusterId)
+	if err != nil {
+		log.Printf("[WARN] error retrieving volume usage: %s", err)
+	}
+	volumeUsage := utils.PathSearch(fmt.Sprintf("[?logical_cluster_name=='%s']|[0]", logicalClusterName), volumes, nil)
+
 	mErr = multierror.Append(
 		mErr,
 		d.Set("region", region),
-		d.Set("logical_cluster_name", utils.PathSearch("logical_cluster_name", cluster, nil)),
+		d.Set("logical_cluster_name", logicalClusterName),
 		d.Set("cluster_rings", flattenResponseBodyClusterRings(cluster)),
 		d.Set("status", utils.PathSearch("status", cluster, nil)),
 		d.Set("first_logical_cluster", utils.PathSearch("first_logical_cluster", cluster, nil)),
 		d.Set("edit_enable", utils.PathSearch("edit_enable", cluster, nil)),
 		d.Set("restart_enable", utils.PathSearch("restart_enable", cluster, nil)),
 		d.Set("delete_enable", utils.PathSearch("delete_enable", cluster, nil)),
+		d.Set("volume_usage", flattenVolumeUsage(volumeUsage)),
 	)
 	return diag.FromErr(mErr.ErrorOrNil())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Support querying volume usage information for logical cluster

**Which issue this PR fixes**:
Fix create polling status handling problem
Since logical cluster creation takes a long time, the `waitingForStateCompleted` function should return `pending` when the query result is empty.

**Special notes for your reviewer**:

**Release note**:

```release-note
1. change the provider implement
2. change the provider document
3. change the provider acceptance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccLogicalCluster_basic -timeout 360m -parallel 10
=== RUN   TestAccLogicalCluster_basic
=== PAUSE TestAccLogicalCluster_basic
=== CONT  TestAccLogicalCluster_basic
--- PASS: TestAccLogicalCluster_basic (1789.99s)
PASS
coverage: 11.5% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1790.057s       coverage: 11.5% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
