### PR TITLE
feat(dataarts/security): add new data source to query dynamic masking policy list

### DIFF
--- a/docs/data-sources/dataarts_security_dynamic_masking_policies.md
+++ b/docs/data-sources/dataarts_security_dynamic_masking_policies.md
@@ -1,0 +1,109 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_dynamic_masking_policies"
+description: |-
+  Use this data source to get the list of DataArts Security dynamic masking policies within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_dynamic_masking_policies
+
+Use this data source to get the list of DataArts Security dynamic masking policies within HuaweiCloud.
+
+## Example Usage
+
+### Query all dynamic masking policies under a specified workspace
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_security_dynamic_masking_policies" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+### Query dynamic masking policies by name
+
+```hcl
+variable "workspace_id" {}
+variable "policy_name" {}
+
+data "huaweicloud_dataarts_security_dynamic_masking_policies" "test" {
+  workspace_id = var.workspace_id
+  name         = var.policy_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the dynamic masking policies.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the dynamic masking policies belong.
+
+* `name` - (Optional, String) Specifies the name of the dynamic masking policy to be queried.  
+  Fuzzy search is supported.
+
+* `cluster_name` - (Optional, String) Specifies the name of the cluster to be queried.  
+  Fuzzy search is supported.
+
+* `database_name` - (Optional, String) Specifies the name of the database to be queried.  
+  Fuzzy search is supported.
+
+* `table_name` - (Optional, String) Specifies the name of the data table to be queried.  
+  Fuzzy search is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `policies` - The list of dynamic masking policies that matched filter parameters.  
+  The [policies](#dataarts_security_dynamic_masking_policies_attr) structure is documented below.
+
+<a name="dataarts_security_dynamic_masking_policies_attr"></a>
+The `policies` block supports:
+
+* `id` - The ID of the dynamic masking policy.
+
+* `name` - The name of the dynamic masking policy.
+
+* `datasource_type` - The data source type of the dynamic masking policy.
+  + **DWS**
+  + **DLI**
+  + **HIVE**
+
+* `cluster_id` - The ID of the cluster corresponding to the data source.
+
+* `cluster_name` - The name of the cluster corresponding to the data source.
+
+* `database_name` - The name of the database.
+
+* `table_name` - The name of the data table.
+
+* `user_groups` - The user groups of the dynamic masking policy, separated by commas (,).
+
+* `users` - The users of the dynamic masking policy, separated by commas (,).
+
+* `sync_status` - The synchronization status of the dynamic masking policy.  
+  + **UNKNOWN**
+  + **NOT_SYNC**
+  + **SYNC_SUCCESS**
+  + **SYNC_FAIL**
+  + **SYNC_PARTIAL_FAIL**
+  + **DATA_UPDATED**
+
+* `sync_time` - The synchronization time of the dynamic masking policy, in RFC3339 format.
+
+* `sync_msg` - The synchronization log of the dynamic masking policy.
+
+* `create_time` - The creation time of the dynamic masking policy, in RFC3339 format.
+
+* `create_user` - The creator of the dynamic masking policy.
+
+* `update_time` - The latest update time of the dynamic masking policy, in RFC3339 format.
+
+* `update_user` - The latest updater of the dynamic masking policy.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1095,6 +1095,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_factory_scripts":   dataarts.DataSourceFactoryScripts(),
 			// DataArts Security
 			"huaweicloud_dataarts_security_data_recognition_rules":      dataarts.DataSourceSecurityDataRecognitionRules(),
+			"huaweicloud_dataarts_security_dynamic_masking_policies":    dataarts.DataSourceSecurityDynamicMaskingPolicies(),
 			"huaweicloud_dataarts_security_permission_sets":             dataarts.DataSourceSecurityPermissionSets(),
 			"huaweicloud_dataarts_security_permission_set_members":      dataarts.DataSourceSecurityPermissionSetMembers(),
 			"huaweicloud_dataarts_security_permission_set_privileges":   dataarts.DataSourceSecurityPermissionSetPrivileges(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_dynamic_masking_policies_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_dynamic_masking_policies_test.go
@@ -1,0 +1,232 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// HW_DATAARTS_CONNECTION_ID must be the connection ID corresponding to a DWS type data connection.
+func TestAccDataSecurityDynamicMaskingPolicies_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_security_dynamic_masking_policies.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_dataarts_security_dynamic_masking_policies.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byClusterName   = "data.huaweicloud_dataarts_security_dynamic_masking_policies.filter_by_cluster_name"
+		dcByClusterName = acceptance.InitDataSourceCheck(byClusterName)
+
+		byDatabaseName   = "data.huaweicloud_dataarts_security_dynamic_masking_policies.filter_by_database_name"
+		dcByDatabaseName = acceptance.InitDataSourceCheck(byDatabaseName)
+
+		byTableName   = "data.huaweicloud_dataarts_security_dynamic_masking_policies.filter_by_table_name"
+		dcByTableName = acceptance.InitDataSourceCheck(byTableName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsConnectionID(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+			acceptance.TestAccPreCheckUserName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSecurityDynamicMaskingPolicies_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "policies.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					// Filter by 'name' parameter.
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckResourceAttrSet(byName, "policies.0.id"),
+					resource.TestCheckResourceAttrSet(byName, "policies.0.name"),
+					resource.TestCheckResourceAttrSet(byName, "policies.0.datasource_type"),
+					resource.TestCheckResourceAttrSet(byName, "policies.0.cluster_id"),
+					resource.TestCheckResourceAttrSet(byName, "policies.0.cluster_name"),
+					resource.TestCheckResourceAttrSet(byName, "policies.0.database_name"),
+					resource.TestCheckResourceAttrSet(byName, "policies.0.table_name"),
+					resource.TestCheckResourceAttrSet(byName, "policies.0.user_groups"),
+					resource.TestCheckResourceAttrSet(byName, "policies.0.users"),
+					resource.TestCheckResourceAttrSet(byName, "policies.0.sync_status"),
+					resource.TestMatchResourceAttr(byName, "policies.0.create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(byName, "policies.0.create_user"),
+					resource.TestMatchResourceAttr(byName, "policies.0.update_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(byName, "policies.0.update_user"),
+					// Filter by 'cluster_name' parameter.
+					dcByClusterName.CheckResourceExists(),
+					resource.TestCheckOutput("is_cluster_name_filter_useful", "true"),
+					// Filter by 'database_name' parameter.
+					dcByDatabaseName.CheckResourceExists(),
+					resource.TestCheckOutput("is_database_name_filter_useful", "true"),
+					// Filter by 'table_name' parameter.
+					dcByTableName.CheckResourceExists(),
+					resource.TestCheckOutput("is_table_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSecurityDynamicMaskingPolicies_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_studio_data_connections" "test" {
+  workspace_id  = "%[1]s"
+  connection_id = "%[2]s"
+}
+
+data "huaweicloud_dws_clusters" "test" {}
+
+resource "huaweicloud_identity_group" "test" {
+  name = "%[3]s"
+}
+
+locals {
+  connection_name = try(data.huaweicloud_dataarts_studio_data_connections.test.connections[0].name, "NOT_FOUND")
+  cluster_name    = try([for v in data.huaweicloud_dws_clusters.test.clusters : v.name if v.id == "%[4]s"][0], "NOT_FOUND")
+}
+
+resource "huaweicloud_dataarts_security_dynamic_masking_policy" "test" {
+  workspace_id    = "%[1]s"
+  name            = "%[3]s"
+  datasource_type = "DWS"
+  cluster_id      = "%[4]s"
+  cluster_name    = local.cluster_name
+  database_name   = "gaussdb"
+  table_name      = "%[3]s"
+  users           = "%[5]s"
+  user_groups     = huaweicloud_identity_group.test.name
+  conn_id         = "%[2]s"
+  conn_name       = local.connection_name
+  table_id        = "NativeTable-%[4]s-gaussdb-public-%[3]s"
+  schema_name     = "public"
+
+  policy_list {
+    column_name          = "total"
+    column_type          = "int8"
+    algorithm_type       = "DWS_SELF_CONFIG"
+    algorithm_detail_dto = jsonencode({
+      start      = 1
+      end        = 2
+      int_target = 0
+    })
+  }
+  policy_list {
+    column_name    = "enabled"
+    column_type    = "bool"
+    algorithm_type = "MASK"
+  }
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_CONNECTION_ID, name,
+		acceptance.HW_DWS_CLUSTER_ID, acceptance.HW_USER_NAME)
+}
+
+func testAccDataSecurityDynamicMaskingPolicies_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_dataarts_security_dynamic_masking_policies" "test" {
+  workspace_id = "%[2]s"
+}
+
+# Filter by 'name' parameter.
+locals {
+  policy_name = huaweicloud_dataarts_security_dynamic_masking_policy.test.name
+}
+
+data "huaweicloud_dataarts_security_dynamic_masking_policies" "filter_by_name" {
+  workspace_id = "%[2]s"
+  name         = local.policy_name
+
+  depends_on = [huaweicloud_dataarts_security_dynamic_masking_policy.test]
+}
+
+locals {
+  name_filter_result = [for v in data.huaweicloud_dataarts_security_dynamic_masking_policies.filter_by_name.policies[*].name :
+  strcontains(v, local.policy_name)]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by 'cluster_name' parameter.
+data "huaweicloud_dataarts_security_dynamic_masking_policies" "filter_by_cluster_name" {
+  workspace_id = "%[2]s"
+  cluster_name = local.cluster_name
+
+  depends_on = [huaweicloud_dataarts_security_dynamic_masking_policy.test]
+}
+
+locals {
+  cluster_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_dynamic_masking_policies.filter_by_cluster_name.policies[*].cluster_name :
+    strcontains(v, local.cluster_name)
+  ]
+}
+
+output "is_cluster_name_filter_useful" {
+  value = length(local.cluster_name_filter_result) > 0 && alltrue(local.cluster_name_filter_result)
+}
+
+# Filter by 'database_name' parameter.
+locals {
+  database_name = huaweicloud_dataarts_security_dynamic_masking_policy.test.database_name
+}
+
+data "huaweicloud_dataarts_security_dynamic_masking_policies" "filter_by_database_name" {
+  workspace_id  = "%[2]s"
+  database_name = local.database_name
+
+  depends_on = [huaweicloud_dataarts_security_dynamic_masking_policy.test]
+}
+
+locals {
+  database_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_dynamic_masking_policies.filter_by_database_name.policies[*].database_name :
+    strcontains(v, local.database_name)
+  ]
+}
+
+output "is_database_name_filter_useful" {
+  value = length(local.database_name_filter_result) > 0 && alltrue(local.database_name_filter_result)
+}
+
+# Filter by 'table_name' parameter.
+locals {
+  table_name = huaweicloud_dataarts_security_dynamic_masking_policy.test.table_name
+}
+
+data "huaweicloud_dataarts_security_dynamic_masking_policies" "filter_by_table_name" {
+  workspace_id = "%[2]s"
+  table_name   = local.table_name
+
+  depends_on = [huaweicloud_dataarts_security_dynamic_masking_policy.test]
+}
+
+locals {
+  table_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_dynamic_masking_policies.filter_by_table_name.policies[*].table_name :
+    strcontains(v, local.table_name)
+  ]
+}
+
+output "is_table_name_filter_useful" {
+  value = length(local.table_name_filter_result) > 0 && alltrue(local.table_name_filter_result)
+}
+`, testAccDataSecurityDynamicMaskingPolicies_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_dynamic_masking_policies.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_dynamic_masking_policies.go
@@ -1,0 +1,284 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/security/masking/dynamic/policies
+func DataSourceSecurityDynamicMaskingPolicies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityDynamicMaskingPoliciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the dynamic masking policies are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the dynamic masking policies belong.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the dynamic masking policy to be queried.`,
+			},
+			"cluster_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the cluster to be queried.`,
+			},
+			"database_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the database to be queried.`,
+			},
+			"table_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the data table to be queried.`,
+			},
+
+			// Attributes.
+			"policies": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of dynamic masking policies that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the dynamic masking policy.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the dynamic masking policy.`,
+						},
+						"datasource_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The data source type of the dynamic masking policy.`,
+						},
+						"cluster_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the cluster corresponding to the data source.`,
+						},
+						"cluster_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the cluster corresponding to the data source.`,
+						},
+						"database_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the database.`,
+						},
+						"table_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the data table.`,
+						},
+						"user_groups": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The user groups of the dynamic masking policy, separated by commas (,).`,
+						},
+						"users": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The users of the dynamic masking policy, separated by commas (,).`,
+						},
+						"sync_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The synchronization status of the dynamic masking policy.`,
+						},
+						"sync_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The synchronization time of the dynamic masking policy, in RFC3339 format.`,
+						},
+						"sync_msg": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The synchronization log of the dynamic masking policy.`,
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the dynamic masking policy, in RFC3339 format.`,
+						},
+						"create_user": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator of the dynamic masking policy.`,
+						},
+						"update_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the dynamic masking policy, in RFC3339 format.`,
+						},
+						"update_user": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest updater of the dynamic masking policy.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSecurityDynamicMaskingPoliciesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("cluster_name"); ok {
+		res = fmt.Sprintf("%s&cluster_name=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("database_name"); ok {
+		res = fmt.Sprintf("%s&database_name=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("table_name"); ok {
+		res = fmt.Sprintf("%s&table_name=%v", res, v)
+	}
+
+	return res
+}
+
+func listSecurityDynamicMaskingPolicies(client *golangsdk.ServiceClient, workspaceId string, queryParams ...string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/security/masking/dynamic/policies?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	if len(queryParams) > 0 && queryParams[0] != "" {
+		listPath += queryParams[0]
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		policies := utils.PathSearch("policies", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, policies...)
+		if len(policies) < limit {
+			break
+		}
+
+		offset += len(policies)
+	}
+
+	return result, nil
+}
+
+func flattenSecurityDynamicMaskingPolicies(policies []interface{}) []map[string]interface{} {
+	if len(policies) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(policies))
+	for _, policy := range policies {
+		result = append(result, map[string]interface{}{
+			"id":              utils.PathSearch("id", policy, nil),
+			"name":            utils.PathSearch("name", policy, nil),
+			"datasource_type": utils.PathSearch("datasource_type", policy, nil),
+			"cluster_id":      utils.PathSearch("cluster_id", policy, nil),
+			"cluster_name":    utils.PathSearch("cluster_name", policy, nil),
+			"database_name":   utils.PathSearch("database_name", policy, nil),
+			"table_name":      utils.PathSearch("table_name", policy, nil),
+			"user_groups":     utils.PathSearch("user_groups", policy, nil),
+			"users":           utils.PathSearch("users", policy, nil),
+			"sync_status":     utils.PathSearch("sync_status", policy, nil),
+			"sync_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("sync_time",
+				policy, float64(0)).(float64))/1000, false),
+			"sync_msg": utils.PathSearch("sync_msg", policy, nil),
+			"create_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time",
+				policy, float64(0)).(float64))/1000, false),
+			"create_user": utils.PathSearch("create_user", policy, nil),
+			"update_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time",
+				policy, float64(0)).(float64))/1000, false),
+			"update_user": utils.PathSearch("update_user", policy, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceSecurityDynamicMaskingPoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	policies, err := listSecurityDynamicMaskingPolicies(client, workspaceId, buildSecurityDynamicMaskingPoliciesQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error querying DataArts Security dynamic masking policies: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("policies", flattenSecurityDynamicMaskingPolicies(policies)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 
add a new data source(`huaweicloud_dataarts_security_dynamic_masking_policies`) to query dynamic masking policy list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataSecurityDynamicMaskingPolicies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataSecurityDynamicMaskingPolicies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSecurityDynamicMaskingPolicies_basic
=== PAUSE TestAccDataSecurityDynamicMaskingPolicies_basic
=== CONT  TestAccDataSecurityDynamicMaskingPolicies_basic
--- PASS: TestAccDataSecurityDynamicMaskingPolicies_basic (18.93s)
PASS
coverage: 5.9% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  19.043s coverage: 5.9% of statements in ./huaweicloud/services/dataarts
```
<img width="1382" height="52" alt="image" src="https://github.com/user-attachments/assets/aee6b2a4-1957-462b-b918-6f2f3e19149f" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
