### PR TITLE
feat(dataarts/security): add new data source to query resource permission policy list

### DIFF
--- a/docs/data-sources/dataarts_security_resource_permission_policies.md
+++ b/docs/data-sources/dataarts_security_resource_permission_policies.md
@@ -1,0 +1,104 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_resource_permission_policies"
+description: |-
+  Use this data source to get the list of DataArts Security resource permission policies within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_resource_permission_policies
+
+  Use this data source to get the list of DataArts Security resource permission policies within HuaweiCloud.
+
+## Example Usage
+
+### Query all resource permission policies
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_security_resource_permission_policies" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+### Query resource permission policies by name
+
+```hcl
+variable "workspace_id" {}
+variable "policy_name" {}
+
+data "huaweicloud_dataarts_security_resource_permission_policies" "test" {
+  workspace_id = var.workspace_id
+  policy_name  = var.policy_name
+}
+  ```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource permission policies.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the resource permission policies belong.
+
+* `policy_name` - (Optional, String) Specifies the name of the resource permission policy to be queried.  
+  Fuzzy matching is supported.
+
+* `resource_name` - (Optional, String) Specifies the name of the authorized resource to be queried.  
+  Fuzzy matching is supported.
+
+* `member_name` - (Optional, String) Specifies the name of the authorized member to be queried.  
+  Fuzzy matching is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `policies` - The list of resource permission policies that matched filter parameters.  
+  The [policies](#dataarts_security_resource_permission_policies_attr) structure is documented below.
+
+<a name="dataarts_security_resource_permission_policies_attr"></a>
+The `policies` block supports:
+
+* `policy_id` - The ID of the resource permission policy.
+
+* `policy_name` - The name of the resource permission policy.
+
+* `resources` - The resource list of the resource permission policy.  
+  The [resources](#dataarts_security_resource_permission_policies_resources) structure is documented below.
+
+* `members` - The member list of the resource permission policy.  
+  The [members](#dataarts_security_resource_permission_policies_members) structure is documented below.
+
+* `create_time` - The creation time of the resource permission policy, in RFC3339 format.
+
+* `create_user` - The creator of the resource permission policy.
+
+* `update_time` - The latest update time of the resource permission policy, in RFC3339 format.
+
+<a name="dataarts_security_resource_permission_policies_resources"></a>
+The `resources` block supports:
+
+* `resource_id` - The ID of the resource.
+
+* `resource_name` - The name of the resource.
+
+* `resource_type` - The type of the resource.
+  + **DATA_CONNECTION**
+  + **AGENCY**
+
+  <a name="dataarts_security_resource_permission_policies_members"></a>
+  The `members` block supports:
+
+* `member_id` - The ID of the member.
+
+* `member_name` - The name of the member.
+
+* `member_type` - The type of the member.
+  + **USER**
+  + **USER_GROUP**
+  + **WORKSPACE_ROLE**

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1094,12 +1094,13 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_factory_resources": dataarts.DataSourceFactoryResources(),
 			"huaweicloud_dataarts_factory_scripts":   dataarts.DataSourceFactoryScripts(),
 			// DataArts Security
-			"huaweicloud_dataarts_security_data_recognition_rules":      dataarts.DataSourceSecurityDataRecognitionRules(),
-			"huaweicloud_dataarts_security_dynamic_masking_policies":    dataarts.DataSourceSecurityDynamicMaskingPolicies(),
-			"huaweicloud_dataarts_security_permission_sets":             dataarts.DataSourceSecurityPermissionSets(),
-			"huaweicloud_dataarts_security_permission_set_members":      dataarts.DataSourceSecurityPermissionSetMembers(),
-			"huaweicloud_dataarts_security_permission_set_privileges":   dataarts.DataSourceSecurityPermissionSetPrivileges(),
-			"huaweicloud_dataarts_security_workspace_associated_queues": dataarts.DataSourceSecurityWorkspaceAssociatedQueues(),
+			"huaweicloud_dataarts_security_data_recognition_rules":       dataarts.DataSourceSecurityDataRecognitionRules(),
+			"huaweicloud_dataarts_security_dynamic_masking_policies":     dataarts.DataSourceSecurityDynamicMaskingPolicies(),
+			"huaweicloud_dataarts_security_permission_sets":              dataarts.DataSourceSecurityPermissionSets(),
+			"huaweicloud_dataarts_security_permission_set_members":       dataarts.DataSourceSecurityPermissionSetMembers(),
+			"huaweicloud_dataarts_security_permission_set_privileges":    dataarts.DataSourceSecurityPermissionSetPrivileges(),
+			"huaweicloud_dataarts_security_resource_permission_policies": dataarts.DataSourceSecurityResourcePermissionPolicies(),
+			"huaweicloud_dataarts_security_workspace_associated_queues":  dataarts.DataSourceSecurityWorkspaceAssociatedQueues(),
 			// DataArts Catalog
 			"huaweicloud_dataarts_catalog_metadata_tasks": dataarts.DataSourceCatalogMetadataTasks(),
 

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_resource_permission_policies_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_resource_permission_policies_test.go
@@ -1,0 +1,173 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSecurityResourcePermissionPolicies_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_security_resource_permission_policies.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byPolicyName   = "data.huaweicloud_dataarts_security_resource_permission_policies.filter_by_policy_name"
+		dcByPolicyName = acceptance.InitDataSourceCheck(byPolicyName)
+
+		byResourceName   = "data.huaweicloud_dataarts_security_resource_permission_policies.filter_by_resource_name"
+		dcByResourceName = acceptance.InitDataSourceCheck(byResourceName)
+
+		byMemberName   = "data.huaweicloud_dataarts_security_resource_permission_policies.filter_by_member_name"
+		dcByMemberName = acceptance.InitDataSourceCheck(byMemberName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsConnectionID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSecurityResourcePermissionPolicies_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "policies.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'policy_name' parameter.
+					dcByPolicyName.CheckResourceExists(),
+					resource.TestCheckOutput("is_policy_name_filter_useful", "true"),
+					resource.TestCheckResourceAttrSet(byPolicyName, "policies.0.policy_id"),
+					resource.TestCheckResourceAttrSet(byPolicyName, "policies.0.policy_name"),
+					resource.TestMatchResourceAttr(byPolicyName, "policies.0.create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(byPolicyName, "policies.0.create_user"),
+					resource.TestMatchResourceAttr(byPolicyName, "policies.0.update_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Filter by 'resource_name' parameter.
+					dcByResourceName.CheckResourceExists(),
+					resource.TestCheckOutput("is_resource_name_filter_useful", "true"),
+					// Filter by 'member_name' parameter.
+					dcByMemberName.CheckResourceExists(),
+					resource.TestCheckOutput("is_member_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSecurityResourcePermissionPolicies_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_studio_workspace_user_roles" "test" {
+  workspace_id = "%[1]s"
+}
+
+data "huaweicloud_dataarts_studio_data_connections" "test" {
+  workspace_id  = "%[1]s"
+  connection_id = "%[2]s"
+}
+
+locals {
+  connection_name = try(data.huaweicloud_dataarts_studio_data_connections.test.connections[0].name, "NOT_FOUND")
+  member_name     = try(data.huaweicloud_dataarts_studio_workspace_user_roles.test.roles[0].name, "NOT_FOUND")
+}
+
+resource "huaweicloud_dataarts_security_resource_permission_policy" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[3]s"
+
+  resources {
+    resource_id   = try(data.huaweicloud_dataarts_studio_data_connections.test.connections[0].id, "NOT_FOUND")
+    resource_name = local.connection_name
+    resource_type = "DATA_CONNECTION"
+  }
+
+  members {
+    member_id   = try(data.huaweicloud_dataarts_studio_workspace_user_roles.test.roles[0].id, "NOT_FOUND")
+    member_name = local.member_name
+    member_type = "WORKSPACE_ROLE"
+  }
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_CONNECTION_ID, name)
+}
+
+func testAccDataSecurityResourcePermissionPolicies_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_dataarts_security_resource_permission_policies" "test" {
+  workspace_id = "%[2]s"
+
+  depends_on = [huaweicloud_dataarts_security_resource_permission_policy.test]
+}
+
+# Filter by 'policy_name' parameter.
+locals {
+  policy_name = huaweicloud_dataarts_security_resource_permission_policy.test.name
+}
+
+data "huaweicloud_dataarts_security_resource_permission_policies" "filter_by_policy_name" {
+  workspace_id = "%[2]s"
+  policy_name  = local.policy_name
+
+  depends_on = [huaweicloud_dataarts_security_resource_permission_policy.test]
+}
+
+locals {
+  policy_name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_resource_permission_policies.filter_by_policy_name.policies[*].policy_name
+    : strcontains(v, local.policy_name)
+  ]
+}
+
+output "is_policy_name_filter_useful" {
+  value = length(local.policy_name_filter_result) > 0 && alltrue(local.policy_name_filter_result)
+}
+
+# Filter by 'resource_name' parameter.
+data "huaweicloud_dataarts_security_resource_permission_policies" "filter_by_resource_name" {
+  workspace_id  = "%[2]s"
+  resource_name = local.connection_name
+
+  depends_on = [huaweicloud_dataarts_security_resource_permission_policy.test]
+}
+
+locals {
+  resource_name_filter_result = [for item in
+    [for v in data.huaweicloud_dataarts_security_resource_permission_policies.filter_by_resource_name.policies : v.resources[*].resource_name] :
+    contains(item, local.connection_name)
+  ]
+}
+
+output "is_resource_name_filter_useful" {
+  value = length(local.resource_name_filter_result) > 0 && alltrue(local.resource_name_filter_result)
+}
+
+# Filter by 'member_name' parameter.
+data "huaweicloud_dataarts_security_resource_permission_policies" "filter_by_member_name" {
+  workspace_id = "%[2]s"
+  member_name  = local.member_name
+
+  depends_on = [huaweicloud_dataarts_security_resource_permission_policy.test]
+}
+
+locals {
+  member_name_filter_result = [
+    for item in [for v in data.huaweicloud_dataarts_security_resource_permission_policies.filter_by_member_name.policies : v.members[*].member_name]
+    : contains(item, local.member_name)
+  ]
+}
+
+output "is_member_name_filter_useful" {
+  value = length(local.member_name_filter_result) > 0 && alltrue(local.member_name_filter_result)
+}
+`, testAccDataSecurityResourcePermissionPolicies_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_resource_permission_policies.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_resource_permission_policies.go
@@ -1,0 +1,293 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/security/permission-resource
+func DataSourceSecurityResourcePermissionPolicies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityResourcePermissionPoliciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the resource permission policies are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the resource permission policies belong.`,
+			},
+
+			// Optional parameters.
+			"policy_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the resource permission policy to be queried.`,
+			},
+			"resource_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the authorized resource to be queried.`,
+			},
+			"member_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the authorized member to be queried.`,
+			},
+
+			// Attributes.
+			"policies": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of resource permission policies that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"policy_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the resource permission policy.`,
+						},
+						"policy_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the resource permission policy.`,
+						},
+						"resources": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The resource list of the resource permission policy.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"resource_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the resource.`,
+									},
+									"resource_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the resource.`,
+									},
+									"resource_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The type of the resource.`,
+									},
+								},
+							},
+						},
+						"members": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The member list of the resource permission policy.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"member_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the member.`,
+									},
+									"member_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the member.`,
+									},
+									"member_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The type of the member.`,
+									},
+								},
+							},
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the resource permission policy, in RFC3339 format.`,
+						},
+						"create_user": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator of the resource permission policy.`,
+						},
+						"update_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the resource permission policy, in RFC3339 format.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSecurityResourcePermissionPoliciesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("policy_name"); ok {
+		res = fmt.Sprintf("%s&policy_name=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("resource_name"); ok {
+		res = fmt.Sprintf("%s&resource_name=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("member_name"); ok {
+		res = fmt.Sprintf("%s&member_name=%v", res, v)
+	}
+
+	return res
+}
+
+func listSecurityResourcePermissionPolicies(client *golangsdk.ServiceClient, workspaceId string, queryParams ...string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/security/permission-resource?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	if len(queryParams) > 0 && queryParams[0] != "" {
+		listPath += queryParams[0]
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		policies := utils.PathSearch("policies", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, policies...)
+		if len(policies) < limit {
+			break
+		}
+
+		offset += len(policies)
+	}
+
+	return result, nil
+}
+
+func flattenSecurityResourcePermissionPoliciesResources(resources []interface{}) []map[string]interface{} {
+	if len(resources) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(resources))
+	for _, item := range resources {
+		result = append(result, map[string]interface{}{
+			"resource_id":   utils.PathSearch("resource_id", item, nil),
+			"resource_name": utils.PathSearch("resource_name", item, nil),
+			"resource_type": utils.PathSearch("resource_type", item, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenSecurityResourcePermissionPoliciesMembers(members []interface{}) []map[string]interface{} {
+	if len(members) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(members))
+	for _, member := range members {
+		result = append(result, map[string]interface{}{
+			"member_id":   utils.PathSearch("member_id", member, nil),
+			"member_name": utils.PathSearch("member_name", member, nil),
+			"member_type": utils.PathSearch("member_type", member, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenSecurityResourcePermissionPolicies(policies []interface{}) []map[string]interface{} {
+	if len(policies) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(policies))
+	for _, policy := range policies {
+		result = append(result, map[string]interface{}{
+			"policy_id":   utils.PathSearch("policy_id", policy, nil),
+			"policy_name": utils.PathSearch("policy_name", policy, nil),
+			"resources": flattenSecurityResourcePermissionPoliciesResources(utils.PathSearch("resources",
+				policy, make([]interface{}, 0)).([]interface{})),
+			"members": flattenSecurityResourcePermissionPoliciesMembers(utils.PathSearch("members",
+				policy, make([]interface{}, 0)).([]interface{})),
+			"create_user": utils.PathSearch("create_user", policy, nil),
+			"create_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time",
+				policy, float64(0)).(float64))/1000, false),
+			"update_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time",
+				policy, float64(0)).(float64))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceSecurityResourcePermissionPoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	policies, err := listSecurityResourcePermissionPolicies(client, workspaceId, buildSecurityResourcePermissionPoliciesQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error querying DataArts Security resource permission policies: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("policies", flattenSecurityResourcePermissionPolicies(policies)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_dataarts_security_resource_permission_policies`) to query resource permission policy list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o dataarts -f TestAccDataSecurityResourcePermissionPolicies_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataSecurityResourcePermissionPolicies_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSecurityResourcePermissionPolicies_basic
=== PAUSE TestAccDataSecurityResourcePermissionPolicies_basic
=== CONT  TestAccDataSecurityResourcePermissionPolicies_basic
--- PASS: TestAccDataSecurityResourcePermissionPolicies_basic (16.34s)
PASS
coverage: 6.8% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  16.489s coverage: 6.8% of statements in ./huaweicloud/services/dataarts
```
<img width="1396" height="37" alt="image" src="https://github.com/user-attachments/assets/864d09a0-6daa-4129-9166-3aa674d30861" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
