### PR TITLE
feat(ELB): elb listener support params

### DIFF
--- a/docs/resources/elb_listener.md
+++ b/docs/resources/elb_listener.md
@@ -187,6 +187,26 @@ The following arguments are supported:
   Value range: **0** to **1000000**. Defaults to **0**, indicating that the number is not limited. If the value is greater
   than the number defined in the load balancer specifications, the latter is used as the limit.
 
+* `transparent_client_ip_enable` - (Optional, String) Specifies whether to pass source IP addresses of the clients to
+  backend servers. This parameter is available only for TCP and UDP listeners of shared load balancers.
+  + If this function is enabled, the load balancer communicates with backend servers using client IP addresses. Ensure
+    that security group rules and access control policies are correctly configured.
+  + If this function is enabled, a server cannot serve as both a backend server and a client.
+  + If this function is enabled, the backend server specifications cannot be changed.
+
+  Value options:
+  + TCP or UDP listeners of shared load balancers: The value can be **true** or **false**, and the default value is
+    **false** if this parameter is not passed.
+  + HTTP or HTTPS listeners of shared load balancers: The value can only be **true**, and the default value is **true**
+    if this parameter is not passed.
+  + All listeners of dedicated load balancers: The value can only be **true**, and the default value is **true** if this
+    parameter is not passed.
+
+* `nat64_enable` - (Optional, String) Specifies whether to translate between IPv4 and IPv6 addresses. This option allows
+  a client to access IPv4 or IPv6 backend servers by accessing the IPv4 or IPv6 address of a load balancer. This option
+  can only be enabled for TCP and UDP listeners. `nat64_enable` is mutually exclusive with `transparent_client_ip_enable`.
+  Value options: **true** and **false**. Defaults to **false**.
+
 <a name="ELB_port_ranges"></a>
 The `port_ranges` block supports:
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20260414084204-88bc4e0be281
+	github.com/chnsz/golangsdk v0.0.0-20260421095005-051ea824c1a4
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20260414084204-88bc4e0be281 h1:dkag/pWEGOXqGU3sb9bRK0oKExma7vuKrHhZqc/cvPY=
-github.com/chnsz/golangsdk v0.0.0-20260414084204-88bc4e0be281/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
+github.com/chnsz/golangsdk v0.0.0-20260421095005-051ea824c1a4 h1:7C1DbUXjeIjsrXpNUuPOqHXvvC5qwe80+RL8LHemNl0=
+github.com/chnsz/golangsdk v0.0.0-20260421095005-051ea824c1a4/go.mod h1:PIan4aDeDoNOI4FImVS8osVpShcVnAUKR2XM8Ulgsgw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_listener_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_listener_test.go
@@ -53,8 +53,6 @@ func TestAccElbV3Listener_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_forwarding_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "protection_status", "nonProtection"),
-					resource.TestCheckResourceAttr(resourceName, "max_connection", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "cps", "100"),
 					resource.TestCheckResourceAttrSet(resourceName, "enterprise_project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
@@ -74,8 +72,6 @@ func TestAccElbV3Listener_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "advanced_forwarding_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "protection_status", "consoleProtection"),
 					resource.TestCheckResourceAttr(resourceName, "protection_reason", "test protection reason"),
-					resource.TestCheckResourceAttr(resourceName, "max_connection", "2000"),
-					resource.TestCheckResourceAttr(resourceName, "cps", "200"),
 				),
 			},
 			{
@@ -115,6 +111,24 @@ func TestAccElbV3Listener_with_port_ranges(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "port_ranges.0.start_port", "8000"),
 					resource.TestCheckResourceAttr(resourceName, "port_ranges.0.end_port", "8080"),
 					resource.TestCheckResourceAttr(resourceName, "protection_status", "nonProtection"),
+					resource.TestCheckResourceAttr(resourceName, "nat64_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "transparent_client_ip_enable", "false"),
+				),
+			},
+			{
+				Config: testAccElbV3ListenerConfig_with_port_ranges_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "forward_eip", "false"),
+					resource.TestCheckResourceAttr(resourceName, "forward_port", "false"),
+					resource.TestCheckResourceAttr(resourceName, "forward_request_port", "false"),
+					resource.TestCheckResourceAttr(resourceName, "forward_host", "true"),
+					resource.TestCheckResourceAttr(resourceName, "port_ranges.0.start_port", "8000"),
+					resource.TestCheckResourceAttr(resourceName, "port_ranges.0.end_port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "protection_status", "nonProtection"),
+					resource.TestCheckResourceAttr(resourceName, "nat64_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "transparent_client_ip_enable", "true"),
 				),
 			},
 			{
@@ -370,6 +384,12 @@ resource "huaweicloud_elb_loadbalancer" "test" {
     key   = "value"
     owner = "terraform"
   }
+
+  lifecycle {
+    ignore_changes = [
+      l4_flavor_id, l7_flavor_id
+    ]
+  }
 }
 
 resource "huaweicloud_elb_listener" "test" {
@@ -379,8 +399,6 @@ resource "huaweicloud_elb_listener" "test" {
   protocol_port               = 8080
   loadbalancer_id             = huaweicloud_elb_loadbalancer.test.id
   advanced_forwarding_enabled = false
-  max_connection              = 1000
-  cps                         = 100
 
   idle_timeout     = 62
   request_timeout  = 63
@@ -415,6 +433,12 @@ resource "huaweicloud_elb_loadbalancer" "test" {
     key   = "value"
     owner = "terraform"
   }
+
+  lifecycle {
+    ignore_changes = [
+      l4_flavor_id, l7_flavor_id
+    ]
+  }
 }
 
 resource "huaweicloud_elb_listener" "test" {
@@ -424,8 +448,6 @@ resource "huaweicloud_elb_listener" "test" {
   protocol_port               = 8080
   loadbalancer_id             = huaweicloud_elb_loadbalancer.test.id
   advanced_forwarding_enabled = true
-  max_connection              = 2000
-  cps                         = 200
 
   idle_timeout     = 63
   request_timeout  = 64
@@ -468,6 +490,12 @@ resource "huaweicloud_elb_loadbalancer" "test" {
     key   = "value"
     owner = "terraform"
   }
+
+  lifecycle {
+    ignore_changes = [
+      l4_flavor_id, l7_flavor_id
+    ]
+  }
 }
 
 resource "huaweicloud_elb_listener" "test" {
@@ -475,6 +503,55 @@ resource "huaweicloud_elb_listener" "test" {
   description     = "test description"
   protocol        = "UDP"
   loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
+
+  nat64_enable                 = "true"
+  transparent_client_ip_enable = "false"
+
+  port_ranges {
+    start_port = 8000
+    end_port   = 8080
+  }
+}
+`, rName)
+}
+
+func testAccElbV3ListenerConfig_with_port_ranges_update(rName string) string {
+	return fmt.Sprintf(`
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_elb_loadbalancer" "test" {
+  name            = "%[1]s"
+  ipv4_subnet_id  = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
+
+  availability_zone = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
+  tags = {
+    key   = "value"
+    owner = "terraform"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      l4_flavor_id, l7_flavor_id
+    ]
+  }
+}
+
+resource "huaweicloud_elb_listener" "test" {
+  name            = "%[1]s"
+  description     = "test description"
+  protocol        = "UDP"
+  loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
+
+  nat64_enable                 = "false"
+  transparent_client_ip_enable = "true"
 
   port_ranges {
     start_port = 8000
@@ -511,6 +588,12 @@ resource "huaweicloud_elb_loadbalancer" "test" {
   tags = {
     key   = "value"
     owner = "terraform"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      l4_flavor_id, l7_flavor_id
+    ]
   }
 }
 
@@ -573,6 +656,12 @@ resource "huaweicloud_elb_loadbalancer" "test" {
     key   = "value"
     owner = "terraform"
   }
+
+  lifecycle {
+    ignore_changes = [
+      l4_flavor_id, l7_flavor_id
+    ]
+  }
 }
 
 resource "huaweicloud_elb_pool" "test_update" {
@@ -629,6 +718,12 @@ resource "huaweicloud_elb_loadbalancer" "test" {
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0]
   ]
+
+  lifecycle {
+    ignore_changes = [
+      l4_flavor_id, l7_flavor_id
+    ]
+  }
 }`, rName)
 }
 
@@ -795,6 +890,12 @@ resource "huaweicloud_elb_loadbalancer" "test" {
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0]
   ]
+
+  lifecycle {
+    ignore_changes = [
+      l4_flavor_id, l7_flavor_id
+    ]
+  }
 }
 `, common.TestVpc(rName), rName)
 }

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_listener.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_listener.go
@@ -279,6 +279,22 @@ func ResourceListenerV3() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"transparent_client_ip_enable": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"true", "false",
+				}, false),
+			},
+			"nat64_enable": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"true", "false",
+				}, false),
+			},
 			"tags": common.TagsSchema(),
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
@@ -425,6 +441,14 @@ func resourceListenerV3Create(ctx context.Context, d *schema.ResourceData, meta 
 			EnableQuicUpgrade: &enableQuicUpgrade,
 		}
 	}
