### PR TITLE
feat(rfs): new resource to manage template version

### DIFF
--- a/docs/resources/rfs_template_version.md
+++ b/docs/resources/rfs_template_version.md
@@ -1,0 +1,90 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_template_version"
+description: |-
+  Manages a RFS template version resource within HuaweiCloud.
+---
+
+# huaweicloud_rfs_template_version
+
+Manages a RFS template version resource within HuaweiCloud.
+
+-> Template versions are immutable and append-only. Once a version is created, it cannot be modified.
+To update a template version, you must create a new version with the desired changes.
+
+## Example Usage
+
+```hcl
+variable "template_name" {} 
+variable "template_id" {} 
+variable "version_description" {}
+variable "template_body" {}
+
+resource "huaweicloud_rfs_template_version" "test" {
+  template_name       = var.template_name 
+  template_id         = var.template_id 
+  version_description = var.version_description 
+  template_body       = var.template_body
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource. If omitted, the
+  provider-level region will be used. Changing this will create a new resource.
+
+* `template_name` - (Required, String, NonUpdatable) Specifies the template name. The name must be unique and can
+  contain only letters, digits, hyphens (-), and underscores (_). This field refers to an existing template.
+
+* `template_id` - (Optional, String, NonUpdatable) Specifies the template ID used as a query parameter when creating
+  the version.
+
+* `template_body` - (Optional, String, NonUpdatable) Specifies the Terraform template body. This field
+  and `template_uri` are mutually exclusive, one of them must be specified. The template body must be a valid Terraform
+  configuration in HCL format.
+
+* `template_uri` - (Optional, String, NonUpdatable) Specifies the OBS URL where the Terraform template is stored. This
+  field and `template_body` are mutually exclusive, one of them must be specified. The corresponding file should be a
+  pure Terraform file or a ZIP archive:
+  + For pure Terraform files, the file name must end with `.tf` or `.tf.json` and comply with HCL syntax.
+  + For archives, only ZIP format is supported. The file name must end with `.zip`. After decompression, the archive
+    must not contain `.tfvars` files.
+
+* `version_description` - (Optional, String, NonUpdatable) Specifies the description of this template version.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also version ID).
+
+* `create_time` - The time when the template was created, in RFC3339 format (yyyy-mm-ddTHH:MM:SSZ),
+  such as **1970-01-01T00:00:00Z**.
+
+## Import
+
+The template version can be imported using their `template_name` and `id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_rfs_template_version.test <template_name>/<id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include `template_body`, `template_uri` and `version_description`. It is generally
+recommended running `terraform plan` after importing a resource. You can then decide if changes should be applied to the
+resource, or the resource definition should be updated to align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_rfs_template_version" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      template_body,
+      template_uri,
+      version_description,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2824,6 +2824,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rfs_stack":                       rfs.ResourceStack(),
 			"huaweicloud_rfs_template_analysis_variables": rfs.ResourceTemplateAnalysisVariables(),
 			"huaweicloud_rfs_template":                    rfs.ResourceRfsTemplate(),
+			"huaweicloud_rfs_template_version":            rfs.ResourceRfsTemplateVersion(),
 			"huaweicloud_rfs_private_provider":            rfs.ResourcePrivateProvider(),
 			"huaweicloud_rfs_stack_rollback":              rfs.ResourceStackRollback(),
 

--- a/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_template_version_test.go
+++ b/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_template_version_test.go
@@ -1,0 +1,156 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rfs"
+)
+
+func getRfsTemplateVersionResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region       = acceptance.HW_REGION_NAME
+		product      = "rfs"
+		templateName = state.Primary.Attributes["template_name"]
+		versionId    = state.Primary.ID
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RFS client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate RFS request ID: %s", err)
+	}
+
+	return rfs.QueryRfsTemplateVersion(client, templateName, versionId, requestId)
+}
+
+func TestAccRfsTemplateVersion_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		name         = acceptance.RandomAccResourceName()
+		rName        = "huaweicloud_rfs_template_version.test"
+		templateName = "huaweicloud_rfs_template.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRfsTemplateVersionResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testRfsTemplateVersion_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "template_name", templateName, "template_name"),
+					resource.TestCheckResourceAttrPair(rName, "template_id", templateName, "template_id"),
+					resource.TestCheckResourceAttr(rName, "version_description", "v2 - add subnet support"),
+					resource.TestCheckResourceAttrSet(rName, "create_time"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccRfsTemplateVersionImportStateIdFunc(rName),
+				ImportStateVerifyIgnore: []string{
+					"template_body",
+					"template_uri",
+					"version_description",
+				},
+			},
+		},
+	})
+}
+
+func testTemplateVersion_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rfs_template" "test" {
+  template_name        = "%s"
+  template_description = "base template for version test"
+  version_description  = "v1"
+  template_body        = <<-EOF
+variable "vpc_name" {
+  type    = string
+  default = "my-vpc"
+}
+
+resource "huaweicloud_vpc" "vpc" {
+  name = var.vpc_name
+  cidr = "172.16.0.0/16"
+}
+EOF
+}
+`, name)
+}
+
+func testRfsTemplateVersion_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_rfs_template_version" "test" {
+  template_name       = huaweicloud_rfs_template.test.template_name
+  template_id         = huaweicloud_rfs_template.test.template_id
+  version_description = "v2 - add subnet support"
+  template_body       = <<-EOF
+variable "vpc_name" {
+  type    = string
+  default = "my-vpc"
+}
+
+variable "subnet_name" {
+  type    = string
+  default = "my-subnet"
+}
+
+resource "huaweicloud_vpc" "vpc" {
+  name = var.vpc_name
+  cidr = "172.16.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "subnet" {
+  name       = var.subnet_name
+  vpc_id     = huaweicloud_vpc.vpc.id
+  cidr       = "172.16.1.0/24"
+  gateway_ip = "172.16.1.1"
+}
+EOF
+}
+`, testTemplateVersion_base(name))
+}
+
+func testAccRfsTemplateVersionImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", resourceName)
+		}
+
+		if rs.Primary.Attributes["template_name"] == "" {
+			return "", fmt.Errorf("attribute (template_name) of resource (%s) not found", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return "", fmt.Errorf("attribute (ID) of resource (%s) not found", resourceName)
+		}
+
+		return rs.Primary.Attributes["template_name"] + "/" + rs.Primary.ID, nil
+	}
+}

