### PR TITLE
feat(dataarts/security): add new resource to manage dynamic masking policy

### DIFF
--- a/docs/resources/dataarts_security_dynamic_masking_policy.md
+++ b/docs/resources/dataarts_security_dynamic_masking_policy.md
@@ -1,0 +1,169 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_dynamic_masking_policy"
+description: |-
+  Manages a dynamic masking policy resource for DataArts Studio Security within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_dynamic_masking_policy
+
+Manages a dynamic masking policy resource for DataArts Studio Security within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "policy_name" {}
+variable "dws_cluster_id" {}
+variable "dws_cluster_name" {}
+variable "database_name" {}
+variable "table_name" {}
+variable "connection_name" {}
+variable "connection_id" {}
+variable "users" {}
+variable "user_groups" {}
+variable "schema_name" {}
+
+resource "huaweicloud_dataarts_security_dynamic_masking_policy" "test" {
+  workspace_id    = var.workspace_id
+  name            = var.policy_name
+  datasource_type = "DWS"
+  cluster_id      = var.dws_cluster_id
+  cluster_name    = var.dws_cluster_name
+  database_name   = var.database_name
+  table_name      = var.table_name
+  conn_name       = var.connection_name
+  conn_id         = var.connection_id
+  users           = var.users
+  user_groups     = var.user_groups
+  schema_name     = var.schema_name
+
+  policy_list {
+    column_name          = "name"
+    column_type          = "text"
+    algorithm_type       = "DWS_SELF_CONFIG"
+    algorithm_detail_dto = jsonencode({
+      start         = 1
+      end           = 2
+      string_target = "*"
+    })
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the dynamic masking policy is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the ID of the workspace to which the dynamic masking
+  policy belongs.
+
+* `name` - (Required, String) Specifies the name of the dynamic masking policy.  
+  The valid length is limited from `2` to `64`, only letters, Chinese characters, digits, and underscores (_) are allowed,
+  and must start with letters or Chinese characters.
+
+* `datasource_type` - (Required, String, NonUpdatable) Specifies the data source type of the dynamic masking policy.  
+  The valid values are as follows:
+  + **HIVE**
+  + **DWS**
+  + **DLI**
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster corresponding to the data source.  
+  When the data source type is **DLI**, this parameter must be set to **DLI**.
+
+* `cluster_name` - (Required, String, NonUpdatable) Specifies the name of the cluster corresponding to the
+  data source.  
+  When the data source type is **DLI**, this parameter must be set to **DLI**.
+
+* `database_name` - (Required, String, NonUpdatable) Specifies the name of the database.
+
+* `table_name` - (Required, String, NonUpdatable) Specifies the name of the data table.
+
+* `conn_name` - (Required, String) Specifies the name of the data connection.
+
+* `conn_id` - (Required, String) Specifies the ID of the data connection.
+
+* `policy_list` - (Required, List) Specifies the list of dynamic masking policy configurations.  
+  The [policy_list](#dataarts_security_dynamic_masking_policy_list) structure is documented below.
+
+* `table_id` - (Optional, String) Specifies the ID of the data table.
+
+* `user_groups` - (Optional, String) Specifies the list of user groups, separated by commas (,).  
+  At least one of the `user_groups` and `users` parameters must be specified.
+
+* `users` - (Optional, String) Specifies the list of users, separated by commas (,).  
+  At least one of the `user_groups` and `users` parameters must be specified.
+  
+* `schema_name` - (Optional, String, NonUpdatable) Specifies the schema name corresponding to the DWS data source.
+
+<a name="dataarts_security_dynamic_masking_policy_list"></a>
+The `policy_list` block supports:
+
+* `column_name` - (Required, String) Specifies the field name in the data table.
+
+* `column_type` - (Required, String) Specifies the field type in the data table.
+
+* `algorithm_type` - (Optional, String) Specifies the algorithm type of dynamic masking.  
+  For HIVE data source dynamic masking algorithm, the valid values are as follows:
+  + **MASK**: Mask letters and digits.
+  + **MASK_SHOW_LAST_4**: Show last 4 characters.
+  + **MASK_SHOW_FIRST_4**: Show first 4 characters.
+  + **MASK_HASH**: Hash masking.
+  + **MASK_DATE_SHOW_YEAR**: Mask month and date.
+  + **MASK_NULL**: Null masking.
+
+  For DWS data source dynamic masking algorithm, the valid values are as follows:
+  + **DWS_ALL_MASK**: Full masking.
+  + **DWS_BACK_KEEP**: Keep last 4 characters, mask the rest as *.
+  + **DWS_FRONT_KEEP**: Keep first 2 characters, mask the rest as *.
+  + **DWS_SELF_CONFIG**: Custom masking. The start and end positions and the masking character need to be specified.
+
+  For DLI data source dynamic masking algorithm, the valid values are as follows:
+  + **MASK**: Mask letters and digits.
+  + **MASK_SHOW_LAST_4**: Keep last 4 characters.
+  + **MASK_SHOW_FIRST_4**: Keep first 4 characters.
+  + **MASK_HASH**: Hash masking.
+  + **MASK_DATE_SHOW_YEAR**: Mask month and date.
+  + **MASK_NULL**: Null masking.
+
+* `algorithm_detail_dto` - (Optional, String) Specifies the algorithm detail object of dynamic masking, in
+  JSON format.  
+  For field details, please refer to the [documentation](https://support.huaweicloud.com/api-dataartsstudio/CreateSecurityDynamicMaskingPolicy.html#CreateSecurityDynamicMaskingPolicy__request_AlgorithmDetailDTO).
+  
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `sync_status` - The current synchronization status of the policy.
+  + **UNKNOWN**
+  + **NOT_SYNC**
+  + **SYNC_SUCCESS**
+  + **SYNC_FAIL**
+  + **SYNC_PARTIAL_FAIL**
+  + **DATA_UPDATED**
+
+* `sync_msg` - The synchronization message of the policy.
+
+* `sync_log` - The synchronization log of the policy.
+
+* `create_time` - The creation time of the policy, in RFC3339 format.
+
+* `create_user` - The creator of the policy.
+
+* `update_time` - The latest update time of the policy, in RFC3339 format.
+
+* `update_user` - The latest updater of the policy.
+
+## Import
+
+The resource can be imported using `workspace_id` and `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_security_dynamic_masking_policy.test <workspace_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3889,6 +3889,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_security_data_recognition_rule":       dataarts.ResourceSecurityRule(),
 			"huaweicloud_dataarts_security_data_recognition_rule_group": dataarts.ResourceSecurityDataRecognitionRuleGroup(),
 			"huaweicloud_dataarts_security_data_secrecy_level":          dataarts.ResourceSecurityDataSecrecyLevel(),
+			"huaweicloud_dataarts_security_dynamic_masking_policy":      dataarts.ResourceSecurityDynamicMaskingPolicy(),
 			"huaweicloud_dataarts_security_permission_set":              dataarts.ResourceSecurityPermissionSet(),
 			"huaweicloud_dataarts_security_permission_set_member":       dataarts.ResourceSecurityPermissionSetMember(),
 			"huaweicloud_dataarts_security_permission_set_privilege":    dataarts.ResourceSecurityPermissionSetPrivilege(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_dynamic_masking_policy_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_dynamic_masking_policy_test.go
@@ -1,0 +1,220 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dataarts"
+)
+
+func getSecurityDynamicMaskingPolicyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	return dataarts.GetSecurityDynamicMaskingPolicyById(client, state.Primary.Attributes["workspace_id"], state.Primary.ID)
+}
+
+// HW_DATAARTS_CONNECTION_ID must be the connection ID corresponding to a DWS type data connection.
+func TestAccSecurityDynamicMaskingPolicy_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_dataarts_security_dynamic_masking_policy.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getSecurityDynamicMaskingPolicyResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsConnectionID(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityDynamicMaskingPolicy_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "datasource_type", "DWS"),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttrSet(rName, "cluster_name"),
+					resource.TestCheckResourceAttr(rName, "database_name", "gaussdb"),
+					resource.TestCheckResourceAttr(rName, "table_name", name),
+					resource.TestCheckResourceAttr(rName, "conn_id", acceptance.HW_DATAARTS_CONNECTION_ID),
+					resource.TestCheckResourceAttrSet(rName, "conn_name"),
+					resource.TestCheckResourceAttr(rName, "policy_list.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "policy_list.*", map[string]string{
+						"column_name":          "total",
+						"column_type":          "int8",
+						"algorithm_type":       "DWS_SELF_CONFIG",
+						"algorithm_detail_dto": `{"end":2,"int_target":0,"start":1}`,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "policy_list.*", map[string]string{
+						"column_name":    "enabled",
+						"column_type":    "bool",
+						"algorithm_type": "MASK",
+					}),
+					resource.TestCheckResourceAttrSet(rName, "users"),
+					resource.TestCheckResourceAttr(rName, "user_groups", fmt.Sprintf("%s0,%s1", name, name)),
+					resource.TestCheckResourceAttr(rName, "schema_name", "public"),
+					resource.TestCheckResourceAttrSet(rName, "sync_status"),
+					resource.TestMatchResourceAttr(rName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(rName, "create_user"),
+				),
+			},
+			{
+				Config: testAccSecurityDynamicMaskingPolicy_basic_step2(name, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "policy_list.#", "1"),
+					resource.TestCheckResourceAttr(rName, "policy_list.0.column_name", "description"),
+					resource.TestCheckResourceAttr(rName, "policy_list.0.column_type", "text"),
+					resource.TestCheckResourceAttr(rName, "policy_list.0.algorithm_type", "DWS_SELF_CONFIG"),
+					resource.TestCheckResourceAttrSet(rName, "policy_list.0.algorithm_detail_dto"),
+					resource.TestCheckResourceAttrPair(rName, "users", "data.huaweicloud_identity_users.test", "users.0.name"),
+					resource.TestCheckResourceAttrPair(rName, "user_groups", "huaweicloud_identity_group.test.0", "name"),
+					resource.TestMatchResourceAttr(rName, "update_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(rName, "update_user"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccSecurityDynamicMaskingPolicyImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccSecurityDynamicMaskingPolicyImportStateFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		workspaceId := rs.Primary.Attributes["workspace_id"]
+		policyId := rs.Primary.ID
+		if workspaceId == "" || policyId == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<workspace_id>/<id>', but got '%s/%s'",
+				workspaceId, policyId)
+		}
+
+		return fmt.Sprintf("%s/%s", workspaceId, policyId), nil
+	}
+}
+
+func testAccSecurityDynamicMaskingPolicy_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_studio_data_connections" "test" {
+  workspace_id  = "%[1]s"
+  connection_id = "%[2]s"
+}
+
+data "huaweicloud_dws_clusters" "test" {}
+
+resource "huaweicloud_identity_group" "test" {
+  count = 2
+  name  = "%[3]s${count.index}"
+}
+
+data "huaweicloud_identity_users" "test" {}
+
+locals {
+  connection_name  = try(data.huaweicloud_dataarts_studio_data_connections.test.connections[0].name, null)
+  dws_cluster_name = try([for v in data.huaweicloud_dws_clusters.test.clusters : v.name if v.id == "%[4]s"][0], null)
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_CONNECTION_ID, name, acceptance.HW_DWS_CLUSTER_ID)
+}
+
+func testAccSecurityDynamicMaskingPolicy_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_security_dynamic_masking_policy" "test" {
+  workspace_id    = "%[2]s"
+  name            = "%[3]s"
+  datasource_type = "DWS"
+  cluster_id      = "%[4]s"
+  cluster_name    = local.dws_cluster_name
+  database_name   = "gaussdb"
+  table_name      = "%[3]s"
+  users           = join(",", slice(data.huaweicloud_identity_users.test.users[*].name, 0, 2))
+  user_groups     = join(",", huaweicloud_identity_group.test[*].name)
+  conn_id         = "%[5]s"
+  conn_name       = local.connection_name
+  table_id        = "NativeTable-%[4]s-gaussdb-public-%[3]s"
+  schema_name     = "public"
+
+  policy_list {
+    column_name          = "total"
+    column_type          = "int8"
+    algorithm_type       = "DWS_SELF_CONFIG"
+    algorithm_detail_dto = jsonencode({
+      start      = 1
+      end        = 2
+      int_target = 0
+    })
+  }
+  policy_list {
+    column_name    = "enabled"
+    column_type    = "bool"
+    algorithm_type = "MASK"
+  }
+}
+`, testAccSecurityDynamicMaskingPolicy_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name,
+		acceptance.HW_DWS_CLUSTER_ID, acceptance.HW_DATAARTS_CONNECTION_ID)
+}
+
+func testAccSecurityDynamicMaskingPolicy_basic_step2(name, updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_security_dynamic_masking_policy" "test" {
+  workspace_id    = "%[2]s"
+  name            = "%[3]s"
+  datasource_type = "DWS"
+  cluster_id      = "%[4]s"
+  cluster_name    = local.dws_cluster_name
+  database_name   = "gaussdb"
+  table_name      = "%[5]s"
+  users           = try(data.huaweicloud_identity_users.test.users[0].name, null)
+  user_groups     = try(huaweicloud_identity_group.test[0].name, null)
+  conn_id         = "%[6]s"
+  conn_name       = local.connection_name
+  table_id        = "NativeTable-%[4]s-gaussdb-public-%[3]s"
+  schema_name     = "public"
+
+  policy_list {
+    column_name          = "description"
+    column_type          = "text"
+    algorithm_type       = "DWS_SELF_CONFIG"
+    algorithm_detail_dto = jsonencode({
+      start         = 1
+      end           = 2
+	  string_target = "*"
+    })
+  }
+}
+`, testAccSecurityDynamicMaskingPolicy_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, updateName,
+		acceptance.HW_DWS_CLUSTER_ID, name, acceptance.HW_DATAARTS_CONNECTION_ID,
+	)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_dynamic_masking_policy.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_dynamic_masking_policy.go
@@ -1,0 +1,485 @@
+package dataarts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	dynamicMaskingPolicyResourceNotFoundCodes = []string{
+		"DLS.6036", // Workspace does not exist, error code key is "errorCode".
+		"DLS.2040", // The resource does not exist, error code key is "error_code".
+	}
+	dynamicMaskingPolicyResourceDeleteNotFoundCodes = []string{
+		"DLS.6036", // Workspace does not exist, error code key is "errorCode".
+		"DLS.2052", // The resource does not exist, error code key is "error_code".
+	}
+	dynamicMaskingPolicyNonUpdatableParams = []string{
+		"workspace_id",
+		"datasource_type",
+		"cluster_id",
+		"cluster_name",
+		"database_name",
+		"table_name",
+		"schema_name",
+	}
+)
+
+// @API DataArtsStudio POST /v1/{project_id}/security/masking/dynamic/policies
+// @API DataArtsStudio GET /v1/{project_id}/security/masking/dynamic/policies/{id}
+// @API DataArtsStudio PUT /v1/{project_id}/security/masking/dynamic/policies/{id}
+// @API DataArtsStudio POST /v1/{project_id}/security/masking/dynamic/policies/batch-delete
+func ResourceSecurityDynamicMaskingPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSecurityDynamicMaskingPolicyCreate,
+		ReadContext:   resourceSecurityDynamicMaskingPolicyRead,
+		UpdateContext: resourceSecurityDynamicMaskingPolicyUpdate,
+		DeleteContext: resourceSecurityDynamicMaskingPolicyDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(dynamicMaskingPolicyNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceSecurityDynamicMaskingPolicyImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the dynamic masking policy is located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the dynamic masking policy belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the dynamic masking policy.`,
+			},
+			"datasource_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The data source type of the dynamic masking policy.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the cluster corresponding to the data source.`,
+			},
+			"cluster_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the cluster corresponding to the data source.`,
+			},
+			"database_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the database.`,
+			},
+			"table_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the data table.`,
+			},
+			"conn_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the data connection.`,
+			},
+			"conn_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the data connection.`,
+			},
+			"policy_list": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: `The list of dynamic masking policy configurations.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"column_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The field name in the data table.`,
+						},
+						"column_type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The field type in the data table.`,
+						},
+						"algorithm_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The algorithm type of dynamic masking.`,
+						},
+						"algorithm_detail_dto": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsJSON,
+							Description:  `The algorithm detail object of dynamic masking, in JSON format.`,
+						},
+					},
+				},
+			},
+
+			// Optional parameters.
+			"table_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The ID of the data table.`,
+			},
+			"user_groups": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The list of user groups, separated by commas (,).`,
+			},
+			"users": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The list of user names, separated by commas (,).`,
+			},
+			"schema_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The schema name corresponding to the DWS data source.`,
+			},
+
+			// Attributes.
+			"sync_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current synchronization status of the policy.`,
+			},
+			"sync_msg": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The synchronization message of the policy.`,
+			},
+			"sync_log": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The synchronization log of the policy.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the policy, in RFC3339 format.`,
+			},
+			"create_user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the policy.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the policy, in RFC3339 format.`,
+			},
+			"update_user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest updater of the policy.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+func createSecurityDynamicMaskingPolicy(client *golangsdk.ServiceClient, d *schema.ResourceData, workspaceId string) (string, error) {
+	httpUrl := "v1/{project_id}/security/masking/dynamic/policies"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+		JSONBody:         utils.RemoveNil(buildSecurityDynamicMaskingPolicyBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", createPath, &opts)
+	if err != nil {
+		return "", err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return "", err
+	}
+
+	policyId := utils.PathSearch("id", respBody, "").(string)
+	if policyId == "" {
+		return "", errors.New("unable to find the ID of the dynamic masking policy from the API response")
+	}
+
+	return policyId, nil
+}
+
+func resourceSecurityDynamicMaskingPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	policyId, err := createSecurityDynamicMaskingPolicy(client, d, d.Get("workspace_id").(string))
+	if err != nil {
+		return diag.Errorf("error creating dynamic masking policy: %s", err)
+	}
+
+	d.SetId(policyId)
+
+	return resourceSecurityDynamicMaskingPolicyRead(ctx, d, meta)
+}
+
+func buildSecurityDynamicMaskingPolicyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":            d.Get("name"),
+		"datasource_type": d.Get("datasource_type"),
+		"cluster_id":      d.Get("cluster_id"),
+		"cluster_name":    d.Get("cluster_name"),
+		"database_name":   d.Get("database_name"),
+		"table_name":      d.Get("table_name"),
+		"conn_name":       d.Get("conn_name"),
+		"conn_id":         d.Get("conn_id"),
+		"policy_list":     buildSecurityDynamicMaskingPolicies(d.Get("policy_list").(*schema.Set)),
+		"table_id":        utils.ValueIgnoreEmpty(d.Get("table_id")),
+		"user_groups":     utils.ValueIgnoreEmpty(d.Get("user_groups")),
+		"users":           utils.ValueIgnoreEmpty(d.Get("users")),
+		"schema_name":     utils.ValueIgnoreEmpty(d.Get("schema_name")),
+	}
+}
+
+func buildSecurityDynamicMaskingPolicies(policies *schema.Set) []map[string]interface{} {
+	if policies.Len() == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, policies.Len())
+	for _, policy := range policies.List() {
+		result = append(result, map[string]interface{}{
+			"column_name":          utils.PathSearch("column_name", policy, nil),
+			"column_type":          utils.PathSearch("column_type", policy, nil),
+			"algorithm_type":       utils.PathSearch("algorithm_type", policy, nil),
+			"algorithm_detail_dto": utils.StringToJson(utils.PathSearch("algorithm_detail_dto", policy, "").(string)),
+		})
+	}
+
+	return result
+}
+
+func GetSecurityDynamicMaskingPolicyById(client *golangsdk.ServiceClient, workspaceId, policyId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/security/masking/dynamic/policies/{id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", policyId)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+	}
+
+	resp, err := client.Request("GET", getPath, &opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceSecurityDynamicMaskingPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	respBody, err := GetSecurityDynamicMaskingPolicyById(client, d.Get("workspace_id").(string), d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected400ErrInto404Err(common.ConvertExpected400ErrInto404Err(err, "errorCode",
+				dynamicMaskingPolicyResourceNotFoundCodes...), "error_code", dynamicMaskingPolicyResourceNotFoundCodes...),
+			fmt.Sprintf("error retrieving dynamic masking policy (%s)", d.Id()),
+		)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("datasource_type", utils.PathSearch("datasource_type", respBody, nil)),
+		d.Set("cluster_id", utils.PathSearch("cluster_id", respBody, nil)),
+		d.Set("cluster_name", utils.PathSearch("cluster_name", respBody, nil)),
+		d.Set("database_name", utils.PathSearch("database_name", respBody, nil)),
+		d.Set("table_name", utils.PathSearch("table_name", respBody, nil)),
+		d.Set("conn_name", utils.PathSearch("conn_name", respBody, nil)),
+		d.Set("conn_id", utils.PathSearch("conn_id", respBody, nil)),
+		d.Set("policy_list", flattenSecurityDynamicMaskingPolicyList(utils.PathSearch("policy_list", respBody,
+			make([]interface{}, 0)).([]interface{}))),
+		d.Set("table_id", utils.PathSearch("table_id", respBody, nil)),
+		d.Set("user_groups", utils.PathSearch("user_groups", respBody, nil)),
+		d.Set("users", utils.PathSearch("users", respBody, nil)),
+		d.Set("schema_name", utils.PathSearch("schema_name", respBody, nil)),
+		d.Set("sync_status", utils.PathSearch("sync_status", respBody, nil)),
+		d.Set("sync_msg", utils.PathSearch("sync_msg", respBody, nil)),
+		d.Set("sync_log", utils.PathSearch("sync_log", respBody, nil)),
+		d.Set("create_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time",
+			respBody, float64(0)).(float64))/1000, false)),
+		d.Set("create_user", utils.PathSearch("create_user", respBody, nil)),
+		d.Set("update_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time",
+			respBody, float64(0)).(float64))/1000, false)),
+		d.Set("update_user", utils.PathSearch("update_user", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSecurityDynamicMaskingPolicyList(policies []interface{}) []interface{} {
+	if len(policies) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(policies))
+	for _, policy := range policies {
+		result = append(result, map[string]interface{}{
+			"column_name":    utils.PathSearch("column_name", policy, nil),
+			"column_type":    utils.PathSearch("column_type", policy, nil),
+			"algorithm_type": utils.PathSearch("algorithm_type", policy, nil),
+			// 'algorithm_detail' and 'algorithm_detail_dto' only differ in type, but they represent the same content.
+			// 'algorithm_detail' is a JSON string without null values.
+			// 'algorithm_detail_dto' is a struct object that may contain null values.
+			"algorithm_detail_dto": utils.PathSearch("algorithm_detail", policy, nil),
+		})
+	}
+
+	return result
+}
+
+func updateSecurityDynamicMaskingPolicy(client *golangsdk.ServiceClient, d *schema.ResourceData, workspaceId string) error {
+	httpUrl := "v1/{project_id}/security/masking/dynamic/policies/{id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{id}", d.Id())
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+		JSONBody:         utils.RemoveNil(buildSecurityDynamicMaskingPolicyBodyParams(d)),
+	}
+
+	_, err := client.Request("PUT", updatePath, &opts)
+	return err
+}
+
+func resourceSecurityDynamicMaskingPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	err = updateSecurityDynamicMaskingPolicy(client, d, d.Get("workspace_id").(string))
+	if err != nil {
+		return diag.Errorf("error updating dynamic masking policy (%s): %s", d.Id(), err)
+	}
+
+	return resourceSecurityDynamicMaskingPolicyRead(ctx, d, meta)
+}
+
+func deleteSecurityDynamicMaskingPolicy(client *golangsdk.ServiceClient, d *schema.ResourceData, workspaceId string) error {
+	httpUrl := "v1/{project_id}/security/masking/dynamic/policies/batch-delete"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+		JSONBody: map[string]interface{}{
+			"ids": []string{d.Id()},
+		},
+		OkCodes: []int{204},
+	}
+
+	_, err := client.Request("POST", deletePath, &opts)
+	return err
+}
+
+func resourceSecurityDynamicMaskingPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	err = deleteSecurityDynamicMaskingPolicy(client, d, workspaceId)
+	if err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected400ErrInto404Err(common.ConvertExpected400ErrInto404Err(err, "errorCode",
+				dynamicMaskingPolicyResourceDeleteNotFoundCodes...), "error_code", dynamicMaskingPolicyResourceDeleteNotFoundCodes...),
+			fmt.Sprintf("error deleting dynamic masking policy (%s)", d.Id()),
+		)
+	}
+
+	return nil
+}
+func resourceSecurityDynamicMaskingPolicyImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<id>', but got '%s'",
+			importedId)
+	}
+
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, d.Set("workspace_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource to manage dynamic masking policy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccResourceSecurityDynamicMaskingPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccResourceSecurityDynamicMaskingPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceSecurityDynamicMaskingPolicy_basic
=== PAUSE TestAccResourceSecurityDynamicMaskingPolicy_basic
=== CONT  TestAccResourceSecurityDynamicMaskingPolicy_basic
--- PASS: TestAccResourceSecurityDynamicMaskingPolicy_basic (71.26s)
PASS
coverage: 6.0% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  71.439s coverage: 6.0% of statements in ./huaweicloud/services/dataarts
```
<img width="1406" height="35" alt="image" src="https://github.com/user-attachments/assets/f37c2701-b6bc-4531-a632-87d448f66d5f" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1196" height="868" alt="image" src="https://github.com/user-attachments/assets/7bafff89-62b5-4eae-8e8a-c6108c253998" />

    ab. Related resources (parent resources) not found
    The Workspace ID does not exist.
    <img width="1132" height="818" alt="image" src="https://github.com/user-attachments/assets/cf307190-8802-43e4-8a99-bdda24ccfd9a" />

   
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1160" height="834" alt="image" src="https://github.com/user-attachments/assets/bec3ed0a-b4c0-4075-ba50-3b579a3d5edb" />

    bb. Related resources (parent resources) not found
    The Workspace ID does not exist.
    <img width="1167" height="849" alt="image" src="https://github.com/user-attachments/assets/056b45a3-9744-4832-8d5b-6bb3ae1ff747" />

