### PR TITLE
feat(CSS): add data source to query tags of css specified cluster

### DIFF
--- a/docs/data-sources/css_cluster_resource_tags.md
+++ b/docs/data-sources/css_cluster_resource_tags.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_css_cluster_resource_tags"
+description: |-
+  Use this data source to get the all tags of a specific cluster.
+---
+
+# huaweicloud_css_cluster_resource_tags
+
+Use this data source to get the all tags of a specific cluster.
+
+## Example Usage
+
+```hcl
+varivale "cluster_id" {}
+
+data "huaweicloud_css_cluster_resource_tags" "test" {
+  resource_type = "css-cluster"
+  cluster_id    = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `resource_type` - (Required, String) Specifies the resource type.
+  Currently, its value can only be **css-cluster**.
+
+* `cluster_id` - (Required, String) Specifies the ID of the cluster.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of cluster tags.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1062,6 +1062,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_css_upgrade_target_images":     css.DataSourceCssUpgradeTargetImages(),
 			"huaweicloud_css_logstash_templates":        css.DataSourceCssLogstashTemplates(),
 			"huaweicloud_css_cluster_tags":              css.DataSourceCssClusterTags(),
+			"huaweicloud_css_cluster_resource_tags":     css.DataSourceCssClusterResourceTags(),
 			"huaweicloud_css_log_backup_records":        css.DataSourceCssLogBackupRecords(),
 			"huaweicloud_css_resize_flavors":            css.DataSourceResizeFlavors(),
 			"huaweicloud_css_scan_tasks":                css.DataSourceCssScanTasks(),

--- a/huaweicloud/services/acceptance/css/data_source_huaweicloud_css_cluster_resource_tags_test.go
+++ b/huaweicloud/services/acceptance/css/data_source_huaweicloud_css_cluster_resource_tags_test.go
@@ -1,0 +1,41 @@
+package css
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCssClusterResourceTags_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_css_cluster_resource_tags.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCssClusterResourceTags_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSource, "tags.key", "value"),
+					resource.TestCheckResourceAttr(dataSource, "tags.foo", "bar"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCssClusterResourceTags_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_css_cluster_resource_tags" "test" {
+  resource_type = "css-cluster"
+  cluster_id    = "%s"
+}
+`, acceptance.HW_CSS_CLUSTER_ID)
+}

--- a/huaweicloud/services/css/data_source_huaweicloud_css_cluster_resource_tags.go
+++ b/huaweicloud/services/css/data_source_huaweicloud_css_cluster_resource_tags.go
@@ -1,0 +1,108 @@
+package css
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSS GET /v1.0/{project_id}/{resource_type}/{resource_id}/tags
+func DataSourceCssClusterResourceTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCssClusterResourceTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"resource_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceCssClusterResourceTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v1.0/{project_id}/{resource_type}/{cluster_id}/tags"
+		resourceType = d.Get("resource_type").(string)
+		clusterId    = d.Get("cluster_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("css", region)
+	if err != nil {
+		return diag.Errorf("error creating CSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{resource_type}", resourceType)
+	requestPath = strings.ReplaceAll(requestPath, "{cluster_id}", clusterId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CSS cluster(%s) tags: %s", clusterId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("tags", flattenClusterTags(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenClusterTags(resp interface{}) map[string]interface{} {
+	curJson := utils.PathSearch("tags", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	res := make(map[string]interface{})
+	for _, v := range curArray {
+		key := utils.PathSearch("key", v, "").(string)
+		value := utils.PathSearch("value", v, "").(string)
+		if key != "" {
+			res[key] = value
+		}
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source to query tags of css specified cluster
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data source to query tags of css specified cluster
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run=TestAccDataSourceCssClusterResourceTags_basic'
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run=TestAccDataSourceCssClusterResourceTags_basic -coverprofile=.coverage.out -coverpkg=./huaweicloud/services/css -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCssClusterResourceTags_basic
=== PAUSE TestAccDataSourceCssClusterResourceTags_basic
=== CONT  TestAccDataSourceCssClusterResourceTags_basic
--- PASS: TestAccDataSourceCssClusterResourceTags_basic (13.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       13.921s
```
<img width="1147" height="36" alt="image" src="https://github.com/user-attachments/assets/85449362-8a2b-4e4a-a451-950709674eb6" />


<img width="1619" height="901" alt="image" src="https://github.com/user-attachments/assets/038ad76b-74f4-4774-bc63-85df461c0bc4" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