--- a/huaweicloud/services/rfs/resource_huaweicloud_rfs_template_version.go
+++ b/huaweicloud/services/rfs/resource_huaweicloud_rfs_template_version.go
@@ -1,0 +1,274 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS POST /v1/{project_id}/templates/{template_name}/versions
+// @API RFS GET /v1/{project_id}/templates/{template_name}/versions/{version_id}/metadata
+// @API RFS DELETE /v1/{project_id}/templates/{template_name}/versions/{version_id}
+func ResourceRfsTemplateVersion() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRfsTemplateVersionCreate,
+		UpdateContext: resourceRfsTemplateVersionUpdate,
+		ReadContext:   resourceRfsTemplateVersionRead,
+		DeleteContext: resourceRfsTemplateVersionDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceRfsTemplateVersionImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"template_name",
+			"template_body",
+			"template_uri",
+			"template_id",
+			"version_description",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"template_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"template_body": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"template_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"template_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"version_description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCreateRfsTemplateVersionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"version_description": utils.ValueIgnoreEmpty(d.Get("version_description")),
+		"template_body":       utils.ValueIgnoreEmpty(d.Get("template_body")),
+		"template_uri":        utils.ValueIgnoreEmpty(d.Get("template_uri")),
+	}
+
+	return bodyParams
+}
+
+func buildTemplateVersionQueryParams(templateId string) string {
+	if templateId == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("?template_id=%s", templateId)
+}
+
+func resourceRfsTemplateVersionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v1/{project_id}/templates/{template_name}/versions"
+		product      = "rfs"
+		templateName = d.Get("template_name").(string)
+		templateId   = d.Get("template_id").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request ID: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{template_name}", templateName)
+	createPath += buildTemplateVersionQueryParams(templateId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": requestId,
+			"Content-Type":      "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildCreateRfsTemplateVersionBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating RFS template version: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	versionId := utils.PathSearch("version_id", respBody, "").(string)
+	if versionId == "" {
+		return diag.Errorf("error creating RFS template version: version_id is not found in API response")
+	}
+	d.SetId(versionId)
+
+	return resourceRfsTemplateVersionRead(ctx, d, meta)
+}
+
+func QueryRfsTemplateVersion(client *golangsdk.ServiceClient, templateName, versionId, uuid string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/{project_id}/templates/{template_name}/versions/{version_id}/metadata"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{template_name}", templateName)
+	requestPath = strings.ReplaceAll(requestPath, "{version_id}", versionId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type":      "application/json",
+			"Client-Request-Id": uuid,
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceRfsTemplateVersionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		product      = "rfs"
+		templateName = d.Get("template_name").(string)
+		versionId    = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request ID: %s", err)
+	}
+
+	respBody, err := QueryRfsTemplateVersion(client, templateName, versionId, requestId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving RFS template version")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("template_name", utils.PathSearch("template_name", respBody, "")),
+		d.Set("template_id", utils.PathSearch("template_id", respBody, "")),
+		d.Set("create_time", utils.PathSearch("create_time", respBody, "")),
+		d.Set("version_description", utils.PathSearch("version_description", respBody, "")),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceRfsTemplateVersionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// Template versions are immutable and append-only.
+	return nil
+}
+
+func resourceRfsTemplateVersionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v1/{project_id}/templates/{template_name}/versions/{version_id}"
+		product      = "rfs"
+		templateName = d.Get("template_name").(string)
+		versionId    = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request ID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{template_name}", templateName)
+	requestPath = strings.ReplaceAll(requestPath, "{version_id}", versionId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": requestId,
+			"Content-Type":      "application/json",
+		},
+	}
+
+	_, err = client.Request("DELETE", requestPath, &opt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting RFS template version")
+	}
+
+	return nil
+}
+
+func resourceRfsTemplateVersionImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid import ID format, expected '<template_name>/<id>', but got: %s", d.Id())
+	}
+
+	templateName := parts[0]
+	versionId := parts[1]
+
+	d.SetId(versionId)
+
+	if err := d.Set("template_name", templateName); err != nil {
+		return nil, fmt.Errorf("error setting template_name during import: %s", err)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_template_version` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_template_version` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccRfsTemplateVersion_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs-v -run TestAccRfsTemplateVersion_basic -timeout 360m -parallel 4
=== RUN   TestAccRfsTemplateVersion_basic
=== PAUSE TestAccRfsTemplateVersion_basic
=== CONT  TestAccRfsTemplateVersion_basic
--- PASS: TestAccRfsTemplateVersion_basic (14.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       21.311s
```
<img width="674" height="38" alt="image" src="https://github.com/user-attachments/assets/9d34538c-04cd-4b80-ad86-465a67619420" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
   <img width="963" height="220" alt="image" src="https://github.com/user-attachments/assets/a7c70082-8750-45b5-8a54-5c30228c8622" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="977" height="324" alt="image" src="https://github.com/user-attachments/assets/0bc267bf-7032-412e-a865-c19f86043467" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
