### PR TITLE
feat(cfw): add source to batch delete address groups

### DIFF
--- a/docs/resources/cfw_batch_delete_address_groups.md
+++ b/docs/resources/cfw_batch_delete_address_groups.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Cloud Firewall (CFW)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cfw_batch_delete_address_groups"
+description: |-
+  Manages a resource to batch delete address groups within HuaweiCloud.
+---
+
+# huaweicloud_cfw_batch_delete_address_groups
+
+Manages a resource to batch delete address groups within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource used to batch delete address groups. Deleting this resource will not
+  clear the corresponding request record, but will only remove the resource information from the tf state file.
+  <br/>2. After the successful execution of the resource, it is necessary to pay attention to the value of the `data`
+  attribute. If the value of `data` is empty, it means that the current operation has not taken effect.
+
+## Example Usage
+
+```hcl
+variable "object_id" {}
+variable "set_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_cfw_batch_delete_address_groups" "test" {
+  object_id = var.object_id
+  set_ids   = var.set_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `object_id` - (Required, String, NonUpdatable) Specifies the protected object ID.
+
+* `set_ids` - (Required, List, NonUpdatable) Specifies the IDs of address groups to be deleted.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `object_id`.
+
+* `data` - The address groups for batch deletion.
+
+  The [data](#Batch_Delete_Address_Groups_Data) structure is documented below.
+
+<a name="Batch_Delete_Address_Groups_Data"></a>
+The `data` block supports:
+
+* `name` - The name of the address group for batch deletion.
+
+* `id` - The ID of the address group for batch deletion.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3091,6 +3091,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cfw_eip_all_protection_switch":          cfw.ResourceEipAllProtectionSwitch(),
 			"huaweicloud_cfw_ip_blacklist_retry":                 cfw.ResourceIpBlacklistRetry(),
 			"huaweicloud_cfw_ip_blacklist_switch":                cfw.ResourceIpBlacklistSwitch(),
+			"huaweicloud_cfw_batch_delete_address_groups":        cfw.ResourceBatchDeleteAddressGroups(),
 
 			"huaweicloud_cloudtable_cluster": cloudtable.ResourceCloudTableCluster(),
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_batch_delete_address_groups_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_batch_delete_address_groups_test.go
@@ -1,0 +1,46 @@
+package cfw
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchDeleteAddressGroups_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+			acceptance.TestAccPreCheckCfwAddressGroupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchDeleteAddressGroups_basic(),
+			},
+		},
+	})
+}
+
+func testBatchDeleteAddressGroups_base() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_firewalls" "test" {
+  fw_instance_id = "%s"
+}
+`, acceptance.HW_CFW_INSTANCE_ID)
+}
+
+func testBatchDeleteAddressGroups_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cfw_batch_delete_address_groups" "test" {
+  object_id = data.huaweicloud_cfw_firewalls.test.records[0].protect_objects[0].object_id
+  set_ids   = ["%[2]s"]
+}
+`, testBatchDeleteAddressGroups_base(), acceptance.HW_CFW_ADDRESS_GROUP_ID)
+}

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_batch_delete_address_groups.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_batch_delete_address_groups.go
@@ -1,0 +1,157 @@
+package cfw
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CFW POST /v1/{project_id}/address-groups/batch-delete
+func ResourceBatchDeleteAddressGroups() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBatchDeleteAddressGroupsCreate,
+		ReadContext:   resourceBatchDeleteAddressGroupsRead,
+		UpdateContext: resourceBatchDeleteAddressGroupsUpdate,
+		DeleteContext: resourceBatchDeleteAddressGroupsDelete,
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"object_id",
+			"set_ids",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"object_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"set_ids": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildBatchDeleteAddressGroupsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"object_id": d.Get("object_id").(string),
+		"set_ids":   utils.ExpandToStringList(d.Get("set_ids").([]interface{})),
+	}
+
+	return bodyParams
+}
+
+func resourceBatchDeleteAddressGroupsCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		httpUrl  = "v1/{project_id}/address-sets/batch-delete"
+		objectId = d.Get("object_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("cfw", region)
+	if err != nil {
+		return diag.Errorf("error creating CFW client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildBatchDeleteAddressGroupsBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch deleting CFW address groups: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(objectId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenBatchDeleteAddressGroupsDataResp(respBody)))
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenBatchDeleteAddressGroupsDataResp(respBody interface{}) []map[string]interface{} {
+	responseDataResp := utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{})
+	if len(responseDataResp) == 0 {
+		return nil
+	}
+
+	responseData := make([]map[string]interface{}, 0, len(responseDataResp))
+	for _, v := range responseDataResp {
+		item := map[string]interface{}{
+			"name": utils.PathSearch("name", v, nil),
+			"id":   utils.PathSearch("id", v, nil),
+		}
+		responseData = append(responseData, item)
+	}
+
+	return responseData
+}
+
+func resourceBatchDeleteAddressGroupsRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Read()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchDeleteAddressGroupsUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Update()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchDeleteAddressGroupsDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch delete address groups. Deleting this resource
+    will not clear of corresponding request record, but will only remove resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add source to batch delete address groups

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add source to batch delete address groups
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o cfw -f TestAccBatchDeleteAddressGroups_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccBatchDeleteAddressGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchDeleteAddressGroups_basic
=== PAUSE TestAccBatchDeleteAddressGroups_basic
=== CONT  TestAccBatchDeleteAddressGroups_basic
--- PASS: TestAccBatchDeleteAddressGroups_basic (41.95s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/cfw
```
<img width="999" height="68" alt="Snipaste_2026-04-20_20-02-12" src="https://github.com/user-attachments/assets/63de29fd-8f38-42fd-b4e5-780c8b8298c7" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
