### PR TITLE
feat(dataarts): add new data source to query associated members

### DIFF
--- a/docs/data-sources/dataarts_security_permission_set_members.md
+++ b/docs/data-sources/dataarts_security_permission_set_members.md
@@ -1,0 +1,95 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_permission_set_members"
+description: |-
+  Use this data source to get the list of associated members under a specified permission set for DataArts Studio
+  Security within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_permission_set_members
+
+Use this data source to get the list of associated members under a specified permission set for DataArts Studio Security
+within HuaweiCloud.
+
+## Example Usage
+
+### Query all associated members under a specified permission set
+
+```hcl
+variable "workspace_id" {}
+variable "permission_set_id" {}
+
+data "huaweicloud_dataarts_security_permission_set_members" "test" {
+  workspace_id      = var.workspace_id
+  permission_set_id = var.permission_set_id
+}
+```
+
+### Query the associated members under a specified permission set and using member type to filter
+
+```hcl
+variable "workspace_id" {}
+variable "permission_set_id" {}
+
+data "huaweicloud_dataarts_security_permission_set_members" "test" {
+  workspace_id      = var.workspace_id
+  permission_set_id = var.permission_set_id
+  member_type       = "USER"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the permission set associated members are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the permission set belongs.
+
+* `permission_set_id` - (Required, String) Specifies the ID of the permission set which the members associated.
+
+* `member_name` - (Optional, String) Specifies the name of the specified permission set member to be queried.
+
+* `member_type` - (Optional, String) Specifies the type of the permission set members to be queried.  
+  The valid values are as follows:
+  + **USER**
+  + **USER_GROUP**
+  + **WORKSPACE_ROLE**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `members` - The list of permission set associated members that match the filter parameters.  
+  The [members](#dataarts_security_permission_set_associated_members_attr) structure is documented below.
+
+<a name="dataarts_security_permission_set_associated_members_attr"></a>
+The `members` block supports:
+
+* `id` - The ID of the permission set member.
+
+* `type` - The type of the permission set member.
+
+* `name` - The name of the permission set member.
+
+* `status` - The status of the permission set member.
+
+* `instance_id` - The instance ID to which the permission set member belongs.
+
+* `workspace` - The workspace ID to which the permission set member belongs.
+
+* `permission_set_id` - The ID of the permission set to which the permission set member belongs.
+
+* `cluster_id` - The cluster ID to which the permission set member belongs.
+
+* `cluster_type` - The cluster type to which the permission set member belongs.
+
+* `cluster_name` - The cluster name to which the permission set member belongs.
+
+* `create_user` - The creator of the permission set member.
+
+* `created_at` - The creation time of the permission set member, in RFC3339 format.
+
+* `deadline` - The deadline time of the permission set member, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1093,6 +1093,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_factory_scripts":   dataarts.DataSourceFactoryScripts(),
 			// DataArts Security
 			"huaweicloud_dataarts_security_data_recognition_rules":      dataarts.DataSourceSecurityDataRecognitionRules(),
+			"huaweicloud_dataarts_security_permission_set_members":      dataarts.DataSourceSecurityPermissionSetMembers(),
 			"huaweicloud_dataarts_security_permission_set_privileges":   dataarts.DataSourceSecurityPermissionSetPrivileges(),
 			"huaweicloud_dataarts_security_workspace_associated_queues": dataarts.DataSourceSecurityWorkspaceAssociatedQueues(),
 

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_permission_set_members_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_permission_set_members_test.go
@@ -1,0 +1,167 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSecurityPermissionSetMembers_basic(t *testing.T) {
+	var (
+		rName = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_security_permission_set_members.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byMemberName   = "data.huaweicloud_dataarts_security_permission_set_members.filter_by_member_name"
+		dcByMemberName = acceptance.InitDataSourceCheck(byMemberName)
+
+		byMemberType   = "data.huaweicloud_dataarts_security_permission_set_members.filter_by_member_type"
+		dcByMemberType = acceptance.InitDataSourceCheck(byMemberType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsManagerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSecurityPermissionSetMembers_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(all, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttrSet(all, "permission_set_id"),
+					resource.TestCheckResourceAttrSet(all, "region"),
+					resource.TestMatchResourceAttr(all, "members.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestCheckResourceAttrSet(all, "members.0.id"),
+					resource.TestCheckResourceAttrSet(all, "members.0.name"),
+					resource.TestCheckResourceAttrSet(all, "members.0.type"),
+					// Filter by member_name
+					dcByMemberName.CheckResourceExists(),
+					resource.TestCheckOutput("is_member_name_filter_useful", "true"),
+					// Filter by member_type
+					dcByMemberType.CheckResourceExists(),
+					resource.TestCheckOutput("is_member_type_filter_useful", "true"),
+					resource.TestCheckResourceAttr(byMemberType, "members.0.type", "USER"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSecurityPermissionSetMembers_basic_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_studio_workspace_user_roles" "test" {
+  workspace_id = "%[1]s"
+}
+
+data "huaweicloud_identity_users" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_dataarts_studio_workspace_user" "test" {
+  workspace_id = "%[1]s"
+  user_id      = try(data.huaweicloud_identity_users.test.users[0].id, "NOT_FOUND")
+
+  dynamic "roles" {
+    for_each = slice(data.huaweicloud_dataarts_studio_workspace_user_roles.test.roles, 0, 1)
+
+	content {
+      id = roles.value.id
+    }
+  }
+}
+
+resource "huaweicloud_dataarts_security_permission_set" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[3]s"
+  parent_id    = "0"
+  manager_id   = "%[4]s"
+}
+
+resource "huaweicloud_dataarts_security_permission_set_member" "test" {
+  workspace_id      = "%[1]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  object_id         = huaweicloud_dataarts_studio_workspace_user.test.id
+  name              = "%[3]s"
+  type              = "USER"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_USER_NAME, name, acceptance.HW_DATAARTS_MANAGER_ID)
+}
+
+func testAccDataSecurityPermissionSetMembers_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all members and without any filter
+data "huaweicloud_dataarts_security_permission_set_members" "all" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_member.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+}
+
+# Filter by member_name
+locals {
+  member_name = huaweicloud_dataarts_security_permission_set_member.test.name
+}
+
+data "huaweicloud_dataarts_security_permission_set_members" "filter_by_member_name" {
+  # The behavior of parameter 'member_name' of the data source is 'Required', means this parameter does not
+  # have 'Know After Apply' behavior.
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_member.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  member_name       = local.member_name
+}
+
+locals {
+  member_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_members.filter_by_member_name.members[*].name :
+      v == local.member_name
+  ]
+}
+
+output "is_member_name_filter_useful" {
+  value = length(local.member_name_filter_result) > 0 && alltrue(local.member_name_filter_result)
+}
+
+# Filter by member_type
+locals {
+  member_type = "USER"
+}
+
+data "huaweicloud_dataarts_security_permission_set_members" "filter_by_member_type" {
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set_member.test,
+  ]
+
+  workspace_id      = "%[2]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  member_type       = local.member_type
+}
+
+locals {
+  member_type_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_set_members.filter_by_member_type.members[*].type :
+      v == local.member_type
+  ]
+}
+
+output "is_member_type_filter_useful" {
+  value = length(local.member_type_filter_result) > 0 && alltrue(local.member_type_filter_result)
+}
+`, testAccDataSecurityPermissionSetMembers_basic_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_permission_set_members.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_permission_set_members.go
@@ -1,0 +1,251 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/security/permission-sets/{permission_set_id}/members
+func DataSourceSecurityPermissionSetMembers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityPermissionSetMembersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the permission set associated members are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the permission set belongs.`,
+			},
+			"permission_set_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the permission set which the members associated.`,
+			},
+
+			// Optional parameters.
+			"member_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the specified permission set member to be queried.`,
+			},
+			"member_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of the permission set members to be queried.`,
+			},
+
+			// Attributes.
+			"members": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the permission set member.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the permission set member.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the permission set member.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the permission set member.`,
+						},
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The instance ID to which the permission set member belongs.`,
+						},
+						"workspace": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The workspace ID to which the permission set member belongs.`,
+						},
+						"permission_set_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the permission set to which the permission set member belongs.`,
+						},
+						"cluster_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The cluster ID to which the permission set member belongs.`,
+						},
+						"cluster_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The cluster type to which the permission set member belongs.`,
+						},
+						"cluster_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The cluster name to which the permission set member belongs.`,
+						},
+						"create_user": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator of the permission set member.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the permission set member, in RFC3339 format.`,
+						},
+						"deadline": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The deadline time of the permission set member, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `The list of permission set associated members that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildSecurityPermissionSetMembersQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("member_name"); ok {
+		res = fmt.Sprintf("%s&member_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("member_type"); ok {
+		res = fmt.Sprintf("%s&member_type=%v", res, v)
+	}
+
+	return res
+}
+
+func listSecurityPermissionSetMembers(client *golangsdk.ServiceClient, workspaceId, permissionSetId string,
+	queryParams ...string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/security/permission-sets/{permission_set_id}/members?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{permission_set_id}", permissionSetId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	if len(queryParams) > 0 && queryParams[0] != "" {
+		listPath += queryParams[0]
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		members := utils.PathSearch("permission_set_members", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, members...)
+		if len(members) < limit {
+			break
+		}
+		offset += len(members)
+	}
+
+	return result, nil
+}
+
+func flattenSecurityPermissionSetMembers(members []interface{}) []map[string]interface{} {
+	if len(members) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(members))
+	for _, member := range members {
+		result = append(result, map[string]interface{}{
+			"id":                utils.PathSearch("member_id", member, nil),
+			"type":              utils.PathSearch("member_type", member, nil),
+			"name":              utils.PathSearch("member_name", member, nil),
+			"status":            utils.PathSearch("member_status", member, nil),
+			"instance_id":       utils.PathSearch("instance_id", member, nil),
+			"workspace":         utils.PathSearch("workspace", member, nil),
+			"permission_set_id": utils.PathSearch("permission_set_id", member, nil),
+			"cluster_id":        utils.PathSearch("cluster_id", member, nil),
+			"cluster_type":      utils.PathSearch("cluster_type", member, nil),
+			"cluster_name":      utils.PathSearch("cluster_name", member, nil),
+			"create_user":       utils.PathSearch("create_user", member, nil),
+			"created_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time",
+				member, float64(0)).(float64))/1000, false),
+			"deadline": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("deadline",
+				member, float64(0)).(float64))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceSecurityPermissionSetMembersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		region          = cfg.GetRegion(d)
+		workspaceId     = d.Get("workspace_id").(string)
+		permissionSetId = d.Get("permission_set_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	members, err := listSecurityPermissionSetMembers(client, workspaceId, permissionSetId, buildSecurityPermissionSetMembersQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error querying permission set members: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("members", flattenSecurityPermissionSetMembers(members)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source for DataArts Studio Security that used to query associated members under a specified permission set.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance test:
<img width="1118" height="317" alt="image" src="https://github.com/user-attachments/assets/7889ef18-9fe4-46c9-a6a5-5436c4603295" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query associated members
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataSecurityPermissionSetMembers_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataSecurityPermissionSetMembers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSecurityPermissionSetMembers_basic
=== PAUSE TestAccDataSecurityPermissionSetMembers_basic
=== CONT  TestAccDataSecurityPermissionSetMembers_basic
--- PASS: TestAccDataSecurityPermissionSetMembers_basic (15.97s)
PASS
coverage: 8.4% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  16.073s coverage: 8.4% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
