### PR TITLE
feat(dcs): new data source to query dcs backup file links

### DIFF
--- a/docs/data-sources/dcs_backup_file_links.md
+++ b/docs/data-sources/dcs_backup_file_links.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Distributed Cache Service (DCS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dcs_backup_file_links"
+description: |-
+  Use this data source to get the list of DCS backup file links.
+---
+
+# huaweicloud_dcs_backup_file_links
+
+Use this data source to get the list of DCS backup file links.
+
+## Example Usage
+
+```hcl
+var "instance_id" {}
+var "backup_id" {}
+
+data "huaweicloud_dcs_backups" "test" {
+  instance_id = var.instance_id
+  backup_id   = var.backup_id
+  expiration  = 3600
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the DCS instance.
+
+* `backup_id` - (Required, String) Specifies the ID of the DCS instance backup.
+
+* `expiration` - (Required, Int) Specifies the expiration time of the download link.
+  The value ranges from **300** to **86400** seconds.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `bucket_name` - Indicates the name of the OBS bucket where the backup file is stored.
+
+* `file_path` - Indicates the path of the backup file in the OBS bucket.
+
+* `links` - Indicates the list of backup file download links.
+  The [links](#links_struct) structure is documented below.
+
+<a id="links_struct"></a>
+The `links` block supports:
+
+* `file_name` - Indicates the name of the backup file.
+
+* `link` - Indicates the download link of the backup file.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1134,6 +1134,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dcs_batch_instance_nodes":                dcs.DataSourceDcsBatchInstanceNodes(),
 			"huaweicloud_dcs_templates":                           dcs.DataSourceTemplates(),
 			"huaweicloud_dcs_template_detail":                     dcs.DataSourceTemplateDetail(),
+			"huaweicloud_dcs_backup_file_links":                   dcs.DataSourceBackupFileLinks(),
 			"huaweicloud_dcs_backups":                             dcs.DataSourceBackups(),
 			"huaweicloud_dcs_hotkey_analyses":                     dcs.DataSourceDcsHotkeyAnalyses(),
 			"huaweicloud_dcs_bigkey_analyses":                     dcs.DataSourceDcsBigkeyAnalyses(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -744,6 +744,7 @@ var (
 	HW_DCS_BEGIN_TIME        = os.Getenv("HW_DCS_BEGIN_TIME")
 	HW_DCS_END_TIME          = os.Getenv("HW_DCS_END_TIME")
 	HW_DCS_OBS_BUCKET_NAME   = os.Getenv("HW_DCS_OBS_BUCKET_NAME")
+	HW_DCS_BACKUP_ID         = os.Getenv("HW_DCS_BACKUP_ID")
 
 	HW_ELB_GATEWAY_TYPE = os.Getenv("HW_ELB_GATEWAY_TYPE")
 
@@ -4211,6 +4212,13 @@ func TestAccPreCheckDcsTimeRange(t *testing.T) {
 func TestAccPreCheckDcsObsBucketName(t *testing.T) {
 	if HW_DCS_OBS_BUCKET_NAME == "" {
 		t.Skip("HW_DCS_OBS_BUCKET_NAME must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDcsBackupId(t *testing.T) {
+	if HW_DCS_BACKUP_ID == "" {
+		t.Skip("HW_DCS_BACKUP_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dcs/data_source_huaweicloud_dcs_backup_file_links_test.go
+++ b/huaweicloud/services/acceptance/dcs/data_source_huaweicloud_dcs_backup_file_links_test.go
@@ -1,0 +1,47 @@
+package dcs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceBackupFileLinks_basic(t *testing.T) {
+	rName := "data.huaweicloud_dcs_backup_file_links.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDCSInstanceID(t)
+			acceptance.TestAccPreCheckDcsBackupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceBackupFileLinks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "links.#"),
+					resource.TestCheckResourceAttrSet(rName, "links.0.file_name"),
+					resource.TestCheckResourceAttrSet(rName, "links.0.link"),
+					resource.TestCheckResourceAttrSet(rName, "bucket_name"),
+					resource.TestCheckResourceAttrSet(rName, "file_path"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceBackupFileLinks_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dcs_backup_file_links" "test" {
+  instance_id = "%[1]s"
+  backup_id   = "%[2]s"
+  expiration  = 3600
+}
+`, acceptance.HW_DCS_INSTANCE_ID, acceptance.HW_DCS_BACKUP_ID)
+}

--- a/huaweicloud/services/dcs/data_source_huaweicloud_dcs_backup_file_links.go
+++ b/huaweicloud/services/dcs/data_source_huaweicloud_dcs_backup_file_links.go
@@ -1,0 +1,142 @@
+package dcs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DCS POST /v2/{project_id}/instances/{instance_id}/backups/{backup_id}/links
+func DataSourceBackupFileLinks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDcsBackupFileLinksRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"backup_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"expiration": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"file_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bucket_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"links": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"file_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"link": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDcsBackupFileLinksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		listBackupFileLinksHttpUrl = "v2/{project_id}/instances/{instance_id}/backups/{backup_id}/links"
+		listBackupFileLinksProduct = "dcs"
+	)
+	listBackupFileLinksClient, err := cfg.NewServiceClient(listBackupFileLinksProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DCS client: %s", err)
+	}
+
+	listBackupFileLinksPath := listBackupFileLinksClient.Endpoint + listBackupFileLinksHttpUrl
+	listBackupFileLinksPath = strings.ReplaceAll(
+		listBackupFileLinksPath, "{project_id}", listBackupFileLinksClient.ProjectID)
+	listBackupFileLinksPath = strings.ReplaceAll(
+		listBackupFileLinksPath, "{instance_id}", d.Get("instance_id").(string))
+	listBackupFileLinksPath = strings.ReplaceAll(
+		listBackupFileLinksPath, "{backup_id}", d.Get("backup_id").(string))
+
+	getBody := map[string]interface{}{
+		"expiration": d.Get("expiration").(int),
+	}
+
+	getBackupFileLinksOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	getBackupFileLinksOpt.JSONBody = utils.RemoveNil(getBody)
+	listBackupFileLinksResp, err := listBackupFileLinksClient.Request(
+		"POST", listBackupFileLinksPath, &getBackupFileLinksOpt)
+
+	if err != nil {
+		return diag.Errorf("error retrieving DCS backup file links: %s", err)
+	}
+
+	listBackupFileLinksRespBody, err := utils.FlattenResponse(listBackupFileLinksResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("bucket_name",
+			utils.PathSearch("bucket_name", listBackupFileLinksRespBody, nil)),
+		d.Set("file_path", utils.PathSearch("file_path", listBackupFileLinksRespBody, nil)),
+		d.Set("links", flattenListBackupFileLinksBody(
+			utils.PathSearch("links", listBackupFileLinksRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListBackupFileLinksBody(resp []interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		item := map[string]interface{}{
+			"file_name": utils.PathSearch("file_name", v, ""),
+			"link":      utils.PathSearch("link", v, ""),
+		}
+		rst = append(rst, item)
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
new data source to query dcs backgup file links
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
new data source to query dcs backgup file links
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run TestAccDatasourceBackupFileLinks_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccDatasourceBackupFileLinks_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceBackupFileLinks_basic
=== PAUSE TestAccDatasourceBackupFileLinks_basic
=== CONT  TestAccDatasourceBackupFileLinks_basic
--- PASS: TestAccDatasourceBackupFileLinks_basic (44.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       44.917s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
