### PR TITLE
feat(dataarts/security): add new resource to manage resource permission policy

### DIFF
--- a/docs/resources/dataarts_security_resource_permission_policy.md
+++ b/docs/resources/dataarts_security_resource_permission_policy.md
@@ -1,0 +1,125 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_resource_permission_policy"
+description: |-
+  Manages a DataArts Studio Security resource permission policy resource within HuaweiCloud.
+---
+
+
+# huaweicloud_dataarts_security_resource_permission_policy
+
+Manages a DataArts Studio Security resource permission policy resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "policy_name" {}
+variable "resources" {
+  type = list(object({
+    resource_id   = string
+    resource_name = string
+    resource_type = string
+  }))
+}
+
+variable "members" {
+  type = list(object({
+    member_id   = string
+    member_name = string
+    member_type = string
+  }))
+}
+
+resource "huaweicloud_dataarts_security_resource_permission_policy" "test" {
+  workspace_id = var.workspace_id
+  name         = var.policy_name
+
+  dynamic "resources" {
+    for_each = var.resources
+
+    content {
+      resource_id   = resources.value.resource_id
+      resource_name = resources.value.resource_name
+      resource_type = resources.value.resource_type
+    }
+  }
+
+  dynamic "members" {
+    for_each = var.members
+
+    content {
+      member_id   = members.value.member_id
+      member_name = members.value.member_name
+      member_type = members.value.member_type
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the ID of the workspace to which the resource permission
+  policy belongs.
+
+* `name` - (Required, String) Specifies the name of the resource permission policy.  
+  The name can contain `2` to `64` characters.  
+  Only letters, Chinese characters, digits, and underscores (_) are allowed, and must start with
+  a letter or Chinese character.  
+
+* `resources` - (Required, List) Specifies the list of resources.  
+  The [resources](#resource_permission_policy_resources) structure is documented below.
+
+* `members` - (Required, List) Specifies the list of members.  
+  The [members](#resource_permission_policy_members) structure is documented below.
+
+<a name="resource_permission_policy_resources"></a>
+The `resources` block supports:
+
+* `resource_id` - (Required, String) Specifies the ID of the resource.
+
+* `resource_name` - (Required, String) Specifies the name of the resource.
+
+* `resource_type` - (Required, String) Specifies the type of the resource.  
+  The valid values are as follows:
+  + **DATA_CONNECTION**
+  + **AGENCY**
+
+<a name="resource_permission_policy_members"></a>
+The `members` block supports:
+
+* `member_id` - (Required, String) Specifies the ID of the member.
+
+* `member_name` - (Required, String) Specifies the name of the member.
+
+* `member_type` - (Required, String) Specifies the type of the member.  
+  The valid values are as follows:
+  + **USER**
+  + **USER_GROUP**
+  + **WORKSPACE_ROLE**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `create_time` - The creation time of the resource permission policy, in RFC3339 format.
+
+* `create_user` - The creator of the resource permission policy.
+
+* `update_time` - The latest update time of the resource permission policy, in RFC3339 format.
+
+## Import
+
+The resource can be imported using `workspace_id` and `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_security_resource_permission_policy.test <workspace_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3899,6 +3899,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_security_permission_set":              dataarts.ResourceSecurityPermissionSet(),
 			"huaweicloud_dataarts_security_permission_set_member":       dataarts.ResourceSecurityPermissionSetMember(),
 			"huaweicloud_dataarts_security_permission_set_privilege":    dataarts.ResourceSecurityPermissionSetPrivilege(),
+			"huaweicloud_dataarts_security_resource_permission_policy":  dataarts.ResourceSecurityResourcePermissionPolicy(),
 			"huaweicloud_dataarts_security_workspace_queue_associate":   dataarts.ResourceSecurityWorkspaceQueueAssociate(),
 			// DataArts DataService
 			"huaweicloud_dataarts_dataservice_api":             dataarts.ResourceDataServiceApi(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_resource_permission_policy_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_resource_permission_policy_test.go
@@ -1,0 +1,224 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	da "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dataarts"
+)
+
+func getSecurityResourcePermissionPolicyFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	return da.GetSecurityResourcePermissionPolicyById(client, state.Primary.Attributes["workspace_id"], state.Primary.ID)
+}
+
+// HW_USER_NAME cannot be the creator of the Workspace.
+func TestAccSecurityResourcePermissionPolicy_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_dataarts_security_resource_permission_policy.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getSecurityResourcePermissionPolicyFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckUserName(t)
+			acceptance.TestAccPreCheckDataArtsConnectionID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityResourcePermissionPolicy_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "resources.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "resources.*", map[string]string{
+						"resource_id":   acceptance.HW_DATAARTS_CONNECTION_ID,
+						"resource_type": "DATA_CONNECTION",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(rName, "resources.*.resource_name",
+						"data.huaweicloud_dataarts_studio_data_connections.test", "connections.0.name"),
+					resource.TestCheckTypeSetElemAttrPair(rName, "resources.*.resource_id", "huaweicloud_identity_agency.test.0", "id"),
+					resource.TestCheckTypeSetElemAttrPair(rName, "resources.*.resource_name", "huaweicloud_identity_agency.test.0", "name"),
+					resource.TestCheckResourceAttr(rName, "members.#", "2"),
+					resource.TestCheckTypeSetElemAttrPair(rName, "members.*.member_id", "huaweicloud_dataarts_studio_workspace_user.test", "id"),
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "members.*", map[string]string{
+						"member_name": acceptance.HW_USER_NAME,
+						"member_type": "USER",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(rName, "members.*.member_id",
+						"data.huaweicloud_dataarts_studio_workspace_user_roles.test", "roles.0.id"),
+					resource.TestCheckTypeSetElemAttrPair(rName, "members.*.member_name",
+						"data.huaweicloud_dataarts_studio_workspace_user_roles.test", "roles.0.name"),
+					resource.TestMatchResourceAttr(rName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(rName, "create_user"),
+				),
+			},
+			{
+				Config: testAccSecurityResourcePermissionPolicy_basic_step2(name, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "resources.#", "2"),
+					resource.TestCheckTypeSetElemAttrPair(rName, "resources.*.resource_id", "huaweicloud_identity_agency.test.0", "id"),
+					resource.TestCheckTypeSetElemAttrPair(rName, "resources.*.resource_name", "huaweicloud_identity_agency.test.0", "name"),
+					resource.TestCheckTypeSetElemAttrPair(rName, "resources.*.resource_id", "huaweicloud_identity_agency.test.1", "id"),
+					resource.TestCheckTypeSetElemAttrPair(rName, "resources.*.resource_name", "huaweicloud_identity_agency.test.1", "name"),
+					resource.TestCheckResourceAttr(rName, "resources.0.resource_type", "AGENCY"),
+					resource.TestCheckResourceAttr(rName, "resources.1.resource_type", "AGENCY"),
+					resource.TestCheckResourceAttr(rName, "members.#", "2"),
+					resource.TestCheckTypeSetElemAttrPair(rName, "members.*.member_id",
+						"data.huaweicloud_dataarts_studio_workspace_user_roles.test", "roles.0.id"),
+					resource.TestCheckTypeSetElemAttrPair(rName, "members.*.member_name",
+						"data.huaweicloud_dataarts_studio_workspace_user_roles.test", "roles.0.name"),
+					resource.TestCheckTypeSetElemAttrPair(rName, "members.*.member_name",
+						"data.huaweicloud_dataarts_studio_workspace_user_roles.test", "roles.1.name"),
+					resource.TestCheckTypeSetElemAttrPair(rName, "members.*.member_id",
+						"data.huaweicloud_dataarts_studio_workspace_user_roles.test", "roles.1.id"),
+					resource.TestCheckResourceAttr(rName, "members.0.member_type", "WORKSPACE_ROLE"),
+					resource.TestCheckResourceAttr(rName, "members.1.member_type", "WORKSPACE_ROLE"),
+					resource.TestMatchResourceAttr(rName, "update_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccSecurityResourcePermissionPolicyImportStateIDFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccSecurityResourcePermissionPolicyImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found in state", resourceName)
+		}
+
+		workspaceId := rs.Primary.Attributes["workspace_id"]
+		policyId := rs.Primary.ID
+		if workspaceId == "" || policyId == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<workspace_id>/<id>', but got '%s/%s'", workspaceId, policyId)
+		}
+		return fmt.Sprintf("%s/%s", workspaceId, policyId), nil
+	}
+}
+
+func testAccSecurityResourcePermissionPolicy_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_agency" "test" {
+  count = 2
+
+  name                   = "%[1]s${count.index}"
+  delegated_service_name = "op_svc_dlg"
+}
+
+data "huaweicloud_dataarts_studio_workspace_user_roles" "test" {
+  workspace_id = "%[2]s"
+}
+
+data "huaweicloud_identity_users" "test" {
+  name = "%[3]s"
+}
+
+resource "huaweicloud_dataarts_studio_workspace_user" "test" {
+  workspace_id = "%[2]s"
+  user_id      = try(data.huaweicloud_identity_users.test.users[0].id, "NOT_FOUND")
+
+  roles {
+    id = try(data.huaweicloud_dataarts_studio_workspace_user_roles.test.roles[0].id, "NOT_FOUND")
+  }
+}
+
+data "huaweicloud_dataarts_studio_data_connections" "test" {
+  workspace_id  = "%[2]s"
+  connection_id = "%[4]s"
+}
+`, name, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_USER_NAME, acceptance.HW_DATAARTS_CONNECTION_ID)
+}
+
+func testAccSecurityResourcePermissionPolicy_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_security_resource_permission_policy" "test" {
+  workspace_id = "%[2]s"
+  name         = "%[3]s"
+
+  resources {
+    resource_id   = try(data.huaweicloud_dataarts_studio_data_connections.test.connections[0].id, "NOT_FOUND")
+    resource_name = try(data.huaweicloud_dataarts_studio_data_connections.test.connections[0].name, "NOT_FOUND")
+    resource_type = "DATA_CONNECTION"
+  }
+  resources {
+    resource_id   = try(huaweicloud_identity_agency.test[0].id, "NOT_FOUND")
+    resource_name = try(huaweicloud_identity_agency.test[0].name, "NOT_FOUND")
+    resource_type = "AGENCY"
+  }
+
+  members {
+    member_id   = huaweicloud_dataarts_studio_workspace_user.test.id
+    member_name = try(data.huaweicloud_identity_users.test.users[0].name, "NOT_FOUND")
+    member_type = "USER"
+  }
+  members {
+    member_id   = try(data.huaweicloud_dataarts_studio_workspace_user_roles.test.roles[0].id, "NOT_FOUND")
+    member_name = try(data.huaweicloud_dataarts_studio_workspace_user_roles.test.roles[0].name, "NOT_FOUND")
+    member_type = "WORKSPACE_ROLE"
+  }
+}
+`, testAccSecurityResourcePermissionPolicy_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccSecurityResourcePermissionPolicy_basic_step2(name, updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_security_resource_permission_policy" "test" {
+  workspace_id = "%[2]s"
+  name         = "%[3]s"
+
+  dynamic "resources" {
+    for_each = huaweicloud_identity_agency.test[*]
+
+    content {
+      resource_id   = resources.value.id
+      resource_name = resources.value.name
+      resource_type = "AGENCY"
+    }
+  }
+
+  dynamic "members" {
+    for_each = slice(data.huaweicloud_dataarts_studio_workspace_user_roles.test.roles, 0, 2)
+
+    content {
+      member_id   = members.value.id
+      member_name = members.value.name
+      member_type = "WORKSPACE_ROLE"
+    }
+  }
+}
+`, testAccSecurityResourcePermissionPolicy_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, updateName)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_resource_permission_policy.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_resource_permission_policy.go
@@ -1,0 +1,421 @@
+package dataarts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	securityResourcePermissionPolicyNonUpdatableParams = []string{
+		"workspace_id",
+	}
+	securityResourcePermissionPolicyResourceNotFoundCodes = []string{
+		"DLS.3080", // The resource permission policy is not found.
+		"DLS.6036", // The Workspace ID is not found, error code key is "errorCode".
+	}
+)
+
+// @API DataArtsStudio POST /v1/{project_id}/security/permission-resource
+// @API DataArtsStudio GET /v1/{project_id}/security/permission-resource/{policy_id}
+// @API DataArtsStudio PUT /v1/{project_id}/security/permission-resource/{policy_id}
+// @API DataArtsStudio POST /v1/{project_id}/security/permission-resource/batch-delete
+func ResourceSecurityResourcePermissionPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSecurityResourcePermissionPolicyCreate,
+		ReadContext:   resourceSecurityResourcePermissionPolicyRead,
+		UpdateContext: resourceSecurityResourcePermissionPolicyUpdate,
+		DeleteContext: resourceSecurityResourcePermissionPolicyDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(securityResourcePermissionPolicyNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceSecurityResourcePermissionPolicyImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the resource permission policy is located.`,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the resource permission policy belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the resource permission policy.`,
+			},
+			"resources": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: `The list of resources.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The ID of the resource.`,
+						},
+						"resource_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the resource.`,
+						},
+						"resource_type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The type of the resource.`,
+						},
+					},
+				},
+			},
+			"members": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: `The list of members.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"member_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The ID of the member.`,
+						},
+						"member_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the member.`,
+						},
+						"member_type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The type of the member.`,
+						},
+					},
+				},
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the resource permission policy, in RFC3339 format.`,
+			},
+			"create_user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the resource permission policy.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the resource permission policy, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func buildSecurityResourcePermissionPolicyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"policy_name": d.Get("name"),
+		"resources":   buildSecurityResourcePermissionPolicyResources(d.Get("resources").(*schema.Set)),
+		"members":     buildSecurityResourcePermissionPolicyMembers(d.Get("members").(*schema.Set)),
+	}
+}
+
+func buildSecurityResourcePermissionPolicyResources(resources *schema.Set) []map[string]interface{} {
+	if resources.Len() == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, resources.Len())
+	for _, v := range resources.List() {
+		result = append(result, map[string]interface{}{
+			"resource_id":   utils.PathSearch("resource_id", v, nil),
+			"resource_name": utils.PathSearch("resource_name", v, nil),
+			"resource_type": utils.PathSearch("resource_type", v, nil),
+		})
+	}
+
+	return result
+}
+
+func buildSecurityResourcePermissionPolicyMembers(members *schema.Set) []map[string]interface{} {
+	if members.Len() == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, members.Len())
+	for _, v := range members.List() {
+		result = append(result, map[string]interface{}{
+			"member_id":   utils.PathSearch("member_id", v, nil),
+			"member_name": utils.PathSearch("member_name", v, nil),
+			"member_type": utils.PathSearch("member_type", v, nil),
+		})
+	}
+
+	return result
+}
+
+func createSecurityResourcePermissionPolicy(client *golangsdk.ServiceClient, d *schema.ResourceData, workspaceId string) (string, error) {
+	httpUrl := "v1/{project_id}/security/permission-resource"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+		JSONBody:         buildSecurityResourcePermissionPolicyBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", path, &opts)
+	if err != nil {
+		return "", err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return "", err
+	}
+
+	policyId := utils.PathSearch("policy_id", respBody, "").(string)
+	if policyId == "" {
+		return "", errors.New("unable to find the policy ID of the resource permission policy from the API response")
+	}
+
+	return policyId, nil
+}
+
+func resourceSecurityResourcePermissionPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	policyId, err := createSecurityResourcePermissionPolicy(client, d, workspaceId)
+	if err != nil {
+		return diag.Errorf("error creating resource permission policy: %s", err)
+	}
+
+	d.SetId(policyId)
+
+	return resourceSecurityResourcePermissionPolicyRead(ctx, d, meta)
+}
+
+// GetSecurityResourcePermissionPolicyById is a method used to query a resource permission policy by its ID.
+func GetSecurityResourcePermissionPolicyById(client *golangsdk.ServiceClient, workspaceId, policyId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/security/permission-resource/{policy_id}"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{policy_id}", policyId)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+	}
+
+	resp, err := client.Request("GET", path, &opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceSecurityResourcePermissionPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		policyId    = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	respBody, err := GetSecurityResourcePermissionPolicyById(client, workspaceId, policyId)
+	if err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected400ErrInto404Err(common.ConvertExpected400ErrInto404Err(err, "errorCode",
+				securityResourcePermissionPolicyResourceNotFoundCodes...), "error_code",
+				securityResourcePermissionPolicyResourceNotFoundCodes...),
+			fmt.Sprintf("error retrieving resource permission policy (%s)", policyId),
+		)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("policy_name", respBody, nil)),
+		d.Set("resources", flattenSecurityResourcePermissionPolicyResources(utils.PathSearch("resources", respBody,
+			make([]interface{}, 0)).([]interface{}))),
+		d.Set("members", flattenSecurityResourcePermissionPolicyMembers(utils.PathSearch("members",
+			respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("create_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time",
+			respBody, float64(0)).(float64))/1000, false)),
+		d.Set("create_user", utils.PathSearch("create_user", respBody, nil)),
+		d.Set("update_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time",
+			respBody, float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSecurityResourcePermissionPolicyResources(resources []interface{}) []interface{} {
+	if len(resources) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resources))
+	for _, v := range resources {
+		result = append(result, map[string]interface{}{
+			"resource_id":   utils.PathSearch("resource_id", v, nil),
+			"resource_name": utils.PathSearch("resource_name", v, nil),
+			"resource_type": utils.PathSearch("resource_type", v, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenSecurityResourcePermissionPolicyMembers(members []interface{}) []interface{} {
+	if len(members) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(members))
+	for _, member := range members {
+		result = append(result, map[string]interface{}{
+			"member_id":   utils.PathSearch("member_id", member, nil),
+			"member_name": utils.PathSearch("member_name", member, nil),
+			"member_type": utils.PathSearch("member_type", member, nil),
+		})
+	}
+
+	return result
+}
+
+func updateSecurityResourcePermissionPolicy(client *golangsdk.ServiceClient, d *schema.ResourceData, workspaceId string) error {
+	httpUrl := "v1/{project_id}/security/permission-resource/{policy_id}"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{policy_id}", d.Id())
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+		JSONBody:         buildSecurityResourcePermissionPolicyBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", path, &opts)
+	return err
+}
+
+func resourceSecurityResourcePermissionPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	if err = updateSecurityResourcePermissionPolicy(client, d, workspaceId); err != nil {
+		return diag.Errorf("error updating resource permission policy (%s): %s", d.Id(), err)
+	}
+
+	return resourceSecurityResourcePermissionPolicyRead(ctx, d, meta)
+}
+
+func deleteSecurityResourcePermissionPolicy(client *golangsdk.ServiceClient, workspaceId, policyId string) error {
+	httpUrl := "v1/{project_id}/security/permission-resource/batch-delete"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+		JSONBody: map[string]interface{}{
+			"ids": []string{policyId},
+		},
+		OkCodes: []int{204},
+	}
+
+	_, err := client.Request("POST", path, &opts)
+	return err
+}
+
+func resourceSecurityResourcePermissionPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		policyId    = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	if err = deleteSecurityResourcePermissionPolicy(client, workspaceId, policyId); err != nil {
+		// DLS.6036: The Workspace ID is not found.
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected400ErrInto404Err(err, "errorCode", "DLS.6036"),
+			fmt.Sprintf("error deleting resource permission policy (%s)", policyId),
+		)
+	}
+
+	return nil
+}
+
+func resourceSecurityResourcePermissionPolicyImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<id>', but got '%s'", importedId)
+	}
+
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, d.Set("workspace_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new resource (`huaweicloud_dataarts_security_resource_permission_policy`) to manage resource permission policy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccSecurityResourcePermissionPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccSecurityResourcePermissionPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccSecurityResourcePermissionPolicy_basic
=== PAUSE TestAccSecurityResourcePermissionPolicy_basic
=== CONT  TestAccSecurityResourcePermissionPolicy_basic
--- PASS: TestAccSecurityResourcePermissionPolicy_basic (151.19s)
PASS
coverage: 8.2% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  151.397s        coverage: 8.2% of statements in ./huaweicloud/services/dataarts
```
<img width="1436" height="46" alt="image" src="https://github.com/user-attachments/assets/dd0e3199-b329-4cba-8230-1ce5f95d875b" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1191" height="754" alt="image" src="https://github.com/user-attachments/assets/c775dd83-9c15-4207-a3f4-de3215d62e4a" />

    ab. Related resources (parent resources) not found
    <img width="1185" height="787" alt="image" src="https://github.com/user-attachments/assets/262a710b-30d7-4c10-9d2e-ea547c058324" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
     ba. Resource not found
     Delete a non-exist resource permission policy will not report an error
    <img width="1171" height="852" alt="image" src="https://github.com/user-attachments/assets/906d7087-c899-45ca-b6b4-b0461670348b" />
    
    bb. Related resources (parent resources) not found
    <img width="1264" height="824" alt="image" src="https://github.com/user-attachments/assets/d396a68b-62f6-48a4-8427-3ce747edaa13" />

