### PR TITLE
feat(rfs): new resource to deploy stack set

### DIFF
--- a/docs/resources/rfs_stack_set_deployment.md
+++ b/docs/resources/rfs_stack_set_deployment.md
@@ -1,0 +1,238 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_stack_set_deployment"
+description: |-
+  Manages a resource to deploy stack set within HuaweiCloud.
+---
+
+# huaweicloud_rfs_stack_set_deployment
+
+Manages a resource to deploy stack set within HuaweiCloud.
+
+-> This resource is a one-time action resource used to trigger stack set deployment. Deleting this resource will
+  not cancel deployment operation, but will only remove resource information from tf state file.
+
+## Example Usage
+
+```hcl
+variable "stack_set_name" {}
+variable "region" {}
+variable "domain_id" {}
+
+resource "huaweicloud_rfs_stack_set_deployment" "test" {
+  stack_set_name = var.stack_set_name
+
+  deployment_targets {
+    regions    = [var.region]
+    domain_ids = [var.domain_id]
+  }
+
+  template_body = <<-EOT
+    resource "huaweicloud_vpc" "example" {
+      name = "example-vpc"
+      cidr = "192.168.0.0/16"
+    }
+  EOT
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `stack_set_name` - (Required, String, NonUpdatable) Specifies the name of the stack set.
+
+* `deployment_targets` - (Required, List, NonUpdatable) Specifies the deployment target information.
+
+  The [deployment_targets](#deployment_targets_struct) structure is documented below.
+
+* `stack_set_id` - (Optional, String, NonUpdatable) Specifies the unique ID of the stack set.
+  For parallel development in a team, users may want to ensure that the stack set they operate is the one created by
+  themselves, not the one with the same name created by other teammates after deleting the previous one.
+  Therefore, they can use this ID for strong matching.
+  RFS ensures that the ID of each stack set is different and does not change with updates. If the `stack_set_id` value
+  is different from the current stack set ID, `400` is returned.
+
+* `template_body` - (Optional, String, NonUpdatable) Specifies the HCL template that describes the target state of
+  resources. The resource orchestration service will compare the differences between this template and the current
+  remote resource state.
+
+* `template_uri` - (Optional, String, NonUpdatable) Specifies the OBS address of an HCL template. The template describes
+  the target status of a resource. RFS compares the difference between the statuses of this template and the current
+  remote resource. Ensure that the OBS address is located in the same region as the RFS.
+  The corresponding file must be a tf file or a zip package.
+  A ".tf" file must be named with a ".tf" or ".tf.json" suffix, compatible with HCL, and UTF-8 encoded.
+  Currently, only the ".zip" package is supported. The file name extension must be ".zip". The decompressed files cannot
+  contain ".tfvars" files. The maximum size of the file is `1` MB before decompression and `1` MB after decompression.
+  A maximum of `100` files can be archived to one ".zip" package.
+
+-> Either `template_body` or `template_uri` must be specified, but not both.
+
+* `vars_uri` - (Optional, String, NonUpdatable) Specifies the OBS address of the HCL parameter file.
+  Transferring parameters is supported by the HCL template.
+  The same template can use different parameters for different purposes.
+  + The value of `vars_uri` needs to point to a pre-signed URL address of OBS; other addresses are not currently supported.
+  + The resource orchestration service supports both `vars_body` and `vars_uri`. If the same variable is declared using
+    either of these methods, a `400` error will occur.
+  + The content in `vars_uri` uses HCL's tfvars format. Users can save the content in ".tfvars" to a file and upload it
+    to OBS, passing the OBS pre-signed URL to `vars_uri`.
+  + The resource stack does not support encryption of sensitive data; the resource orchestration service will directly
+    use, log, display, and store the parameter file content corresponding to `vars_uri` in plaintext.
+
+* `vars_body` - (Optional, String, NonUpdatable) Specifies the content of the HCL variable file. Transferring parameters
+  is supported by the HCL template. The same template can use different parameters for different purposes.
+  + The `vars_body` uses the tfvars format of HCL. You can submit the content in the ".tfvars" file to the `vars_body`.
+  + RFS supports `vars_structure`, `vars_body`, and `vars_uri`. If they declare the same variable, error `400` will be
+    reported.
+  + If `vars_body` is too large, you can use `vars_uri`.
+  + Stack sets do not encrypt sensitive data. RFS uses logs, displays, and stores `vars_body` as plaintext.
+
+-> Either `vars_body` or `vars_uri` can be specified, but not both.
+
+* `operation_preferences` - (Optional, List, NonUpdatable) Specifies the user-specified preferences for how to perform
+  a stack set operation. This parameter takes effect only in a specified single operation.
+  If this parameter is not specified, the default operation preferences is that only one stack is deployed at a time and
+  after all stack instances in a region are deployed completely, the next region will be selected randomly for deployment.
+  The default value of failure tolerance count in a region is `0`.
+
+  The [operation_preferences](#operation_preferences_struct) structure is documented below.
+
+* `call_identity` - (Optional, String, NonUpdatable) Specifies the call identity. The parameter is only supported when
+  the stack set permission model is **SERVICE_MANAGED**. Specify whether you are acting as an account administrator in
+  the organization's management account or as a delegated administrator in a member account. Defaults to **SELF**.
+  When the resource stack permission mode is **SELF_MANAGED**, defaults to **SELF**.
+  No matter what call identity is specified, the stack set involved in request is always belonging to management account.
+  Valid values are:
+  + **SELF**: Call as organization management account.
+  + **DELEGATED_ADMIN**: Call as service delegated administrator.
+
+<a name="deployment_targets_struct"></a>
+The `deployment_targets` block supports:
+
+* `regions` - (Required, List of String, NonUpdatable) Specifies the list of regions involved in the stack set operation.
+  Stack instances in the stack set are selected for deployment. This operation applies to the Cartesian product of
+  the `regions` and `domain_ids` input by the user. If a region that is not managed by the stack set is specified,
+  an error is reported.
+
+* `domain_ids` - (Optional, List of String, NonUpdatable) Specifies the list of tenant IDs involved in the operation.
+  Stack instances in the stack set are selected for deployment. This operation applies to the Cartesian product of
+  the `regions` and `domain_ids` input by the user. If a `domain_id` that is not managed by the stack set is specified,
+  an error is reported. When the stack set permission model is **SERVICE_MANAGED**, this parameter needs to be used with
+  `domain_id_filter_type`. It's used to specify, exclude or additionally deploy the domain IDs of member accounts from
+  the organizational units in the deployment target.
+
+* `domain_ids_uri` - (Optional, String, NonUpdatable) Specifies the OBS address of the file containing tenant IDs.
+  Tenant IDs are separated by commas (,) and line breaks are supported. Currently, only CSV files are supported, and the
+  files should be encoded in UTF-8. The file size cannot exceed `100` KB.
+  Do not use Excel for operations on the CSV file to be uploaded. Otherwise, inconsistencies may occur in results read
+  from the CSV file. You are advised to use Notepad to open the file and check whether the content complies with your
+  expectation.
+  If this parameter is specified in the DeployStackSet API, stack instances in the stack set are selected for deployment.
+  This operation applies to the Cartesian product of the `domain_ids_uri` file and regions input by the user.
+  If a `domain_id` that is not managed by the stack set is specified, an error is reported.
+  When the stack set permission model is **SERVICE_MANAGED**, this parameter needs to be used with `domain_id_filter_type`.
+  Used to specify, exclude or additionally deploy the domain IDs of member accounts from the organizational units in
+  the deployment target.
+
+  -> Either `domain_ids` or `domain_ids_uri` must be specified, but not both.
+
+* `organizational_unit_ids` - (Optional, List of String, NonUpdatable) Specifies the list of organizational unit IDs.
+  This parameter is only allowed to be specified when the stack set permission model is **SERVICE_MANAGED**.
+  The list of `organizational_unit_ids`, it can be the root organization (Root) ID or the ID of organizational units.
+  Only OU IDs that have been managed by the resource stack set are allowed to be specified. If you specify OU IDs that
+  are not managed by the resource stack set records, an error will be reported.
+
+* `domain_id_filter_type` - (Optional, String, NonUpdatable) Specifies the domain IDs filter type. This parameter is only
+  supported when stack set permission model is **SERVICE_MANAGED**. Defaults to **NONE**.
+  Valid values are:
+  + **INTERSECTION**: Select specified accounts from the OUs in deployment target for deployment. You can specify either
+    `domain_ids` or `domain_ids_uri`, but not both.
+  + **DIFFERENCE**: Exclude specified accounts from the OUs in deployment target for deployment. You can specify either
+    `domain_ids` or `domain_ids_uri`, but not both.
+  + **UNION**: In addition to deploy all accounts from the OUs in deployment target, it will also deploy to the specified
+    account. Users can deploy the OU and specific individual accounts in stack set operation by specifying both
+    `organizational_unit_ids` and `domain_ids`/`domain_ids_uri`. You can specify either `domain_ids` or `domain_ids_uri`,
+    but not both. CreateStackInstances does not allow using this type.
+  + **NONE**: Only deploy to all accounts from the OUs in deployment target. You can not specify `domain_ids` or
+    `domain_ids_uri`.
+
+<a name="operation_preferences_struct"></a>
+The `operation_preferences` block supports:
+
+* `region_concurrency_type` - (Optional, String, NonUpdatable) Specifies the concurrency type of deploying stack
+  instances in regions. The value is case-sensitive.
+  Valid values are:
+  + **SEQUENTIAL**: Stack instances are deployed in sequence among regions, that is, after all stack instances in a
+    region are deployed completely, the next region will be selected for deployment.
+  + **PARALLEL**: Stack instances are deployed in all specified regions concurrently.
+
+* `region_order` - (Optional, List of String, NonUpdatable) Specifies the region deployment order. This parameter can be
+  specified only when `region_concurrency_type` is set to **SEQUENTIAL**. The `region_order` must only contain all
+  regions in this deployment target. If this parameter is not specified, the region deployment order is random.
+  The `region_order` takes effect only during a specified single operation.
+
+* `failure_tolerance_count` - (Optional, Int, NonUpdatable) Specifies the maximum number of failed stack instances in
+  a region. The value must be `0` or a positive integer. Defaults to `0`.
+  If the value of `region_concurrency_type` is **SEQUENTIAL**, when the number of stack instances that deploy failed in
+  a region exceeds the `failure_tolerance_count`, all other instances that are still in **WAIT_IN_PROGRESS** status will
+  be canceled. The status of the canceled instance changes to **CANCEL_COMPLETE**.
+  If the value of `region_concurrency_type` is **PARALLEL**, when the number of stack instances that deploy failed in
+  a region exceeds the `failure_tolerance_count`, the stack set only cancels all instances that are still in
+  **WAIT_IN_PROGRESS** status in this region. The status of the canceled instance changes to **CANCEL_COMPLETE**.
+  Stack instances that are in **OPERATION_IN_PROGRESS** status or have been deployed
+  (that is, in **OPERATION_COMPLETE** or **OPERATION_FAILED** status) are not affected.
+
+* `failure_tolerance_percentage` - (Optional, Int, NonUpdatable) Specifies the maximum percentage of failed stack
+  instances in a region. The value must be `0` or a positive integer. Defaults to `0`.
+  By multiplying the `failure_tolerance_percentage` by the number of stack instances in the region and rounding it down,
+  the actual number of failure tolerance count can be obtained.
+
+-> Either `failure_tolerance_count` or `failure_tolerance_percentage` can be specified, but not both.
+
+* `max_concurrent_count` - (Optional, Int, NonUpdatable) Specifies the maximum number of concurrent accounts can be
+  deployed in a region. The value must be a positive integer. The default value is `1`.
+  `max_concurrent_count` is at most one more than the failure tolerance count. If `failure_tolerance_percentage` is
+  specified, `max_concurrent_count` is at most one more than the result of `failure_tolerance_percentage` multiplied by
+  the number of stack instances in a region to guarantee that the deployment stops at the required level of failure
+  tolerance.
+
+* `max_concurrent_percentage` - (Optional, Int, NonUpdatable) Specifies the maximum percentage of concurrent accounts
+  can be deployed in a region. The value must be a positive integer. The default value is `1`.
+  The RFS calculates the actual maximum number of concurrent accounts by rounding down the value obtained by multiplying
+  the percentage by the number of stack instances in each region.
+  This actual maximum number of concurrent accounts is at most one more than the failure tolerance count.
+  If `failure_tolerance_percentage` is specified, this actual maximum number of concurrent accounts is at most one more
+  than the result of `failure_tolerance_percentage` multiplied by the number of stack instances in a region to guarantee
+  that the deployment stops at the required level of failure tolerance.
+
+-> Either `max_concurrent_count` or `max_concurrent_percentage` can be specified, but not both.
+
+* `failure_tolerance_mode` - (Optional, String, NonUpdatable) Specifies the failure tolerance mode of deploying stack
+  instances in regions. The value can be **STRICT_FAILURE_TOLERANCE** or **SOFT_FAILURE_TOLERANCE**.
+  Defaults to **STRICT_FAILURE_TOLERANCE**. The value is case-sensitive.
+  Detailed introduction:
+  + **STRICT_FAILURE_TOLERANCE**: This option dynamically lowers the concurrency level to ensure the number of failed
+    stack instances never exceeds the value of failure_tolerance_count + `1`. If failure_tolerance_percentage is specified,
+    this option ensures the number of failed stack instances never exceeds the result of failure_tolerance_percentage
+    multiplied by the number of stack instances in a region.
+  + The initial actual maximum number of concurrent accounts is max_concurrent_count. If `max_concurrent_percentage` is
+    specified, the initial actual maximum number of concurrent accounts is the result of `max_concurrent_percentage`
+    multiplied by the number of stack instances. The actual maximum number of concurrent accounts is then reduced
+    proportionally by the number of failed stack instances.
+  + **SOFT_FAILURE_TOLERANCE**: This option separates `failure_tolerance_count` (`failure_tolerance_percentage`) from
+    the actual maximum number of concurrent accounts. This option allows actual maximum number of concurrent accounts
+    to keep at the concurrency level set by the `max_concurrent_count`, or `max_concurrent_percentage`.
+  + This option does not ensure the number of failed stack instances is less than failure_tolerance_count + `1`.
+    If `failure_tolerance_percentage` is specified, this option does not ensure the number of failed stack instances is
+    less than the result of `max_concurrent_percentage` multiplied by the number of stack instances.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the stack set operation ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2822,6 +2822,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rfs_template":                    rfs.ResourceRfsTemplate(),
 			"huaweicloud_rfs_private_provider":            rfs.ResourcePrivateProvider(),
 			"huaweicloud_rfs_stack_rollback":              rfs.ResourceStackRollback(),
+			"huaweicloud_rfs_stack_set_deployment":        rfs.ResourceStackSetDeployment(),
 
 			"huaweicloud_api_gateway_api":         apigateway.ResourceAPI(),
 			"huaweicloud_api_gateway_environment": apigateway.ResourceEnvironment(),

--- a/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_stack_set_deployment_test.go
+++ b/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_stack_set_deployment_test.go
@@ -1,0 +1,47 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccStackSetDeployment_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDomainId(t)
+			acceptance.TestAccPreCheckRfsStackSetName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStackSetDeployment_basic(),
+			},
+		},
+	})
+}
+
+func testAccStackSetDeployment_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rfs_stack_set_deployment" "test" {
+  stack_set_name = "%[1]s"
+  
+  deployment_targets {
+    regions    = ["%[2]s"]
+    domain_ids = ["%[3]s"]
+  }
+
+  template_body = <<-EOT
+    resource "huaweicloud_vpc" "example" {
+      name = "example-vpc"
+      cidr = "192.168.0.0/16"
+    }
+  EOT
+}
+`, acceptance.HW_RFS_STACK_SET_NAME, acceptance.HW_REGION_NAME, acceptance.HW_DOMAIN_ID)
+}

