### PR TITLE
feat(rfs): add source to private module version

### DIFF
--- a/docs/resources/rfs_private_module_version.md
+++ b/docs/resources/rfs_private_module_version.md
@@ -1,0 +1,94 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_private_module_version"
+description: |-
+  Manages a RFS private module version resource within HuaweiCloud.
+---
+
+# huaweicloud_rfs_private_module_version
+
+Manages a RFS private module version resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "module_name" {}
+variable "module_version" {}
+variable "module_uri" {}
+
+resource "huaweicloud_rfs_private_module_version" "test" {
+  module_name    = var.module_name
+  module_version = var.module_version
+  module_uri     = var.module_uri
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the resource is located.
+  If omitted, the provider-level region will be used. Change this parameter will create a new resource.
+
+* `module_name` - (Required, String, NonUpdatable) Specifies the name of a private module. The name is unique within its
+  domain and region. Only letters, digits, underscores (_), and hyphens (-) are allowed. It is case-sensitive and must
+  start with a letter.
+
+* `module_version` - (Required, String, NonUpdatable) Specifies the module version number. Each version number can be
+  defined by following the semantic versioning format.
+
+* `module_uri` - (Required, String, NonUpdatable) Specifies the address for accessing the module package in OBS. Modules
+  allow you to bundle reusable code together. The OBS address can be accessed across regions of the same type. Regions
+  are classified into universal regions and dedicated regions. A universal region provides universal cloud services for
+  common tenants. A dedicated region provides specific services for specific tenants. The module package must be
+  ZIP-formatted. To ensure the validity of the module package, the module package:
+  + Cannot contain files whose names end with ".tfvars".
+  + Cannot exceed `1` MB in size before and after decompression.
+  + Cannot contain more than `100` files.
+  + Cannot contain file paths starting with a forward slash (/).
+  + Disallow spaces (" "), single periods ("."), or double periods ("..") between separators in file paths.
+  + Allow each file path to be up to `2,048` characters long.
+  + Allow each file name to be up to `255` characters long.
+  + Must include at least one template file (whose name ends with ".tf" or ".tf.json").
+
+  -> Modules do not support encryption for sensitive data. The module package associated with the module_uri is used,
+  logged, displayed, and stored in plaintext by RFS.
+
+* `module_id` - (Optional, String, NonUpdatable) Specifies the ID of a private module.
+
+* `version_description` - (Optional, String, NonUpdatable) Specifies the description of a module version.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The format is `<module_name>/<module_version>`.
+
+* `create_time` - The creation time of a private module version. It is represented in UTC format
+  (YYYY-MM-DDTHH:mm:ss.SSSZ), such as **1970-01-01T00:00:00.000Z**.
+
+## Import
+
+Private module version can be imported using `module_name` and `module_version` separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_rfs_private_module_version.test <module_name>/<module_version>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include `module_uri`. It is generally recommended running `terraform plan` after
+importing a resource. You can then decide if changes should be applied to the resource, or the resource definition
+should be updated to align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_rfs_private_module_version" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      module_uri,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2835,6 +2835,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rfs_private_provider_version":    rfs.ResourcePrivateProviderVersion(),
 			"huaweicloud_rfs_stack_rollback":              rfs.ResourceStackRollback(),
 			"huaweicloud_rfs_stack_set_deployment":        rfs.ResourceStackSetDeployment(),
+			"huaweicloud_rfs_private_module_version":      rfs.ResourcePrivateModuleVersion(),
 
 			"huaweicloud_api_gateway_api":         apigateway.ResourceAPI(),
 			"huaweicloud_api_gateway_environment": apigateway.ResourceEnvironment(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -840,6 +840,7 @@ var (
 	HW_RFS_STACK_SET_NAME         = os.Getenv("HW_RFS_STACK_SET_NAME")
 	HW_RFS_STACK_SET_OPERATION_ID = os.Getenv("HW_RFS_STACK_SET_OPERATION_ID")
 	HW_RFS_MODULE_NAME            = os.Getenv("HW_RFS_MODULE_NAME")
+	HW_RFS_MODULE_URI             = os.Getenv("HW_RFS_MODULE_URI")
 
 	HW_DMS_KAFKA_INSTANCE_ID         = os.Getenv("HW_DMS_KAFKA_INSTANCE_ID")
 	HW_DMS_KAFKA_TOPIC_NAME          = os.Getenv("HW_DMS_KAFKA_TOPIC_NAME")
@@ -4591,6 +4592,13 @@ func TestAccPreCheckRfsStackSetOperationId(t *testing.T) {
 func TestAccPreCheckRfsModuleName(t *testing.T) {
 	if HW_RFS_MODULE_NAME == "" {
 		t.Skip("HW_RFS_MODULE_NAME must be set for RFS acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckRfsModuleURI(t *testing.T) {
+	if HW_RFS_MODULE_URI == "" {
+		t.Skip("HW_RFS_MODULE_URI must be set for RFS acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_private_module_version_test.go
+++ b/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_private_module_version_test.go
@@ -1,0 +1,116 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rfs"
+)
+
+func getPrivateModuleVersionResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region        = acceptance.HW_REGION_NAME
+		moduleName    = state.Primary.Attributes["module_name"]
+		moduleVersion = state.Primary.Attributes["module_version"]
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RFS client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("error creating RFS client: %s", err)
+	}
+
+	return rfs.QueryPrivateModuleVersion(client, moduleName, moduleVersion, requestId)
+}
+func TestAccPrivateModuleVersion_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_rfs_private_module_version.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPrivateModuleVersionResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRfsModuleURI(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testPrivateModuleVersion_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "module_name", "huaweicloud_rfs_private_module.test", "module_name"),
+					resource.TestCheckResourceAttrSet(rName, "module_version"),
+					resource.TestCheckResourceAttrSet(rName, "module_uri"),
+					resource.TestCheckResourceAttrSet(rName, "version_description"),
+					resource.TestCheckResourceAttrSet(rName, "module_id"),
+					resource.TestCheckResourceAttrSet(rName, "create_time"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"module_uri"},
+				ImportStateIdFunc:       testPrivateModuleVersionImportState(rName),
+			},
+		},
+	})
+}
+
+func testPrivateModuleVersion_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rfs_private_module" "test" {
+  module_name        = "%[1]s"
+  module_description = "acc private module for version test"
+}
+`, name)
+}
+
+func testPrivateModuleVersion_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "huaweicloud_rfs_private_module_version" "test" {
+  module_name         = huaweicloud_rfs_private_module.test.module_name
+  module_version      = "3.0.0"
+  module_uri          = "%[2]s"
+  version_description = "private module version test"
+}
+`, testPrivateModuleVersion_base(name), acceptance.HW_RFS_MODULE_URI)
+}
+
+func testPrivateModuleVersionImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		moduleName := rs.Primary.Attributes["module_name"]
+		moduleVersion := rs.Primary.Attributes["module_version"]
+		if moduleName == "" || moduleVersion == "" {
+			return "", fmt.Errorf("the module_name (%s) or module_version (%s) is nil",
+				moduleName, moduleVersion)
+		}
+
+		return moduleName + "/" + moduleVersion, nil
+	}
+}

