### PR TITLE
fix(iam): repair some incorrect API references

### DIFF
--- a/huaweicloud/services/iam/resource_huaweicloud_identity_user_role_assignment.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_user_role_assignment.go
@@ -16,9 +16,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
-// @API IAM PUT /v3.0/OS-PERMISSION/enterprise-projects/{enterpriseProjectID}/users/{user_id}/roles/{role_id}
-// @API IAM DELETE /v3.0/OS-PERMISSION/enterprise-projects/{enterpriseProjectID}/users/{user_id}/roles/{role_id}
-// @API IAM GET /v3.0/OS-PERMISSION/enterprise-projects/{enterpriseProjectID}/users/{user_id}/roles
+// @API IAM PUT /v3.0/OS-PERMISSION/enterprise-projects/{enterprise_project_id}/users/{user_id}/roles/{role_id}
+// @API IAM DELETE /v3.0/OS-PERMISSION/enterprise-projects/{enterprise_project_id}/users/{user_id}/roles/{role_id}
+// @API IAM GET /v3.0/OS-PERMISSION/enterprise-projects/{enterprise_project_id}/users/{user_id}/roles
 func ResourceIdentityUserRoleAssignment() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceIdentityUserRoleAssignmentCreate,

--- a/huaweicloud/services/iam/resource_huaweicloud_identityv5_service_linked_agency.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identityv5_service_linked_agency.go
@@ -17,6 +17,7 @@ import (
 
 // ResourceIdentityv5ServiceLinkedAgency
 // @API IAM PUT /v5/service-linked-agencies
+// @API IAM GET /v5/agencies/{agency_id}
 func ResourceIdentityv5ServiceLinkedAgency() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceServiceLinkedAgencyCreate,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix some incorrect API references:
- missing a GET API reference in v5 service linked agency resource
- the URI which includes 'enterpriseProjectID' words should be specified as 'enterprise_project_id'

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. repair some incorrect API references
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
