### PR TITLE
refactor(dws): support renaming and changing time zones for cluster resources

### DIFF
--- a/docs/resources/dws_cluster.md
+++ b/docs/resources/dws_cluster.md
@@ -53,9 +53,8 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `name` - (Required, String, ForceNew) Cluster name, which must be unique and contains 4 to 64 characters, which
+* `name` - (Required, String) Cluster name, which must be unique and contains 4 to 64 characters, which
   consist of letters, digits, hyphens(-), or underscores(_) only and must start with a letter.
-  Changing this creates a new cluster resource.
 
 * `node_type` - (Required, String, ForceNew) The flavor of the cluster.  
  [For details](https://support.huaweicloud.com/intl/en-us/productdesc-dws/dws_01_00018.html).
@@ -136,6 +135,14 @@ The following arguments are supported:
 * `force_backup` - (Optional, Bool) Specified whether to automatically execute snapshot when shrinking the number of nodes.
   The default value is **true**.
   This parameter is required and available only when scaling-in the `number_of_node` parameter value.
+
+* `timezone` - (Optional, String) Specifies the timezone of the cluster.
+  When not specified, the cloud default timezone is used.
+  This parameter can be updated, but resetting it to empty will skip API call and keep the cloud timezone unchanged.
+
+~> **Note:** When `timezone` is reset to empty or removed from configuration,
+   no API call will be made and the cloud timezone setting remains unchanged.
+   To change the timezone, explicitly specify a new timezone value.
 
 <a name="DwsCluster_PublicIp"></a>
 The `PublicIp` block supports:

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_test.go
@@ -65,13 +65,14 @@ func TestAccResourceCluster_basicV1(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", "huaweicloud_networking_secgroup.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created v1 cluster by terraform script"),
+					resource.TestCheckResourceAttr(resourceName, "timezone", "UTC"),
 				),
 			},
 			{
 				Config: testAccDwsCluster_basic_step2(name, updatePassword),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", name+"_updated"),
 					resource.TestCheckResourceAttr(resourceName, "number_of_node", "6"),
 					resource.TestCheckResourceAttr(resourceName, "logical_cluster_enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
@@ -81,6 +82,7 @@ func TestAccResourceCluster_basicV1(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar1"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", "huaweicloud_networking_secgroup.test2", "id"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated cluster info"),
+					resource.TestCheckResourceAttr(resourceName, "timezone", "Asia/Shanghai"),
 				),
 			},
 			{
@@ -88,7 +90,7 @@ func TestAccResourceCluster_basicV1(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated cluster info"),
 					resource.TestCheckResourceAttr(resourceName, "number_of_node", "3"),
 					resource.TestCheckResourceAttr(resourceName, "public_ip.0.public_bind_type", dws.PublicBindTypeNotUse),
 					resource.TestCheckResourceAttr(resourceName, "public_ip.0.eip_id", ""),
@@ -100,10 +102,11 @@ func TestAccResourceCluster_basicV1(t *testing.T) {
 				Config: testAccDwsCluster_basic_step4(name, updatePassword),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"user_pwd", "number_of_cn", "volume", "endpoints", "logical_cluster_enable", "force_backup"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"user_pwd", "number_of_cn", "volume", "endpoints", "logical_cluster_enable", "force_backup",
+					"timezone", "status"},
 			},
 		},
 	})
