### PR TITLE
feat(dataarts): Supports new data source and resource for workspace user management

### DIFF
--- a/docs/data-sources/dataarts_studio_workspace_users.md
+++ b/docs/data-sources/dataarts_studio_workspace_users.md
@@ -1,0 +1,62 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_studio_workspace_users"
+description: |-
+  Use this data source to get the list of workspace users for DataArts Studio Management Center within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_studio_workspace_users
+
+Use this data source to get the list of workspace users for DataArts Studio Management Center within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_studio_workspace_users" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the workspace users are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID to which the users belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `users` - The list of workspace users.  
+  The [users](#dataarts_studio_workspace_users_attr) structure is documented below.
+
+<a name="dataarts_studio_workspace_users_attr"></a>
+The `users` block supports:
+
+* `id` - The ID of the IAM user to which the workspace user correspond.
+
+* `name` - The name of the IAM user to which the workspace user correspond.
+
+* `roles` - The role list of the workspace user.  
+  The [roles](#dataarts_studio_workspace_users_roles_attr) structure is documented below.
+
+* `created_at` - The creation time of the workspace user, in RFC3339 format.
+
+* `updated_at` - The latest update time of the workspace user, in RFC3339 format.
+
+<a name="dataarts_studio_workspace_users_roles_attr"></a>
+The `roles` block supports:
+
+* `id` - The role ID.
+
+* `code` - The role code.
+
+* `name` - The role name.
+
+* `description` - The role description.

--- a/docs/resources/dataarts_studio_workspace_user.md
+++ b/docs/resources/dataarts_studio_workspace_user.md
@@ -1,0 +1,81 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_studio_workspace_user"
+description: |-
+  Manages a workspace user for DataArts Studio Management Center within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_studio_workspace_user
+
+Manages a workspace user for DataArts Studio Management Center within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "user_id" {}
+
+resource "huaweicloud_dataarts_studio_workspace_user" "test" {
+  workspace_id = var.workspace_id
+  user_id      = var.user_id
+
+  roles {
+    id = "r00003"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the workspace user is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the ID of the workspace to which the user belongs.
+
+* `user_id` - (Required, String, NonUpdatable) Specifies the ID of the IAM user to which the workspace user correspond.
+
+* `roles` - (Required, List) Specifies the role list of the workspace user.  
+  The [roles](#dataarts_studio_workspace_user_roles) structure is documented below.
+
+<a name="dataarts_studio_workspace_user_roles"></a>
+The `roles` block supports:
+
+* `id` - (Required, String) Specifies the role ID.  
+  The valid values are as follows:
+  + **r00001**: administrator
+  + **r00002**: developer
+  + **r00003**: operator
+  + **r00004**: viewer
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also same with the parameter `user_id`.
+
+* `roles` - The role list of the workspace user.  
+  The [roles](#dataarts_studio_workspace_user_roles_attr) structure is documented below.
+
+* `created_at` - The creation time of the workspace user, in RFC3339 format.
+
+* `updated_at` - The latest update time of the workspace user, in RFC3339 format.
+
+<a name="dataarts_studio_workspace_user_roles_attr"></a>
+The `roles` block supports:
+
+* `code` - The role code.
+
+* `name` - The role name.
+
+* `description` - The role description.
+
+## Import
+
+The resource can be imported using `workspace_id` and `user_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_studio_workspace_user.test <workspace_id>/<user_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3846,6 +3846,7 @@ func Provider() *schema.Provider {
 			// DataArts Studio - Management Center
 			"huaweicloud_dataarts_studio_data_connection": dataarts.ResourceDataConnection(),
 			"huaweicloud_dataarts_studio_instance":        dataarts.ResourceStudioInstance(),
+			"huaweicloud_dataarts_studio_workspace_user":  dataarts.ResourceStudioWorkspaceUser(),
 			// DataArts Architecture
 			"huaweicloud_dataarts_architecture_batch_publish":          dataarts.ResourceArchitectureBatchPublish(),
 			"huaweicloud_dataarts_architecture_batch_publishment":      dataarts.ResourceArchitectureBatchPublishment(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1072,6 +1072,7 @@ func Provider() *schema.Provider {
 			// DataArts Studio Management Center
 			"huaweicloud_dataarts_studio_data_connections":     dataarts.DataSourceStudioDataConnections(),
 			"huaweicloud_dataarts_studio_workspaces":           dataarts.DataSourceDataArtsStudioWorkspaces(),
+			"huaweicloud_dataarts_studio_workspace_users":      dataarts.DataSourceStudioWorkspaceUsers(),
 			"huaweicloud_dataarts_studio_workspace_user_roles": dataarts.DataSourceStudioWorkspaceUserRoles(),
 			// DataArts Architecture
 			"huaweicloud_dataarts_architecture_ds_template_optionals": dataarts.DataSourceTemplateOptionalFields(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_studio_workspace_users_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_studio_workspace_users_test.go
@@ -1,0 +1,104 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataStudioWorkspaceUsers_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_dataarts_studio_workspace_users.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckUserName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataStudioWorkspaceUsers_nonExistentWorkspace(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSource, "users.#", "0"),
+				),
+			},
+			{
+				Config: testAccDataStudioWorkspaceUsers_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSource, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestMatchResourceAttr(dataSource, "users.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "users.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "users.0.name"),
+					resource.TestMatchResourceAttr(dataSource, "users.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(dataSource, "users.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(dataSource, "users.0.roles.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "users.0.roles.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "users.0.roles.0.code"),
+					resource.TestCheckResourceAttrSet(dataSource, "users.0.roles.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataStudioWorkspaceUsers_nonExistentWorkspace() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_studio_workspace_users" "test" {
+  workspace_id = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataStudioWorkspaceUsers_basic_base() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_studio_workspace_user_roles" "test" {
+  workspace_id = "%[1]s"
+}
+
+data "huaweicloud_identity_users" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_dataarts_studio_workspace_user" "test" {
+  workspace_id = "%[1]s"
+  user_id      = try(data.huaweicloud_identity_users.test.users[0].id, "NOT_FOUND")
+
+  dynamic "roles" {
+    for_each = slice(data.huaweicloud_dataarts_studio_workspace_user_roles.test.roles, 0, 1)
+
+    content {
+      id = roles.value.id
+    }
+  }
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_USER_NAME)
+}
+
+func testAccDataStudioWorkspaceUsers_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dataarts_studio_workspace_users" "test" {
+  depends_on = [
+    huaweicloud_dataarts_studio_workspace_user.test,
+  ]
+
+  workspace_id = "%[2]s"
+}
+`, testAccDataStudioWorkspaceUsers_basic_base(), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_workspace_user_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_workspace_user_test.go
@@ -1,0 +1,143 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dataarts"
+)
+
+func getStudioWorkspaceUserFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	return dataarts.GetStudioWorkspaceUserById(client, state.Primary.Attributes["workspace_id"], state.Primary.ID)
+}
+
+func TestAccStudioWorkspaceUser_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_dataarts_studio_workspace_user.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getStudioWorkspaceUserFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckUserName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStudioWorkspaceUser_basic_step1(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "user_id", "data.huaweicloud_identity_users.test", "users.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "roles.0.id",
+						"data.huaweicloud_dataarts_studio_workspace_user_roles.test", "roles.0.id"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccStudioWorkspaceUser_basic_step2(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "roles.0.id",
+						"data.huaweicloud_dataarts_studio_workspace_user_roles.test", "roles.1.id"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccStudioWorkspaceUserImportStateIDFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccStudioWorkspaceUserImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		workspaceId := rs.Primary.Attributes["workspace_id"]
+		userId := rs.Primary.Attributes["user_id"]
+		if workspaceId == "" || userId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<user_id>', but got '%s/%s'",
+				workspaceId, userId)
+		}
+		return fmt.Sprintf("%s/%s", workspaceId, userId), nil
+	}
+}
+
+func testAccStudioWorkspaceUser_basic_step1() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_studio_workspace_user_roles" "test" {
+  workspace_id = "%[1]s"
+}
+
+data "huaweicloud_identity_users" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_dataarts_studio_workspace_user" "test" {
+  workspace_id = "%[1]s"
+  user_id      = try(data.huaweicloud_identity_users.test.users[0].id, "NOT_FOUND")
+
+  dynamic "roles" {
+    for_each = slice(data.huaweicloud_dataarts_studio_workspace_user_roles.test.roles, 0, 1)
+
+    content {
+      id = roles.value.id
+    }
+  }
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_USER_NAME)
+}
+
+func testAccStudioWorkspaceUser_basic_step2() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_studio_workspace_user_roles" "test" {
+  workspace_id = "%[1]s"
+}
+
+data "huaweicloud_identity_users" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_dataarts_studio_workspace_user" "test" {
+  workspace_id = "%[1]s"
+  user_id      = try(data.huaweicloud_identity_users.test.users[0].id, "NOT_FOUND")
+
+  dynamic "roles" {
+    for_each = slice(data.huaweicloud_dataarts_studio_workspace_user_roles.test.roles, 1, 2)
+
+    content {
+      id = roles.value.id
+    }
+  }
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_USER_NAME)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_studio_workspace_users.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_studio_workspace_users.go
@@ -1,0 +1,147 @@
+package dataarts
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/{workspace_id}/users
+func DataSourceStudioWorkspaceUsers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceStudioWorkspaceUsersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the workspace users are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The workspace ID to which the users belong.`,
+			},
+
+			// Attributes.
+			"users": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the IAM user to which the workspace user correspond.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the IAM user to which the workspace user correspond.`,
+						},
+						"roles": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The role ID.`,
+									},
+									"code": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The role code.`,
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The role name.`,
+									},
+									"description": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The role description.`,
+									},
+								},
+							},
+							Description: `The role list of the workspace user.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the workspace user, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the workspace user, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `The list of workspace users.`,
+			},
+		},
+	}
+}
+
+func flattenStudioWorkspaceUsers(users []interface{}) []map[string]interface{} {
+	if len(users) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(users))
+	for _, user := range users {
+		result = append(result, map[string]interface{}{
+			"id":    utils.PathSearch("user_id", user, nil),
+			"name":  utils.PathSearch("user_name", user, nil),
+			"roles": flattenStudioWorkspaceUserRoles(utils.PathSearch("roles", user, make([]interface{}, 0)).([]interface{})),
+			"created_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", user,
+				float64(0)).(float64))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", user,
+				float64(0)).(float64))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceStudioWorkspaceUsersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	users, err := listStudioWorkspaceUsers(client, workspaceId)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Studio workspace users: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("users", flattenStudioWorkspaceUsers(users)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_workspace_user.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_workspace_user.go
@@ -1,0 +1,458 @@
+package dataarts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const studioWorkspaceUserTypeUser = 0
+
+var studioWorkspaceUserNonUpdatableParams = []string{
+	"workspace_id",
+	"user_id",
+}
+
+// @API IAM GET /v3.0/OS-USER/users/{user_id}
+// @API DataArtsStudio POST /v2/{project_id}/{workspace_id}/users
+// @API DataArtsStudio GET /v2/{project_id}/{workspace_id}/users
+// @API DataArtsStudio PUT /v2/{project_id}/{workspace_id}/users/{user_id}
+// @API DataArtsStudio POST /v2/{project_id}/{workspace_id}/delete-users
+func ResourceStudioWorkspaceUser() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStudioWorkspaceUserCreate,
+		ReadContext:   resourceStudioWorkspaceUserRead,
+		UpdateContext: resourceStudioWorkspaceUserUpdate,
+		DeleteContext: resourceStudioWorkspaceUserDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(studioWorkspaceUserNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceStudioWorkspaceUserImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the workspace user is located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the user belongs.`,
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the IAM user to which the workspace user correspond.`,
+			},
+			"roles": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The role ID.`,
+						},
+						"code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The role code.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The role name.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The role description.`,
+						},
+					},
+				},
+				Description: `The role list of the workspace user.`,
+			},
+
+			// Attributes.
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the workspace user, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the workspace user, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func buildStudioWorkspaceUserRoleIds(roleIds []interface{}) []map[string]interface{} {
+	if len(roleIds) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(roleIds))
+	for _, v := range roleIds {
+		result = append(result, map[string]interface{}{
+			"role_id": utils.PathSearch("id", v, nil),
+		})
+	}
+	return result
+}
+
+func getIdentityUserById(client *golangsdk.ServiceClient, userId string) (interface{}, error) {
+	httpUrl := "v3.0/OS-USER/users/{user_id}"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{user_id}", userId)
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", path, &opts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+// The client is the IAM client, before building the body params, we need to get the user detail using IAM client.
+func buildStudioWorkspaceUserBodyParams(client *golangsdk.ServiceClient, d *schema.ResourceData) (map[string]interface{}, error) {
+	userId := d.Get("user_id").(string)
+	user, err := getIdentityUserById(client, userId)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		"type":      studioWorkspaceUserTypeUser,
+		"roles_ids": buildStudioWorkspaceUserRoleIds(d.Get("roles").(*schema.Set).List()),
+		"user_ids": []map[string]interface{}{
+			{
+				"user_id":         userId,
+				"user_name":       utils.PathSearch("user.name", user, "").(string),
+				"domain_id":       utils.PathSearch("user.domain_id", user, "").(string),
+				"is_domain_owner": utils.PathSearch("user.is_domain_owner", user, false).(bool),
+			},
+		},
+	}, nil
+}
+
+func createStudioWorkspaceUser(dataartsClient, iamClient *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v2/{project_id}/{workspace_id}/users"
+	path := dataartsClient.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", dataartsClient.ProjectID)
+	path = strings.ReplaceAll(path, "{workspace_id}", d.Get("workspace_id").(string))
+
+	bodyParams, err := buildStudioWorkspaceUserBodyParams(iamClient, d)
+	if err != nil {
+		return err
+	}
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(bodyParams),
+	}
+
+	requestResp, err := dataartsClient.Request("POST", path, &opts)
+	if err != nil {
+		return err
+	}
+	resBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return err
+	}
+
+	if !utils.PathSearch("is_success", resBody, false).(bool) {
+		return errors.New(utils.PathSearch("message", resBody, "").(string))
+	}
+	return nil
+}
+
+func resourceStudioWorkspaceUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		userId = d.Get("user_id").(string)
+	)
+
+	dataartsClient, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	iamClient, err := cfg.NewServiceClient("iam", region)
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	if err := createStudioWorkspaceUser(dataartsClient, iamClient, d); err != nil {
+		return diag.Errorf("error adding workspace user (%s): %s", userId, err)
+	}
+
+	d.SetId(userId)
+	return resourceStudioWorkspaceUserRead(ctx, d, meta)
+}
+
+func listStudioWorkspaceUsers(client *golangsdk.ServiceClient, workspaceId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/{workspace_id}/users?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{workspace_id}", workspaceId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opts)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		users := utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, users...)
+		if len(users) < limit {
+			break
+		}
+		offset += len(users)
+	}
+
+	return result, nil
+}
+
+func GetStudioWorkspaceUserById(client *golangsdk.ServiceClient, workspaceId, userId string) (interface{}, error) {
+	users, err := listStudioWorkspaceUsers(client, workspaceId)
+	if err != nil {
+		return nil, err
+	}
+
+	user := utils.PathSearch(fmt.Sprintf("[?user_id=='%s']|[0]", userId), users, nil)
+	if user == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/{workspace_id}/users",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the workspace user (%s) does not exist", userId)),
+			},
+		}
+	}
+	return user, nil
+}
+
+func resourceStudioWorkspaceUserRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		userId      = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	user, err := GetStudioWorkspaceUserById(client, workspaceId, userId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving workspace user")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("roles", flattenStudioWorkspaceUserRoles(utils.PathSearch("roles", user, make([]interface{}, 0)).([]interface{}))),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", user, float64(0)).(float64))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", user, float64(0)).(float64))/1000, false)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func updateStudioWorkspaceUser(dataartsClient, iamClient *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl     = "v2/{project_id}/{workspace_id}/users/{user_id}"
+		workspaceId = d.Get("workspace_id").(string)
+		userId      = d.Get("user_id").(string)
+	)
+
+	path := dataartsClient.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", dataartsClient.ProjectID)
+	path = strings.ReplaceAll(path, "{workspace_id}", workspaceId)
+	path = strings.ReplaceAll(path, "{user_id}", userId)
+
+	bodyParams, err := buildStudioWorkspaceUserBodyParams(iamClient, d)
+	if err != nil {
+		return err
+	}
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(bodyParams),
+	}
+
+	requestResp, err := dataartsClient.Request("PUT", path, &opts)
+	if err != nil {
+		return err
+	}
+	resBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return err
+	}
+	if !utils.PathSearch("is_success", resBody, false).(bool) {
+		return errors.New(utils.PathSearch("message", resBody, "").(string))
+	}
+	return nil
+}
+
+func resourceStudioWorkspaceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		userId = d.Id()
+	)
+
+	dataartsClient, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	iamClient, err := cfg.NewServiceClient("iam", region)
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	if d.HasChange("roles") {
+		if err := updateStudioWorkspaceUser(dataartsClient, iamClient, d); err != nil {
+			return diag.Errorf("error updating workspace user (%s): %s", userId, err)
+		}
+	}
+
+	return resourceStudioWorkspaceUserRead(ctx, d, meta)
+}
+
+func deleteStudioWorkspaceUser(dataartsClient *golangsdk.ServiceClient, workspaceId, userId string) error {
+	httpUrl := "v2/{project_id}/{workspace_id}/delete-users"
+	path := dataartsClient.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", dataartsClient.ProjectID)
+	path = strings.ReplaceAll(path, "{workspace_id}", workspaceId)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"user_ids": []interface{}{userId},
+		},
+	}
+
+	requestResp, err := dataartsClient.Request("POST", path, &opts)
+	if err != nil {
+		return err
+	}
+	resBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return err
+	}
+	if !utils.PathSearch("is_success", resBody, false).(bool) {
+		return golangsdk.ErrDefault400{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v2/{project_id}/{workspace_id}/users",
+				RequestId: "NONE",
+				Body:      []byte(utils.PathSearch("message", resBody, "").(string)),
+			},
+		}
+	}
+	return nil
+}
+
+func resourceStudioWorkspaceUserDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		userId      = d.Get("user_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	if err := deleteStudioWorkspaceUser(client, workspaceId, userId); err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting workspace user (%s)", userId))
+	}
+	return nil
+}
+
+func resourceStudioWorkspaceUserImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.SplitN(importedId, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<user_id>', but got '%s'", importedId)
+	}
+
+	d.SetId(parts[1])
+	mErr := multierror.Append(nil,
+		d.Set("workspace_id", parts[0]),
+		d.Set("user_id", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

For the DataArts Studio Management Center, supports a new resource to manage workspace user and supports a corresponding data source to query workspace users.
+ huaweicloud_dataarts_studio_workspace_user
+ data.huaweicloud_dataarts_studio_workspace_users

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance tests:
1. resource of workspace user management
<img width="1192" height="217" alt="image" src="https://github.com/user-attachments/assets/82fe6dc3-4f07-4ef2-83cb-8aaea82909bd" />

2. data source of workspace user querying
<img width="1081" height="275" alt="image" src="https://github.com/user-attachments/assets/3d83cbd7-3e33-48f8-880a-cf023076d068" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports a new resource to manage workspace user
2. supports a data source to query workspace users
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccStudioWorkspaceUser_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccStudioWorkspaceUser_basic -timeout 360m -parallel 10
=== RUN   TestAccStudioWorkspaceUser_basic
=== PAUSE TestAccStudioWorkspaceUser_basic
=== CONT  TestAccStudioWorkspaceUser_basic
--- PASS: TestAccStudioWorkspaceUser_basic (93.91s)
PASS
coverage: 6.3% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  94.037s coverage: 6.3% of statements in ./huaweicloud/services/dataarts
```
```
./scripts/coverage.sh -o dataarts -f TestAccDataStudioWorkspaceUsers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataStudioWorkspaceUsers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataStudioWorkspaceUsers_basic
=== PAUSE TestAccDataStudioWorkspaceUsers_basic
=== CONT  TestAccDataStudioWorkspaceUsers_basic
--- PASS: TestAccDataStudioWorkspaceUsers_basic (16.34s)
PASS
coverage: 6.0% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  16.499s coverage: 6.0% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="903" height="340" alt="image" src="https://github.com/user-attachments/assets/7bb09329-d6c4-47cb-a88d-f309b67b9971" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    currently, delete a non-exist workspace user will not report an error
    <img width="731" height="467" alt="image" src="https://github.com/user-attachments/assets/b2497dd8-e86b-46e9-9a40-6975a9053767" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
