### PR TITLE
feat(rfs): support `rfs_stacks` data source

### DIFF
--- a/docs/data-sources/rfs_stacks.md
+++ b/docs/data-sources/rfs_stacks.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_stacks"
+description: |-
+  Use this datasource to get the list of resource stacks.
+---
+
+# huaweicloud_rfs_stacks
+
+Use this datasource to get the list of resource stacks.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_rfs_stacks" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `stacks` - The list of resource stacks. By default, these stacks are sorted in descending order of the
+  generation time.
+
+  The [stacks](#stacks_struct) structure is documented below.
+
+<a name="stacks_struct"></a>
+The `stacks` block supports:
+
+* `stack_name` - The name of the resource stack.
+
+* `description` - The description of the resource stack.
+
+* `stack_id` - The unique ID of the resource stack.
+
+* `status` - The status of the resource stack.
+
+* `create_time` - The creation time of a resource stack. It is represented in UTC format (yyyy-mm-ddTHH:MM:SSZ),
+  such as **1970-01-01T00:00:00Z**.
+
+* `update_time` - The update time of a resource stack. It is represented in UTC format (yyyy-mm-ddTHH:MM:SSZ),
+  such as **1970-01-01T00:00:00Z**.
+
+* `status_message` - A brief error summary when the stack status ends with **FAILED**, for debugging.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2034,6 +2034,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rfs_private_hook_versions":        rfs.DataSourcePrivateHookVersions(),
 			"huaweicloud_rfs_stack_instances":              rfs.DataSourceStackInstances(),
 			"huaweicloud_rfs_stack_resources":              rfs.DataSourceStackResources(),
+			"huaweicloud_rfs_stacks":                       rfs.DataSourceStacks(),
 			"huaweicloud_rfs_stack_set_operation_metadata": rfs.DataSourceStackSetOperationMetadata(),
 			"huaweicloud_rfs_private_providers":            rfs.DataSourcePrivateProviders(),
 			"huaweicloud_rfs_private_provider_versions":    rfs.DataSourcePrivateProviderVersions(),

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_stacks_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_stacks_test.go
@@ -1,0 +1,58 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceStacks_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_stacks.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceNameWithDash()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceStacks_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "stacks.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "stacks.0.stack_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "stacks.0.stack_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "stacks.0.description"),
+					resource.TestCheckResourceAttrSet(dataSource, "stacks.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "stacks.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "stacks.0.update_time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceStacks_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rfs_stack" "test" {
+  name        = "%[1]s"
+  description = "Create by acc test for stacks data source"
+}
+`, name)
+}
+
+func testDataSourceStacks_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rfs_stacks" "test" {
+  depends_on = [huaweicloud_rfs_stack.test]
+}
+`, testDataSourceStacks_base(name))
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_stacks.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_stacks.go
@@ -1,0 +1,158 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/{project_id}/stacks
+func DataSourceStacks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceStacksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"stacks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"stack_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"stack_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status_message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildListStacksQueryParams(marker string) string {
+	if marker != "" {
+		return fmt.Sprintf("?marker=%s", marker)
+	}
+
+	return ""
+}
+
+func dataSourceStacksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1/{project_id}/stacks"
+		allStacks  = make([]interface{}, 0)
+		nextMarker string
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	reqUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request UUID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Client-Request-Id": reqUUID},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildListStacksQueryParams(nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RFS stacks: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		stacks := utils.PathSearch("stacks", respBody, make([]interface{}, 0)).([]interface{})
+		if len(stacks) == 0 {
+			break
+		}
+
+		allStacks = append(allStacks, stacks...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	d.SetId(reqUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("stacks", flattenStacks(allStacks)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenStacks(stacks []interface{}) []interface{} {
+	if len(stacks) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(stacks))
+	for _, v := range stacks {
+		rst = append(rst, map[string]interface{}{
+			"stack_name":     utils.PathSearch("stack_name", v, nil),
+			"description":    utils.PathSearch("description", v, nil),
+			"stack_id":       utils.PathSearch("stack_id", v, nil),
+			"status":         utils.PathSearch("status", v, nil),
+			"create_time":    utils.PathSearch("create_time", v, nil),
+			"update_time":    utils.PathSearch("update_time", v, nil),
+			"status_message": utils.PathSearch("status_message", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_stacks` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_stacks` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccDataSourceStacks_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs -v -run TestAccDataSourceStacks_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceStacks_basic
=== PAUSE TestAccDataSourceStacks_basic
=== CONT  TestAccDataSourceStacks_basic
--- PASS: TestAccDataSourceStacks_basic (26.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       27.011s
```
<img width="803" height="32" alt="image" src="https://github.com/user-attachments/assets/e3246f06-e167-4d1f-8e81-1f4152220ba5" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
