### PR TITLE
feat(rfs): support `rfs_private_provider_versions` data source

### DIFF
--- a/docs/data-sources/rfs_private_provider_versions.md
+++ b/docs/data-sources/rfs_private_provider_versions.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_private_provider_versions"
+description: |-
+  Use this datasource to get the list of private provider versions.
+---
+
+# huaweicloud_rfs_private_provider_versions
+
+Use this datasource to get the list of private provider versions.
+
+## Example Usage
+
+```hcl
+variable "provider_name" {}
+
+data "huaweicloud_rfs_private_provider_versions" "test" {
+  provider_name = var.provider_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `provider_name` - (Required, String) Specifies the name of the private provider.
+
+* `provider_id` - (Optional, String) Specifies the ID of the private provider.
+
+* `sort_key` - (Optional, String) Specifies the sort field, only supports **create_time**.
+
+* `sort_dir` - (Optional, String) Specifies the ascending or descending order.
+  Valid values are **asc** and **desc**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `versions` - The list of private provider versions. By default, these versions are sorted in descending order of the
+  creation time.
+
+  The [versions](#versions_struct) structure is documented below.
+
+<a name="versions_struct"></a>
+The `versions` block supports:
+
+* `provider_id` - The unique ID of the private provider.
+
+* `provider_name` - The name of the private provider.
+
+* `provider_version` - The version number of the private provider.
+
+* `version_description` - The description of the private provider version.
+
+* `function_graph_urn` - The URN of the FunctionGraph function.
+
+* `create_time` - The creation time of a private provider version. It is represented in UTC format
+  (YYYY-MM-DDTHH:mm:ss.SSSZ), such as **1970-01-01T00:00:00.000Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2033,6 +2033,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rfs_stack_resources":              rfs.DataSourceStackResources(),
 			"huaweicloud_rfs_stack_set_operation_metadata": rfs.DataSourceStackSetOperationMetadata(),
 			"huaweicloud_rfs_private_providers":            rfs.DataSourcePrivateProviders(),
+			"huaweicloud_rfs_private_provider_versions":    rfs.DataSourcePrivateProviderVersions(),
 			"huaweicloud_rfs_templates":                    rfs.DataSourceRfsTemplates(),
 
 			"huaweicloud_rgc_home_region":                           rgc.DataSourceHomeRegion(),

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_private_provider_versions_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_private_provider_versions_test.go
@@ -1,0 +1,100 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcePrivateProviderVersions_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_private_provider_versions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceNameWithDash()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourcePrivateProviderVersions_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.provider_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.provider_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.provider_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.function_graph_urn"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourcePrivateProviderVersions_base(name string) string {
+	return fmt.Sprintf(`
+variable "request_resp_print_script_content" {
+  default = <<EOT
+exports.handler = async (event, context) => {
+    const result =
+    {
+        'repsonse_code': 200,
+        'headers':
+        {
+            'Content-Type': 'application/json'
+        },
+        'isBase64Encoded': false,
+        'body': JSON.stringify(event)
+    }
+    return result
+}
+EOT
+}
+
+resource "huaweicloud_fgs_function" "test" {
+  name        = "%[1]s"
+  app         = "default"
+  agency      = "function_all_trust"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  code_type   = "inline"
+  runtime     = "Node.js12.13"
+  func_code   = base64encode(var.request_resp_print_script_content)
+}
+
+resource "huaweicloud_rfs_private_provider" "test" {
+  provider_name        = "%[1]s"
+  function_graph_urn   = huaweicloud_fgs_function.test.urn
+  provider_description = "acc private provider for version test"
+  provider_version     = "1.0.0"
+  version_description  = "initial version"
+}
+
+resource "huaweicloud_rfs_private_provider_version" "test" {
+  provider_name       = huaweicloud_rfs_private_provider.test.provider_name
+  provider_version    = "2.0.0"
+  function_graph_urn  = huaweicloud_fgs_function.test.urn
+  version_description = "private provider version test"
+}
+`, name)
+}
+
+func testDataSourcePrivateProviderVersions_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_rfs_private_provider_versions" "test" {
+  provider_name = huaweicloud_rfs_private_provider.test.provider_name
+  provider_id   = huaweicloud_rfs_private_provider.test.provider_id
+  sort_key      = "create_time"
+  sort_dir      = "desc"
+}
+`, testDataSourcePrivateProviderVersions_base(name), name)
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_private_provider_versions.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_private_provider_versions.go
@@ -1,0 +1,188 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/private-providers/{provider_name}/versions
+func DataSourcePrivateProviderVersions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePrivateProviderVersionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"provider_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"provider_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"provider_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"provider_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"provider_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"function_graph_urn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildListPrivateProviderVersionsQueryParams(d *schema.ResourceData, marker string) string {
+	rst := ""
+
+	if v, ok := d.GetOk("provider_id"); ok {
+		rst += fmt.Sprintf("&provider_id=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%s", v.(string))
+	}
+
+	if marker != "" {
+		rst += fmt.Sprintf("&marker=%s", marker)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourcePrivateProviderVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v1/private-providers/{provider_name}/versions"
+		allVersions  = make([]interface{}, 0)
+		nextMarker   string
+		providerName = d.Get("provider_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	reqUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request UUID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{provider_name}", providerName)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Client-Request-Id": reqUUID},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildListPrivateProviderVersionsQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RFS private provider versions: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		versions := utils.PathSearch("versions", respBody, make([]interface{}, 0)).([]interface{})
+		if len(versions) == 0 {
+			break
+		}
+
+		allVersions = append(allVersions, versions...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	d.SetId(reqUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("versions", flattenPrivateProviderVersions(allVersions)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPrivateProviderVersions(versions []interface{}) []interface{} {
+	if len(versions) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(versions))
+	for _, v := range versions {
+		rst = append(rst, map[string]interface{}{
+			"provider_id":         utils.PathSearch("provider_id", v, nil),
+			"provider_name":       utils.PathSearch("provider_name", v, nil),
+			"provider_version":    utils.PathSearch("provider_version", v, nil),
+			"version_description": utils.PathSearch("version_description", v, nil),
+			"function_graph_urn":  utils.PathSearch("function_graph_urn", v, nil),
+			"create_time":         utils.PathSearch("create_time", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_private_provider_versions` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_private_provider_versions` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccDataSourcePrivateProviderVersions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs -v -run TestAccDataSourcePrivateProviderVersions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePrivateProviderVersions_basic
=== PAUSE TestAccDataSourcePrivateProviderVersions_basic
=== CONT  TestAccDataSourcePrivateProviderVersions_basic
--- PASS: TestAccDataSourcePrivateProviderVersions_basic (18.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       18.308s
```
<img width="907" height="33" alt="image" src="https://github.com/user-attachments/assets/85cb0d0f-f88b-4f3d-99ae-a91a59bc4e04" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
