### PR TITLE
feat(dataarts): add new datasource for query app authorized apis

### DIFF
--- a/docs/data-sources/dataarts_dataservice_app_authorized_apis.md
+++ b/docs/data-sources/dataarts_dataservice_app_authorized_apis.md
@@ -1,0 +1,74 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCLoud: huaweicloud_dataarts_dataservice_app_authorized_apis"
+description: |-
+  Use this data source to get the list of authorized APIs under specified APP within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_dataservice_app_authorized_apis
+
+Use this data source to get the list of authorized APIs under specified APP within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "app_id" {}
+
+data "huaweicloud_dataarts_dataservice_app_authorized_apis" "test" {
+  workspace_id = var.workspace_id
+  app_id       = var.app_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the authorized APIs are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the APP belongs.
+
+* `app_id` - (Required, String) Specifies the ID of the APP used to query authorized APIs.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `apis` - The list of APIs authorized to the APP.  
+  The [apis](#dataarts_dataservice_app_authorized_apis_elem) structure is documented below.
+
+<a name="dataarts_dataservice_app_authorized_apis_elem"></a>
+The `apis` block supports:
+
+* `id` - The ID of the API.
+
+* `name` - The name of the API.
+
+* `description` - The description of the API.
+
+* `approval_time` - The approval time, in RFC3339 format.
+
+* `manager` - The name of the API reviewer.
+
+* `deadline` - The deadline for using the API, in RFC3339 format.
+
+* `relationship_type` - The relationship between the authorized API and the APP.
+  + **LINK_WAITING_CHECK**: Pending to approval for authorize operation.
+  + **LINKED**: Already authorized.
+  + **OFFLINE_WAITING_CHECK**: Pending to approval for offline operation.
+  + **RENEW_WAITING_CHECK**: Pending to approval for renew operation.
+
+* `static_params` - The configuration of the static parameters.  
+  The [static_params](#dataarts_dataservice_app_authorized_api_static_param) structure is documented below.
+
+<a name="dataarts_dataservice_app_authorized_api_static_param"></a>
+The `static_params` block supports:
+
+* `name` - The name of the static parameter.
+
+* `value` - The value of the static parameter.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1084,6 +1084,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_dataservice_apis":                dataarts.DataSourceDataServiceApis(),
 			"huaweicloud_dataarts_dataservice_approvers":           dataarts.DataSourceDataServiceApprovers(),
 			"huaweicloud_dataarts_dataservice_apps":                dataarts.DataSourceDataServiceApps(),
+			"huaweicloud_dataarts_dataservice_app_authorized_apis": dataarts.DataSourceDataServiceAppAuthorizedApis(),
 			"huaweicloud_dataarts_dataservice_catalog_apis":        dataarts.DataSourceDataServiceCatalogApis(),
 			"huaweicloud_dataarts_dataservice_instances":           dataarts.DataSourceDataServiceInstances(),
 			"huaweicloud_dataarts_dataservice_messages":            dataarts.DataSourceDataServiceMessages(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_dataservice_app_authorized_apis_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_dataservice_app_authorized_apis_test.go
@@ -1,0 +1,203 @@
+package dataarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataDataServiceAppAuthorizedApis_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_dataservice_app_authorized_apis.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsReviewerName(t)
+			acceptance.TestAccPreCheckDataArtsConnectionID(t)
+			acceptance.TestAccPreCheckDataArtsRelatedDliQueueName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataDataServiceAppAuthorizedApis_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(all, "apis.#", "2"),
+					resource.TestCheckResourceAttrSet(all, "apis.0.id"),
+					resource.TestCheckResourceAttrSet(all, "apis.0.name"),
+					resource.TestCheckResourceAttrSet(all, "apis.0.approval_time"),
+					resource.TestCheckResourceAttrSet(all, "apis.0.manager"),
+					resource.TestCheckResourceAttrSet(all, "apis.0.relationship_type"),
+				),
+			},
+			{
+				// Require authorization revocation before resource deletion.
+				Config: testAccDataDataServiceAppAuthorizedApis_basic_step2(name),
+			},
+		},
+	})
+}
+
+func testAccDataDataServiceAppAuthorizedApis_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_dataservice_instances" "test" {
+  workspace_id = "%[1]s"
+}
+
+resource "huaweicloud_dataarts_dataservice_catalog" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  dlm_type     = "EXCLUSIVE"
+}
+
+resource "huaweicloud_dli_database" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_dli_table" "test" {
+  database_name = huaweicloud_dli_database.test.name
+  name          = "%[2]s"
+  data_location = "DLI"
+
+  columns {
+    name = "test_request_field"
+    type = "string"
+  }
+  columns {
+    name = "test_response_field"
+    type = "string"
+  }
+}
+
+resource "huaweicloud_dataarts_dataservice_api" "test" {
+  count = 2
+
+  workspace_id = "%[1]s"
+  dlm_type     = "EXCLUSIVE"
+  type         = "API_SPECIFIC_TYPE_CONFIGURATION"
+  catalog_id   = huaweicloud_dataarts_dataservice_catalog.test.id
+  name         = format("%[2]s_%%d", count.index)
+  auth_type    = "APP"
+  manager      = "%[3]s"
+  path         = format("/%[2]s/test_%%d", count.index)
+  protocol     = "PROTOCOL_TYPE_HTTPS"
+  request_type = "REQUEST_TYPE_POST"
+  visibility   = "WORKSPACE"
+
+  request_params {
+    name      = "test_request_field"
+    position  = "REQUEST_PARAMETER_POSITION_BODY"
+    type      = "REQUEST_PARAMETER_TYPE_STRING"
+    necessary = true
+  }
+
+  datasource_config {
+    type          = "DLI"
+    connection_id = "%[4]s"
+    queue         = "%[5]s"
+    database      = huaweicloud_dli_database.test.name
+    datatable     = huaweicloud_dli_table.test.name
+
+    backend_params {
+      name      = "test_request_field"
+      mapping   = "test_request_field"
+      condition = "CONDITION_TYPE_EQ"
+    }
+    response_params {
+      name  = "test_response_field"
+      type  = "REQUEST_PARAMETER_TYPE_STRING"
+      field = "test_response_field"
+    }
+  }
+
+  depends_on = [huaweicloud_dli_table.test]
+}
+
+resource "huaweicloud_dataarts_dataservice_api_debug" "test" {
+  count = 2
+
+  workspace_id = "%[1]s"
+  api_id       = huaweicloud_dataarts_dataservice_api.test[count.index].id
+  instance_id  = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+  max_retries  = 6
+
+  params = jsonencode({
+    "page_num": "1",
+    "page_size": "100",
+    "test_request_field": "{\"foo\": \"bar\"}"
+  })
+}
+
+resource "huaweicloud_dataarts_dataservice_api_publishment" "test" {
+  count = 2
+
+  workspace_id = "%[1]s"
+  api_id       = huaweicloud_dataarts_dataservice_api.test[count.index].id
+  instance_id  = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+
+  depends_on = [huaweicloud_dataarts_dataservice_api_debug.test]
+}
+
+resource "huaweicloud_dataarts_dataservice_app" "test" {
+  workspace_id = "%[1]s"
+  dlm_type     = "EXCLUSIVE"
+  name         = "%[2]s"
+  app_type     = "APP"
+
+  depends_on = [huaweicloud_dataarts_dataservice_api_publishment.test]
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID,
+		name,
+		acceptance.HW_DATAARTS_REVIEWER_NAME,
+		acceptance.HW_DATAARTS_CONNECTION_ID,
+		acceptance.HW_DATAARTS_DLI_QUEUE_NAME)
+}
+
+func testAccDataDataServiceAppAuthorizedApis_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_api_auth" "test" {
+  count = 2
+
+  workspace_id = "%[2]s"
+  api_id       = huaweicloud_dataarts_dataservice_api.test[count.index].id
+  instance_id  = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+  app_ids      = [huaweicloud_dataarts_dataservice_app.test.id]
+
+  depends_on = [huaweicloud_dataarts_dataservice_api_publishment.test]
+}
+
+data "huaweicloud_dataarts_dataservice_app_authorized_apis" "test" {
+  workspace_id = "%[2]s"
+  app_id       = huaweicloud_dataarts_dataservice_app.test.id
+
+  depends_on = [huaweicloud_dataarts_dataservice_api_auth.test]
+}
+`, testAccDataDataServiceAppAuthorizedApis_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func testAccDataDataServiceAppAuthorizedApis_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_api_auth_action" "test" {
+  count = 2
+
+  workspace_id = "%[2]s"
+  api_id       = huaweicloud_dataarts_dataservice_api.test[count.index].id
+  instance_id  = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+  app_id       = huaweicloud_dataarts_dataservice_app.test.id
+  type         = "APPLY_TYPE_APP_CANCEL_AUTHORIZE"
+}
+`, testAccDataDataServiceAppAuthorizedApis_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_dataservice_app_authorized_apis.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_dataservice_app_authorized_apis.go
@@ -1,0 +1,225 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/service/authorize/apps/{app_id}
+func DataSourceDataServiceAppAuthorizedApis() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDataServiceAppAuthorizedApisRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the authorized APIs are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the APP belongs.`,
+			},
+			"app_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the APP used to query authorized APIs.`,
+			},
+
+			// Attributes.
+			"apis": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataServiceAppAuthorizedApiElemSchema(),
+				Description: `The list of APIs authorized to the APP.`,
+			},
+		},
+	}
+}
+
+func dataServiceAppAuthorizedApiElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the API.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the API.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the API.`,
+			},
+			"approval_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The approval time, in RFC3339 format.`,
+			},
+			"manager": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the API reviewer.`,
+			},
+			"deadline": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The deadline for using the API, in RFC3339 format.`,
+			},
+			"relationship_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The relationship between the authorized API and the APP.`,
+			},
+			"static_params": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataServiceAppAuthorizedApiStaticParamElemSchema(),
+				Description: `The configuration of the static parameters.`,
+			},
+		},
+	}
+}
+
+func dataServiceAppAuthorizedApiStaticParamElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the static parameter.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the static parameter.`,
+			},
+		},
+	}
+}
+
+func queryDataServiceAppAuthorizedApis(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/service/authorize/apps/{app_id}?limit={limit}"
+		offset  = 0
+		limit   = 100
+		result  = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{app_id}", d.Get("app_id").(string))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"dlm-type":     "EXCLUSIVE",
+			"workspace":    d.Get("workspace_id").(string),
+		},
+	}
+
+	for {
+		listPathWithOffset := listPathWithLimit + fmt.Sprintf("&offset=%s", strconv.Itoa(offset))
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		apis := utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, apis...)
+		if len(apis) < limit {
+			break
+		}
+		offset += len(apis)
+	}
+
+	return result, nil
+}
+
+func flattenDataServiceAppAuthorizedApiStaticParams(staticParams []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(staticParams))
+
+	for _, staticParam := range staticParams {
+		result = append(result, map[string]interface{}{
+			"name":  utils.PathSearch("para_name", staticParam, nil),
+			"value": utils.PathSearch("para_value", staticParam, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenDataServiceAppAuthorizedApis(apis []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(apis))
+
+	for _, api := range apis {
+		result = append(result, map[string]interface{}{
+			"id":                utils.PathSearch("id", api, nil),
+			"name":              utils.PathSearch("name", api, nil),
+			"description":       utils.PathSearch("description", api, nil),
+			"approval_time":     utils.FormatTimeStampRFC3339(int64(utils.PathSearch("approval_time", api, float64(0)).(float64))/1000, false),
+			"manager":           utils.PathSearch("manager", api, nil),
+			"deadline":          utils.FormatTimeStampRFC3339(int64(utils.PathSearch("deadline", api, float64(0)).(float64))/1000, false),
+			"relationship_type": utils.PathSearch("relationship_type", api, nil),
+			"static_params": flattenDataServiceAppAuthorizedApiStaticParams(
+				utils.PathSearch("static_params", api, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func dataSourceDataServiceAppAuthorizedApisRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	authorizedApis, err := queryDataServiceAppAuthorizedApis(client, d)
+	if err != nil {
+		return diag.Errorf("error getting authorized APIs for APP (%s): %s", d.Get("app_id").(string), err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("apis", flattenDataServiceAppAuthorizedApis(authorizedApis)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add data source to query APIs associated with the APP.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
Since instance creation is time-consuming, it needs to be injected via environment variables.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataDataServiceAppAuthorizedApis_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDataServiceAppAuthorizedApis_basic
--- PASS: TestAccDataDataServiceAppAuthorizedApis_basic (64.26s)
PASS
coverage: 10.9% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  64.398s coverage: 10.9% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
