### PR TITLE
feat(dataarts): add new data source to query data recognition rule groups

### DIFF
--- a/docs/data-sources/dataarts_security_data_recognition_rule_groups.md
+++ b/docs/data-sources/dataarts_security_data_recognition_rule_groups.md
@@ -1,0 +1,114 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_data_recognition_rule_groups"
+description: |-
+  Use this data source to get the list of DataArts Security data recognition rule groups within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_data_recognition_rule_groups
+
+Use this data source to get the list of DataArts Security data recognition rule groups within HuaweiCloud.
+
+## Example Usage
+
+### Query all data recognition rule groups under a specified workspace
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_security_data_recognition_rule_groups" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+### Query the data recognition rule groups under a specified workspace and using group name to filter
+
+```hcl
+variable "workspace_id" {}
+variable "group_name" {}
+
+data "huaweicloud_dataarts_security_data_recognition_rule_groups" "test" {
+  workspace_id = var.workspace_id
+  name         = var.group_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the data recognition rule groups are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the data recognition rule groups belong.
+
+* `name` - (Optional, String) Specifies the name of the data recognition rule groups to be queried.
+
+* `creator` - (Optional, String) Specifies the creator of the data recognition rule groups to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `groups` - The list of data recognition rule groups that matched filter parameters.  
+  The [groups](#dataarts_security_data_recognition_rule_groups_attr) structure is documented below.
+
+<a name="dataarts_security_data_recognition_rule_groups_attr"></a>
+The `groups` block supports:
+
+* `id` - The ID of the data recognition rule group.
+
+* `name` - The name of the data recognition rule group.
+
+* `description` - The description of the data recognition rule group.
+
+* `created_by` - The creator of the data recognition rule group.
+
+* `created_at` - The creation time of the data recognition rule group, in RFC3339 format.
+
+* `updated_by` - The updater of the data recognition rule group.
+
+* `updated_at` - The latest update time of the data recognition rule group, in RFC3339 format.
+
+* `project_id` - The project ID to which the data recognition rule group belongs.
+
+* `rules` - The list of data recognition rules that the group contains.  
+  The [rules](#dataarts_security_data_recognition_rule_groups_rules_attr) structure is documented below.
+
+<a name="dataarts_security_data_recognition_rule_groups_rules_attr"></a>
+The `rules` block supports:
+
+* `id` - The ID of the data recognition rule.
+
+* `type` - The type of the data recognition rule.
+
+* `secrecy_level` - The secrecy level name of the data recognition rule.
+
+* `secrecy_level_num` - The secrecy level number of the data recognition rule.
+
+* `name` - The name of the data recognition rule.
+
+* `enable` - Whether the data recognition rule is enabled.
+
+* `method` - The method of the data recognition rule.
+
+* `content_expression` - The content expression of the data recognition rule.
+
+* `column_expression` - The column expression of the data recognition rule.
+
+* `comment_expression` - The comment expression of the data recognition rule.
+
+* `description` - The description of the data recognition rule.
+
+* `created_by` - The creator of the data recognition rule.
+
+* `created_at` - The creation time of the data recognition rule, in RFC3339 format.
+
+* `updated_by` - The updater of the data recognition rule.
+
+* `updated_at` - The latest update time of the data recognition rule, in RFC3339 format.
+
+* `builtin_rule_id` - The builtin rule ID of the data recognition rule.
+
+* `category_id` - The category ID to which the data recognition rule belongs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1114,6 +1114,7 @@ func Provider() *schema.Provider {
 			// DataArts Security
 			"huaweicloud_dataarts_security_data_categories":              dataarts.DataSourceSecurityDataCategories(),
 			"huaweicloud_dataarts_security_data_recognition_rules":       dataarts.DataSourceSecurityDataRecognitionRules(),
+			"huaweicloud_dataarts_security_data_recognition_rule_groups": dataarts.DataSourceSecurityDataRecognitionRuleGroups(),
 			"huaweicloud_dataarts_security_dynamic_masking_policies":     dataarts.DataSourceSecurityDynamicMaskingPolicies(),
 			"huaweicloud_dataarts_security_permission_sets":              dataarts.DataSourceSecurityPermissionSets(),
 			"huaweicloud_dataarts_security_permission_set_members":       dataarts.DataSourceSecurityPermissionSetMembers(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_data_recognition_rule_groups_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_data_recognition_rule_groups_test.go
@@ -1,0 +1,176 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSecurityDataRecognitionRuleGroups_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dataarts_security_data_recognition_rule_groups.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_dataarts_security_data_recognition_rule_groups.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byCreator   = "data.huaweicloud_dataarts_security_data_recognition_rule_groups.filter_by_creator"
+		dcByCreator = acceptance.InitDataSourceCheck(byCreator)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsSecurityDataCategoryIds(t, 2)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSecurityDataRecognitionRuleGroups_nonExistentWorkspace(),
+				ExpectError: regexp.MustCompile("error querying DataArts Security data recognition rule groups"),
+			},
+			{
+				Config: testAccDataSecurityDataRecognitionRuleGroups_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(all, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttrSet(all, "region"),
+					resource.TestMatchResourceAttr(all, "groups.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestCheckResourceAttrSet(all, "groups.0.id"),
+					resource.TestCheckResourceAttrSet(all, "groups.0.project_id"),
+					resource.TestCheckResourceAttrSet(all, "groups.0.created_by"),
+					resource.TestCheckResourceAttrSet(all, "groups.0.created_at"),
+					resource.TestCheckResourceAttrSet(all, "groups.0.rules.0.id"),
+					resource.TestCheckResourceAttr(all, "groups.0.rules.0.type", "CUSTOM"),
+
+					// Filter by name
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckResourceAttr(byName, "groups.#", "1"),
+					resource.TestCheckResourceAttr(byName, "groups.0.rules.#", "2"),
+
+					// Filter by creator
+					dcByCreator.CheckResourceExists(),
+					resource.TestCheckOutput("is_creator_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSecurityDataRecognitionRuleGroups_nonExistentWorkspace() string {
+	randomUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_security_data_recognition_rule_groups" "test" {
+  workspace_id = "%[1]s"
+}
+`, randomUUID)
+}
+
+func testAccDataSecurityDataRecognitionRuleGroups_basic_base(name string) string {
+	return fmt.Sprintf(`
+locals {
+  category_ids = try(split(",", "%[1]s"), [])
+}
+
+resource "huaweicloud_dataarts_security_data_secrecy_level" "test" {
+  count = 2
+
+  workspace_id = "%[2]s"
+  name         = format("%[3]s_%%d", count.index) 
+}
+
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
+  count = 2
+
+  workspace_id     = "%[2]s"
+  rule_type        = "CUSTOM"
+  name             = format("%[3]s_%%d", count.index)
+  secrecy_level_id = huaweicloud_dataarts_security_data_secrecy_level.test[count.index].id
+  category_id      = local.category_ids[count.index]
+  method           = "NONE"
+}
+
+resource "huaweicloud_dataarts_security_data_recognition_rule_group" "test" {
+  workspace_id = "%[2]s"
+  name         = "%[3]s"
+  description  = "Created by terraform"
+  rule_ids     = huaweicloud_dataarts_security_data_recognition_rule.test[*].id
+}
+`, acceptance.HW_DATAARTS_SECURITY_DATA_CATEGORY_IDS, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccDataSecurityDataRecognitionRuleGroups_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all groups and without any filter
+data "huaweicloud_dataarts_security_data_recognition_rule_groups" "all" {
+  depends_on = [
+    huaweicloud_dataarts_security_data_recognition_rule_group.test,
+  ]
+
+  workspace_id = "%[2]s"
+}
+
+# Filter by name
+locals {
+  group_name = huaweicloud_dataarts_security_data_recognition_rule_group.test.name
+}
+
+data "huaweicloud_dataarts_security_data_recognition_rule_groups" "filter_by_name" {
+  depends_on = [
+    huaweicloud_dataarts_security_data_recognition_rule_group.test,
+  ]
+
+  workspace_id = "%[2]s"
+  name         = local.group_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dataarts_security_data_recognition_rule_groups.filter_by_name.groups[*].name :
+      v == local.group_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by creator
+locals {
+  creator = huaweicloud_dataarts_security_data_recognition_rule_group.test.created_by
+}
+
+data "huaweicloud_dataarts_security_data_recognition_rule_groups" "filter_by_creator" {
+  depends_on = [
+    huaweicloud_dataarts_security_data_recognition_rule_group.test,
+  ]
+
+  workspace_id = "%[2]s"
+  creator      = local.creator
+}
+
+locals {
+  creator_filter_result = [
+    for v in data.huaweicloud_dataarts_security_data_recognition_rule_groups.filter_by_creator.groups[*].created_by :
+      v == local.creator
+  ]
+}
+
+output "is_creator_filter_useful" {
+  value = length(local.creator_filter_result) > 0 && alltrue(local.creator_filter_result)
+}
+`, testAccDataSecurityDataRecognitionRuleGroups_basic_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_data_recognition_rule_groups.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_data_recognition_rule_groups.go
@@ -1,0 +1,301 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/security/data-classification/rule/group
+func DataSourceSecurityDataRecognitionRuleGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityDataRecognitionRuleGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the data recognition rule groups are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the data recognition rule groups belong.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the data recognition rule groups to be queried.`,
+			},
+			"creator": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The creator of the data recognition rule groups to be queried.`,
+			},
+
+			// Attributes.
+			"groups": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of data recognition rule groups that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the data recognition rule group.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the data recognition rule group.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the data recognition rule group.`,
+						},
+						"created_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator of the data recognition rule group.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the data recognition rule group, in RFC3339 format.`,
+						},
+						"updated_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The updater of the data recognition rule group.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the data recognition rule group, in RFC3339 format.`,
+						},
+						"project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The project ID to which the data recognition rule group belongs.`,
+						},
+						"rules": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of data recognition rules that the group contains.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the data recognition rule.`,
+									},
+									"type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The type of the data recognition rule.`,
+									},
+									"secrecy_level": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The secrecy level name of the data recognition rule.`,
+									},
+									"secrecy_level_num": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The secrecy level number of the data recognition rule.`,
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the data recognition rule.`,
+									},
+									"enable": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: `Whether the data recognition rule is enabled.`,
+									},
+									"method": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The method of the data recognition rule.`,
+									},
+									"content_expression": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The content expression of the data recognition rule.`,
+									},
+									"column_expression": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The column expression of the data recognition rule.`,
+									},
+									"comment_expression": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The comment expression of the data recognition rule.`,
+									},
+									"description": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The description of the data recognition rule.`,
+									},
+									"created_by": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The creator of the data recognition rule.`,
+									},
+									"created_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The creation time of the data recognition rule, in RFC3339 format.`,
+									},
+									"updated_by": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The updater of the data recognition rule.`,
+									},
+									"updated_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The latest update time of the data recognition rule, in RFC3339 format.`,
+									},
+									"builtin_rule_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The builtin rule ID of the data recognition rule.`,
+									},
+									"category_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The category ID to which the data recognition rule belongs.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSecurityDataRecognitionRuleGroupsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("creator"); ok {
+		res = fmt.Sprintf("%s&creator=%v", res, v)
+	}
+
+	return res
+}
+
+func flattenSecurityDataRecognitionRuleGroupsRules(rules []interface{}) []map[string]interface{} {
+	if len(rules) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(rules))
+	for _, rule := range rules {
+		result = append(result, map[string]interface{}{
+			"id":                 utils.PathSearch("uuid", rule, nil),
+			"type":               utils.PathSearch("rule_type", rule, nil),
+			"secrecy_level":      utils.PathSearch("secrecy_level", rule, nil),
+			"secrecy_level_num":  int(utils.PathSearch("secrecy_level_num", rule, float64(0)).(float64)),
+			"name":               utils.PathSearch("name", rule, nil),
+			"enable":             utils.PathSearch("enable", rule, nil),
+			"method":             utils.PathSearch("method", rule, nil),
+			"content_expression": utils.PathSearch("content_expression", rule, nil),
+			"column_expression":  utils.PathSearch("column_expression", rule, nil),
+			"comment_expression": utils.PathSearch("commit_expression", rule, nil),
+			"description":        utils.PathSearch("description", rule, nil),
+			"created_by":         utils.PathSearch("created_by", rule, nil),
+			"created_at": utils.FormatTimeStampRFC3339(
+				int64(utils.PathSearch("created_at", rule, float64(0)).(float64))/1000, false),
+			"updated_by": utils.PathSearch("updated_by", rule, nil),
+			"updated_at": utils.FormatTimeStampRFC3339(
+				int64(utils.PathSearch("updated_at", rule, float64(0)).(float64))/1000, false),
+			"builtin_rule_id": utils.PathSearch("builtin_rule_id", rule, nil),
+			"category_id":     utils.PathSearch("category_id", rule, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenSecurityDataRecognitionRuleGroups(groups []interface{}) []map[string]interface{} {
+	if len(groups) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(groups))
+	for _, group := range groups {
+		rulesRaw := utils.PathSearch("rules", group, nil)
+		rules := make([]interface{}, 0)
+		if rulesRaw != nil {
+			rules = rulesRaw.([]interface{})
+		}
+
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("uuid", group, nil),
+			"name":        utils.PathSearch("name", group, nil),
+			"description": utils.PathSearch("description", group, nil),
+			"created_by":  utils.PathSearch("created_by", group, nil),
+			"created_at": utils.FormatTimeStampRFC3339(
+				int64(utils.PathSearch("created_at", group, float64(0)).(float64))/1000, false),
+			"updated_by": utils.PathSearch("updated_by", group, nil),
+			"updated_at": utils.FormatTimeStampRFC3339(
+				int64(utils.PathSearch("updated_at", group, float64(0)).(float64))/1000, false),
+			"project_id": utils.PathSearch("project_id", group, nil),
+			"rules":      flattenSecurityDataRecognitionRuleGroupsRules(rules),
+		})
+	}
+
+	return result
+}
+
+func dataSourceSecurityDataRecognitionRuleGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	groups, err := listSecurityDataRecognitionRuleGroups(client, workspaceId, buildSecurityDataRecognitionRuleGroupsQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error querying DataArts Security data recognition rule groups: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("groups", flattenSecurityDataRecognitionRuleGroups(groups)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule_group.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule_group.go
@@ -162,7 +162,7 @@ func resourceSecurityDataRecognitionRuleGroupCreate(ctx context.Context, d *sche
 	return resourceSecurityDataRecognitionRuleGroupRead(ctx, d, meta)
 }
 
-func listSecurityDataRecognitionRuleGroups(client *golangsdk.ServiceClient, workspaceId string) ([]interface{}, error) {
+func listSecurityDataRecognitionRuleGroups(client *golangsdk.ServiceClient, workspaceId string, queryParams ...string) ([]interface{}, error) {
 	var (
 		httpUrl = "v1/{project_id}/security/data-classification/rule/group?limit={limit}"
 		limit   = 100
@@ -173,6 +173,9 @@ func listSecurityDataRecognitionRuleGroups(client *golangsdk.ServiceClient, work
 	listPath := client.Endpoint + httpUrl
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	if len(queryParams) > 0 && queryParams[0] != "" {
+		listPath += queryParams[0]
+	}
 
 	opts := golangsdk.RequestOpts{
 		KeepResponseBody: true,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source to query DataArts Studio data recognition rule groups.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance test:
<img width="1066" height="194" alt="image" src="https://github.com/user-attachments/assets/65d04ad1-2a02-4b6c-a1e0-12c27e4003ae" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query data recognition rule groups
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataSecurityDataRecognitionRuleGroups_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataSecurityDataRecognitionRuleGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSecurityDataRecognitionRuleGroups_basic
=== PAUSE TestAccDataSecurityDataRecognitionRuleGroups_basic
=== CONT  TestAccDataSecurityDataRecognitionRuleGroups_basic
--- PASS: TestAccDataSecurityDataRecognitionRuleGroups_basic (16.16s)
PASS
coverage: 6.8% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  16.273s coverage: 6.8% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
