### PR TITLE
feat(dataarts): add new data source to query data recognition rules

### DIFF
--- a/docs/data-sources/dataarts_security_data_recognition_rules.md
+++ b/docs/data-sources/dataarts_security_data_recognition_rules.md
@@ -1,0 +1,102 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_data_recognition_rules"
+description: |-
+  Use this data source to get the list of DataArts Security data recognition rules within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_data_recognition_rules
+
+Use this data source to get the list of DataArts Security data recognition rules within HuaweiCloud.
+
+## Example Usage
+
+### Query all data recognition rules under a specified workspace
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_security_data_recognition_rules" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+### Query the data recognition rules under a specified workspace and using rule name to filter
+
+```hcl
+variable "workspace_id" {}
+variable "rule_name" {}
+
+data "huaweicloud_dataarts_security_data_recognition_rules" "test" {
+  workspace_id = var.workspace_id
+  rule_name    = var.rule_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the data recognition rules are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the data recognition rules belong.
+
+* `secrecy_level` - (Optional, String) Specifies the secrecy level to which the data recognition rules belong.
+
+* `rule_name` - (Optional, String) Specifies the name of the specified data recognition rule to be queried.
+
+* `creator` - (Optional, String) Specifies the creator of the data recognition rules to be queried.
+
+* `enable` - (Optional, Bool) Specifies whether the data recognition rules are enabled to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `rules` - The list of data recognition rules that matched filter parameters.  
+  The [rules](#dataarts_security_data_recognition_rules_attr) structure is documented below.
+
+<a name="dataarts_security_data_recognition_rules_attr"></a>
+The `rules` block supports:
+
+* `id` - The ID of the data recognition rule.
+
+* `type` - The type of the data recognition rule.
+
+* `secrecy_level` - The secrecy level name of the data recognition rule.
+
+* `secrecy_level_num` - The secrecy level number of the data recognition rule.
+
+* `name` - The name of the data recognition rule.
+
+* `enable` - Whether the rule is enabled.
+
+* `method` - The method of the data recognition rule.
+
+* `content_expression` - The content expression of the data recognition rule.
+
+* `column_expression` - The column expression of the data recognition rule.
+
+* `comment_expression` - The comment expression of the data recognition rule.
+
+* `combine_expression` - The combine expression of the data recognition rule.
+
+* `description` - The description of the data recognition rule.
+
+* `created_by` - The creator of the data recognition rule.
+
+* `created_at` - The creation time of the data recognition rule, in RFC3339 format.
+
+* `updated_by` - The updater of the data recognition rule.
+
+* `updated_at` - The latest update time of the data recognition rule, in RFC3339 format.
+
+* `builtin_rule_id` - The builtin rule ID of the data recognition rule.
+
+* `category_id` - The category ID to which the data recognition rule belongs.
+
+* `instance_id` - The instance ID to which the data recognition rule belongs.
+
+* `match_type` - The match type of the data recognition rule.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1091,6 +1091,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_factory_resources": dataarts.DataSourceFactoryResources(),
 			"huaweicloud_dataarts_factory_scripts":   dataarts.DataSourceFactoryScripts(),
 			// DataArts Security
+			"huaweicloud_dataarts_security_data_recognition_rules":      dataarts.DataSourceSecurityDataRecognitionRules(),
 			"huaweicloud_dataarts_security_permission_set_privileges":   dataarts.DataSourceSecurityPermissionSetPrivileges(),
 			"huaweicloud_dataarts_security_workspace_associated_queues": dataarts.DataSourceSecurityWorkspaceAssociatedQueues(),
 

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_data_recognition_rules_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_data_recognition_rules_test.go
@@ -1,0 +1,219 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSecurityDataRecognitionRules_basic(t *testing.T) {
+	var (
+		rName = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_security_data_recognition_rules.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_dataarts_security_data_recognition_rules.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		bySecrecyLevel   = "data.huaweicloud_dataarts_security_data_recognition_rules.filter_by_secrecy_level"
+		dcBySecrecyLevel = acceptance.InitDataSourceCheck(bySecrecyLevel)
+
+		byCreator   = "data.huaweicloud_dataarts_security_data_recognition_rules.filter_by_creator"
+		dcByCreator = acceptance.InitDataSourceCheck(byCreator)
+
+		byEnable   = "data.huaweicloud_dataarts_security_data_recognition_rules.filter_by_enable"
+		dcByEnable = acceptance.InitDataSourceCheck(byEnable)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsSecurityDataCategoryIds(t, 1)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSecurityDataRecognitionRules_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(all, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttrSet(all, "region"),
+					resource.TestMatchResourceAttr(all, "rules.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckResourceAttr(byName, "rules.#", "1"),
+					resource.TestCheckResourceAttr(byName, "rules.0.name", rName),
+					resource.TestCheckResourceAttr(byName, "rules.0.type", "CUSTOM"),
+					resource.TestCheckResourceAttrSet(byName, "rules.0.id"),
+					resource.TestCheckResourceAttrSet(byName, "rules.0.enable"),
+					resource.TestCheckResourceAttrSet(byName, "rules.0.created_at"),
+					resource.TestCheckResourceAttrSet(byName, "rules.0.created_by"),
+					resource.TestCheckResourceAttrSet(byName, "rules.0.updated_at"),
+					resource.TestCheckResourceAttrSet(byName, "rules.0.updated_by"),
+
+					// Filter by secrecy_level
+					dcBySecrecyLevel.CheckResourceExists(),
+					resource.TestCheckOutput("is_secrecy_level_filter_useful", "true"),
+					resource.TestMatchResourceAttr(bySecrecyLevel, "rules.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestCheckResourceAttrSet(bySecrecyLevel, "rules.0.secrecy_level"),
+
+					// Filter by creator
+					dcByCreator.CheckResourceExists(),
+					resource.TestCheckOutput("is_creator_filter_useful", "true"),
+					resource.TestMatchResourceAttr(byCreator, "rules.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestCheckResourceAttrSet(byCreator, "rules.0.created_by"),
+
+					// Filter by enable
+					dcByEnable.CheckResourceExists(),
+					resource.TestCheckOutput("is_enable_filter_useful", "true"),
+					resource.TestMatchResourceAttr(byEnable, "rules.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestCheckResourceAttr(byEnable, "rules.0.enable", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSecurityDataRecognitionRules_basic_base(name string) string {
+	return fmt.Sprintf(`
+locals {
+  category_ids = try(split(",", "%[1]s"), [])
+}
+
+resource "huaweicloud_dataarts_security_data_secrecy_level" "test" {
+  workspace_id = "%[2]s"
+  name         = "%[3]s"
+}
+
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
+  workspace_id     = "%[2]s"
+  rule_type        = "CUSTOM"
+  name             = "%[3]s"
+  secrecy_level_id = huaweicloud_dataarts_security_data_secrecy_level.test.id
+  category_id      = try(local.category_ids[0], null)
+  method           = "NONE"
+}
+`, acceptance.HW_DATAARTS_SECURITY_DATA_CATEGORY_IDS, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccDataSecurityDataRecognitionRules_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all rules and without any filter
+data "huaweicloud_dataarts_security_data_recognition_rules" "all" {
+  depends_on = [
+    huaweicloud_dataarts_security_data_recognition_rule.test,
+  ]
+
+  workspace_id = "%[2]s"
+}
+
+# Filter by name
+locals {
+  rule_name = huaweicloud_dataarts_security_data_recognition_rule.test.name
+}
+
+data "huaweicloud_dataarts_security_data_recognition_rules" "filter_by_name" {
+  depends_on = [
+    huaweicloud_dataarts_security_data_recognition_rule.test,
+  ]
+
+  workspace_id = "%[2]s"
+  name         = local.rule_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_data_recognition_rules.filter_by_name.rules[*].name :
+      v == local.rule_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by secrecy_level
+locals {
+  secrecy_level = huaweicloud_dataarts_security_data_recognition_rule.test.secrecy_level
+}
+
+data "huaweicloud_dataarts_security_data_recognition_rules" "filter_by_secrecy_level" {
+  depends_on = [
+    huaweicloud_dataarts_security_data_recognition_rule.test,
+  ]
+
+  workspace_id  = "%[2]s"
+  secrecy_level = huaweicloud_dataarts_security_data_recognition_rule.test.secrecy_level
+}
+
+locals {
+  secrecy_level_filter_result = [
+    for v in data.huaweicloud_dataarts_security_data_recognition_rules.filter_by_secrecy_level.rules[*].secrecy_level :
+      v == local.secrecy_level
+  ]
+}
+
+output "is_secrecy_level_filter_useful" {
+  value = length(local.secrecy_level_filter_result) > 0 && alltrue(local.secrecy_level_filter_result)
+}
+
+# Filter by creator
+locals {
+  creator = huaweicloud_dataarts_security_data_recognition_rule.test.created_by
+}
+
+data "huaweicloud_dataarts_security_data_recognition_rules" "filter_by_creator" {
+  depends_on = [
+    huaweicloud_dataarts_security_data_recognition_rule.test,
+  ]
+
+  workspace_id = "%[2]s"
+  creator      = huaweicloud_dataarts_security_data_recognition_rule.test.created_by
+}
+
+locals {
+  creator_filter_result = [
+    for v in data.huaweicloud_dataarts_security_data_recognition_rules.filter_by_creator.rules[*].created_by :
+    v == local.creator
+  ]
+}
+
+output "is_creator_filter_useful" {
+  value = length(local.creator_filter_result) > 0 && alltrue(local.creator_filter_result)
+}
+
+# Filter by enable
+locals {
+  is_rule_enable = true
+}
+
+data "huaweicloud_dataarts_security_data_recognition_rules" "filter_by_enable" {
+  depends_on = [
+    huaweicloud_dataarts_security_data_recognition_rule.test,
+  ]
+
+  workspace_id = "%[2]s"
+  enable       = local.is_rule_enable
+}
+
+locals {
+  enable_filter_result = [
+    for v in data.huaweicloud_dataarts_security_data_recognition_rules.filter_by_enable.rules[*].enable :
+      v == local.is_rule_enable
+  ]
+}
+
+output "is_enable_filter_useful" {
+  value = length(local.enable_filter_result) > 0 && alltrue(local.enable_filter_result)
+}
+`, testAccDataSecurityDataRecognitionRules_basic_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_data_recognition_rules.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_data_recognition_rules.go
@@ -1,0 +1,301 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/security/data-classification/rule
+func DataSourceSecurityDataRecognitionRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityDataRecognitionRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the data recognition rules are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the data recognition rules belong.`,
+			},
+
+			// Optional parameters.
+			"secrecy_level": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The secrecy level to which the data recognition rules belong.`,
+			},
+			"rule_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the specified data recognition rule to be queried.`,
+			},
+			"creator": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The creator of the data recognition rules to be queried.`,
+			},
+			"enable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether the data recognition rules are enabled to be queried.`,
+			},
+
+			// Attributes.
+			"rules": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of data recognition rules that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the data recognition rule.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the data recognition rule.`,
+						},
+						"secrecy_level": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The secrecy level name of the data recognition rule.`,
+						},
+						"secrecy_level_num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The secrecy level number of the data recognition rule.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the data recognition rule.`,
+						},
+						"enable": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the data recognition rule is enabled.`,
+						},
+						"method": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The method of the data recognition rule.`,
+						},
+						"content_expression": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The content expression of the data recognition rule.`,
+						},
+						"column_expression": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The column expression of the data recognition rule.`,
+						},
+						"comment_expression": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The comment expression of the data recognition rule.`,
+						},
+						"combine_expression": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The combine expression of the data recognition rule.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the data recognition rule.`,
+						},
+						"created_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator of the data recognition rule.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the data recognition rule, in RFC3339 format.`,
+						},
+						"updated_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The updater of the data recognition rule.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the data recognition rule, in RFC3339 format.`,
+						},
+						"builtin_rule_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The builtin rule ID of the data recognition rule.`,
+						},
+						"category_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The category ID to which the data recognition rule belongs.`,
+						},
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The instance ID to which the data recognition rule belongs.`,
+						},
+						"match_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The match type of the data recognition rule.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSecurityDataRecognitionRulesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("secrecy_level"); ok {
+		res = fmt.Sprintf("%s&secrecy_level=%v", res, v)
+	}
+	if v, ok := d.GetOk("rule_name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("creator"); ok {
+		res = fmt.Sprintf("%s&creator=%v", res, v)
+	}
+	if v, ok := d.GetOk("enable"); ok {
+		res = fmt.Sprintf("%s&enable=%v", res, v)
+	}
+
+	return res
+}
+
+func listSecurityDataRecognitionRules(client *golangsdk.ServiceClient, workspaceId string, queryParams ...string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/security/data-classification/rule?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	if len(queryParams) > 0 && queryParams[0] != "" {
+		listPath += queryParams[0]
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		rules := utils.PathSearch("content", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, rules...)
+		if len(rules) < limit {
+			break
+		}
+		offset += len(rules)
+	}
+
+	return result, nil
+}
+
+func flattenSecurityDataRecognitionRules(rules []interface{}) []map[string]interface{} {
+	if len(rules) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(rules))
+	for _, rule := range rules {
+		result = append(result, map[string]interface{}{
+			"id":                 utils.PathSearch("uuid", rule, nil),
+			"type":               utils.PathSearch("rule_type", rule, nil),
+			"secrecy_level":      utils.PathSearch("secrecy_level", rule, nil),
+			"secrecy_level_num":  int(utils.PathSearch("secrecy_level_num", rule, float64(0)).(float64)),
+			"name":               utils.PathSearch("name", rule, nil),
+			"enable":             utils.PathSearch("enable", rule, nil),
+			"method":             utils.PathSearch("method", rule, nil),
+			"content_expression": utils.PathSearch("content_expression", rule, nil),
+			"column_expression":  utils.PathSearch("column_expression", rule, nil),
+			"comment_expression": utils.PathSearch("commit_expression", rule, nil),
+			"combine_expression": utils.PathSearch("combine_expression", rule, nil),
+			"description":        utils.PathSearch("description", rule, nil),
+			"builtin_rule_id":    utils.PathSearch("builtin_rule_id", rule, nil),
+			"category_id":        utils.PathSearch("category_id", rule, nil),
+			"instance_id":        utils.PathSearch("instance_id", rule, nil),
+			"match_type":         utils.PathSearch("match_type", rule, nil),
+			"created_by":         utils.PathSearch("created_by", rule, nil),
+			"created_at": utils.FormatTimeStampRFC3339(
+				int64(utils.PathSearch("created_at", rule, float64(0)).(float64))/1000, false),
+			"updated_by": utils.PathSearch("updated_by", rule, nil),
+			"updated_at": utils.FormatTimeStampRFC3339(
+				int64(utils.PathSearch("updated_at", rule, float64(0)).(float64))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceSecurityDataRecognitionRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	rules, err := listSecurityDataRecognitionRules(client, workspaceId, buildSecurityDataRecognitionRulesQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error querying DataArts Security data recognition rules: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("rules", flattenSecurityDataRecognitionRules(rules)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source for DataArts Studio Security and used to query data recognition rules.
`data.huaweicloud_dataarts_security_data_recognition_rules`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance test:
<img width="1093" height="286" alt="image" src="https://github.com/user-attachments/assets/b67e3b76-afc4-4802-b6b1-a736ebee19fa" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query data recognition rules.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataSecurityDataRecognitionRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataSecurityDataRecognitionRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSecurityDataRecognitionRules_basic
=== PAUSE TestAccDataSecurityDataRecognitionRules_basic
=== CONT  TestAccDataSecurityDataRecognitionRules_basic
--- PASS: TestAccDataSecurityDataRecognitionRules_basic (257.75s)
PASS
coverage: 6.3% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  257.903s   coverage: 6.3% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
