### PR TITLE
feat(dataarts/catalog): add a one-time action resource for metadata task

### DIFF
--- a/docs/resources/dataarts_catalog_metadata_task_action.md
+++ b/docs/resources/dataarts_catalog_metadata_task_action.md
@@ -1,0 +1,52 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_catalog_metadata_task_action"
+description: |-
+  Use this resource to operate a DataArts Catalog metadata task within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_catalog_metadata_task_action
+
+Use this resource to operate a DataArts Catalog metadata task within HuaweiCloud.
+
+-> This resource is only a one-time action resource for operating a metadata task. Deleting this resource will not
+   clear the corresponding request record, but will only remove the resource information from the tfstate file,
+   but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "task_id" {}
+
+resource "huaweicloud_dataarts_catalog_metadata_task_action" "test" {
+  workspace_id = var.workspace_id
+  task_id      = var.task_id
+  action       = "run"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the metadata task is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the ID of the workspace to which the metadata task
+  belongs.
+
+* `task_id` - (Required, String, NonUpdatable) Specifies the task ID of the metadata task.
+
+* `action` - (Required, String, NonUpdatable) Specifies the supported action of the metadata task status.  
+  The valid values are as follows:
+  + **run**
+  + **runimmediate**
+  + **stop**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3862,7 +3862,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_subject":                dataarts.ResourceArchitectureSubject(),
 			"huaweicloud_dataarts_architecture_table_model":            dataarts.ResourceArchitectureTableModel(),
 			// DataAtrs Catalog
-			"huaweicloud_dataarts_catalog_metadata_task": dataarts.ResourceCatalogMetadataTask(),
+			"huaweicloud_dataarts_catalog_metadata_task":        dataarts.ResourceCatalogMetadataTask(),
+			"huaweicloud_dataarts_catalog_metadata_task_action": dataarts.ResourceCatalogMetadataTaskAction(),
 			// DataArts Factory
 			"huaweicloud_dataarts_factory_job":            dataarts.ResourceFactoryJob(),
 			"huaweicloud_dataarts_factory_job_action":     dataarts.ResourceFactoryJobAction(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_catalog_metadata_task_action_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_catalog_metadata_task_action_test.go
@@ -1,0 +1,195 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccCatalogMetadataTaskAction_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_dataarts_catalog_metadata_task.test"
+		rcActionTask = acceptance.InitResourceCheck(resourceName, &obj, getCatalogMetadataTaskResourceFunc)
+
+		name        = acceptance.RandomAccResourceName()
+		currentTime = time.Now().Local().Format(time.RFC3339)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.12.1",
+			},
+		},
+		// This resource is a one-time action resource and the instance record will not delete even if resource is deleted.
+		// So we need to ignore the check destroy.
+		// lintignore:AT001
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcActionTask.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCatalogMetadataTaskAction_nonExistentMetadataTask(),
+				ExpectError: regexp.MustCompile(`error action metadata task`),
+			},
+			{
+				Config: testAccCatalogMetadataTaskAction_basic(name, currentTime),
+				Check: resource.ComposeTestCheckFunc(
+					rcActionTask.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccCatalogMetadataTaskAction_nonExistentMetadataTask() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_catalog_metadata_task_action" "non_existent_metadata_task" {
+  workspace_id = "%[1]s"
+  task_id      = "%[2]s"
+  action       = "run"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, randUUID)
+}
+
+func testAccCatalogMetadataTaskAction_basic_base(name, currentTime string) string {
+	return fmt.Sprintf(` 
+variable "data_connection_id" {
+  type    = string
+  default = "%[1]s"
+}
+
+resource "huaweicloud_dataarts_studio_data_connection" "test" {
+  count = var.data_connection_id == "" ? 1 : 0
+  
+  workspace_id = "%[2]s"
+  type         = "DLI"
+  name         = "%[3]s"
+  env_type     = 0
+  config       = jsonencode({
+    "cdmPropertyEnable"             = false
+    "metadata.collectionScope"      = ""
+    "metadata.enableAutoCollection" = false
+    "metadata.enableRealtimeSync"   = false
+  })
+  
+  lifecycle {
+    ignore_changes = [
+      config,
+    ]
+  }
+}
+  
+data "huaweicloud_dataarts_studio_data_connections" "test" {
+  workspace_id  = "%[2]s"
+  connection_id = var.data_connection_id != "" ? var.data_connection_id : huaweicloud_dataarts_studio_data_connection.test[0].id
+}
+
+resource "huaweicloud_dli_database" "test" {
+  name        = "%[3]s"
+  description = "Created by Terraform Script"
+}
+  
+resource "huaweicloud_dli_table" "test" {
+  database_name = huaweicloud_dli_database.test.name
+  name          = "%[3]s"
+  data_location = "DLI"
+  description   = "Created by Terraform Script"
+  
+  columns {
+    name = "name"
+    type = "string"
+  }
+  
+  columns {
+    name = "age"
+    type = "int"
+  }
+}
+  
+resource "huaweicloud_dataarts_catalog_metadata_task" "test" {
+  depends_on = [
+    huaweicloud_dli_database.test,
+    huaweicloud_dli_table.test,
+  ]
+
+  workspace_id = "%[2]s"
+  name         = "%[3]s"
+  dir_id       = "0"
+  
+  schedule_config {
+    cron_expression = "00 */15 9-23 * * ?"
+    max_time_out    = 60
+    end_time        = format("%%s +08", split("+", timeadd("%[4]s", "24h"))[0])
+    interval        = "15 minutes"
+    schedule_type   = "CRON"
+    start_time      = format("%%s +08", split("+", timeadd("%[4]s", "1h"))[0])
+    enabled         = 0
+  }
+  
+  data_source_type = "DLI"
+  task_config      = jsonencode({
+    data_connection_name        = try(data.huaweicloud_dataarts_studio_data_connections.test.connections[0].name, "")
+    data_connection_id          = try(data.huaweicloud_dataarts_studio_data_connections.test.connections[0].id, "")
+    data_connection_create_time = try(data.huaweicloud_dataarts_studio_data_connections.test.connections[0].create_timestamp, "")
+    databaseName                = [
+      huaweicloud_dli_database.test.name,
+    ]
+    tableName                   = [
+      format("%%s.%%s", huaweicloud_dli_database.test.name, huaweicloud_dli_table.test.name),
+    ]
+    alive_object_policy         = "3"
+    deleted_obkect_policy       = "1"
+    deleted_object_policy       = "10"
+    enableDataProfile           = true
+    enableDataClassification    = false
+    sampling                    = "10"
+    queue                       = "default"
+    unique                      = true
+  })
+  description      = "Created by terraform script"
+}
+`, acceptance.HW_DATAARTS_CONNECTION_ID, acceptance.HW_DATAARTS_WORKSPACE_ID, name, currentTime)
+}
+
+func testAccCatalogMetadataTaskAction_basic(name, currentTime string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_catalog_metadata_task_action" "run" {
+  workspace_id = "%[2]s"
+  task_id      = huaweicloud_dataarts_catalog_metadata_task.test.id
+  action       = "run"
+}
+
+resource "time_sleep" "wait_30_seconds" {
+  depends_on = [huaweicloud_dataarts_catalog_metadata_task_action.run]
+
+  create_duration = "30s"
+}
+
+resource "huaweicloud_dataarts_catalog_metadata_task_action" "stop" {
+  depends_on  = [time_sleep.wait_30_seconds]
+
+  workspace_id = "%[2]s"
+  task_id      = huaweicloud_dataarts_catalog_metadata_task.test.id
+  action       = "stop"
+}
+`, testAccCatalogMetadataTaskAction_basic_base(name, currentTime), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_catalog_metadata_task_action.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_catalog_metadata_task_action.go
@@ -1,0 +1,142 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var catalogMetadataTaskActionNonUpdatableParams = []string{
+	"workspace_id",
+	"task_id",
+	"action",
+}
+
+// @API DataArtsStudio POST /v3/{project_id}/metadata/tasks/{task_id}/action
+func ResourceCatalogMetadataTaskAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceMetadataTaskActionCreate,
+		ReadContext:   resourceMetadataTaskActionRead,
+		UpdateContext: resourceMetadataTaskActionUpdate,
+		DeleteContext: resourceMetadataTaskActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(catalogMetadataTaskActionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the metadata task is located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the metadata task belongs.`,
+			},
+			"task_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The task ID of the metadata task.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The action of the metadata task status flag.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func actionMetadataTask(client *golangsdk.ServiceClient, workspaceId, taskId, action string) error {
+	httpUrl := "v3/{project_id}/metadata/tasks/{task_id}/action"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{task_id}", taskId)
+	path = fmt.Sprintf(path+"?action=%s", action)
+
+	metadataTaskActionOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      bulidCatalogMoreHeaders(workspaceId),
+		OkCodes:          []int{200, 204},
+	}
+
+	_, err := client.Request("POST", path, &metadataTaskActionOpt)
+	return err
+}
+
+func resourceMetadataTaskActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		taskId      = d.Get("task_id").(string)
+		action      = d.Get("action").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	err = actionMetadataTask(client, workspaceId, taskId, action)
+	if err != nil {
+		return diag.Errorf("error action metadata task (%s): %s", taskId, err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(resourceId)
+
+	return resourceDataServiceApiActionRead(ctx, d, meta)
+}
+
+func resourceMetadataTaskActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// This resource is only a one-time action resource for run/runimmediate/stop the API.
+	// There is no API for the provider to query the history of this API action.
+	return nil
+}
+
+func resourceMetadataTaskActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceMetadataTaskActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	msg := `This resource is only a one-time action resource for operating a metadata task. Deleting this resource will not
+clear the corresponding request record, but will only remove the resource information from the tfstate file,
+but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  msg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a one-time action resource for metadata task
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
The coverage of acceptance test：
<img width="1049" height="72" alt="image" src="https://github.com/user-attachments/assets/755e20e8-c023-42e9-96da-471a8525131c" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a one-time action resource for metadata task，primarily for changing the status of metadata tasks, including running, starting, and stopping tasks.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccCatalogMetadataTaskAction_basic
--- PASS: TestAccCatalogMetadataTaskAction_basic (52.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  52.879s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
