### PR TITLE
feat(rfs): support `rfs_stack_set_operations` data source

### DIFF
--- a/docs/data-sources/rfs_stack_set_operations.md
+++ b/docs/data-sources/rfs_stack_set_operations.md
@@ -1,0 +1,90 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_stack_set_operations"
+description: |-
+  Use this datasource to get the list of stack set operations.
+---
+
+# huaweicloud_rfs_stack_set_operations
+
+Use this datasource to get the list of stack set operations.
+
+## Example Usage
+
+```hcl
+variable "stack_set_name" {}
+
+data "huaweicloud_rfs_stack_set_operations" "test" {
+  stack_set_name = var.stack_set_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `stack_set_name` - (Required, String) Specifies the name of the stack set.
+
+* `stack_set_id` - (Optional, String) Specifies the ID of the stack set.
+
+* `filter` - (Optional, String) Specifies the filter condition.  
+  The use of this parameter must comply with the following conditions:
+  + The AND operator is defined with a comma (`,`).
+  + The OR operator is defined with a vertical line (`|`), and the OR operator has higher priority than the
+    AND operator.
+  + Does not support parentheses.
+  + The filter only supports the double equals (`==`) operator.
+  + The filter parameter name and its value can only contain English letters, digits, and underscores.
+  + Semicolons are not allowed; if a semicolon exists, the filter entry is ignored.  
+  + A filtering parameter can only be related to one condition, and one condition or multiple conditions in the
+    condition can only be related to one filtering parameter.
+
+* `sort_key` - (Optional, String) Specifies the sort field, only supports **create_time**.
+
+* `sort_dir` - (Optional, String) Specifies the ascending or descending order.
+  Valid values are **asc** and **desc**.
+
+* `call_identity` - (Optional, String) This parameter is only used when the stack set permission model is
+  **SERVICE_MANAGED**. It specifies whether the call is made as the organization management account or as the
+  delegated service administrator in a member account. The default is **SELF**.
+
+  The valid values are as follows:
+  + **SELF**: Call as an organizational management account.
+  + **DELEGATED_ADMIN**: Call as a service delegation administrator. The user's Huawei Cloud account must have been
+    registered as a delegated administrator for the "Resource orchestration Resource Stack Service" within the
+    organization.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `stack_set_operations` - The list of stack set operations.
+
+  The [stack_set_operations](#stack_set_operations_struct) structure is documented below.
+
+<a name="stack_set_operations_struct"></a>
+The `stack_set_operations` block supports:
+
+* `operation_id` - The ID of the stack set operation.
+
+* `stack_set_id` - The unique ID of the stack set.
+
+* `stack_set_name` - The name of the stack set.
+
+* `action` - The current user action.
+
+* `status` - The status of the stack set operation.
+
+* `status_message` - A brief message when the stack set operation fails.
+
+* `create_time` - The creation time of a stack set operation. It is represented in UTC format
+  (YYYY-MM-DDTHH:mm:ss.SSSZ), such as **1970-01-01T00:00:00.000Z**.
+
+* `update_time` - The update time of a stack set operation. It is represented in UTC format
+  (YYYY-MM-DDTHH:mm:ss.SSSZ), such as **1970-01-01T00:00:00.000Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2039,6 +2039,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rfs_stack_resources":              rfs.DataSourceStackResources(),
 			"huaweicloud_rfs_stacks":                       rfs.DataSourceStacks(),
 			"huaweicloud_rfs_stack_set_operation_metadata": rfs.DataSourceStackSetOperationMetadata(),
+			"huaweicloud_rfs_stack_set_operations":         rfs.DataSourceStackSetOperations(),
 			"huaweicloud_rfs_private_providers":            rfs.DataSourcePrivateProviders(),
 			"huaweicloud_rfs_private_provider_versions":    rfs.DataSourcePrivateProviderVersions(),
 			"huaweicloud_rfs_templates":                    rfs.DataSourceRfsTemplates(),

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_stack_set_operations_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_stack_set_operations_test.go
@@ -1,0 +1,44 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceStackSetOperations_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_stack_set_operations.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare the stack set in the environment before running this test case.
+			acceptance.TestAccPreCheckRfsStackSetName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceStackSetOperations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_set_operations.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceStackSetOperations_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_rfs_stack_set_operations" "test" {
+  stack_set_name = "%[1]s"
+  sort_key       = "create_time"
+  sort_dir       = "desc"
+}
+`, acceptance.HW_RFS_STACK_SET_NAME)
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_stack_set_operations.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_stack_set_operations.go
@@ -1,0 +1,215 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/stack-sets/{stack_set_name}/operations
+func DataSourceStackSetOperations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceStackSetOperationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"stack_set_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"stack_set_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"call_identity": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"stack_set_operations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"operation_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"stack_set_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"stack_set_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"action": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status_message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildListStackSetOperationsQueryParams(d *schema.ResourceData, marker string) string {
+	rst := ""
+
+	if v, ok := d.GetOk("stack_set_id"); ok {
+		rst += fmt.Sprintf("&stack_set_id=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("filter"); ok {
+		rst += fmt.Sprintf("&filter=%s", url.QueryEscape(v.(string)))
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("call_identity"); ok {
+		rst += fmt.Sprintf("&call_identity=%s", v.(string))
+	}
+
+	if marker != "" {
+		rst += fmt.Sprintf("&marker=%s", marker)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourceStackSetOperationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                   = meta.(*config.Config)
+		region                = cfg.GetRegion(d)
+		httpUrl               = "v1/stack-sets/{stack_set_name}/operations"
+		allStackSetOperations = make([]interface{}, 0)
+		nextMarker            string
+		stackSetName          = d.Get("stack_set_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	reqUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request UUID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{stack_set_name}", stackSetName)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Client-Request-Id": reqUUID},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildListStackSetOperationsQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RFS stack set operations: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		stackSetOperations := utils.PathSearch("stack_set_operations", respBody, make([]interface{}, 0)).([]interface{})
+		if len(stackSetOperations) == 0 {
+			break
+		}
+
+		allStackSetOperations = append(allStackSetOperations, stackSetOperations...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	d.SetId(reqUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("stack_set_operations", flattenStackSetOperations(allStackSetOperations)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenStackSetOperations(stackSetOperations []interface{}) []interface{} {
+	if len(stackSetOperations) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(stackSetOperations))
+	for _, v := range stackSetOperations {
+		rst = append(rst, map[string]interface{}{
+			"operation_id":   utils.PathSearch("operation_id", v, nil),
+			"stack_set_id":   utils.PathSearch("stack_set_id", v, nil),
+			"stack_set_name": utils.PathSearch("stack_set_name", v, nil),
+			"action":         utils.PathSearch("action", v, nil),
+			"status":         utils.PathSearch("status", v, nil),
+			"status_message": utils.PathSearch("status_message", v, nil),
+			"create_time":    utils.PathSearch("create_time", v, nil),
+			"update_time":    utils.PathSearch("update_time", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_stack_set_operations` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_stack_set_operations` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccDataSourceStackSetOperations_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs -v -run TestAccDataSourceStackSetOperations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceStackSetOperations_basic
=== PAUSE TestAccDataSourceStackSetOperations_basic
=== CONT  TestAccDataSourceStackSetOperations_basic
--- PASS: TestAccDataSourceStackSetOperations_basic (11.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       11.083s
```
<img width="889" height="35" alt="image" src="https://github.com/user-attachments/assets/80dcdc65-2f46-47eb-b28a-36df41744889" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