--- a/huaweicloud/services/rfs/resource_huaweicloud_rfs_private_module_version.go
+++ b/huaweicloud/services/rfs/resource_huaweicloud_rfs_private_module_version.go
@@ -1,0 +1,277 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS POST /v1/private-modules/{module_name}/versions
+// @API RFS GET /v1/private-modules/{module_name}/versions
+// @API RFS DELETE /v1/private-modules/{module_name}/versions/{module_version}
+func ResourcePrivateModuleVersion() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePrivateModuleVersionCreate,
+		UpdateContext: resourcePrivateModuleVersionUpdate,
+		ReadContext:   resourcePrivateModuleVersionRead,
+		DeleteContext: resourcePrivateModuleVersionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePrivateModuleVersionImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"module_name",
+			"module_version",
+			"module_uri",
+			"module_id",
+			"version_description",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"module_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"module_version": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"module_uri": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"module_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"version_description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCreatePrivateModuleVersionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"module_version":      d.Get("module_version"),
+		"module_uri":          d.Get("module_uri"),
+		"module_id":           utils.ValueIgnoreEmpty(d.Get("module_id")),
+		"version_description": utils.ValueIgnoreEmpty(d.Get("version_description")),
+	}
+
+	return bodyParams
+}
+
+func resourcePrivateModuleVersionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1/private-modules/{module_name}/versions"
+		moduleName = d.Get("module_name").(string)
+	)
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request ID: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{module_name}", moduleName)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": requestId,
+		},
+		JSONBody: utils.RemoveNil(buildCreatePrivateModuleVersionBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating RFS private module version: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", moduleName, d.Get("module_version").(string)))
+
+	return resourcePrivateModuleVersionRead(ctx, d, meta)
+}
+
+func QueryPrivateModuleVersion(client *golangsdk.ServiceClient, moduleName, moduleVersion, uuid string) (interface{}, error) {
+	requestPath := client.Endpoint + "v1/private-modules/{module_name}/versions"
+	requestPath = strings.ReplaceAll(requestPath, "{module_name}", moduleName)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": uuid,
+		},
+	}
+
+	nextMarker := ""
+	for {
+		requestPathWithQueryParams := requestPath + buildListPrivateModuleVersionsQuery(nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		targetVersion := utils.PathSearch(fmt.Sprintf("versions[?module_version=='%s'] | [0]", moduleVersion), respBody, nil)
+		if targetVersion != nil {
+			return targetVersion, nil
+		}
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func resourcePrivateModuleVersionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		moduleName    = d.Get("module_name").(string)
+		moduleVersion = d.Get("module_version").(string)
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request ID: %s", err)
+	}
+
+	respBody, err := QueryPrivateModuleVersion(client, moduleName, moduleVersion, requestId)
+
+	if err != nil {
+		// If the resource does not exist, the response HTTP status code of the details API is `404`.
+		return common.CheckDeletedDiag(d, err, "error retrieving RFS private module version")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("module_name", utils.PathSearch("module_name", respBody, "")),
+		d.Set("module_id", utils.PathSearch("module_id", respBody, "")),
+		d.Set("module_version", utils.PathSearch("module_version", respBody, "")),
+		d.Set("create_time", utils.PathSearch("create_time", respBody, "")),
+		d.Set("version_description", utils.PathSearch("version_description", respBody, "")),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourcePrivateModuleVersionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourcePrivateModuleVersionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/private-modules/{module_name}/versions/{module_version}"
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request ID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{module_name}", d.Get("module_name").(string))
+	requestPath = strings.ReplaceAll(requestPath, "{module_version}", d.Get("module_version").(string))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": requestId,
+		},
+	}
+
+	_, err = client.Request("DELETE", requestPath, &opt)
+	if err != nil {
+		return diag.Errorf("error deleting RFS private module version: %s", err)
+	}
+
+	return nil
+}
+
+func resourcePrivateModuleVersionImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid import ID format, expected '<module_name>/<module_version>', but got: %s", d.Id())
+	}
+
+	moduleName := parts[0]
+	moduleVersion := parts[1]
+
+	mErr := multierror.Append(
+		d.Set("module_name", moduleName),
+		d.Set("module_version", moduleVersion),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return nil, fmt.Errorf("error setting attributes during import: %s", mErr.ErrorOrNil())
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func buildListPrivateModuleVersionsQuery(marker string) string {
+	if marker == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("?marker=%s", marker)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add source to private module version

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add source to private module version
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o rfs -f TestAccPrivateModuleVersion_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rfs" -v -coverprofile="./huaweicloud/services/acceptance/rfs/rfs_coverage.cov" -coverpkg="./huaweicloud/services/rfs" -run TestAccPrivateModuleVersion_basic -timeout 360m -parallel 10
=== RUN   TestAccPrivateModuleVersion_basic
=== PAUSE TestAccPrivateModuleVersion_basic
=== CONT  TestAccPrivateModuleVersion_basic
--- PASS: TestAccPrivateModuleVersion_basic (43.88s)
PASS
coverage: 9.4% of statements in ./huaweicloud/services/rfs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       43.975s coverage: 9.4% of statements in ./huaweicloud/services/rfs
```
<img width="970" height="43" alt="Snipaste_2026-04-22_19-04-09" src="https://github.com/user-attachments/assets/7ad093a2-c3c4-4323-a6a3-63cd15b3d6ce" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> 
<img width="768" height="168" alt="Snipaste_2026-04-23_14-44-23" src="https://github.com/user-attachments/assets/87a2a6e9-113d-42b3-8c6d-155420b7f6ca" />


 <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
