### PR TITLE
feat(dataarts): add new datasource for query the list of approvers

### DIFF
--- a/docs/data-sources/dataarts_dataservice_approvers.md
+++ b/docs/data-sources/dataarts_dataservice_approvers.md
@@ -1,0 +1,76 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCLoud: huaweicloud_dataarts_dataservice_approvers"
+description: |-
+  Use this data source to get the list of approvers for DataArts Studio Data Service within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_dataservice_approvers
+
+Use this data source to get the list of approvers for DataArts Studio Data Service within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_dataservice_approvers" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the approvers are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the approvers belong.
+
+* `name` - (Optional, String) Specifies the name of the approver to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `approvers` - The list of approvers that match the filter parameters.  
+  The [approvers](#dataarts_dataservice_approvers_attr) structure is documented below.
+
+<a name="dataarts_dataservice_approvers_attr"></a>  
+The `approvers` block supports:
+
+* `id` - The ID of the approver.
+
+* `name` - The name of the approver.
+
+* `user_id` - The user ID of the approver.
+
+* `user_name` - The user name of the approver.
+
+* `email` - The email of the approver.
+
+* `phone_number` - The phone number of the approver.
+
+* `department` - The department of the approver.
+
+* `description` - The description of the approver.
+
+* `character` - The character of the approver.
+
+* `create_by` - The creator of the approver.
+
+* `create_time` - The creation time of the approver, in RFC3339 format.
+
+* `app_name` - The application name.
+
+* `topic_urn` - The topic URN.
+
+* `template_id` - The template ID.
+
+* `project_id` - The project ID.
+
+* `approver_type` - The type of the approver.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1079,6 +1079,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_table_models":          dataarts.DataSourceArchitectureTableModels(),
 			// DataArts DataService
 			"huaweicloud_dataarts_dataservice_apis":            dataarts.DataSourceDataServiceApis(),
+			"huaweicloud_dataarts_dataservice_approvers":       dataarts.DataSourceDataServiceApprovers(),
 			"huaweicloud_dataarts_dataservice_apps":            dataarts.DataSourceDataServiceApps(),
 			"huaweicloud_dataarts_dataservice_authorized_apps": dataarts.DataSourceDataServiceAuthorizedApps(),
 			"huaweicloud_dataarts_dataservice_instances":       dataarts.DataSourceDataServiceInstances(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_dataservice_approvers_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_dataservice_approvers_test.go
@@ -1,0 +1,78 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataDataServiceApprovers_basic(t *testing.T) {
+	var (
+		name = "data.huaweicloud_dataarts_dataservice_approvers.test"
+		dc   = acceptance.InitDataSourceCheck(name)
+
+		byName   = "data.huaweicloud_dataarts_dataservice_approvers.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataDataServiceApprovers_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(name, "approvers.#", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttrSet(name, "approvers.0.id"),
+					resource.TestCheckResourceAttrSet(name, "approvers.0.name"),
+					resource.TestCheckResourceAttrSet(name, "approvers.0.user_id"),
+					resource.TestCheckResourceAttrSet(name, "approvers.0.user_name"),
+					resource.TestCheckResourceAttrSet(name, "approvers.0.create_by"),
+					resource.TestMatchResourceAttr(name, "approvers.0.create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(name, "approvers.0.approver_type", regexp.MustCompile(`^\d+$`)),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataDataServiceApprovers_basic() string {
+	return fmt.Sprintf(`
+# Query all approvers and without any filter
+data "huaweicloud_dataarts_dataservice_approvers" "test" {
+  workspace_id = "%[1]s"
+}
+
+# Filter by name
+locals {
+  approver_name = try(data.huaweicloud_dataarts_dataservice_approvers.test.approvers[0].name, "NOT_FOUND")
+}
+
+data "huaweicloud_dataarts_dataservice_approvers" "filter_by_name" {
+  workspace_id = "%[1]s"
+  name         = local.approver_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dataarts_dataservice_approvers.filter_by_name.approvers[*].name 
+    : v == local.approver_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_dataservice_approvers.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_dataservice_approvers.go
@@ -1,0 +1,255 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/service/authorizeapply/approver
+func DataSourceDataServiceApprovers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDataServiceApproversRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the approvers are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the approvers belong.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the approver to be queried.`,
+			},
+
+			// Attributes.
+			"approvers": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataServiceApproverElem(),
+				Description: `The list of approvers that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataServiceApproverElem() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the approver.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the approver.`,
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user ID of the approver.`,
+			},
+			"user_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user name of the approver.`,
+			},
+			"email": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The email of the approver.`,
+			},
+			"phone_number": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The phone number of the approver.`,
+			},
+			"department": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The department of the approver.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the approver.`,
+			},
+			"character": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The character of the approver.`,
+			},
+			"create_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the approver.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the approver, in RFC3339 format.`,
+			},
+			"app_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The application name.`,
+			},
+			"topic_urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The topic URN.`,
+			},
+			"template_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The template ID.`,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The project ID.`,
+			},
+			"approver_type": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The type of the approver.`,
+			},
+		},
+	}
+}
+
+func buildDataServiceApproversQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if approverName, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&approver_name=%v", res, approverName)
+	}
+	return res
+}
+
+func listDataServiceApprovers(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/service/authorizeapply/approver?size={size}"
+		page    = 1
+		size    = 100
+		result  = make([]interface{}, 0)
+	)
+
+	listPathWithSize := client.Endpoint + httpUrl
+	listPathWithSize = strings.ReplaceAll(listPathWithSize, "{project_id}", client.ProjectID)
+	listPathWithSize = strings.ReplaceAll(listPathWithSize, "{size}", strconv.Itoa(size))
+	listPathWithSize += buildDataServiceApproversQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    d.Get("workspace_id").(string),
+			"dlm-type":     "EXCLUSIVE",
+		},
+	}
+
+	for {
+		listPathWithPage := listPathWithSize + fmt.Sprintf("&page=%s", strconv.Itoa(page))
+		requestResp, err := client.Request("GET", listPathWithPage, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		approvers := utils.PathSearch("approvers", respBody, make([]interface{}, 0)).([]interface{})
+		if len(approvers) < 1 {
+			break
+		}
+		result = append(result, approvers...)
+		page++
+	}
+
+	return result, nil
+}
+
+func flattenDataServiceApprovers(approvers []interface{}) []interface{} {
+	if len(approvers) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(approvers))
+	for _, approver := range approvers {
+		result = append(result, map[string]interface{}{
+			"id":            utils.PathSearch("id", approver, nil),
+			"name":          utils.PathSearch("approver_name", approver, nil),
+			"user_id":       utils.PathSearch("user_id", approver, nil),
+			"user_name":     utils.PathSearch("user_name", approver, nil),
+			"email":         utils.PathSearch("email", approver, nil),
+			"phone_number":  utils.PathSearch("phone_number", approver, nil),
+			"department":    utils.PathSearch("department", approver, nil),
+			"description":   utils.PathSearch("description", approver, nil),
+			"character":     utils.PathSearch("character", approver, nil),
+			"create_by":     utils.PathSearch("create_by", approver, nil),
+			"create_time":   utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", approver, float64(0)).(float64))/1000, false),
+			"app_name":      utils.PathSearch("app_name", approver, nil),
+			"topic_urn":     utils.PathSearch("topic_urn", approver, nil),
+			"template_id":   utils.PathSearch("template_id", approver, nil),
+			"project_id":    utils.PathSearch("project_id", approver, nil),
+			"approver_type": utils.PathSearch("approver_type", approver, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceDataServiceApproversRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	approvers, err := listDataServiceApprovers(client, d)
+	if err != nil {
+		return diag.Errorf("error querying Data Service approvers: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("approvers", flattenDataServiceApprovers(approvers)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add data source for querying Data Service approvers.

**Which issue this PR fixes**:

**Special notes for your reviewer**:


**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataDataServiceApprovers_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDataServiceApprovers_basic
--- PASS: TestAccDataDataServiceApprovers_basic (14.86s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  14.980s coverage: 4.2% of statements in ./huaweicloud/services/dataarts
```

<img width="1445" height="1040" alt="image" src="https://github.com/user-attachments/assets/39f5d01d-1a42-43d0-bdc6-58a2c5b39939" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.