### PR TITLE
feat(smn): add new resource to manage topic subscription

### DIFF
--- a/docs/resources/smn_topic_subscription.md
+++ b/docs/resources/smn_topic_subscription.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Simple Message Notification (SMN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_smn_topic_subscription"
+description: |-
+  Manages a resource to subscribe SMN topic within HuaweiCloud.
+---
+
+# huaweicloud_smn_topic_subscription
+
+Manages a resource to subscribe SMN topic within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "token" {}
+variable "topic_urn" {}
+
+resource "huaweicloud_smn_topic_subscription" "test" {
+  token     = var.token
+  topic_urn = var.topic_urn
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the SMN topic subscriber resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `token` - (Required, String, NonUpdatable) Specifies the token information of a subscribed topic.
+
+* `topic_urn` - (Optional, String, NonUpdatable) Specifies the unique resource identifier of the topic.
+
+* `endpoint` - (Optional, String, NonUpdatable) Specifies the address of the subscription endpoint.
+
+-> Exactly one of `topic_urn` or `endpoint` must be specified.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `subscription_urn` - The unique resource identifier of a subscriber.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4092,6 +4092,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_smn_topic":                      smn.ResourceTopic(),
 			"huaweicloud_smn_topic_subscriber":           smn.ResourceTopicSubscriber(),
+			"huaweicloud_smn_topic_subscription":         smn.ResourceTopicSubscription(),
 			"huaweicloud_smn_subscription":               smn.ResourceSubscription(),
 			"huaweicloud_smn_message_template":           smn.ResourceSmnMessageTemplate(),
 			"huaweicloud_smn_logtank":                    smn.ResourceSmnLogtank(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -868,6 +868,7 @@ var (
 	HW_SMN_FLAG                 = os.Getenv("HW_SMN_FLAG")
 	HW_SMN_SUBSCRIBED_TOPIC_URN = os.Getenv("HW_SMN_SUBSCRIBED_TOPIC_URN")
 	HW_SMN_SUBSCRIBE_ID         = os.Getenv("HW_SMN_SUBSCRIBE_ID")
+	HW_SMN_SUBSCRIBE_TOKEN      = os.Getenv("HW_SMN_SUBSCRIBE_TOKEN")
 
 	HW_SERVICESTAGE_JAR_PKG_STORAGE_URLS = os.Getenv("HW_SERVICESTAGE_JAR_PKG_STORAGE_URLS")
 	HW_SERVICESTAGE_ZIP_STORAGE_URLS     = os.Getenv("HW_SERVICESTAGE_ZIP_STORAGE_URLS")
@@ -5066,6 +5067,13 @@ func TestAccPrecheckSmnSubscribedTopicUrn(t *testing.T) {
 func TestAccPrecheckSmnSubscribeId(t *testing.T) {
 	if HW_SMN_SUBSCRIBE_ID == "" {
 		t.Skip("HW_SMN_SUBSCRIBE_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckSmnSubscribeToken(t *testing.T) {
+	if HW_SMN_SUBSCRIBE_TOKEN == "" {
+		t.Skip("HW_SMN_SUBSCRIBE_TOKEN must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_topic_subscription_test.go
+++ b/huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_topic_subscription_test.go
@@ -1,0 +1,36 @@
+package smn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTopicSubscription_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckSmnSubscribeToken(t)
+			acceptance.TestAccPrecheckSmnSubscribedTopicUrn(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testTopicSubscription_basic(),
+			},
+		},
+	})
+}
+
+func testTopicSubscription_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic_subscription" "test" {
+  token     = "%[1]s"
+  topic_urn = "%[2]s"
+}
+`, acceptance.HW_SMN_SUBSCRIBE_TOKEN, acceptance.HW_SMN_SUBSCRIBED_TOPIC_URN)
+}

--- a/huaweicloud/services/smn/resource_huaweicloud_smn_topic_subscription.go
+++ b/huaweicloud/services/smn/resource_huaweicloud_smn_topic_subscription.go
@@ -1,0 +1,132 @@
+package smn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var topicSubscriptionNonUpdatableParams = []string{
+	"token",
+	"topic_urn",
+	"endpoint",
+}
+
+// @API SMN GET /v2/notifications/subscriptions/subscribe
+func ResourceTopicSubscription() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTopicSubscriptionCreate,
+		ReadContext:   resourceTopicSubscriptionRead,
+		UpdateContext: resourceTopicSubscriptionUpdate,
+		DeleteContext: resourceTopicSubscriptionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(topicSubscriptionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"token": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"topic_urn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"endpoint"},
+			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"subscription_urn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildTopicSubscriptionQueryParams(d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("?token=%v", d.Get("token"))
+
+	if v, ok := d.GetOk("topic_urn"); ok {
+		queryParams = fmt.Sprintf("%s&topic_urn=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("endpoint"); ok {
+		queryParams = fmt.Sprintf("%s&endpoint=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func resourceTopicSubscriptionCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/notifications/subscriptions/subscribe"
+	)
+
+	client, err := cfg.NewServiceClient("smn", region)
+	if err != nil {
+		return diag.Errorf("error creating SMN client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath += buildTopicSubscriptionQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error subscribing SMN topic: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return diag.FromErr(d.Set("subscription_urn", utils.PathSearch("subscription_urn", respBody, nil)))
+}
+
+func resourceTopicSubscriptionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceTopicSubscriptionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceTopicSubscriptionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting topic subscription resource is not supported. The resource is only removed from the " +
+		"state, the resource remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to manage topic subscription.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new resource to manage topic subscription.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/smn" TESTARGS="-run TestAccTopicSubscription_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/smn -v -run TestAccTopicSubscription_basic -timeout 360m -parallel 4
=== RUN   TestAccTopicSubscription_basic
=== PAUSE TestAccTopicSubscription_basic
=== CONT  TestAccTopicSubscription_basic
--- PASS: TestAccTopicSubscription_basic (21.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/smn       21.668s
```
<img width="1208" height="19" alt="image" src="https://github.com/user-attachments/assets/aeeb73cb-bdf1-4a2f-b0d4-818d3a729efe" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
