### PR TITLE
fix(dws): fix create polling timeout

### DIFF
--- a/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
@@ -48,7 +48,7 @@ func ResourceLogicalCluster() *schema.Resource {
 			StateContext: resourceLogicalClusterImportState,
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
+			Create: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
@@ -270,8 +270,12 @@ func buildCreateRetryFunc(client *golangsdk.ServiceClient, createPath string, cr
 
 func waitingForStateCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
 	timeout time.Duration) (interface{}, error) {
-	clusterName := d.Get("logical_cluster_name").(string)
-	expression := fmt.Sprintf("logical_clusters[?logical_cluster_name=='%s']|[0]", clusterName)
+	var (
+		clusterName = d.Get("logical_cluster_name").(string)
+		ringCount   = d.Get("cluster_rings").(*schema.Set).Len()
+		expression  = fmt.Sprintf("logical_clusters[?logical_cluster_name=='%s']|[0]", clusterName)
+	)
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
@@ -298,8 +302,8 @@ func waitingForStateCompleted(ctx context.Context, client *golangsdk.ServiceClie
 			return cluster, "PENDING", nil
 		},
 		Timeout:      timeout,
-		Delay:        30 * time.Second,
-		PollInterval: 30 * time.Second,
+		Delay:        time.Duration(5*ringCount) * time.Minute,
+		PollInterval: time.Duration(5*ringCount) * time.Minute,
 	}
 	return stateConf.WaitForStateContext(ctx)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adjust the polling interval during creation to dynamically vary based on the number of rings.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
Convert ringCount to time.Duration before multiplying with time.Minute
to resolve the "mismatched types int and time.Duration" compilation error.

**Release note**:

```release-note
1. change the implement of provider.
```

## PR Checklist

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccLogicalCluster_basic -timeout 360m -parallel 10
=== RUN   TestAccLogicalCluster_basic
=== PAUSE TestAccLogicalCluster_basic
=== CONT  TestAccLogicalCluster_basic
--- PASS: TestAccLogicalCluster_basic (1818.52s)
PASS
coverage: 12.0% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1818.633s       coverage: 12.0% of statements in ./huaweicloud/services/dws
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.