### PR TITLE
feat(dataarts): data recognition rule supports switch enable status

### DIFF
--- a/docs/resources/dataarts_security_data_recognition_rule.md
+++ b/docs/resources/dataarts_security_data_recognition_rule.md
@@ -110,6 +110,8 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of data recognition rule.
 
+* `enable` - (Optional, Bool) Specifies whether the current data recognition rule is available.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -128,8 +130,6 @@ In addition to all arguments above, the following attributes are exported:
 * `secrecy_level_num` - The level of data secrecy.The larger the secrecy level number,
   the higher the secrecy level. Currently, a maximum of 10 levels of confidentiality can be created.
   It corresponds to `secrecy_level_id` one-to-one.
-
-* `enable` - Whether the current data recognition rule is available.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -679,12 +679,6 @@ var (
 	HW_DATAARTS_CDM_NAME                                   = os.Getenv("HW_DATAARTS_CDM_NAME")
 	HW_DATAARTS_MANAGER_ID                                 = os.Getenv("HW_DATAARTS_MANAGER_ID")
 	HW_DATAARTS_BIZ_CATALOG_ID                             = os.Getenv("HW_DATAARTS_BIZ_CATALOG_ID")
-	HW_DATAARTS_SECRECY_LEVEL_ID                           = os.Getenv("HW_DATAARTS_SECRECY_LEVEL_ID")
-	HW_DATAARTS_SECRECY_LEVEL_ID_UPDATE                    = os.Getenv("HW_DATAARTS_SECRECY_LEVEL_ID_UPDATE")
-	HW_DATAARTS_CATEGORY_ID                                = os.Getenv("HW_DATAARTS_CATEGORY_ID")
-	HW_DATAARTS_CATEGORY_ID_UPDATE                         = os.Getenv("HW_DATAARTS_CATEGORY_ID_UPDATE")
-	HW_DATAARTS_BUILTIN_RULE_ID                            = os.Getenv("HW_DATAARTS_BUILTIN_RULE_ID")
-	HW_DATAARTS_BUILTIN_RULE_NAME                          = os.Getenv("HW_DATAARTS_BUILTIN_RULE_NAME")
 	HW_DATAARTS_SUBJECT_ID                                 = os.Getenv("HW_DATAARTS_SUBJECT_ID")
 	HW_DATAARTS_ARCHITECTURE_USER_ID                       = os.Getenv("HW_DATAARTS_ARCHITECTURE_USER_ID")
 	HW_DATAARTS_ARCHITECTURE_USER_NAME                     = os.Getenv("HW_DATAARTS_ARCHITECTURE_USER_NAME")
@@ -697,6 +691,10 @@ var (
 	HW_DATAARTS_REVIEWER_NAME       = os.Getenv("HW_DATAARTS_REVIEWER_NAME")
 	HW_DATAARTS_DLI_QUEUE_NAME      = os.Getenv("HW_DATAARTS_DLI_QUEUE_NAME")
 	HW_DATAARTS_INSTANCE_ID_IN_APIG = os.Getenv("HW_DATAARTS_INSTANCE_ID_IN_APIG")
+	// Security
+	HW_DATAARTS_SECURITY_DATA_CATEGORY_IDS             = os.Getenv("HW_DATAARTS_SECURITY_DATA_CATEGORY_IDS")
+	HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_ID   = os.Getenv("HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_ID")
+	HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_NAME = os.Getenv("HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_NAME")
 
 	HW_ER_SHARED_INSTANCE_ID   = os.Getenv("HW_ER_SHARED_INSTANCE_ID")
 	HW_ER_SHARED_ATTACHMENT_ID = os.Getenv("HW_ER_SHARED_ATTACHMENT_ID")
@@ -3985,20 +3983,16 @@ func TestAccPreCheckDataArtsCdmName(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckDataArtsDataClassificationID(t *testing.T) {
-	if HW_DATAARTS_SECRECY_LEVEL_ID == "" || HW_DATAARTS_SECRECY_LEVEL_ID_UPDATE == "" {
-		t.Skip("HW_DATAARTS_SECRECY_LEVEL_ID and HW_DATAARTS_SECRECY_LEVEL_ID_UPDATE must be set for the acceptance test")
-	}
-
-	if HW_DATAARTS_CATEGORY_ID == "" || HW_DATAARTS_CATEGORY_ID_UPDATE == "" {
-		t.Skip("HW_DATAARTS_CATEGORY_ID and HW_DATAARTS_CATEGORY_ID_UPDATE must be set for the acceptance test")
+func TestAccPreCheckDataArtsSecurityDataCategoryIds(t *testing.T, n int) {
+	if HW_DATAARTS_SECURITY_DATA_CATEGORY_IDS == "" || len(strings.Split(HW_DATAARTS_SECURITY_DATA_CATEGORY_IDS, ",")) < n {
+		t.Skipf("at lease %d category ID(s) for HW_DATAARTS_SECURITY_DATA_CATEGORY_IDS must be set, separated by the comma (,) character", n)
 	}
 }
 
 // lintignore:AT003
 func TestAccPreCheckDataArtsBuiltinRule(t *testing.T) {
-	if HW_DATAARTS_BUILTIN_RULE_ID == "" || HW_DATAARTS_BUILTIN_RULE_NAME == "" {
-		t.Skip("HW_DATAARTS_BUILTIN_RULE_ID and HW_DATAARTS_BUILTIN_RULE_NAME must be set for the acceptance test")
+	if HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_ID == "" || HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_NAME == "" {
+		t.Skip("HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_ID and HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_NAME must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getSecurityRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getSecurityDataRecognitionRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	getRuleClient, err := conf.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DataArts Studio V1 client: %s", err)
@@ -38,37 +38,36 @@ func getSecurityRuleResourceFunc(conf *config.Config, state *terraform.ResourceS
 	return utils.FlattenResponse(getRuleResp)
 }
 
-func TestAccResourceSecurityRule_custom(t *testing.T) {
-	var obj interface{}
-	resourceName := "huaweicloud_dataarts_security_data_recognition_rule.test"
-	rName := acceptance.RandomAccResourceName()
+func TestAccSecurityDataRecognitionRule_custom(t *testing.T) {
+	var (
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&obj,
-		getSecurityRuleResourceFunc,
+		resourceName = "huaweicloud_dataarts_security_data_recognition_rule.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getSecurityDataRecognitionRuleResourceFunc)
+
+		name = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
-			acceptance.TestAccPreCheckDataArtsDataClassificationID(t)
+			acceptance.TestAccPreCheckDataArtsSecurityDataCategoryIds(t, 2)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityRule_custom(rName),
+				Config: testAccSecurityDataRecognitionRule_custom_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "rule_type", "CUSTOM"),
 					resource.TestCheckResourceAttr(resourceName, "method", "NONE"),
-					resource.TestCheckResourceAttr(resourceName, "category_id", acceptance.HW_DATAARTS_CATEGORY_ID),
+					resource.TestCheckResourceAttrSet(resourceName, "category_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "secrecy_level"),
 					resource.TestCheckResourceAttrSet(resourceName, "secrecy_level_num"),
-					resource.TestCheckResourceAttrSet(resourceName, "enable"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
@@ -76,20 +75,20 @@ func TestAccResourceSecurityRule_custom(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSecurityRule_custom_update1(rName),
+				Config: testAccSecurityDataRecognitionRule_custom_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "rule_type", "CUSTOM"),
 					resource.TestCheckResourceAttr(resourceName, "method", "REGULAR"),
-					resource.TestCheckResourceAttr(resourceName, "category_id", acceptance.HW_DATAARTS_CATEGORY_ID_UPDATE),
+					resource.TestCheckResourceAttrSet(resourceName, "category_id"),
 					resource.TestCheckResourceAttr(resourceName, "content_expression", "^male$|^female&"),
 					resource.TestCheckResourceAttr(resourceName, "column_expression", "phoneNumber|email"),
 					resource.TestCheckResourceAttr(resourceName, "comment_expression", ".*comment*."),
 					resource.TestCheckResourceAttr(resourceName, "description", "rule_description_custom_update1"),
 					resource.TestCheckResourceAttrSet(resourceName, "secrecy_level"),
 					resource.TestCheckResourceAttrSet(resourceName, "secrecy_level_num"),
-					resource.TestCheckResourceAttrSet(resourceName, "enable"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
@@ -97,20 +96,20 @@ func TestAccResourceSecurityRule_custom(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSecurityRule_custom_update2(rName),
+				Config: testAccSecurityDataRecognitionRule_custom_step3(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "rule_type", "CUSTOM"),
 					resource.TestCheckResourceAttr(resourceName, "method", "REGULAR"),
-					resource.TestCheckResourceAttr(resourceName, "category_id", acceptance.HW_DATAARTS_CATEGORY_ID),
+					resource.TestCheckResourceAttrSet(resourceName, "category_id"),
 					resource.TestCheckResourceAttr(resourceName, "content_expression", "^boy$|^girl&"),
 					resource.TestCheckResourceAttr(resourceName, "column_expression", "sex|gender"),
 					resource.TestCheckResourceAttr(resourceName, "comment_expression", ".*commentUpdate*."),
 					resource.TestCheckResourceAttr(resourceName, "description", "rule_description_custom_update2"),
 					resource.TestCheckResourceAttrSet(resourceName, "secrecy_level"),
 					resource.TestCheckResourceAttrSet(resourceName, "secrecy_level_num"),
-					resource.TestCheckResourceAttrSet(resourceName, "enable"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
@@ -128,34 +127,105 @@ func TestAccResourceSecurityRule_custom(t *testing.T) {
 	})
 }
 
-func TestAccResourceSecurityRule_builtin(t *testing.T) {
-	var obj interface{}
-	resourceName := "huaweicloud_dataarts_security_data_recognition_rule.test"
+func testAccSecurityDataRecognitionRule_base(name string) string {
+	return fmt.Sprintf(`
+locals {
+  category_ids = try(split(",", "%[1]s"), [])
+}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&obj,
-		getSecurityRuleResourceFunc,
+resource "huaweicloud_dataarts_security_data_secrecy_level" "test" {
+  count = 2
+
+  workspace_id = "%[2]s"
+  name         = format("%[3]s_%%d", count.index) 
+}
+`, acceptance.HW_DATAARTS_SECURITY_DATA_CATEGORY_IDS, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccSecurityDataRecognitionRule_custom_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
+  workspace_id     = "%[2]s"
+  rule_type        = "CUSTOM"
+  name             = "%[3]s"
+  secrecy_level_id = huaweicloud_dataarts_security_data_secrecy_level.test[0].id
+  category_id      = local.category_ids[0]
+  method           = "NONE"
+}
+`, testAccSecurityDataRecognitionRule_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccSecurityDataRecognitionRule_custom_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
+  workspace_id       = "%[2]s"
+  rule_type          = "CUSTOM"
+  name               = "%[3]s"
+  secrecy_level_id   = huaweicloud_dataarts_security_data_secrecy_level.test[1].id
+  category_id        = local.category_ids[1]
+  method             = "REGULAR"
+  content_expression = "^male$|^female&"
+  column_expression  = "phoneNumber|email"
+  comment_expression = ".*comment*."
+  description        = "rule_description_custom_update1"
+  enable             = false
+}
+`, testAccSecurityDataRecognitionRule_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccSecurityDataRecognitionRule_custom_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
+  workspace_id       = "%[2]s"
+  rule_type          = "CUSTOM"
+  name               = "%[3]s"
+  secrecy_level_id   = huaweicloud_dataarts_security_data_secrecy_level.test[0].id
+  category_id        = local.category_ids[0]
+  method             = "REGULAR"
+  content_expression = "^boy$|^girl&"
+  column_expression  = "sex|gender"
+  comment_expression = ".*commentUpdate*."
+  description        = "rule_description_custom_update2"
+  enable             = true
+}
+`, testAccSecurityDataRecognitionRule_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func TestAccSecurityDataRecognitionRule_builtin(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_dataarts_security_data_recognition_rule.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getSecurityDataRecognitionRuleResourceFunc)
+
+		name = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
-			acceptance.TestAccPreCheckDataArtsDataClassificationID(t)
+			acceptance.TestAccPreCheckDataArtsSecurityDataCategoryIds(t, 2)
 			acceptance.TestAccPreCheckDataArtsBuiltinRule(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecurityRule_builtin(),
+				Config: testAccSecurityDataRecognitionRule_builtin_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_DATAARTS_BUILTIN_RULE_NAME),
-					resource.TestCheckResourceAttr(resourceName, "builtin_rule_id", acceptance.HW_DATAARTS_BUILTIN_RULE_ID),
 					resource.TestCheckResourceAttr(resourceName, "rule_type", "BUILTIN"),
-					resource.TestCheckResourceAttr(resourceName, "category_id", acceptance.HW_DATAARTS_CATEGORY_ID),
+					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_NAME),
+					resource.TestCheckResourceAttr(resourceName, "builtin_rule_id", acceptance.HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_ID),
+					resource.TestCheckResourceAttrSet(resourceName, "secrecy_level_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "category_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "secrecy_level"),
 					resource.TestCheckResourceAttrSet(resourceName, "secrecy_level_num"),
 					resource.TestCheckResourceAttrSet(resourceName, "enable"),
@@ -166,14 +236,14 @@ func TestAccResourceSecurityRule_builtin(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSecurityRule_builtin_update(),
+				Config: testAccSecurityDataRecognitionRule_builtin_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(resourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "rule_type", "BUILTIN"),
-					resource.TestCheckResourceAttr(resourceName, "builtin_rule_id", acceptance.HW_DATAARTS_BUILTIN_RULE_ID),
-					resource.TestCheckResourceAttr(resourceName, "secrecy_level_id", acceptance.HW_DATAARTS_SECRECY_LEVEL_ID_UPDATE),
-					resource.TestCheckResourceAttr(resourceName, "category_id", acceptance.HW_DATAARTS_CATEGORY_ID_UPDATE),
+					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_NAME),
+					resource.TestCheckResourceAttr(resourceName, "builtin_rule_id", acceptance.HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_ID),
+					resource.TestCheckResourceAttrSet(resourceName, "secrecy_level_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "category_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "secrecy_level"),
 					resource.TestCheckResourceAttrSet(resourceName, "secrecy_level_num"),
 					resource.TestCheckResourceAttrSet(resourceName, "enable"),
@@ -187,78 +257,35 @@ func TestAccResourceSecurityRule_builtin(t *testing.T) {
 	})
 }
 
-func testAccSecurityRule_custom(name string) string {
+func testAccSecurityDataRecognitionRule_builtin_step1(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
-  workspace_id     = "%[1]s"
-  rule_type        = "CUSTOM"
-  name             = "%[2]s"
-  secrecy_level_id = "%[3]s"
-  category_id      = "%[4]s"
-  method           = "NONE"
-}
-`, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_SECRECY_LEVEL_ID, acceptance.HW_DATAARTS_CATEGORY_ID)
-}
+%[1]s
 
-func testAccSecurityRule_custom_update1(name string) string {
-	return fmt.Sprintf(`
 resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
-  workspace_id       = "%[1]s"
-  rule_type          = "CUSTOM"
-  name               = "%[2]s"
-  secrecy_level_id   = "%[3]s"
-  category_id        = "%[4]s"
-  method             = "REGULAR"
-  content_expression = "^male$|^female&"
-  column_expression  = "phoneNumber|email"
-  comment_expression = ".*comment*."
-  description        = "rule_description_custom_update1"
-}
-`, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_SECRECY_LEVEL_ID_UPDATE, acceptance.HW_DATAARTS_CATEGORY_ID_UPDATE)
-}
-
-func testAccSecurityRule_custom_update2(name string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
-  workspace_id       = "%[1]s"
-  rule_type          = "CUSTOM"
-  name               = "%[2]s"
-  secrecy_level_id   = "%[3]s"
-  category_id        = "%[4]s"
-  method             = "REGULAR"
-  content_expression = "^boy$|^girl&"
-  column_expression  = "sex|gender"
-  comment_expression = ".*commentUpdate*."
-  description        = "rule_description_custom_update2"
-}
-`, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_SECRECY_LEVEL_ID, acceptance.HW_DATAARTS_CATEGORY_ID)
-}
-
-func testAccSecurityRule_builtin() string {
-	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
-  workspace_id     = "%[1]s"
+  workspace_id     = "%[2]s"
   rule_type        = "BUILTIN"
-  name             = "%[2]s"
-  builtin_rule_id  = "%[3]s"
-  secrecy_level_id = "%[4]s"
-  category_id      = "%[5]s"
+  name             = "%[3]s"
+  builtin_rule_id  = "%[4]s"
+  secrecy_level_id = huaweicloud_dataarts_security_data_secrecy_level.test[0].id
+  category_id      = local.category_ids[0]
 }
-`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_BUILTIN_RULE_NAME, acceptance.HW_DATAARTS_BUILTIN_RULE_ID,
-		acceptance.HW_DATAARTS_SECRECY_LEVEL_ID, acceptance.HW_DATAARTS_CATEGORY_ID)
+`, testAccSecurityDataRecognitionRule_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_NAME,
+		acceptance.HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_ID)
 }
 
-func testAccSecurityRule_builtin_update() string {
+func testAccSecurityDataRecognitionRule_builtin_step2(name string) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
-  workspace_id     = "%[1]s"
+  workspace_id     = "%[2]s"
   rule_type        = "BUILTIN"
-  name             = "%[2]s"
-  builtin_rule_id  = "%[3]s"
-  secrecy_level_id = "%[4]s"
-  category_id      = "%[5]s"
+  name             = "%[3]s"
+  builtin_rule_id  = "%[4]s"
+  secrecy_level_id = huaweicloud_dataarts_security_data_secrecy_level.test[1].id
+  category_id      = local.category_ids[1]
   description      = "rule_description_builtin_update"
 }
-`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_BUILTIN_RULE_NAME, acceptance.HW_DATAARTS_BUILTIN_RULE_ID,
-		acceptance.HW_DATAARTS_SECRECY_LEVEL_ID_UPDATE, acceptance.HW_DATAARTS_CATEGORY_ID_UPDATE)
+`, testAccSecurityDataRecognitionRule_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_NAME,
+		acceptance.HW_DATAARTS_SECURITY_BUILTIN_RECOGNITION_RULE_ID)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule.go
@@ -16,9 +16,10 @@ import (
 )
 
 // @API DataArtsStudio POST /v1/{project_id}/security/data-classification/rule
-// @API DataArtsStudio DELETE /v1/{project_id}/security/data-classification/rule/{id}
 // @API DataArtsStudio GET /v1/{project_id}/security/data-classification/rule/{id}
 // @API DataArtsStudio PUT /v1/{project_id}/security/data-classification/rule/{id}
+// @API DataArtsStudio PUT /v1/{project_id}/security/data-classification/rule/switch-status/{id}
+// @API DataArtsStudio DELETE /v1/{project_id}/security/data-classification/rule/{id}
 func ResourceSecurityRule() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceSecurityRuleCreate,
@@ -96,6 +97,7 @@ func ResourceSecurityRule() *schema.Resource {
 			},
 			"enable": {
 				Type:     schema.TypeBool,
+				Optional: true,
 				Computed: true,
 			},
 			"created_at": {
@@ -229,30 +231,66 @@ func resourceSecurityRuleRead(_ context.Context, d *schema.ResourceData, meta in
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
+func updateDataRecognitionRule(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/security/data-classification/rule/{id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(d.Get("workspace_id").(string)),
+		JSONBody:         utils.RemoveNil(buildCreateOrUpdateSecurityRuleBodyParams(d)),
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func updateDataRecognitionRuleStatus(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl = "v1/{project_id}/security/data-classification/rule/switch-status/{id}"
+	)
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(d.Get("workspace_id").(string)),
+		JSONBody: utils.RemoveNil(map[string]interface{}{
+			"enable": d.Get("enable"),
+		}),
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
 func resourceSecurityRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
 
-	updateRuleHttpUrl := "v1/{project_id}/security/data-classification/rule/{id}"
-	updateRuleProduct := "dataarts"
-
-	updateRuleClient, err := cfg.NewServiceClient(updateRuleProduct, region)
+	client, err := cfg.NewServiceClient("dataarts", region)
 	if err != nil {
 		return diag.Errorf("error creating DataArts Studio V1 Client: %s", err)
 	}
-	updateRulePath := updateRuleClient.Endpoint + updateRuleHttpUrl
-	updateRulePath = strings.ReplaceAll(updateRulePath, "{project_id}", updateRuleClient.ProjectID)
-	updateRulePath = strings.ReplaceAll(updateRulePath, "{id}", d.Id())
 
-	updateRuleOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	if d.HasChangeExcept("enable") {
+		err = updateDataRecognitionRule(client, d)
+		if err != nil {
+			return diag.Errorf("error updating DataArts Security data recognition rule: %s", err)
+		}
 	}
 
-	updateRuleOpt.JSONBody = utils.RemoveNil(buildCreateOrUpdateSecurityRuleBodyParams(d))
-	_, err = updateRuleClient.Request("PUT", updateRulePath, &updateRuleOpt)
-	if err != nil {
-		return diag.Errorf("error updating DataArts Security data recognition rule: %s", err)
+	if d.HasChange("enable") {
+		err = updateDataRecognitionRuleStatus(client, d)
+		if err != nil {
+			return diag.Errorf("error updating DataArts Security data recognition rule status: %s", err)
+		}
 	}
 
 	return resourceSecurityRuleRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

For the existing resource `huaweicloud_dataarts_security_data_recognition_rule`, supports the switch feature for enable parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance test:
<img width="1065" height="82" alt="image" src="https://github.com/user-attachments/assets/2a6e5d44-6590-4340-a2a1-07ff9ac94d82" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. data recognition rule supports switch enable status
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccResourceSecurityRule_custom
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccResourceSecurityRule_custom -timeout 360m -parallel 10
=== RUN   TestAccResourceSecurityRule_custom
=== PAUSE TestAccResourceSecurityRule_custom
=== CONT  TestAccResourceSecurityRule_custom
--- PASS: TestAccResourceSecurityRule_custom (48.22s)
PASS
coverage: 6.2% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  48.365s coverage: 6.2% of statements in ./huaweicloud/services/dataarts
```
```
./scripts/coverage.sh -o dataarts -f TestAccResourceSecurityRule_builtin
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccResourceSecurityRule_builtin -timeout 360m -parallel 10
=== RUN   TestAccResourceSecurityRule_builtin
=== PAUSE TestAccResourceSecurityRule_builtin
=== CONT  TestAccResourceSecurityRule_builtin
--- PASS: TestAccResourceSecurityRule_builtin (32.32s)
PASS
coverage: 5.9% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  32.415s coverage: 5.9% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
