### PR TITLE
feat(rfs): add datasource to get the list of RFS private hooks

### DIFF
--- a/docs/data-sources/rfs_private_hooks.md
+++ b/docs/data-sources/rfs_private_hooks.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_private_hooks"
+description: |-
+  Use this data source to get the list of RFS private hooks.
+---
+
+# huaweicloud_rfs_private_hooks
+
+Use this data source to get the list of RFS private hooks.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_rfs_private_hooks" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `sort_key` - (Optional, String) Specifies the sort field, only supports **create_time**.
+
+* `sort_dir` - (Optional, String) Specifies the ascending or descending order.
+  Valid values are **asc** and **desc**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `hooks` - The list of private hooks. By default, these hooks are sorted in descending order of the creation time.
+
+  The [hooks](#hooks_struct) structure is documented below.
+
+<a name="hooks_struct"></a>
+The `hooks` block supports:
+
+* `hook_id` - The ID of the private hook.
+
+* `hook_name` - The name of the private hook.
+
+* `hook_description` - The description of the private hook.
+
+* `default_version` - The default version of the private hook.
+
+* `configuration` - The configuration of the hook.
+
+  The [configuration](#configuration_struct) structure is documented below.
+
+* `create_time` - The time when the hook was created, in RFC3339 format (yyyy-mm-ddTHH:MM:SSZ),
+  such as **1970-01-01T00:00:00Z**.
+
+* `update_time` - The time when the hook was last updated, in RFC3339 format (yyyy-mm-ddTHH:MM:SSZ),
+  such as **1970-01-01T00:00:00Z**.
+
+<a name="configuration_struct"></a>
+The `configuration` block supports:
+
+* `target_stacks` - The target stacks.
+
+* `failure_mode` - The failure mode.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2031,6 +2031,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_rfs_private_module_versions":      rfs.DataSourcePrivateModuleVersions(),
 			"huaweicloud_rfs_private_modules":              rfs.DataSourcePrivateModules(),
+			"huaweicloud_rfs_private_hooks":                rfs.DataSourceRfsPrivateHooks(),
 			"huaweicloud_rfs_private_hook_versions":        rfs.DataSourcePrivateHookVersions(),
 			"huaweicloud_rfs_stack_instances":              rfs.DataSourceStackInstances(),
 			"huaweicloud_rfs_stack_resources":              rfs.DataSourceStackResources(),

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_private_hooks_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_private_hooks_test.go
@@ -1,0 +1,49 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRfsPrivateHooks_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_private_hooks.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRfsPrivateHooks_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "hooks.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "hooks.0.hook_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "hooks.0.hook_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "hooks.0.default_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "hooks.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "hooks.0.update_time"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRfsPrivateHooks_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rfs_private_hooks" "test" {
+  sort_key = "create_time"
+  sort_dir = "desc"
+}
+`, testAccPrivateModule_basic(name))
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_private_hooks.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_private_hooks.go
@@ -1,0 +1,207 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/private-hooks
+func DataSourceRfsPrivateHooks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRfsPrivateHooksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"hooks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"hook_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hook_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hook_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"default_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"configuration": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"target_stacks": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"failure_mode": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildPrivateHooksQueryParams(d *schema.ResourceData, marker string) string {
+	rst := ""
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%s", v.(string))
+	}
+
+	if marker != "" {
+		rst += fmt.Sprintf("&marker=%s", marker)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourceRfsPrivateHooksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1/private-hooks"
+		allHooks   = make([]interface{}, 0)
+		nextMarker string
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": uuid,
+			"Content-Type":      "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildPrivateHooksQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RFS private hooks: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		hooks := utils.PathSearch("hooks", respBody, make([]interface{}, 0)).([]interface{})
+		if len(hooks) == 0 {
+			break
+		}
+
+		allHooks = append(allHooks, hooks...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("hooks", flattenPrivateHooks(allHooks)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPrivateHooks(hooks []interface{}) []interface{} {
+	if len(hooks) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(hooks))
+	for _, hook := range hooks {
+		rst = append(rst, map[string]interface{}{
+			"hook_id":          utils.PathSearch("hook_id", hook, nil),
+			"hook_name":        utils.PathSearch("hook_name", hook, nil),
+			"hook_description": utils.PathSearch("hook_description", hook, nil),
+			"default_version":  utils.PathSearch("default_version", hook, nil),
+			"configuration":    flattenRfsHookConfiguration(utils.PathSearch("configuration", hook, nil)),
+			"create_time":      utils.PathSearch("create_time", hook, nil),
+			"update_time":      utils.PathSearch("update_time", hook, nil),
+		})
+	}
+	return rst
+}
+
+func flattenRfsHookConfiguration(configuration interface{}) []interface{} {
+	if configuration == nil {
+		return nil
+	}
+
+	result := []interface{}{
+		map[string]interface{}{
+			"target_stacks": utils.PathSearch("target_stacks", configuration, nil),
+			"failure_mode":  utils.PathSearch("failure_mode", configuration, nil),
+		},
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_private_hooks` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_private_hooks` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccDataSourceRfsPrivateHooks_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs-v -run TestAccDataSourceRfsPrivateHooks_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRfsPrivateHooks_basic
=== PAUSE TestAccDataSourceRfsPrivateHooks_basic
=== CONT  TestAccDataSourceRfsPrivateHooks_basic
--- PASS: TestAccDataSourceRfsPrivateHooks_basic (12.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       21.311s
```
<img width="942" height="23" alt="image" src="https://github.com/user-attachments/assets/ba788aa5-18b1-40d3-86a9-96e961ee5d87" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