@@ -147,6 +150,7 @@ resource "huaweicloud_dws_cluster" "test" {
   logical_cluster_enable = true
   enterprise_project_id  = "%[5]s"
   description            = "Created v1 cluster by terraform script"
+  timezone               = "UTC"
 
   public_ip {
     # Automatically purchase EIP when creating cluster.
@@ -175,7 +179,7 @@ resource "huaweicloud_networking_secgroup" "test2" {
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_dws_cluster" "test" {
-  name                   = "%[3]s"
+  name                   = "%[3]s_updated"
   node_type              = "dwsk2.xlarge"
   number_of_node         = 6
   vpc_id                 = huaweicloud_vpc.test.id
@@ -187,6 +191,7 @@ resource "huaweicloud_dws_cluster" "test" {
   logical_cluster_enable = false
   enterprise_project_id  = "%[5]s"
   description            = "Updated cluster info"
+  timezone               = "Asia/Shanghai"
 
   public_ip {
     # Modify the associated EIP.
@@ -228,6 +233,7 @@ resource "huaweicloud_dws_cluster" "test" {
   user_pwd               = "%[4]s"
   logical_cluster_enable = false
   enterprise_project_id  = "%[5]s"
+  description            = "Updated cluster info"
 
   public_ip {
     # Unbind the associated EIP.
@@ -289,6 +295,7 @@ func TestAccResourceCluster_basicV2(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "elb.0.name", name+"_elb0"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", "huaweicloud_networking_secgroup.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created v2 cluster by terraform script"),
+					resource.TestCheckResourceAttr(resourceName, "timezone", "UTC"),
 				),
 			},
 			// Assert all modifiable parameters.
@@ -296,7 +303,7 @@ func TestAccResourceCluster_basicV2(t *testing.T) {
 				Config: testAccDwsCluster_basicV2_step2(name, updatePassword),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", name+"_updated"),
 					resource.TestCheckResourceAttr(resourceName, "number_of_node", "6"),
 					resource.TestCheckResourceAttrPair(resourceName, "public_ip.0.eip_id", "huaweicloud_vpc_eip.test.1", "id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "val"),
@@ -307,6 +314,7 @@ func TestAccResourceCluster_basicV2(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "elb.0.name", name+"_elb1"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", "huaweicloud_networking_secgroup.test2", "id"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated cluster info"),
+					resource.TestCheckResourceAttr(resourceName, "timezone", "Asia/Shanghai"),
 				),
 			},
 			// Assert that ELB and EIP are unbound and delete all tags.
@@ -332,7 +340,7 @@ func TestAccResourceCluster_basicV2(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"user_pwd", "number_of_cn", "volume", "endpoints", "lts_enable",
-					"logical_cluster_enable", "elb_id", "force_backup"},
+					"logical_cluster_enable", "elb_id", "force_backup", "timezone"},
 			},
 		},
 	})
@@ -397,6 +405,7 @@ resource "huaweicloud_dws_cluster" "testv2" {
   enterprise_project_id  = "%[4]s"
   elb_id                 = huaweicloud_elb_loadbalancer.test[0].id
   description            = "Created v2 cluster by terraform script"
+  timezone               = "UTC"
 
   public_ip {
     # Binging a EIP for cluster.
@@ -422,7 +431,7 @@ func testAccDwsCluster_basicV2_step2(rName, password string) string {
 %[1]s
 
 resource "huaweicloud_dws_cluster" "testv2" {
-  name                   = "%[2]s"
+  name                   = "%[2]s_updated"
   node_type              = "dwsk2.xlarge"
   number_of_node         = 6
   vpc_id                 = huaweicloud_vpc.test.id
@@ -438,6 +447,7 @@ resource "huaweicloud_dws_cluster" "testv2" {
   enterprise_project_id  = "%[4]s"
   elb_id                 = huaweicloud_elb_loadbalancer.test[1].id
   description            = "Updated cluster info"
+  timezone               = "Asia/Shanghai"
 
   public_ip {
     # Modify the associated EIP.

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
@@ -56,6 +56,8 @@ const ClusterIdIllegalErrCode = "DWS.0001"
 // @API DWS POST /v1/{project_id}/clusters/{cluster_id}/description
 // @API DWS PUT /v1/{project_id}/clusters/{cluster_id}/security-group
 // @API DWS POST /v1.0/{project_id}/clusters/{cluster_id}/cluster-shrink
+// @API DWS PUT /v1.0/{project_id}/clusters/{cluster_id}/name
+// @API DWS POST /v2/{project_id}/clusters/{cluster_id}/timezone
 func ResourceDwsCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDwsClusterCreate,
@@ -83,7 +85,6 @@ func ResourceDwsCluster() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The cluster name.`,
 			},
 			"node_type": {
@@ -218,6 +219,18 @@ func ResourceDwsCluster() *schema.Resource {
 				Optional:    true,
 				Default:     true,
 				Description: `Whether to automatically execute snapshot when shrinking the number of nodes.`,
+			},
+			"timezone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+					if newVal == "" {
+						return true
+					}
+					return oldVal == newVal
+				},
+				Description: `The timezone of the cluster.`,
 			},
 			"status": {
 				Type:        schema.TypeString,
@@ -529,6 +542,12 @@ func resourceDwsClusterCreateV2(ctx context.Context, d *schema.ResourceData, met
 			return diag.FromErr(err)
 		}
 	}
+
+	if v, ok := d.GetOk("timezone"); ok {
+		if err := updateClusterTimezone(ctx, createDwsClusterClient, clusterId, v.(string), d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
 	return resourceDwsClusterRead(ctx, d, meta)
 }
 
@@ -593,6 +612,12 @@ func resourceDwsClusterCreateV1(ctx context.Context, d *schema.ResourceData, met
 
 	if v, ok := d.GetOk("description"); ok {
 		if err := updateDescription(createDwsClusterClient, clusterId, v.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if v, ok := d.GetOk("timezone"); ok {
+		if err := updateClusterTimezone(ctx, createDwsClusterClient, clusterId, v.(string), d.Timeout(schema.TimeoutCreate)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -786,6 +811,8 @@ func resourceDwsClusterRead(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("maintain_window", flattenGetDwsClusterRespBodyMaintainWindow(getDwsClusterRespBody)),
 		d.Set("elb", flattenGetDwsClusterRespBodyElb(getDwsClusterRespBody)),
 		d.Set("description", utils.PathSearch("cluster.cluster_description_info", getDwsClusterRespBody, nil)),
+		d.Set("name", utils.PathSearch("cluster.name", getDwsClusterRespBody, nil)),
+		d.Set("timezone", utils.PathSearch("cluster.cluster_timezone", getDwsClusterRespBody, "")),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -1031,6 +1058,21 @@ func resourceDwsClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	if d.HasChange("security_group_id") {
 		if err := updateSecurityGroup(clusterClient, clusterId, d.Get("security_group_id").(string)); err != nil {
 			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("name") {
+		if err := updateClusterName(ctx, clusterClient, clusterId, d.Get("name").(string), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("timezone") {
+		timezoneValue := d.Get("timezone").(string)
+		if timezoneValue != "" {
+			if err := updateClusterTimezone(ctx, clusterClient, clusterId, timezoneValue, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 	return resourceDwsClusterRead(ctx, d, meta)
@@ -1338,7 +1380,7 @@ func bindElb(ctx context.Context, d *schema.ResourceData, client *golangsdk.Serv
 		return fmt.Errorf("error binding ELB to DWS cluster: job ID is not found in API response")
 	}
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"INIT"},
+		Pending:      []string{"PENDING"},
 		Target:       []string{"SUCCESS"},
 		Refresh:      jobStatusRefreshFunc(client, jobId),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
@@ -1386,7 +1428,7 @@ func unbindElb(ctx context.Context, d *schema.ResourceData, client *golangsdk.Se
 		return fmt.Errorf("error unbinding ELB from DWS cluster: job ID is not found in API response: %s", jobId)
 	}
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"INIT"},
+		Pending:      []string{"PENDING"},
 		Target:       []string{"SUCCESS"},
 		Refresh:      jobStatusRefreshFunc(client, jobId),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
@@ -1460,14 +1502,19 @@ func jobStatusRefreshFunc(client *golangsdk.ServiceClient, jobId string) resourc
 			return nil, "", err
 		}
 
-		status := utils.PathSearch("status", getJobStatusRespBody, "")
-		if status.(string) == "FAIL" {
+		status := utils.PathSearch("status", getJobStatusRespBody, "").(string)
+		if status == "FAIL" {
 			failedCode := utils.PathSearch("failed_code", getJobStatusRespBody, "")
 			failedDetail := utils.PathSearch("failed_detail", getJobStatusRespBody, "")
-			return nil, "", fmt.Errorf("DWS cluster binding ELB job failed,"+
-				" job ID: %s, failed_code: %s, failed_detail: %s", jobId, failedCode, failedDetail)
+			return nil, "", fmt.Errorf("DWS cluster job failed, job ID: %s, failed_code: %s, failed_detail: %s",
+				jobId, failedCode, failedDetail)
 		}
-		return getJobStatusRespBody, status.(string), nil
+
+		if status == "SUCCESS" {
+			return getJobStatusRespBody, "SUCCESS", nil
+		}
+
+		return getJobStatusRespBody, "PENDING", nil
 	}
 }
 
@@ -1572,6 +1619,90 @@ func updateSecurityGroup(client *golangsdk.ServiceClient, clusterId, securityGro
 	_, err := client.Request("PUT", path, &opt)
 	if err != nil {
 		return fmt.Errorf("error updating security group for the cluster (%s): %s", clusterId, err)
+	}
+
+	return nil
+}
+
+func updateClusterName(ctx context.Context, client *golangsdk.ServiceClient, clusterId, name string, timeout time.Duration) error {
+	httpUrl := "v1/{project_id}/clusters/{cluster_id}/cluster-name"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{cluster_id}", clusterId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"cluster_name": name,
+		},
+	}
+	resp, err := client.Request("PUT", path, &opt)
+	if err != nil {
+		return fmt.Errorf("error updating name for cluster (%s): %s", clusterId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return fmt.Errorf("error updating name for cluster (%s): job ID is not found in API response", clusterId)
+	}
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      jobStatusRefreshFunc(client, jobId),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for updating name of cluster (%s) to complete: %s", clusterId, err)
+	}
+
+	return nil
+}
+
+func updateClusterTimezone(ctx context.Context, client *golangsdk.ServiceClient, clusterId, timezone string, timeout time.Duration) error {
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/timezone"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{cluster_id}", clusterId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"cluster_timezone": timezone,
+		},
+	}
+	resp, err := client.Request("POST", path, &opt)
+	if err != nil {
+		return fmt.Errorf("error updating timezone for cluster (%s): %s", clusterId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return fmt.Errorf("error updating timezone for cluster (%s): job ID is not found in API response", clusterId)
+	}
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      jobStatusRefreshFunc(client, jobId),
+		Timeout:      timeout,
+		Delay:        60 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for updating timezone of cluster (%s) to complete: %s", clusterId, err)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:


**Which issue this PR fixes**:
Support renaming and changing time zones for cluster resources

**Special notes for your reviewer**:

**Release note**:

```release-note
1. change the provider implement
2. change the document
3. change the acceptance case
```

## PR Checklist

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccResourceCluster_basicV1 -timeout 360m -parallel 10
=== RUN   TestAccResourceCluster_basicV1
=== PAUSE TestAccResourceCluster_basicV1
=== CONT  TestAccResourceCluster_basicV1
--- PASS: TestAccResourceCluster_basicV1 (3180.27s)
PASS
coverage: 11.2% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       3180.416s       coverage: 11.2% of statements in ./huaweicloud/services/dws
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.