### PR TITLE
feat(dataarts): add new resource to manage data recognition rule group

### DIFF
--- a/docs/resources/dataarts_security_data_recognition_rule_group.md
+++ b/docs/resources/dataarts_security_data_recognition_rule_group.md
@@ -1,0 +1,64 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_data_recognition_rule_group"
+description: |-
+  Use this resource to manage a data recognition rule group for DataArts Studio Security within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_data_recognition_rule_group
+
+Use this resource to manage a data recognition rule group for DataArts Studio Security within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "group_name" {}
+variable "data_recognition_rule_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_dataarts_security_data_recognition_rule_group" "test" {
+  workspace_id = var.workspace_id
+  name         = var.group_name
+  rule_ids     = var.data_recognition_rule_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the data recognition rule group is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the ID of the workspace to which the rule group belongs.
+
+* `name` - (Required, String) Specifies the name of the data recognition rule group.
+
+* `rule_ids` - (Required, List) Specifies the list of data recognition rule IDs that the rule group contains.
+
+* `description` - (Optional, String) Specifies the description of the data recognition rule group.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `created_by` - The creator of the data recognition rule group.
+
+* `created_at` - The creation time of the data recognition rule group, in RFC3339 format.
+
+* `updated_by` - The updater of the data recognition rule group.
+
+* `updated_at` - The update time of the data recognition rule group, in RFC3339 format.
+
+## Import
+
+The resource can be imported using `workspace_id` and `id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_security_data_recognition_rule_group.test <workspace_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3882,11 +3882,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_factory_script":         dataarts.ResourceDataArtsFactoryScript(),
 			"huaweicloud_dataarts_factory_script_execute": dataarts.ResourceFactoryScriptExecute(),
 			// DataArts Security
-			"huaweicloud_dataarts_security_data_recognition_rule":    dataarts.ResourceSecurityRule(),
-			"huaweicloud_dataarts_security_data_secrecy_level":       dataarts.ResourceSecurityDataSecrecyLevel(),
-			"huaweicloud_dataarts_security_permission_set":           dataarts.ResourceSecurityPermissionSet(),
-			"huaweicloud_dataarts_security_permission_set_member":    dataarts.ResourceSecurityPermissionSetMember(),
-			"huaweicloud_dataarts_security_permission_set_privilege": dataarts.ResourceSecurityPermissionSetPrivilege(),
+			"huaweicloud_dataarts_security_data_recognition_rule":       dataarts.ResourceSecurityRule(),
+			"huaweicloud_dataarts_security_data_recognition_rule_group": dataarts.ResourceSecurityDataRecognitionRuleGroup(),
+			"huaweicloud_dataarts_security_data_secrecy_level":          dataarts.ResourceSecurityDataSecrecyLevel(),
+			"huaweicloud_dataarts_security_permission_set":              dataarts.ResourceSecurityPermissionSet(),
+			"huaweicloud_dataarts_security_permission_set_member":       dataarts.ResourceSecurityPermissionSetMember(),
+			"huaweicloud_dataarts_security_permission_set_privilege":    dataarts.ResourceSecurityPermissionSetPrivilege(),
 			// DataArts DataService
 			"huaweicloud_dataarts_dataservice_api":             dataarts.ResourceDataServiceApi(),
 			"huaweicloud_dataarts_dataservice_api_action":      dataarts.ResourceDataServiceApiAction(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule_group_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule_group_test.go
@@ -1,0 +1,168 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dataarts"
+)
+
+func getSecurityDataRecognitionRuleGroupResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	return dataarts.GetSecurityDataRecognitionRuleGroupById(client, state.Primary.Attributes["workspace_id"], state.Primary.ID)
+}
+
+func TestAccSecurityDataRecognitionRuleGroup_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_dataarts_security_data_recognition_rule_group.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getSecurityDataRecognitionRuleGroupResourceFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsSecurityDataCategoryIds(t, 2)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccSecurityDataRecognitionRuleGroup_nonExistentWorkspaceAndRule(name),
+				ExpectError: regexp.MustCompile("error creating DataArts Security data recognition rule group"),
+			},
+			{
+				Config: testAccSecurityDataRecognitionRuleGroup_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "rule_ids.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "rule_ids.0",
+						"huaweicloud_dataarts_security_data_recognition_rule.test.0", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccSecurityDataRecognitionRuleGroup_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "rule_ids.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "rule_ids.0",
+						"huaweicloud_dataarts_security_data_recognition_rule.test.1", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_by"),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccSecurityDataRecognitionRuleGroupImportStateIDFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccSecurityDataRecognitionRuleGroupImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		workspaceID := rs.Primary.Attributes["workspace_id"]
+		id := rs.Primary.ID
+		if workspaceID == "" || id == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<id>', but got '%s/%s'",
+				workspaceID, id)
+		}
+		return fmt.Sprintf("%s/%s", workspaceID, id), nil
+	}
+}
+
+func testAccSecurityDataRecognitionRuleGroup_nonExistentWorkspaceAndRule(name string) string {
+	randomUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_security_data_recognition_rule_group" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  rule_ids     = ["%[1]s"]
+}
+`, randomUUID, name)
+}
+
+func testAccSecurityDataRecognitionRuleGroup_basic_base(name string) string {
+	return fmt.Sprintf(`
+locals {
+  category_ids = try(split(",", "%[1]s"), [])
+}
+
+resource "huaweicloud_dataarts_security_data_secrecy_level" "test" {
+  count = 2
+
+  workspace_id = "%[2]s"
+  name         = format("%[3]s_%%d", count.index) 
+}
+
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
+  count = 2
+
+  workspace_id     = "%[2]s"
+  rule_type        = "CUSTOM"
+  name             = format("%[3]s_%%d", count.index)
+  secrecy_level_id = huaweicloud_dataarts_security_data_secrecy_level.test[count.index].id
+  category_id      = local.category_ids[count.index]
+  method           = "NONE"
+}
+`, acceptance.HW_DATAARTS_SECURITY_DATA_CATEGORY_IDS, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccSecurityDataRecognitionRuleGroup_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_security_data_recognition_rule_group" "test" {
+  workspace_id = "%[2]s"
+  name         = "%[3]s"
+  description  = "Created by terraform"
+  rule_ids     = slice(huaweicloud_dataarts_security_data_recognition_rule.test[*].id, 0, 1)
+}
+`, testAccSecurityDataRecognitionRuleGroup_basic_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccSecurityDataRecognitionRuleGroup_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_security_data_recognition_rule_group" "test" {
+  workspace_id = "%[2]s"
+  name         = "%[3]s_update"
+  rule_ids     = slice(huaweicloud_dataarts_security_data_recognition_rule.test[*].id, 1, 2)
+}
+`, testAccSecurityDataRecognitionRuleGroup_basic_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule_group.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule_group.go
@@ -1,0 +1,340 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var securityDataRecognitionRuleGroupNonUpdatableParams = []string{
+	"workspace_id",
+}
+
+// @API DataArtsStudio POST /v1/{project_id}/security/data-classification/rule/group
+// @API DataArtsStudio GET /v1/{project_id}/security/data-classification/rule/group
+// @API DataArtsStudio PUT /v1/{project_id}/security/data-classification/rule/group/{id}
+// @API DataArtsStudio POST /v1/{project_id}/security/data-classification/rule/group/batch-delete
+func ResourceSecurityDataRecognitionRuleGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSecurityDataRecognitionRuleGroupCreate,
+		ReadContext:   resourceSecurityDataRecognitionRuleGroupRead,
+		UpdateContext: resourceSecurityDataRecognitionRuleGroupUpdate,
+		DeleteContext: resourceSecurityDataRecognitionRuleGroupDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(securityDataRecognitionRuleGroupNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceSecurityDataRecognitionRuleGroupImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the data recognition rule group is located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the rule group belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the data recognition rule group.`,
+			},
+			"rule_ids": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of data recognition rule IDs that the rule group contains.`,
+			},
+
+			// Optional parameters.
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the data recognition rule group.`,
+			},
+
+			// Attributes.
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the data recognition rule group.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the data recognition rule group, in RFC3339 format.`,
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The updater of the data recognition rule group.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the data recognition rule group, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true},
+				),
+			},
+		},
+	}
+}
+
+func buildSecurityDataRecognitionRuleGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"rule_ids":    d.Get("rule_ids").(*schema.Set).List(),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
+func createSecurityDataRecognitionRuleGroup(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl     = "v1/{project_id}/security/data-classification/rule/group"
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+		JSONBody:         utils.RemoveNil(buildSecurityDataRecognitionRuleGroupBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", path, &opts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(resp)
+}
+
+func resourceSecurityDataRecognitionRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	respBody, err := createSecurityDataRecognitionRuleGroup(client, d)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Security data recognition rule group: %s", err)
+	}
+
+	groupId := utils.PathSearch("uuid", respBody, "").(string)
+	if groupId == "" {
+		return diag.Errorf("unable to find the ID of the DataArts Security data recognition rule group from the API response")
+	}
+	d.SetId(groupId)
+
+	return resourceSecurityDataRecognitionRuleGroupRead(ctx, d, meta)
+}
+
+func listSecurityDataRecognitionRuleGroups(client *golangsdk.ServiceClient, workspaceId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/security/data-classification/rule/group?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opts)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		ruleGroups := utils.PathSearch("rule_groups", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, ruleGroups...)
+		if len(ruleGroups) < limit {
+			break
+		}
+		offset += len(ruleGroups)
+	}
+	return result, nil
+}
+
+func GetSecurityDataRecognitionRuleGroupById(client *golangsdk.ServiceClient, workspaceId, groupId string) (interface{}, error) {
+	groups, err := listSecurityDataRecognitionRuleGroups(client, workspaceId)
+	if err != nil {
+		return nil, err
+	}
+
+	group := utils.PathSearch(fmt.Sprintf("[?uuid=='%s']|[0]", groupId), groups, nil)
+	if group == nil {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/security/data-classification/rule/group",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("the data recognition rule group (%s) does not exist", groupId)),
+			},
+		}
+	}
+	return group, nil
+}
+
+func resourceSecurityDataRecognitionRuleGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		groupId     = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	respBody, err := GetSecurityDataRecognitionRuleGroupById(client, workspaceId, groupId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving DataArts Security data recognition rule group (%s)", groupId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("rule_ids", utils.PathSearch("rules[*].uuid", respBody, make([]interface{}, 0)).([]interface{})),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("created_by", utils.PathSearch("created_by", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(
+			int64(utils.PathSearch("created_at", respBody, float64(0)).(float64))/1000, false)),
+		d.Set("updated_by", utils.PathSearch("updated_by", respBody, nil)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(
+			int64(utils.PathSearch("updated_at", respBody, float64(0)).(float64))/1000, false)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func updateSecurityDataRecognitionRuleGroup(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/security/data-classification/rule/group/{id}"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{id}", d.Id())
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(d.Get("workspace_id").(string)),
+		JSONBody: map[string]interface{}{
+			"name":        d.Get("name"),
+			"rule_ids":    d.Get("rule_ids").(*schema.Set).List(),
+			"description": d.Get("description"),
+		},
+	}
+	_, err := client.Request("PUT", path, &opts)
+	return err
+}
+
+func resourceSecurityDataRecognitionRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	if d.HasChanges("name", "rule_ids", "description") {
+		err = updateSecurityDataRecognitionRuleGroup(client, d)
+		if err != nil {
+			return diag.Errorf("error updating DataArts Security data recognition rule group (%s): %s", d.Id(), err)
+		}
+	}
+
+	return resourceSecurityDataRecognitionRuleGroupRead(ctx, d, meta)
+}
+
+func deleteSecurityDataRecognitionRuleGroup(client *golangsdk.ServiceClient, workspaceId, groupId string) error {
+	httpUrl := "v1/{project_id}/security/data-classification/rule/group/batch-delete"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+		JSONBody: map[string]interface{}{
+			"rule_group_ids": []string{groupId},
+		},
+		OkCodes: []int{204},
+	}
+	_, err := client.Request("POST", path, &opts)
+	return err
+}
+
+func resourceSecurityDataRecognitionRuleGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		groupId     = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	if err := deleteSecurityDataRecognitionRuleGroup(client, workspaceId, groupId); err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting DataArts Security data recognition rule group (%s)", groupId))
+	}
+
+	return nil
+}
+
+func resourceSecurityDataRecognitionRuleGroupImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.SplitN(importedId, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<id>', but got '%s'", importedId)
+	}
+
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, d.Set("workspace_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource for DataArts Studio Security that used to manage data recognition rule group.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance test:
<img width="1078" height="212" alt="image" src="https://github.com/user-attachments/assets/b4d93bcb-ca99-41cc-b5f1-a100a91f674e" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage data recognition rule group
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccSecurityDataRecognitionRuleGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccSecurityDataRecognitionRuleGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccSecurityDataRecognitionRuleGroup_basic
=== PAUSE TestAccSecurityDataRecognitionRuleGroup_basic
=== CONT  TestAccSecurityDataRecognitionRuleGroup_basic
--- PASS: TestAccSecurityDataRecognitionRuleGroup_basic (37.89s)
PASS
coverage: 6.9% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  38.001s coverage: 6.9% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="915" height="620" alt="image" src="https://github.com/user-attachments/assets/a616a1e4-8294-407e-acaa-c21e923120d4" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    Delete a non-exist data recognition rule group will not report an error
    <img width="1670" height="1201" alt="image" src="https://github.com/user-attachments/assets/393c6448-3b2a-4883-98f1-29ca15b323a2" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