--- a/huaweicloud/services/rfs/resource_huaweicloud_rfs_stack_set_deployment.go
+++ b/huaweicloud/services/rfs/resource_huaweicloud_rfs_stack_set_deployment.go
@@ -1,0 +1,307 @@
+package rfs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var stackSetDeploymentNonUpdatableParams = []string{
+	"stack_set_name",
+	"deployment_targets",
+	"deployment_targets.*.regions",
+	"deployment_targets.*.domain_ids",
+	"deployment_targets.*.domain_ids_uri",
+	"deployment_targets.*.organizational_unit_ids",
+	"deployment_targets.*.domain_id_filter_type",
+	"stack_set_id",
+	"template_body",
+	"template_uri",
+	"vars_uri",
+	"vars_body",
+	"operation_preferences",
+	"operation_preferences.*.region_concurrency_type",
+	"operation_preferences.*.region_order",
+	"operation_preferences.*.failure_tolerance_count",
+	"operation_preferences.*.failure_tolerance_percentage",
+	"operation_preferences.*.max_concurrent_count",
+	"operation_preferences.*.max_concurrent_percentage",
+	"operation_preferences.*.failure_tolerance_mode",
+	"call_identity",
+}
+
+// @API RFS POST /v1/stack-sets/{stack_set_name}/deployments
+func ResourceStackSetDeployment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStackSetDeploymentCreate,
+		ReadContext:   resourceStackSetDeploymentRead,
+		UpdateContext: resourceStackSetDeploymentUpdate,
+		DeleteContext: resourceStackSetDeploymentDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(stackSetDeploymentNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"stack_set_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"deployment_targets": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem:     deploymentTargetsSchema(),
+			},
+			"stack_set_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"template_body": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"template_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vars_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vars_body": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"operation_preferences": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     operationPreferencesSchema(),
+			},
+			"call_identity": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func operationPreferencesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"region_concurrency_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"region_order": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"failure_tolerance_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"failure_tolerance_percentage": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_concurrent_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_concurrent_percentage": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"failure_tolerance_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func deploymentTargetsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"regions": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"domain_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"domain_ids_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"organizational_unit_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"domain_id_filter_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func buildStackSetDeploymentBodyParams(d *schema.ResourceData) map[string]interface{} {
+	body := map[string]interface{}{
+		"deployment_targets":    buildDeploymentTargetsParams(d.Get("deployment_targets").([]interface{})),
+		"stack_set_id":          utils.ValueIgnoreEmpty(d.Get("stack_set_id")),
+		"template_body":         utils.ValueIgnoreEmpty(d.Get("template_body")),
+		"template_uri":          utils.ValueIgnoreEmpty(d.Get("template_uri")),
+		"vars_uri":              utils.ValueIgnoreEmpty(d.Get("vars_uri")),
+		"vars_body":             utils.ValueIgnoreEmpty(d.Get("vars_body")),
+		"operation_preferences": buildOperationPreferencesParams(d.Get("operation_preferences").([]interface{})),
+		"call_identity":         utils.ValueIgnoreEmpty(d.Get("call_identity")),
+	}
+
+	return body
+}
+
+func buildStringListParams(rawArray []interface{}) interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	return rawArray
+}
+
+func buildDeploymentTargetsParams(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"regions":                 rawMap["regions"],
+		"domain_ids":              buildStringListParams(rawMap["domain_ids"].([]interface{})),
+		"domain_ids_uri":          utils.ValueIgnoreEmpty(rawMap["domain_ids_uri"]),
+		"organizational_unit_ids": buildStringListParams(rawMap["organizational_unit_ids"].([]interface{})),
+		"domain_id_filter_type":   utils.ValueIgnoreEmpty(rawMap["domain_id_filter_type"]),
+	}
+}
+
+func buildOperationPreferencesParams(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"region_concurrency_type":      utils.ValueIgnoreEmpty(rawMap["region_concurrency_type"]),
+		"region_order":                 buildStringListParams(rawMap["region_order"].([]interface{})),
+		"failure_tolerance_count":      utils.ValueIgnoreEmpty(rawMap["failure_tolerance_count"]),
+		"failure_tolerance_percentage": utils.ValueIgnoreEmpty(rawMap["failure_tolerance_percentage"]),
+		"max_concurrent_count":         utils.ValueIgnoreEmpty(rawMap["max_concurrent_count"]),
+		"max_concurrent_percentage":    utils.ValueIgnoreEmpty(rawMap["max_concurrent_percentage"]),
+		"failure_tolerance_mode":       utils.ValueIgnoreEmpty(rawMap["failure_tolerance_mode"]),
+	}
+}
+
+func resourceStackSetDeploymentCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		stackSetName = d.Get("stack_set_name").(string)
+		httpUrl      = "v1/stack-sets/{stack_set_name}/deployments"
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate UUID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{stack_set_name}", stackSetName)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": requestId,
+		},
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildStackSetDeploymentBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error triggering RFS stack set deployment: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	operationId := utils.PathSearch("stack_set_operation_id", respBody, "").(string)
+	if operationId == "" {
+		return diag.Errorf("error triggering RFS stack set deployment: Operation ID is not found in API response")
+	}
+
+	d.SetId(operationId)
+
+	return nil
+}
+
+func resourceStackSetDeploymentRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Read()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceStackSetDeploymentUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Update()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceStackSetDeploymentDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to trigger stack set deployment. Deleting this resource
+    will not cancel the deployment operation, but will only remove resource information from
+    tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to deploy stack set

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o rfs -f TestAccStackSetDeployment_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rfs" -v -coverprofile="./huaweicloud/services/acceptance/rfs/rfs_coverage.cov" -coverpkg="./huaweicloud/services/rfs" -run TestAccStackSetDeployment_basic -timeout 360m -parallel 10
=== RUN   TestAccStackSetDeployment_basic
=== PAUSE TestAccStackSetDeployment_basic
=== CONT  TestAccStackSetDeployment_basic
--- PASS: TestAccStackSetDeployment_basic (16.72s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/rfs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       16.820s coverage: 5.2% of statements in ./huaweicloud/services/rfs
```
<img width="1276" height="75" alt="image" src="https://github.com/user-attachments/assets/55844af7-96b2-471e-96ba-517c469f5f84" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
