### PR TITLE
feat(smn): add new resource to manage topic unsubscription

### DIFF
--- a/docs/resources/smn_topic_unsubscription.md
+++ b/docs/resources/smn_topic_unsubscription.md
@@ -1,0 +1,38 @@
+---
+subcategory: "Simple Message Notification (SMN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_smn_topic_unsubscription"
+description: |-
+  Manages a resource to unsubscribe SMN topic within HuaweiCloud.
+---
+
+# huaweicloud_smn_topic_unsubscription
+
+Manages a resource to unsubscribe SMN topic within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "subscription_urn" {}
+
+resource "huaweicloud_smn_topic_unsubscription" "test" {
+  subscription_urn = var.subscription_urn
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the SMN topic subscriber resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `subscription_urn` - (Required, String, NonUpdatable) Specifies the unique resource identifier of a subscriber.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `message` - The response information.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4094,6 +4094,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_smn_topic_subscriber":           smn.ResourceTopicSubscriber(),
 			"huaweicloud_smn_subscription":               smn.ResourceSubscription(),
 			"huaweicloud_smn_message_template":           smn.ResourceSmnMessageTemplate(),
+			"huaweicloud_smn_topic_unsubscription":       smn.ResourceTopicUnsubscription(),
 			"huaweicloud_smn_logtank":                    smn.ResourceSmnLogtank(),
 			"huaweicloud_smn_message_detection":          smn.ResourceMessageDetection(),
 			"huaweicloud_smn_message_publish":            smn.ResourceMessagePublish(),

--- a/huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_topic_unsubscription_test.go
+++ b/huaweicloud/services/acceptance/smn/resource_huaweicloud_smn_topic_unsubscription_test.go
@@ -1,0 +1,34 @@
+package smn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTopicUnsubscription_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckSmnSubscribedTopicUrn(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testTopicUnsubscription_basic(),
+			},
+		},
+	})
+}
+
+func testTopicUnsubscription_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic_unsubscription" "test" {
+  subscription_urn = "%s"
+}
+`, acceptance.HW_SMN_SUBSCRIBED_TOPIC_URN)
+}

--- a/huaweicloud/services/smn/resource_huaweicloud_smn_topic_unsubscription.go
+++ b/huaweicloud/services/smn/resource_huaweicloud_smn_topic_unsubscription.go
@@ -1,0 +1,114 @@
+package smn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var topicUnsubscriptionNonUpdatableParams = []string{
+	"subscription_urn",
+}
+
+// @API SMN GET /v2/notifications/subscriptions/unsubscribe
+func ResourceTopicUnsubscription() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTopicUnsubscriptionCreate,
+		ReadContext:   resourceTopicUnsubscriptionRead,
+		UpdateContext: resourceTopicUnsubscriptionUpdate,
+		DeleteContext: resourceTopicUnsubscriptionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(topicUnsubscriptionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"subscription_urn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"message": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceTopicUnsubscriptionCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/notifications/subscriptions/unsubscribe"
+	)
+
+	client, err := cfg.NewServiceClient("smn", region)
+	if err != nil {
+		return diag.Errorf("error creating SMN client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = fmt.Sprintf("%s?subscription_urn=%s", requestPath, d.Get("subscription_urn").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error unsubscribing SMN topic: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return diag.FromErr(d.Set("message", utils.PathSearch("message", respBody, nil)))
+}
+
+func resourceTopicUnsubscriptionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceTopicUnsubscriptionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceTopicUnsubscriptionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting topic unsubscription resource is not supported. The resource is only removed from the " +
+		"state, the resource remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to manage topic unsubscription.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new resource to manage topic unsubscription.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/smn" TESTARGS="-run TestAccTopicUnsubscription_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/smn -v -run TestAccTopicUnsubscription_basic -timeout 360m -parallel 4
=== RUN   TestAccTopicUnsubscription_basic
=== PAUSE TestAccTopicUnsubscription_basic
=== CONT  TestAccTopicUnsubscription_basic
--- PASS: TestAccTopicUnsubscription_basic (22.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/smn       23.041s
```
<img width="1208" height="19" alt="image" src="https://github.com/user-attachments/assets/6a9c470c-4120-47f6-9533-1a89f50997c1" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
