### PR TITLE
feat(dataarts): add new datasource for query architecture process

### DIFF
--- a/docs/data-sources/dataarts_architecture_process.md
+++ b/docs/data-sources/dataarts_architecture_process.md
@@ -1,0 +1,89 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_architecture_process"
+description: |-
+  Use this data source to get the list of the DataArts Architecture process architectures within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_architecture_process
+
+Use this data source to get the list of the DataArts Architecture process architectures within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_architecture_process" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the process architectures are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace where the process architectures are located.
+
+* `name` - (Optional, String) Specifies the name or code of the process architecture for fuzzy matching.
+
+* `parent_id` - (Optional, String) Specifies the parent directory ID.  
+  An empty value means all, and "-1" means nodes under the root.
+
+* `create_by` - (Optional, String) Specifies the creator of the process architecture.
+
+* `owner` - (Optional, String) Specifies the owner of the process architecture.
+
+* `begin_time` - (Optional, String) Specifies the left boundary of time filtering, in RFC3339 format.
+
+* `end_time` - (Optional, String) Specifies the right boundary of time filtering, in RFC3339 format.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `processes` - The list of process architectures that match the filter parameters.  
+  The [processes](#dataarts_architecture_processes) structure is documented below.
+
+<a name="dataarts_architecture_processes"></a>
+The `processes` block supports:
+
+* `id` - The ID of the process architecture.
+
+* `name` - The name of the process architecture.
+
+* `name_en` - The English name of the process architecture.
+
+* `description` - The description of the process architecture.
+
+* `guid` - The asset ID corresponding to the process architecture.
+
+* `owner` - The owner of the process architecture.
+
+* `parent_id` - The parent directory ID of the process architecture.
+
+* `prev_id` - The previous node ID of the process architecture.
+
+* `next_id` - The next node ID of the process architecture.
+
+* `qualified_id` - The authentication ID of the process architecture, automatically generated.
+
+* `create_by` - The creator of the process architecture.
+
+* `update_by` - The updater of the process architecture.
+
+* `create_time` - The creation time of the process architecture, in RFC3339 format.
+
+* `update_time` - The update time of the process architecture, in RFC3339 format.
+
+* `bizmetric_num` - The number of business metrics owned by the process architecture.
+
+* `children_num` - The number of child processes owned by the process architecture.
+
+* `children` - The list of child directories under the process architecture, in JSON format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1075,10 +1075,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_studio_workspace_users":      dataarts.DataSourceStudioWorkspaceUsers(),
 			"huaweicloud_dataarts_studio_workspace_user_roles": dataarts.DataSourceStudioWorkspaceUserRoles(),
 			// DataArts Architecture
-			"huaweicloud_dataarts_architecture_data_standard_template_optionals": dataarts.DataSourceArchitectureDataStandardTemplateOptionals(),
-			"huaweicloud_dataarts_architecture_model_statistic":                  dataarts.DataSourceArchitectureModelStatistic(),
-			"huaweicloud_dataarts_architecture_processes":                        dataarts.DataSourceArchitectureProcesses(),
-			"huaweicloud_dataarts_architecture_table_models":                     dataarts.DataSourceArchitectureTableModels(),
+			"huaweicloud_dataarts_architecture_ds_template_optionals": dataarts.DataSourceTemplateOptionalFields(),
+			"huaweicloud_dataarts_architecture_model_statistic":       dataarts.DataSourceArchitectureModelStatistic(),
+			"huaweicloud_dataarts_architecture_processes":             dataarts.DataSourceArchitectureProcess(),
+			"huaweicloud_dataarts_architecture_table_models":          dataarts.DataSourceArchitectureTableModels(),
 			// DataArts DataService
 			"huaweicloud_dataarts_dataservice_api_authorized_apps": dataarts.DataSourceDataServiceApiAuthorizedApps(),
 			"huaweicloud_dataarts_dataservice_apis":                dataarts.DataSourceDataServiceApis(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_process_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_process_test.go
@@ -1,0 +1,210 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataArchitectureProcess_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_architecture_process.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_dataarts_architecture_process.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byParentId   = "data.huaweicloud_dataarts_architecture_process.filter_by_parent_id"
+		dcByParentId = acceptance.InitDataSourceCheck(byParentId)
+
+		byOwner   = "data.huaweicloud_dataarts_architecture_process.filter_by_owner"
+		dcByOwner = acceptance.InitDataSourceCheck(byOwner)
+
+		byCreator   = "data.huaweicloud_dataarts_architecture_process.filter_by_creator"
+		dcByCreator = acceptance.InitDataSourceCheck(byCreator)
+
+		byTimeRange   = "data.huaweicloud_dataarts_architecture_process.filter_by_time_range"
+		dcByTimeRange = acceptance.InitDataSourceCheck(byTimeRange)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataArchitectureProcess_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "processes.#", regexp.MustCompile(`^[1-9]([0-9]*)$`)),
+					resource.TestCheckResourceAttrSet(all, "processes.0.id"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.name"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.name_en"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.description"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.guid"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.owner"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.parent_id"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.qualified_id"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.create_by"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.update_by"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.create_time"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.update_time"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.bizmetric_num"),
+					resource.TestCheckResourceAttrSet(all, "processes.0.children_num"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByParentId.CheckResourceExists(),
+					resource.TestCheckOutput("is_parent_id_filter_useful", "true"),
+					dcByOwner.CheckResourceExists(),
+					resource.TestCheckOutput("is_owner_filter_useful", "true"),
+					dcByCreator.CheckResourceExists(),
+					resource.TestCheckOutput("is_creator_filter_useful", "true"),
+					dcByTimeRange.CheckResourceExists(),
+					resource.TestCheckOutput("is_time_range_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataArchitectureProcess_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_process" "parent" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s_parent"
+  owner        = "owner_parent"
+  description  = "Parent process"
+}
+
+resource "huaweicloud_dataarts_architecture_process" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  owner        = "owner"
+  description  = "Child process"
+  parent_id    = huaweicloud_dataarts_architecture_process.parent.id
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccDataArchitectureProcess_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all process architectures without any filter
+data "huaweicloud_dataarts_architecture_process" "test" {
+  workspace_id = "%[2]s"
+
+  depends_on = [huaweicloud_dataarts_architecture_process.test]
+}
+
+# Filter by name
+data "huaweicloud_dataarts_architecture_process" "filter_by_name" {
+  workspace_id = "%[2]s"
+  name         = huaweicloud_dataarts_architecture_process.test.name
+
+  depends_on = [huaweicloud_dataarts_architecture_process.test]
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_process.filter_by_name.processes[*].name:
+    strcontains(v, huaweicloud_dataarts_architecture_process.test.name)
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by parent_id
+data "huaweicloud_dataarts_architecture_process" "filter_by_parent_id" {
+  workspace_id = "%[2]s"
+  parent_id    = huaweicloud_dataarts_architecture_process.parent.id
+
+  depends_on = [huaweicloud_dataarts_architecture_process.test]
+}
+
+locals {
+  parent_id_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_process.filter_by_parent_id.processes[*].parent_id:
+    v == huaweicloud_dataarts_architecture_process.parent.id
+  ]
+}
+
+output "is_parent_id_filter_useful" {
+  value = length(local.parent_id_filter_result) > 0 && alltrue(local.parent_id_filter_result)
+}
+
+# Filter by owner
+data "huaweicloud_dataarts_architecture_process" "filter_by_owner" {
+  workspace_id = "%[2]s"
+  owner        = huaweicloud_dataarts_architecture_process.test.owner
+
+  depends_on = [huaweicloud_dataarts_architecture_process.test]
+}
+
+locals {
+  owner_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_process.filter_by_owner.processes[*].owner:
+    strcontains(v, huaweicloud_dataarts_architecture_process.test.owner)
+  ]
+}
+
+output "is_owner_filter_useful" {
+  value = length(local.owner_filter_result) > 0 && alltrue(local.owner_filter_result)
+}
+
+# Filter by creator
+data "huaweicloud_dataarts_architecture_process" "filter_by_creator" {
+  workspace_id = "%[2]s"
+  create_by    = huaweicloud_dataarts_architecture_process.test.created_by
+
+  depends_on = [huaweicloud_dataarts_architecture_process.test]
+}
+
+locals {
+  creator_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_process.filter_by_creator.processes[*].create_by:
+    v == huaweicloud_dataarts_architecture_process.test.created_by
+  ]
+}
+
+output "is_creator_filter_useful" {
+  value = length(local.creator_filter_result) > 0 && alltrue(local.creator_filter_result)
+}
+
+# Filter by time range
+locals {
+  begin_time = formatdate("YYYY-MM-DD'T'HH:mm:ss'Z'", timeadd(huaweicloud_dataarts_architecture_process.test.created_at, "-24h"))
+  end_time   = formatdate("YYYY-MM-DD'T'HH:mm:ss'Z'", timeadd(huaweicloud_dataarts_architecture_process.test.created_at, "24h"))
+}
+
+data "huaweicloud_dataarts_architecture_process" "filter_by_time_range" {
+  workspace_id = "%[2]s"
+  begin_time   = local.begin_time
+  end_time     = local.end_time
+
+  depends_on = [huaweicloud_dataarts_architecture_process.test]
+}
+
+locals {
+  time_range_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_process.filter_by_time_range.processes[*].create_time:
+	timecmp(v, local.begin_time) >= 0 &&
+	timecmp(v, local.end_time) <= 0
+  ]
+}
+
+output "is_time_range_filter_useful" {
+  value = length(local.time_range_filter_result) > 0 && alltrue(local.time_range_filter_result)
+}
+`, testAccDataArchitectureProcess_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_process.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_process.go
@@ -1,0 +1,303 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/design/biz/catalogs
+func DataSourceArchitectureProcess() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceArchitectureProcessRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the process architectures are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace where the process architectures are located.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name or code of the process architecture for fuzzy matching.`,
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The parent directory ID.`,
+			},
+			"create_by": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The creator of the process architecture.`,
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The owner of the process architecture.`,
+			},
+			"begin_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The left boundary of time filtering, in RFC3339 format.`,
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The right boundary of time filtering, in RFC3339 format.`,
+			},
+
+			// Attributes.
+			"processes": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        processSchema(),
+				Description: `The list of process architectures that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func processSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the process architecture.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the process architecture.`,
+			},
+			"name_en": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The English name of the process architecture.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the process architecture.`,
+			},
+			"guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The asset ID corresponding to the process architecture.`,
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The owner of the process architecture.`,
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The parent directory ID of the process architecture.`,
+			},
+			"prev_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The previous node ID of the process architecture.`,
+			},
+			"next_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The next node ID of the process architecture.`,
+			},
+			"qualified_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The authentication ID of the process architecture, automatically generated.`,
+			},
+			"create_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the process architecture.`,
+			},
+			"update_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The updater of the process architecture.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the process architecture, in RFC3339 format.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the process architecture, in RFC3339 format.`,
+			},
+			"bizmetric_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of business metrics owned by the process architecture.`,
+			},
+			"children_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of child processes owned by the process architecture.`,
+			},
+			"children": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The list of child directories under the process architecture, in JSON format.`,
+			},
+		},
+	}
+}
+
+func buildArchitectureProcessQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("parent_id"); ok {
+		res = fmt.Sprintf("%s&parent_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("create_by"); ok {
+		res = fmt.Sprintf("%s&create_by=%v", res, v)
+	}
+	if v, ok := d.GetOk("owner"); ok {
+		res = fmt.Sprintf("%s&owner=%v", res, v)
+	}
+	if v, ok := d.GetOk("begin_time"); ok {
+		res = fmt.Sprintf("%s&begin_time=%v", res, v)
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		res = fmt.Sprintf("%s&end_time=%v", res, v)
+	}
+
+	return res
+}
+
+func listArchitectureProcesses(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl     = "v2/{project_id}/design/biz/catalogs?limit={limit}"
+		limit       = 100
+		offset      = 0
+		workspaceId = d.Get("workspace_id").(string)
+		result      = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", fmt.Sprintf("%d", limit))
+	listPathWithLimit += buildArchitectureProcessQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    workspaceId,
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPathWithLimit, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving DataArts process architectures: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		processes := utils.PathSearch("data.value.records", respBody, make([]interface{}, 0)).([]interface{})
+		if len(processes) < 1 {
+			break
+		}
+		result = append(result, processes...)
+		offset += len(processes)
+	}
+
+	return result, nil
+}
+
+func flattenProcesses(processes []interface{}) []interface{} {
+	if len(processes) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(processes))
+	for _, process := range processes {
+		result = append(result, map[string]interface{}{
+			"id":            utils.PathSearch("id", process, nil),
+			"name":          utils.PathSearch("name", process, nil),
+			"name_en":       utils.PathSearch("name_en", process, nil),
+			"description":   utils.PathSearch("description", process, nil),
+			"guid":          utils.PathSearch("guid", process, nil),
+			"owner":         utils.PathSearch("owner", process, nil),
+			"parent_id":     utils.PathSearch("parent_id", process, nil),
+			"prev_id":       utils.PathSearch("prev_id", process, nil),
+			"next_id":       utils.PathSearch("next_id", process, nil),
+			"qualified_id":  utils.PathSearch("qualified_id", process, nil),
+			"create_by":     utils.PathSearch("create_by", process, nil),
+			"update_by":     utils.PathSearch("update_by", process, nil),
+			"create_time":   utils.PathSearch("create_time", process, nil),
+			"update_time":   utils.PathSearch("update_time", process, nil),
+			"bizmetric_num": utils.PathSearch("bizmetric_num", process, 0),
+			"children_num":  utils.PathSearch("children_num", process, 0),
+			"children":      utils.JsonToString(utils.PathSearch("children", process, nil)),
+		})
+	}
+
+	return result
+}
+
+func dataSourceArchitectureProcessRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	processes, err := listArchitectureProcesses(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("processes", flattenProcesses(processes)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a data source to query data architecture processes.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
Since instance creation is time-consuming, it needs to be injected via environment variables.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataArchitectureProcess_basic -timeout 360m -parallel 10
=== RUN   TestAccDataArchitectureProcess_basic
=== PAUSE TestAccDataArchitectureProcess_basic
=== CONT  TestAccDataArchitectureProcess_basic
--- PASS: TestAccDataArchitectureProcess_basic (76.99s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  77.113s coverage: 5.2% of statements in ./huaweicloud/services/dataarts
```

<img width="1145" height="905" alt="image" src="https://github.com/user-attachments/assets/abd291e0-5539-47b5-9b89-b2af5b072dd6" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