+	if v, ok := d.GetOk("transparent_client_ip_enable"); ok {
+		transparentClientIpEnable, _ := strconv.ParseBool(v.(string))
+		createOpts.TransparentClientIP = &transparentClientIpEnable
+	}
+	if v, ok := d.GetOk("nat64_enable"); ok {
+		nat64Enable, _ := strconv.ParseBool(v.(string))
+		createOpts.Nat64Enable = &nat64Enable
+	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 
@@ -525,6 +549,8 @@ func resourceListenerV3Read(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("ssl_early_data_enable", listener.SslEarlyDataEnable),
 		d.Set("quic_listener_id", listener.QuicConfig.QuicListenerId),
 		d.Set("enterprise_project_id", listener.EnterpriseProjectID),
+		d.Set("nat64_enable", strconv.FormatBool(listener.Nat64Enable)),
+		d.Set("transparent_client_ip_enable", strconv.FormatBool(listener.TransparentClientIP)),
 		d.Set("created_at", listener.CreatedAt),
 		d.Set("updated_at", listener.UpdatedAt),
 	)
@@ -584,7 +610,7 @@ func resourceListenerV3Update(ctx context.Context, d *schema.ResourceData, meta 
 		"http2_enable", "gzip_enable", "advanced_forwarding_enabled", "protection_status", "protection_reason",
 		"forward_elb", "forward_proto", "real_ip", "forward_tls_certificate", "forward_tls_cipher", "forward_tls_protocol",
 		"enable_member_retry", "proxy_protocol_enable", "sni_match_algo", "security_policy_id", "ssl_early_data_enable",
-		"quic_listener_id", "enable_quic_upgrade", "max_connection", "cps",
+		"quic_listener_id", "enable_quic_upgrade", "max_connection", "cps", "nat64_enable", "transparent_client_ip_enable",
 	}
 	if d.HasChanges(updateListenerChanges...) {
 		err := updateListener(ctx, d, elbClient)
@@ -736,6 +762,14 @@ func updateListener(ctx context.Context, d *schema.ResourceData, elbClient *gola
 	if d.HasChange("ssl_early_data_enable") {
 		sslEarlyDataEnable := d.Get("ssl_early_data_enable").(bool)
 		updateOpts.SslEarlyDataEnable = &sslEarlyDataEnable
+	}
+	if d.HasChange("nat64_enable") {
+		nat64Enable, _ := strconv.ParseBool(d.Get("nat64_enable").(string))
+		updateOpts.Nat64Enable = &nat64Enable
+	}
+	if d.HasChange("transparent_client_ip_enable") {
+		transparentClientIpEnable, _ := strconv.ParseBool(d.Get("transparent_client_ip_enable").(string))
+		updateOpts.TransparentClientIP = &transparentClientIpEnable
 	}
 
 	// if changing custom security policy to default security policy, the security_policy_id must be null

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/requests.go
@@ -120,6 +120,9 @@ type CreateOpts struct {
 
 	// Protection reason
 	ProtectionReason string `json:"protection_reason,omitempty"`
+
+	// Nat64 enable
+	Nat64Enable *bool `json:"nat64_enable,omitempty"`
 }
 
 type IpGroup struct {
@@ -274,6 +277,9 @@ type UpdateOpts struct {
 
 	// Update protection reason
 	ProtectionReason *string `json:"protection_reason,omitempty"`
+
+	// Nat64 enable
+	Nat64Enable *bool `json:"nat64_enable,omitempty"`
 }
 
 // ToListenerUpdateMap builds a request body from UpdateOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/results.go
@@ -121,6 +121,9 @@ type Listener struct {
 
 	// Update protection reason
 	ProtectionReason string `json:"protection_reason"`
+
+	// Nat64 enable
+	Nat64Enable bool `json:"nat64_enable"`
 }
 
 type commonResult struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20260414084204-88bc4e0be281
+# github.com/chnsz/golangsdk v0.0.0-20260421095005-051ea824c1a4
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
elb listener support ransparent_client_ip_enable and nat64_enable
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  elb listener support ransparent_client_ip_enable and nat64_enable
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/elb/ TESTARGS='-run TestAccElbV3Listener_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run TestAccElbV3Listener_ -timeout 360m -parallel 4
=== RUN   TestAccElbV3Listener_basic
=== PAUSE TestAccElbV3Listener_basic
=== RUN   TestAccElbV3Listener_with_port_ranges
=== PAUSE TestAccElbV3Listener_with_port_ranges
=== RUN   TestAccElbV3Listener_with_default_pool
=== PAUSE TestAccElbV3Listener_with_default_pool
=== RUN   TestAccElbV3Listener_with_protocol_https
=== PAUSE TestAccElbV3Listener_with_protocol_https
=== RUN   TestAccElbV3Listener_with_protocol_tls
=== PAUSE TestAccElbV3Listener_with_protocol_tls
=== RUN   TestAccElbV3Listener_with_ip_protocol
=== PAUSE TestAccElbV3Listener_with_ip_protocol
=== CONT  TestAccElbV3Listener_basic
=== CONT  TestAccElbV3Listener_with_protocol_https
=== CONT  TestAccElbV3Listener_with_ip_protocol
=== CONT  TestAccElbV3Listener_with_protocol_tls
=== CONT  TestAccElbV3Listener_with_ip_protocol
    acceptance.go:4219: HW_ELB_GATEWAY_TYPE must be set for the acceptance test
--- SKIP: TestAccElbV3Listener_with_ip_protocol (0.01s)
=== CONT  TestAccElbV3Listener_with_default_pool
--- PASS: TestAccElbV3Listener_basic (232.97s)
=== CONT  TestAccElbV3Listener_with_port_ranges
--- PASS: TestAccElbV3Listener_with_protocol_tls (238.79s)
--- PASS: TestAccElbV3Listener_with_default_pool (302.41s)
--- PASS: TestAccElbV3Listener_with_protocol_https (409.40s)
--- PASS: TestAccElbV3Listener_with_port_ranges (188.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       421.867s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
