### PR TITLE
feat(rfs): support `rfs_stack_outputs` data source

### DIFF
--- a/docs/data-sources/rfs_stack_outputs.md
+++ b/docs/data-sources/rfs_stack_outputs.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_stack_outputs"
+description: |-
+  Use this dataSource to get the list of stack outputs.
+---
+
+# huaweicloud_rfs_stack_outputs
+
+Use this dataSource to get the list of stack outputs.
+
+## Example Usage
+
+```hcl
+variable "stack_name" {}
+
+data "huaweicloud_rfs_stack_outputs" "test" {
+  stack_name = var.stack_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `stack_name` - (Required, String) Specifies the name of the resource stack.
+
+* `stack_id` - (Optional, String) Specifies the ID of the resource stack.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `outputs` - The list of resource stack outputs.
+
+  The [outputs](#outputs_struct) structure is documented below.
+
+<a name="outputs_struct"></a>
+The `outputs` block supports:
+
+* `name` - The name of the stack output, as defined in the template.
+
+* `description` - The description of the stack output, as defined in the template.
+
+* `type` - The type of the stack output.
+
+* `value` - The value of the stack output.
+
+* `sensitive` - Whether the stack output is sensitive, as defined in the template.
+  If the user defines the output as sensitive in the template, the `value` and `type` of the output in the return body
+  will not return the true value, but will return `<sensitive>`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2036,6 +2036,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rfs_private_hook_versions":        rfs.DataSourcePrivateHookVersions(),
 			"huaweicloud_rfs_stack_instances":              rfs.DataSourceStackInstances(),
 			"huaweicloud_rfs_stack_resources":              rfs.DataSourceStackResources(),
+			"huaweicloud_rfs_stack_outputs":                rfs.DataSourceStackOutputs(),
 			"huaweicloud_rfs_stacks":                       rfs.DataSourceStacks(),
 			"huaweicloud_rfs_stack_set_operation_metadata": rfs.DataSourceStackSetOperationMetadata(),
 			"huaweicloud_rfs_private_providers":            rfs.DataSourcePrivateProviders(),

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_stack_outputs_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_stack_outputs_test.go
@@ -1,0 +1,55 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceStackOutputs_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_stack_outputs.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceNameWithDash()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceStackOutputs_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "outputs.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceStackOutputs_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rfs_stack" "test" {
+  name        = "%[1]s"
+  description = "Create by acc test for stack outputs data source"
+}
+`, name)
+}
+
+func testDataSourceStackOutputs_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rfs_stack_outputs" "test" {
+  stack_name = huaweicloud_rfs_stack.test.name
+  stack_id   = huaweicloud_rfs_stack.test.id
+
+  depends_on = [huaweicloud_rfs_stack.test]
+}
+`, testDataSourceStackOutputs_base(name))
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_stack_outputs.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_stack_outputs.go
@@ -1,0 +1,168 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/{project_id}/stacks/{stack_name}/outputs
+func DataSourceStackOutputs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceStackOutputsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"stack_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"stack_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"outputs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sensitive": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildListStackOutputsQueryParams(d *schema.ResourceData, marker string) string {
+	rst := ""
+
+	if v, ok := d.GetOk("stack_id"); ok {
+		rst += fmt.Sprintf("&stack_id=%s", v.(string))
+	}
+
+	if marker != "" {
+		rst += fmt.Sprintf("&marker=%s", marker)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourceStackOutputsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1/{project_id}/stacks/{stack_name}/outputs"
+		allOutputs = make([]interface{}, 0)
+		nextMarker string
+		stackName  = d.Get("stack_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	reqUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request UUID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{stack_name}", stackName)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Client-Request-Id": reqUUID},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildListStackOutputsQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RFS stack outputs: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		outputs := utils.PathSearch("outputs", respBody, make([]interface{}, 0)).([]interface{})
+		if len(outputs) == 0 {
+			break
+		}
+
+		allOutputs = append(allOutputs, outputs...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	d.SetId(reqUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("outputs", flattenStackOutputs(allOutputs)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenStackOutputs(outputs []interface{}) []interface{} {
+	if len(outputs) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(outputs))
+	for _, v := range outputs {
+		rst = append(rst, map[string]interface{}{
+			"name":        utils.PathSearch("name", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+			"type":        utils.PathSearch("type", v, nil),
+			"value":       utils.PathSearch("value", v, nil),
+			"sensitive":   utils.PathSearch("sensitive", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_stack_outputs` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_stack_outputs` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccDataSourceStackOutputs_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs -v -run TestAccDataSourceStackOutputs_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceStackOutputs_basic
=== PAUSE TestAccDataSourceStackOutputs_basic
=== CONT  TestAccDataSourceStackOutputs_basic
--- PASS: TestAccDataSourceStackOutputs_basic (22.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       22.701s
```
<img width="848" height="34" alt="image" src="https://github.com/user-attachments/assets/2c1bf385-75ee-4f45-b0cf-b3bb54cd11b5" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
