### PR TITLE
feat(rfs): support `rfs_execution_plan_prices` data source

### DIFF
--- a/docs/data-sources/rfs_execution_plan_prices.md
+++ b/docs/data-sources/rfs_execution_plan_prices.md
@@ -1,0 +1,98 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_execution_plan_prices"
+description: |-
+  Use this dataSource to get the price estimate of an execution plan.
+---
+
+# huaweicloud_rfs_execution_plan_prices
+
+Use this dataSource to get the price estimate of an execution plan.
+
+## Example Usage
+
+```hcl
+variable "stack_name" {}
+variable "execution_plan_name" {}
+
+data "huaweicloud_rfs_execution_plan_prices" "test" {
+  stack_name          = var.stack_name
+  execution_plan_name = var.execution_plan_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `stack_name` - (Required, String) Specifies the name of the resource stack.
+
+* `execution_plan_name` - (Required, String) Specifies the name of the execution plan.
+
+* `stack_id` - (Optional, String) Specifies the ID of the resource stack.
+
+* `execution_plan_id` - (Optional, String) Specifies the ID of the execution plan.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `currency` - The currency. For example, **CNY** is returned for the Chinese site.
+
+* `items` - The price estimate of all resources in the execution plan.
+
+  The [items](#items_struct) structure is documented below.
+
+<a name="items_struct"></a>
+The `items` block supports:
+
+* `resource_type` - The resource type in the template.
+
+* `resource_name` - The logical resource name in the template, used as the default resource name.
+
+* `index` - The index of the resource. If `count` or `for_each` is used, this value is set.
+
+* `module_address` - The module address of the resource.
+
+* `supported` - Whether the resource or the given parameters support price inquiry.
+
+* `unsupported_message` - The reason the resource does not support price inquiry.
+
+* `resource_price` - The price information for the resource. If the resource is free, this block may be absent.
+
+  The [resource_price](#resource_price_struct) structure is documented below.
+
+<a name="resource_price_struct"></a>
+The `resource_price` block supports:
+
+* `charge_mode` - The billing mode.  
+  The valid values are **PRE_PAID** (Yearly/Monthly), **POST_PAID** (Pay-per-use), and **FREE** (Free).
+
+* `sale_price` - The final amount after all discounts, excluding promotion discounts and coupons, in **CNY**.
+
+* `discount` - The total discount amount, in **CNY**.
+
+* `original_price` - The original price, in **CNY**.
+
+* `period_type` - The billing period unit, used together with `period_count`.  
+  The valid values include **HOUR**, **DAY**, **MONTH**, **YEAR**, **BYTE**, **MB**, and **GB**.
+
+* `period_count` - The number of billing periods.
+
+  For a detailed explanation of this parameter,
+  please refer to [documentation](https://support.huaweicloud.com/intl/en-us/api-aos/EstimateExecutionPlanPrice.html).
+
+* `best_discount_type` - The best discount type.
+
+  For a detailed explanation of this parameter,
+  please refer to [documentation](https://support.huaweicloud.com/intl/en-us/api-aos/EstimateExecutionPlanPrice.html).
+
+* `best_discount_price` - The best discount amount, in **CNY**.
+
+* `official_website_discount_price` - The official website discount amount, in **CNY**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2035,6 +2035,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_intelligent_session_kill_statistic": rds.DataSourceIntelligentSessionKillStatistic(),
 
 			"huaweicloud_rfs_execution_plans":              rfs.DataSourceRfsExecutionPlans(),
+			"huaweicloud_rfs_execution_plan_prices":        rfs.DataSourceExecutionPlanPrices(),
 			"huaweicloud_rfs_private_module_versions":      rfs.DataSourcePrivateModuleVersions(),
 			"huaweicloud_rfs_private_modules":              rfs.DataSourcePrivateModules(),
 			"huaweicloud_rfs_private_hooks":                rfs.DataSourceRfsPrivateHooks(),

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_execution_plan_prices_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_execution_plan_prices_test.go
@@ -1,0 +1,88 @@
+package rfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceExecutionPlanPrices_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_execution_plan_prices.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceNameWithDash()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceExecutionPlanPrices_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "items.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.resource_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.resource_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.supported"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.resource_price.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.resource_price.0.charge_mode"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.resource_price.0.sale_price"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.resource_price.0.discount"),
+					resource.TestCheckResourceAttrSet(dataSource, "items.0.resource_price.0.original_price"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceExecutionPlanPrices_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rfs_stack" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_rfs_execution_plan_v2" "test" {
+  stack_name          = huaweicloud_rfs_stack.test.name
+  execution_plan_name = "%[1]s"
+  description         = "test execution plan"
+  stack_id            = huaweicloud_rfs_stack.test.id
+  template_body       = %[2]s
+  vars_body           = %[3]s
+
+  vars_structure {
+    var_key   = "vpc_name"
+    var_value = "%[1]s-vpc"
+  }
+
+  vars_structure {
+    var_key   = "subnet_name"
+    var_value = "%[1]s-subnet"
+  }
+
+  vars_structure {
+    var_key   = "instance_count"
+    var_value = "2"
+  }
+}
+`, name, updateTemplateInJsonFormat(), basicVariablesInVarsFormat(name))
+}
+
+func testDataSourceExecutionPlanPrices_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rfs_execution_plan_prices" "test" {
+  depends_on = [huaweicloud_rfs_execution_plan_v2.test]
+
+  stack_name          = huaweicloud_rfs_stack.test.name
+  execution_plan_name = huaweicloud_rfs_execution_plan_v2.test.execution_plan_name
+  stack_id            = huaweicloud_rfs_stack.test.id
+  execution_plan_id   = huaweicloud_rfs_execution_plan_v2.test.execution_plan_id
+}
+`, testDataSourceExecutionPlanPrices_base(name))
+}

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_execution_plan_prices.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_execution_plan_prices.go
@@ -1,0 +1,243 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/{project_id}/stacks/{stack_name}/execution-plans/{execution_plan_name}/prices
+func DataSourceExecutionPlanPrices() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceExecutionPlanPricesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"stack_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"execution_plan_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"stack_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"execution_plan_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"currency": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"index": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"module_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"supported": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"unsupported_message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_price": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"charge_mode": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"sale_price": {
+										Type:     schema.TypeFloat,
+										Computed: true,
+									},
+									"discount": {
+										Type:     schema.TypeFloat,
+										Computed: true,
+									},
+									"original_price": {
+										Type:     schema.TypeFloat,
+										Computed: true,
+									},
+									"period_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"period_count": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"best_discount_type": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"best_discount_price": {
+										Type:     schema.TypeFloat,
+										Computed: true,
+									},
+									"official_website_discount_price": {
+										Type:     schema.TypeFloat,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildExecutionPlanPricesQueryParams(d *schema.ResourceData) string {
+	rst := ""
+
+	if v, ok := d.GetOk("stack_id"); ok {
+		rst += fmt.Sprintf("&stack_id=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("execution_plan_id"); ok {
+		rst += fmt.Sprintf("&execution_plan_id=%s", v.(string))
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourceExecutionPlanPricesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v1/{project_id}/stacks/{stack_name}/execution-plans/{execution_plan_name}/prices"
+		stackName = d.Get("stack_name").(string)
+		planName  = d.Get("execution_plan_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	reqUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate RFS request UUID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{stack_name}", stackName)
+	requestPath = strings.ReplaceAll(requestPath, "{execution_plan_name}", planName)
+	requestPath += buildExecutionPlanPricesQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Client-Request-Id": reqUUID},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving RFS execution plan prices: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(reqUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("currency", utils.PathSearch("currency", respBody, nil)),
+		d.Set("items", flattenExecutionPlanPricesItems(
+			utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenExecutionPlanPricesItems(items []interface{}) []interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(items))
+	for _, v := range items {
+		rst = append(rst, map[string]interface{}{
+			"resource_type":       utils.PathSearch("resource_type", v, nil),
+			"resource_name":       utils.PathSearch("resource_name", v, nil),
+			"index":               utils.PathSearch("index", v, nil),
+			"module_address":      utils.PathSearch("module_address", v, nil),
+			"supported":           utils.PathSearch("supported", v, nil),
+			"unsupported_message": utils.PathSearch("unsupported_message", v, nil),
+			"resource_price": flattenResourcePrice(
+				utils.PathSearch("resource_price", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenResourcePrice(resourcePriceResp []interface{}) []interface{} {
+	if len(resourcePriceResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resourcePriceResp))
+	for _, v := range resourcePriceResp {
+		rst = append(rst, map[string]interface{}{
+			"charge_mode":         utils.PathSearch("charge_mode", v, nil),
+			"sale_price":          utils.PathSearch("sale_price", v, nil),
+			"discount":            utils.PathSearch("discount", v, nil),
+			"original_price":      utils.PathSearch("original_price", v, nil),
+			"period_type":         utils.PathSearch("period_type", v, nil),
+			"period_count":        utils.PathSearch("period_count", v, nil),
+			"best_discount_type":  utils.PathSearch("best_discount_type", v, nil),
+			"best_discount_price": utils.PathSearch("best_discount_price", v, nil),
+			"official_website_discount_price": utils.PathSearch(
+				"official_website_discount_price", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `rfs_execution_plan_prices` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `rfs_execution_plan_prices` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/rfs" TESTARGS="-run TestAccDataSourceExecutionPlanPrices_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rfs -v -run TestAccDataSourceExecutionPlanPrices_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceExecutionPlanPrices_basic
=== PAUSE TestAccDataSourceExecutionPlanPrices_basic
=== CONT  TestAccDataSourceExecutionPlanPrices_basic
--- PASS: TestAccDataSourceExecutionPlanPrices_basic (37.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       37.494s
```
<img width="891" height="36" alt="image" src="https://github.com/user-attachments/assets/798e2c60-29a2-406d-a31f-29981844918e" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
