### PR TITLE
feat(dataarts): add new datasource for query security permission sets

### DIFF
--- a/docs/data-sources/dataarts_security_permission_sets.md
+++ b/docs/data-sources/dataarts_security_permission_sets.md
@@ -1,0 +1,132 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_permission_sets"
+description: |-
+  Use this data source to get the list of permission sets for DataArts Studio Security within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_permission_sets
+
+Use this data source to get the list of permission sets for DataArts Studio Security within HuaweiCloud.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_security_permission_sets" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+### Query permission sets by parent ID
+
+```hcl
+variable "workspace_id" {}
+variable "parent_id" {}
+
+data "huaweicloud_dataarts_security_permission_sets" "test" {
+  workspace_id = var.workspace_id
+  parent_id    = var.parent_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the permission sets are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the permission sets belong.
+
+* `name` - (Optional, String) Specifies the name of the permission set to be queried.  
+  This parameter supports fuzzy matching.
+
+* `parent_id` - (Optional, String) Specifies the parent ID of the permission set to be queried.
+
+* `type_filter` - (Optional, String) Specifies the type filter of the permission sets to be queried.  
+  The valid values are as follows:
+  + **TOP_PERMISSION_SET**
+  + **SUB_PERMISSION_SET**
+  + **ALL_PERMISSION_SET**
+
+* `manager_id` - (Optional, String) Specifies the manager ID of the permission set to be queried.
+
+* `manager_name` - (Optional, String) Specifies the manager name of the permission set to be queried.
+
+* `manager_type` - (Optional, String) Specifies the manager type of the permission set to be queried.  
+  The valid values are as follows:
+  + **USER**
+  + **USER_GROUP**
+
+* `datasource_type` - (Optional, String) Specifies the datasource type of the permission set to be queried.  
+  The valid values are as follows:
+  + **HIVE**
+  + **DWS**
+  + **DLI**
+
+* `sync_status` - (Optional, String) Specifies the sync status of the permission set to be queried.  
+  The valid values are as follows:
+  + **UNKNOWN**
+  + **NOT_SYNC**
+  + **SYNCING**
+  + **SYNC_SUCCESS**
+  + **SYNC_FAIL**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `permission_sets` - The list of permission sets that match the filter parameters.  
+  The [permission_sets](#dataarts_security_permission_sets_attr) structure is documented below.
+
+<a name="dataarts_security_permission_sets_attr"></a>
+The `permission_sets` block supports:
+
+* `id` - The ID of the permission set.
+
+* `parent_id` - The parent ID of the permission set.
+
+* `name` - The name of the permission set.
+
+* `description` - The description of the permission set.
+
+* `type` - The type of the permission set.  
+  + **COMMON**
+  + **MRS_MANAGED**
+
+* `managed_cluster_id` - The managed cluster ID of the permission set.
+
+* `managed_cluster_name` - The managed cluster name of the permission set.
+
+* `project_id` - The project ID of the permission set.
+
+* `domain_id` - The domain ID of the permission set.
+
+* `instance_id` - The instance ID of the permission set.
+
+* `manager_id` - The manager ID of the permission set.
+
+* `manager_name` - The manager name of the permission set.
+
+* `manager_type` - The manager type of the permission set.
+
+* `datasource_type` - The datasource type of the permission set.
+
+* `sync_status` - The sync status of the permission set.
+
+* `sync_msg` - The sync message of the permission set.
+
+* `sync_time` - The sync time of the permission set, in RFC3339 format.
+
+* `created_at` - The creation time of the permission set, in RFC3339 format.
+
+* `updated_at` - The update time of the permission set, in RFC3339 format.
+
+* `created_by` - The creator of the permission set.
+
+* `updated_by` - The updater of the permission set.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1094,6 +1094,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_factory_scripts":   dataarts.DataSourceFactoryScripts(),
 			// DataArts Security
 			"huaweicloud_dataarts_security_data_recognition_rules":      dataarts.DataSourceSecurityDataRecognitionRules(),
+			"huaweicloud_dataarts_security_permission_sets":             dataarts.DataSourceSecurityPermissionSets(),
 			"huaweicloud_dataarts_security_permission_set_members":      dataarts.DataSourceSecurityPermissionSetMembers(),
 			"huaweicloud_dataarts_security_permission_set_privileges":   dataarts.DataSourceSecurityPermissionSetPrivileges(),
 			"huaweicloud_dataarts_security_workspace_associated_queues": dataarts.DataSourceSecurityWorkspaceAssociatedQueues(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_permission_sets_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_permission_sets_test.go
@@ -1,0 +1,339 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSecurityPermissionSets_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_security_permission_sets.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byParentId   = "data.huaweicloud_dataarts_security_permission_sets.filter_by_parent_id"
+		dcByParentId = acceptance.InitDataSourceCheck(byParentId)
+
+		byManagerId   = "data.huaweicloud_dataarts_security_permission_sets.filter_by_manager_id"
+		dcByManagerId = acceptance.InitDataSourceCheck(byManagerId)
+
+		byName   = "data.huaweicloud_dataarts_security_permission_sets.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byTypeFilter   = "data.huaweicloud_dataarts_security_permission_sets.filter_by_type_filter"
+		dcByTypeFilter = acceptance.InitDataSourceCheck(byTypeFilter)
+
+		byManagerName   = "data.huaweicloud_dataarts_security_permission_sets.filter_by_manager_name"
+		dcByManagerName = acceptance.InitDataSourceCheck(byManagerName)
+
+		byManagerType   = "data.huaweicloud_dataarts_security_permission_sets.filter_by_manager_type"
+		dcByManagerType = acceptance.InitDataSourceCheck(byManagerType)
+
+		byDatasourceType   = "data.huaweicloud_dataarts_security_permission_sets.filter_by_datasource_type"
+		dcByDatasourceType = acceptance.InitDataSourceCheck(byDatasourceType)
+
+		bySyncStatus   = "data.huaweicloud_dataarts_security_permission_sets.filter_by_sync_status"
+		dcBySyncStatus = acceptance.InitDataSourceCheck(bySyncStatus)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsManagerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSecurityPermissionSets_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(all, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttrSet(all, "region"),
+					resource.TestMatchResourceAttr(all, "permission_sets.#", regexp.MustCompile(`^[1-9]([0-9]*)$`)),
+					resource.TestCheckResourceAttrSet(all, "permission_sets.0.id"),
+					resource.TestCheckResourceAttrSet(all, "permission_sets.0.name"),
+					resource.TestCheckResourceAttrSet(all, "permission_sets.0.parent_id"),
+					resource.TestCheckResourceAttrSet(all, "permission_sets.0.type"),
+					resource.TestCheckResourceAttrSet(all, "permission_sets.0.sync_status"),
+					// Filter by parent_id
+					dcByParentId.CheckResourceExists(),
+					resource.TestCheckOutput("is_parent_id_filter_useful", "true"),
+					// Filter by manager_id
+					dcByManagerId.CheckResourceExists(),
+					resource.TestCheckOutput("is_manager_id_filter_useful", "true"),
+					// Filter by name
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					// Filter by type_filter
+					dcByTypeFilter.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					// Filter by manager_name
+					dcByManagerName.CheckResourceExists(),
+					resource.TestCheckOutput("is_manager_name_filter_useful", "true"),
+					// Filter by manager_type
+					dcByManagerType.CheckResourceExists(),
+					resource.TestCheckOutput("is_manager_type_filter_useful", "true"),
+					// Filter by datasource_type
+					dcByDatasourceType.CheckResourceExists(),
+					resource.TestCheckOutput("is_datasource_type_filter_useful", "true"),
+					// Filter by sync_status
+					dcBySyncStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_sync_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSecurityPermissionSets_basic_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_security_permission_set" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  parent_id    = "0"
+  manager_name = "%[2]s_manager"
+  manager_id   = "%[3]s"
+  manager_type = "USER"
+}
+
+resource "huaweicloud_dataarts_security_permission_set" "sub_test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s_sub"
+  parent_id    = huaweicloud_dataarts_security_permission_set.test.id
+  manager_id   = "%[3]s"
+
+  depends_on = [huaweicloud_dataarts_security_permission_set.test]
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_MANAGER_ID)
+}
+
+func testAccDataSecurityPermissionSets_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all permission sets and without any filter
+data "huaweicloud_dataarts_security_permission_sets" "all" {
+  workspace_id = "%[2]s"
+
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set.test,
+    huaweicloud_dataarts_security_permission_set.sub_test,
+  ]
+}
+
+# Filter by parent_id (root permission sets)
+locals {
+  parent_id = "0"
+}
+
+data "huaweicloud_dataarts_security_permission_sets" "filter_by_parent_id" {
+  workspace_id = "%[2]s"
+  parent_id    = local.parent_id
+
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set.test,
+    huaweicloud_dataarts_security_permission_set.sub_test,
+  ]
+}
+
+locals {
+  parent_id_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_sets.filter_by_parent_id.permission_sets[*].parent_id :
+      v == local.parent_id
+  ]
+}
+
+output "is_parent_id_filter_useful" {
+  value = length(local.parent_id_filter_result) > 0 && alltrue(local.parent_id_filter_result)
+}
+
+# Filter by manager_id
+locals {
+  manager_id = "%[3]s"
+}
+
+data "huaweicloud_dataarts_security_permission_sets" "filter_by_manager_id" {
+  workspace_id = "%[2]s"
+  manager_id   = local.manager_id
+
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set.test,
+    huaweicloud_dataarts_security_permission_set.sub_test,
+  ]
+}
+
+locals {
+  manager_id_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_sets.filter_by_manager_id.permission_sets[*].manager_id :
+      v == local.manager_id
+  ]
+}
+
+output "is_manager_id_filter_useful" {
+  value = length(local.manager_id_filter_result) > 0 && alltrue(local.manager_id_filter_result)
+}
+
+# Filter by name (fuzzy matching)
+locals {
+  permission_set_name = huaweicloud_dataarts_security_permission_set.test.name
+}
+
+data "huaweicloud_dataarts_security_permission_sets" "filter_by_name" {
+  workspace_id = "%[2]s"
+  name         = local.permission_set_name
+
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set.test,
+    huaweicloud_dataarts_security_permission_set.sub_test,
+  ]
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_sets.filter_by_name.permission_sets[*].name :
+      strcontains(v, local.permission_set_name)
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by type_filter
+locals {
+  type_filter = "SUB_PERMISSION_SET"
+}
+
+data "huaweicloud_dataarts_security_permission_sets" "filter_by_type_filter" {
+  workspace_id = "%[2]s"
+  type_filter  = local.type_filter
+
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set.test,
+    huaweicloud_dataarts_security_permission_set.sub_test,
+  ]
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_sets.filter_by_type_filter.permission_sets[*].parent_id :
+      v != "0"
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+
+# Filter by manager_name
+locals {
+  manager_name = huaweicloud_dataarts_security_permission_set.test.manager_name
+}
+
+data "huaweicloud_dataarts_security_permission_sets" "filter_by_manager_name" {
+  workspace_id = "%[2]s"
+  manager_name = local.manager_name
+
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set.test,
+    huaweicloud_dataarts_security_permission_set.sub_test,
+  ]
+}
+
+locals {
+  manager_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_sets.filter_by_manager_name.permission_sets[*].manager_name :
+      v == local.manager_name
+  ]
+}
+
+output "is_manager_name_filter_useful" {
+  value = length(local.manager_name_filter_result) > 0 && alltrue(local.manager_name_filter_result)
+}
+
+# Filter by manager_type
+locals {
+  manager_type = huaweicloud_dataarts_security_permission_set.test.manager_type
+}
+
+data "huaweicloud_dataarts_security_permission_sets" "filter_by_manager_type" {
+  workspace_id = "%[2]s"
+  manager_type = local.manager_type
+
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set.test,
+    huaweicloud_dataarts_security_permission_set.sub_test,
+  ]
+}
+
+locals {
+  manager_type_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_sets.filter_by_manager_type.permission_sets[*].manager_type :
+      v == local.manager_type
+  ]
+}
+
+output "is_manager_type_filter_useful" {
+  value = length(local.manager_type_filter_result) > 0 && alltrue(local.manager_type_filter_result)
+}
+
+# Filter by datasource_type
+locals {
+  datasource_type = data.huaweicloud_dataarts_security_permission_sets.all.permission_sets[0].datasource_type
+}
+
+data "huaweicloud_dataarts_security_permission_sets" "filter_by_datasource_type" {
+  workspace_id    = "%[2]s"
+  datasource_type = local.datasource_type
+
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set.test,
+    huaweicloud_dataarts_security_permission_set.sub_test,
+  ]
+}
+
+locals {
+  datasource_type_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_sets.filter_by_datasource_type.permission_sets[*].datasource_type :
+      v == local.datasource_type
+  ]
+}
+
+output "is_datasource_type_filter_useful" {
+  value = length(local.datasource_type_filter_result) > 0 && alltrue(local.datasource_type_filter_result)
+}
+
+# Filter by sync_status
+locals {
+  sync_status = data.huaweicloud_dataarts_security_permission_sets.all.permission_sets[0].sync_status
+}
+
+data "huaweicloud_dataarts_security_permission_sets" "filter_by_sync_status" {
+  workspace_id = "%[2]s"
+  sync_status  = local.sync_status
+
+  depends_on = [
+    huaweicloud_dataarts_security_permission_set.test,
+    huaweicloud_dataarts_security_permission_set.sub_test,
+  ]
+}
+
+locals {
+  sync_status_filter_result = [
+    for v in data.huaweicloud_dataarts_security_permission_sets.filter_by_sync_status.permission_sets[*].sync_status :
+      v == local.sync_status
+  ]
+}
+
+output "is_sync_status_filter_useful" {
+  value = length(local.sync_status_filter_result) > 0 && alltrue(local.sync_status_filter_result)
+}
+`, testAccDataSecurityPermissionSets_basic_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_MANAGER_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_permission_sets.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_permission_sets.go
@@ -1,0 +1,343 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/security/permission-sets
+func DataSourceSecurityPermissionSets() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityPermissionSetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the permission sets are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the permission sets belong.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the permission set to be queried.`,
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The parent ID of the permission set to be queried.`,
+			},
+			"type_filter": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type filter of the permission sets to be queried.`,
+			},
+			"manager_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The manager ID of the permission set to be queried.`,
+			},
+			"manager_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The manager name of the permission set to be queried.`,
+			},
+			"manager_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The manager type of the permission set to be queried.`,
+			},
+			"datasource_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The datasource type of the permission set to be queried.`,
+			},
+			"sync_status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sync status of the permission set to be queried.`,
+			},
+
+			// Attributes.
+			"permission_sets": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        securityPermissionSetSchema(),
+				Description: `The list of permission sets that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func securityPermissionSetSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the permission set.`,
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The parent ID of the permission set.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the permission set.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the permission set.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the permission set.`,
+			},
+			"managed_cluster_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The managed cluster ID of the permission set.`,
+			},
+			"managed_cluster_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The managed cluster name of the permission set.`,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The project ID of the permission set.`,
+			},
+			"domain_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain ID of the permission set.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The instance ID of the permission set.`,
+			},
+			"manager_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The manager ID of the permission set.`,
+			},
+			"manager_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The manager name of the permission set.`,
+			},
+			"manager_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The manager type of the permission set.`,
+			},
+			"datasource_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The datasource type of the permission set.`,
+			},
+			"sync_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The sync status of the permission set.`,
+			},
+			"sync_msg": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The sync message of the permission set.`,
+			},
+			"sync_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The sync time of the permission set, in RFC3339 format.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the permission set, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the permission set, in RFC3339 format.`,
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the permission set.`,
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The updater of the permission set.`,
+			},
+		},
+	}
+}
+
+func buildSecurityPermissionSetsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("parent_id"); ok {
+		res = fmt.Sprintf("%s&parent_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("type_filter"); ok {
+		res = fmt.Sprintf("%s&type_filter=%v", res, v)
+	}
+	if v, ok := d.GetOk("manager_id"); ok {
+		res = fmt.Sprintf("%s&manager_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("manager_name"); ok {
+		res = fmt.Sprintf("%s&manager_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("manager_type"); ok {
+		res = fmt.Sprintf("%s&manager_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("datasource_type"); ok {
+		res = fmt.Sprintf("%s&datasource_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("sync_status"); ok {
+		res = fmt.Sprintf("%s&sync_status=%v", res, v)
+	}
+
+	return res
+}
+
+func listSecurityPermissionSets(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl     = "v1/{project_id}/security/permission-sets?limit={limit}"
+		limit       = 100
+		offset      = 0
+		workspaceId = d.Get("workspace_id").(string)
+		result      = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+	listPathWithLimit += buildSecurityPermissionSetsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+	}
+
+	for {
+		listPathWithOffset := listPathWithLimit + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		permissionSets := utils.PathSearch("permission_sets", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, permissionSets...)
+		if len(permissionSets) < limit {
+			break
+		}
+		offset += len(permissionSets)
+	}
+
+	return result, nil
+}
+
+func flattenSecurityPermissionSets(permissionSets []interface{}) []map[string]interface{} {
+	if len(permissionSets) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(permissionSets))
+	for _, permissionSet := range permissionSets {
+		result = append(result, map[string]interface{}{
+			"id":                   utils.PathSearch("id", permissionSet, nil),
+			"parent_id":            utils.PathSearch("parent_id", permissionSet, nil),
+			"name":                 utils.PathSearch("name", permissionSet, nil),
+			"description":          utils.PathSearch("description", permissionSet, nil),
+			"type":                 utils.PathSearch("type", permissionSet, nil),
+			"managed_cluster_id":   utils.PathSearch("managed_cluster_id", permissionSet, nil),
+			"managed_cluster_name": utils.PathSearch("managed_cluster_name", permissionSet, nil),
+			"project_id":           utils.PathSearch("project_id", permissionSet, nil),
+			"domain_id":            utils.PathSearch("domain_id", permissionSet, nil),
+			"instance_id":          utils.PathSearch("instance_id", permissionSet, nil),
+			"manager_id":           utils.PathSearch("manager_id", permissionSet, nil),
+			"manager_name":         utils.PathSearch("manager_name", permissionSet, nil),
+			"manager_type":         utils.PathSearch("manager_type", permissionSet, nil),
+			"datasource_type":      utils.PathSearch("datasource_type", permissionSet, nil),
+			"sync_status":          utils.PathSearch("sync_status", permissionSet, nil),
+			"sync_msg":             utils.PathSearch("sync_msg", permissionSet, nil),
+			"sync_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("sync_time",
+				permissionSet, float64(0)).(float64))/1000, false),
+			"created_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time",
+				permissionSet, float64(0)).(float64))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time",
+				permissionSet, float64(0)).(float64))/1000, false),
+			"created_by": utils.PathSearch("created_by", permissionSet, nil),
+			"updated_by": utils.PathSearch("updated_by", permissionSet, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceSecurityPermissionSetsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	permissionSets, err := listSecurityPermissionSets(client, d)
+	if err != nil {
+		return diag.Errorf("error querying permission sets: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("permission_sets", flattenSecurityPermissionSets(permissionSets)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add data source for querying security permission sets.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
Since instance creation is time-consuming, it needs to be injected via environment variables.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataSecurityPermissionSets_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSecurityPermissionSets_basic
=== PAUSE TestAccDataSecurityPermissionSets_basic
=== CONT  TestAccDataSecurityPermissionSets_basic
--- PASS: TestAccDataSecurityPermissionSets_basic (16.07s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  16.213s coverage: 5.1% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.