### PR TITLE
feat(rfs): add datasource to get the list of RFS template versions

### DIFF
--- a/docs/data-sources/rfs_template_versions.md
+++ b/docs/data-sources/rfs_template_versions.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_template_versions"
+description: |-
+  Use this data source to get all versions of an RFS template.
+---
+
+# huaweicloud_rfs_template_versions
+
+Use this data source to get all versions of an RFS template.
+
+## Example Usage
+
+```hcl
+variable "template_name" {}
+
+data "huaweicloud_rfs_template_versions" "test" {
+  template_name = var.template_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `template_name` - (Required, String) Specifies the template name.
+
+* `template_id` - (Optional, String) Specifies the template ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `versions` - The list of template versions.
+
+  The [versions](#versions_struct) structure is documented below.
+
+<a name="versions_struct"></a>
+The `versions` block supports:
+
+* `version_id` - The version ID, such as **V1**, **V2**.
+
+* `template_id` - The template ID.
+
+* `template_name` - The template name.
+
+* `version_description` - The version description.
+
+* `create_time` - The time when the version was created, in RFC3339 format (yyyy-mm-ddTHH:MM:SSZ),
+  such as **1970-01-01T00:00:00Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2035,6 +2035,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rfs_stack_set_operation_metadata": rfs.DataSourceStackSetOperationMetadata(),
 			"huaweicloud_rfs_private_providers":            rfs.DataSourcePrivateProviders(),
 			"huaweicloud_rfs_templates":                    rfs.DataSourceRfsTemplates(),
+			"huaweicloud_rfs_template_versions":            rfs.DataSourceRfsTemplateVersions(),
 
 			"huaweicloud_rgc_home_region":                           rgc.DataSourceHomeRegion(),
 			"huaweicloud_rgc_pre_launch_check":                      rgc.DataSourcePreLaunchCheck(),

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_template_versions_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_template_versions_test.go
@@ -1,0 +1,96 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRfsTemplateVersions_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_template_versions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRfsTemplateVersions_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.version_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.template_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.template_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "versions.0.create_time"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRfsTemplateVersions_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rfs_template" "test" {
+  template_name        = "%s"
+  template_description = "template for versions datasource test"
+  version_description  = "v1"
+  template_body        = <<-EOF
+variable "vpc_name" {
+  type    = string
+  default = "my-vpc"
+}
+
+resource "huaweicloud_vpc" "vpc" {
+  name = var.vpc_name
+  cidr = "172.16.0.0/16"
+}
+EOF
+}
+
+resource "huaweicloud_rfs_template_version" "test" {
+  template_name       = huaweicloud_rfs_template.test.template_name
+  template_id         = huaweicloud_rfs_template.test.template_id
+  version_description = "v2 - add subnet"
+  template_body       = <<-EOF
+variable "vpc_name" {
+  type    = string
+  default = "my-vpc"
+}
+
+resource "huaweicloud_vpc" "vpc" {
+  name = var.vpc_name
+  cidr = "172.16.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "subnet" {
+  name       = "my-subnet"
+  vpc_id     = huaweicloud_vpc.vpc.id
+  cidr       = "172.16.1.0/24"
+  gateway_ip = "172.16.1.1"
+}
+EOF
+}
+`, name)
+}
+
+func testAccDataSourceRfsTemplateVersions_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rfs_template_versions" "test" {
+  template_name = huaweicloud_rfs_template.test.template_name
+
+  depends_on = [
+    huaweicloud_rfs_template_version.test
+  ]
+}
+`, testAccDataSourceRfsTemplateVersions_base(name))
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_template_versions.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_template_versions.go
@@ -1,0 +1,170 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/{project_id}/templates/{template_name}/versions
+func DataSourceRfsTemplateVersions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRfsTemplateVersionRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"template_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"template_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"version_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"template_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"template_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildTemplateVersionsQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+
+	if templateId, ok := d.GetOk("template_id"); ok {
+		queryParams = fmt.Sprintf("&template_id=%s", templateId)
+	}
+
+	return queryParams
+}
+
+func dataSourceRfsTemplateVersionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		product      = "rfs"
+		httpUrl      = "v1/{project_id}/templates/{template_name}/versions"
+		templateName = d.Get("template_name").(string)
+		allVersions  = make([]interface{}, 0)
+		limit        = 1000
+		marker       = ""
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{template_name}", templateName)
+	requestPath = fmt.Sprintf("%s?limit=%d%s", requestPath, limit, buildTemplateVersionsQueryParams(d))
+
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": uuid,
+			"Content-Type":      "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithMarker := requestPath
+		if marker != "" {
+			requestPathWithMarker = fmt.Sprintf("%s&marker=%s", requestPathWithMarker, marker)
+		}
+
+		resp, err := client.Request("GET", requestPathWithMarker, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RFS template versions: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		versions := utils.PathSearch("versions", respBody, make([]interface{}, 0)).([]interface{})
+		if len(versions) == 0 {
+			break
+		}
+
+		allVersions = append(allVersions, versions...)
+
+		marker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if marker == "" {
+			break
+		}
+	}
+
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("versions", flattenRfsTemplateVersions(allVersions)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRfsTemplateVersions(versions []interface{}) []interface{} {
+	if len(versions) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(versions))
+	for _, version := range versions {
+		rst = append(rst, map[string]interface{}{
+			"version_id":          utils.PathSearch("version_id", version, nil),
+			"template_id":         utils.PathSearch("template_id", version, nil),
+			"template_name":       utils.PathSearch("template_name", version, nil),
+			"version_description": utils.PathSearch("version_description", version, nil),
+			"create_time":         utils.PathSearch("create_time", version, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_template_versions` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_template_versions` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccDataSourceRfsTemplateVersions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs-v -run TestAccDataSourceRfsTemplateVersions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRfsTemplateVersions_basic
=== PAUSE TestAccDataSourceRfsTemplateVersions_basic
=== CONT  TestAccDataSourceRfsTemplateVersions_basic
--- PASS: TestAccDataSourceRfsTemplateVersions_basic (13.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs 21.311s
```
<img width="649" height="19" alt="image" src="https://github.com/user-attachments/assets/31781945-98ef-4fa2-b798-1d4df1c334b3" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
