### PR TITLE
feat(CSS): action resource to update css vpcep connections

### DIFF
--- a/docs/resources/css_vpcep_connections_update.md
+++ b/docs/resources/css_vpcep_connections_update.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_css_vpcep_connections_update"
+description: |-
+  Use this resource to update the VPCEP service connections of a CSS cluster.
+---
+
+# huaweicloud_css_vpcep_connections_update
+
+Use this resource to update the VPCEP service connections of a CSS cluster.
+
+-> This resource is only a one-time action resource for updating the VPCEP service connections of a CSS cluster.
+Deleting this resource will not clear the corresponding request record, but will only remove the resource information
+from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "action" {}
+variable "endpoint_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_css_vpcep_connections_update" "test" {
+  cluster_id       = var.cluster_id
+  action           = var.action
+  endpoint_id_list = var.endpoint_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, NonUpdatable) Specifies the ID of the CSS cluster.
+
+* `action` - (Required, String, NonUpdatable) Specifies the expected behavior.
+  The valid values are as follows:
+  + **receive**: Accept the VPC endpoint.
+  + **reject**: Reject the VPC endpoint.
+
+* `endpoint_id_list` - (Required, List, NonUpdatable) Specifies the list of VPC endpoint IDs.
+  The value is a list of strings.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3240,6 +3240,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_css_snapshot":                    css.ResourceCssSnapshot(),
 			"huaweicloud_css_snapshot_restore":            css.ResourceSnapshotRestore(),
 			"huaweicloud_css_thesaurus":                   css.ResourceCssthesaurus(),
+			"huaweicloud_css_vpcep_connections_update":    css.ResourceCssVpcepserviceConnectionsUpdate(),
 
 			"huaweicloud_dbss_audit_risk_rule_action": dbss.ResourceRiskRuleAction(),
 			"huaweicloud_dbss_ecs_database":           dbss.ResourceAddEcsDatabase(),

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_vpcep_connections_update_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_vpcep_connections_update_test.go
@@ -1,0 +1,56 @@
+package css
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccCssVpcepConnectionsUpdate_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testCssVpcepConnectionsUpdate_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("updated_status", "rejected"),
+				),
+			},
+		},
+	})
+}
+
+func testCssVpcepConnectionsUpdate_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_css_vpcep_connections" "test" {
+  cluster_id = "%s"
+}
+
+locals {
+  connection_ids = [for v in data.huaweicloud_css_vpcep_connections.test.connections : v.id]
+}
+
+resource "huaweicloud_css_vpcep_connections_update" "test" {
+  cluster_id       = "%s"
+  action           = "reject"
+  endpoint_id_list = local.connection_ids
+}
+
+data "huaweicloud_css_vpcep_connections" "after" {
+  cluster_id = "%s"
+
+  depends_on = [huaweicloud_css_vpcep_connections_update.test]
+}
+
+output "updated_status" {
+  value = data.huaweicloud_css_vpcep_connections.after.connections[0].status
+}
+`, acceptance.HW_CSS_CLUSTER_ID, acceptance.HW_CSS_CLUSTER_ID, acceptance.HW_CSS_CLUSTER_ID)
+}

--- a/huaweicloud/services/css/resource_huaweicloud_css_vpcep_connections_update.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_vpcep_connections_update.go
@@ -1,0 +1,122 @@
+package css
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var vpcepserviceConnectionsUpdateNonUpdatableParams = []string{
+	"cluster_id", "action", "endpoint_id_list",
+}
+
+// @API CSS POST /v1.0/{project_id}/clusters/{cluster_id}/vpcepservice/connections
+func ResourceCssVpcepserviceConnectionsUpdate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCssVpcepserviceConnectionsUpdateCreate,
+		ReadContext:   resourceCssVpcepserviceConnectionsUpdateRead,
+		UpdateContext: resourceCssVpcepserviceConnectionsUpdateUpdate,
+		DeleteContext: resourceCssVpcepserviceConnectionsUpdateDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(vpcepserviceConnectionsUpdateNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"endpoint_id_list": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceCssVpcepserviceConnectionsUpdateCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v1.0/{project_id}/clusters/{cluster_id}/vpcepservice/connections"
+		clusterId = d.Get("cluster_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("css", region)
+	if err != nil {
+		return diag.Errorf("error creating CSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{cluster_id}", clusterId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildUpdateRequestBody(d),
+	}
+
+	_, err = client.Request("POST", requestPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error updating CSS cluster (%s) vpcep service connections: %s", clusterId, err)
+	}
+
+	d.SetId(clusterId)
+
+	return nil
+}
+
+func buildUpdateRequestBody(d *schema.ResourceData) map[string]interface{} {
+	requestBody := map[string]interface{}{
+		"action":           d.Get("action").(string),
+		"endpoint_id_list": utils.ExpandToStringList(d.Get("endpoint_id_list").([]interface{})),
+	}
+	return requestBody
+}
+
+func resourceCssVpcepserviceConnectionsUpdateRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCssVpcepserviceConnectionsUpdateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCssVpcepserviceConnectionsUpdateDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "This resource only removes the state. The VPC endpoint connections on the CSS cluster remain unchanged."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
action resource to update css vpcep connections
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
action resource to update css vpcep connections
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run=TestAccCssVpcepConnectionsUpdate_basic' 
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run=TestAccCssVpcepConnectionsUpdate_basic -coverprofile=.coverage.out -coverpkg=./huaweicloud/services/css -timeout 360m -parallel 4
=== RUN   TestAccCssVpcepConnectionsUpdate_basic
=== PAUSE TestAccCssVpcepConnectionsUpdate_basic
=== CONT  TestAccCssVpcepConnectionsUpdate_basic
--- PASS: TestAccCssVpcepConnectionsUpdate_basic (30.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       30.550s
```
<img width="1152" height="45" alt="image" src="https://github.com/user-attachments/assets/a28ce741-bc96-457b-8600-e4f8a9c849e7" />


<img width="1361" height="981" alt="image" src="https://github.com/user-attachments/assets/1e125805-fc70-4a5c-989e-ffc802bc8110" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
