### PR TITLE
feat(rfs): add datasource to get the list of RFS execution plans

### DIFF
--- a/docs/data-sources/rfs_execution_plans.md
+++ b/docs/data-sources/rfs_execution_plans.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_execution_plans"
+description: |-
+  Use this data source to list all execution plans of a specified stack.
+---
+
+# huaweicloud_rfs_execution_plans
+
+Use this data source to list all execution plans of a specified stack.
+
+## Example Usage
+
+```hcl
+variable "stack_name" {}
+
+data "huaweicloud_rfs_execution_plans" "test" {
+  stack_name = var.stack_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `stack_name` - (Required, String) Specifies the name of the resource stack.
+
+* `stack_id` - (Optional, String) Specifies the unique ID of the resource stack for strong matching.
+  If it does not match the current resource stack, the API will return an error.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `execution_plans` - The list of execution plans.
+
+  The [execution_plans](#execution_plans_struct) structure is documented below.
+
+<a name="execution_plans_struct"></a>
+The `execution_plans` block supports:
+
+* `stack_name` - The name of the stack.
+
+* `stack_id` - The unique ID of the stack.
+
+* `execution_plan_id` - The ID of the execution plan.
+
+* `execution_plan_name` - The name of the execution plan.
+
+* `description` - The description of the execution plan.
+
+* `status` - The status of the execution plan. Valid values are:
+  + **CREATION_IN_PROGRESS**: The execution plan is being created.
+  + **CREATION_FAILED**: Creating the execution plan failed. Please retrieve the error message summary from status_message.
+  + **AVAILABLE**: The execution plan has been created and is ready to be applied.
+  + **APPLY_IN_PROGRESS**: The execution plan is being applied.
+  + **APPLIED**: The execution plan has been applied.
+
+* `status_message` - The status message of the execution plan, which provides a brief error summary for debugging
+  when the status is **CREATION_FAILED** or **DELETE_FAILED**.
+
+* `create_time` - The creation time of the execution plan, in RFC3339 format (yyyy-mm-ddTHH:MM:SSZ),
+  such as **1970-01-01T00:00:00Z**.
+
+* `apply_time` - The application time of the execution plan, in RFC3339 format (yyyy-mm-ddTHH:MM:SSZ),
+  such as **1970-01-01T00:00:00Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2030,6 +2030,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_intelligent_session_kill_history":   rds.DataSourceIntelligentSessionKillHistory(),
 			"huaweicloud_rds_intelligent_session_kill_statistic": rds.DataSourceIntelligentSessionKillStatistic(),
 
+			"huaweicloud_rfs_execution_plans":              rfs.DataSourceRfsExecutionPlans(),
 			"huaweicloud_rfs_private_module_versions":      rfs.DataSourcePrivateModuleVersions(),
 			"huaweicloud_rfs_private_modules":              rfs.DataSourcePrivateModules(),
 			"huaweicloud_rfs_private_hooks":                rfs.DataSourceRfsPrivateHooks(),

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_execution_plans_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_execution_plans_test.go
@@ -1,0 +1,47 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRfsExecutionPlans_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_execution_plans.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRfsStackName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRfsExecutionPlans_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "execution_plans.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "execution_plans.0.stack_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "execution_plans.0.stack_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "execution_plans.0.execution_plan_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "execution_plans.0.execution_plan_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "execution_plans.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "execution_plans.0.create_time"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRfsExecutionPlans_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_rfs_execution_plans" "test" {
+  stack_name = "%s"
+}
+`, acceptance.HW_RFS_STACK_NAME)
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_execution_plans.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_execution_plans.go
@@ -1,0 +1,191 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/{project_id}/stacks/{stack_name}/execution-plans
+func DataSourceRfsExecutionPlans() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRfsExecutionPlansRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"stack_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"stack_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"execution_plans": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"stack_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"stack_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"execution_plan_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"execution_plan_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status_message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"apply_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildExecutionPlansQueryParams(d *schema.ResourceData, marker string) string {
+	rst := ""
+
+	if v, ok := d.GetOk("stack_id"); ok {
+		rst += fmt.Sprintf("&stack_id=%s", v.(string))
+	}
+
+	if marker != "" {
+		rst += fmt.Sprintf("&marker=%s", marker)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourceRfsExecutionPlansRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1/{project_id}/stacks/{stack_name}/execution-plans"
+		stackName  = d.Get("stack_name").(string)
+		allPlans   = make([]interface{}, 0)
+		nextMarker string
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{stack_name}", stackName)
+
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": uuid,
+			"Content-Type":      "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildExecutionPlansQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RFS execution plans: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		plans := utils.PathSearch("execution_plans", respBody, make([]interface{}, 0)).([]interface{})
+		if len(plans) == 0 {
+			break
+		}
+
+		allPlans = append(allPlans, plans...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("execution_plans", flattenRfsExecutionPlans(allPlans)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRfsExecutionPlans(plans []interface{}) []interface{} {
+	if len(plans) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(plans))
+	for _, plan := range plans {
+		rst = append(rst, map[string]interface{}{
+			"stack_name":          utils.PathSearch("stack_name", plan, nil),
+			"stack_id":            utils.PathSearch("stack_id", plan, nil),
+			"execution_plan_id":   utils.PathSearch("execution_plan_id", plan, nil),
+			"execution_plan_name": utils.PathSearch("execution_plan_name", plan, nil),
+			"description":         utils.PathSearch("description", plan, nil),
+			"status":              utils.PathSearch("status", plan, nil),
+			"status_message":      utils.PathSearch("status_message", plan, nil),
+			"create_time":         utils.PathSearch("create_time", plan, nil),
+			"apply_time":          utils.PathSearch("apply_time", plan, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_execution_plans` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_execution_plans` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccDataSourceRfsExecutionPlans_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs-v -run TestAccDataSourceRfsExecutionPlans_basic-timeout 360m -parallel 4
=== RUN   TestAccDataSourceRfsExecutionPlans_basic
=== PAUSE TestAccDataSourceRfsExecutionPlans_basic
=== CONT  TestAccDataSourceRfsExecutionPlans_basic
--- PASS: TestAccDataSourceRfsExecutionPlans_basic (10.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       21.311s
```
<img width="929" height="23" alt="image" src="https://github.com/user-attachments/assets/d88c5675-2c01-4452-aa4a-6557f96158c1" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
