### PR TITLE
feat(rfs): rfs stack resource support updating API

### DIFF
--- a/docs/resources/rfs_stack.md
+++ b/docs/resources/rfs_stack.md
@@ -124,13 +124,26 @@ The following arguments are supported:
   The name must start with a lowercase letter and end with a lowercase letter or digit.
   Change this parameter will create a new resource.
 
-* `description` - (Optional, String, ForceNew) Specifies the description of the resource stack, which contain maximum of
+* `description` - (Optional, String) Specifies the description of the resource stack, which contain maximum of
   `255` characters.  
-  Change this parameter will create a new resource.
 
-* `agency` - (Optional, List, ForceNew) Specifies the configuration of the agencies authorized to IAC.  
-  Change this parameter will create a new resource.
-  The [object](#stack_agency) structure is documented below.
+* `agency` - (Optional, List) Specifies the configuration of the agencies authorized to IAC.  
+  The [agency](#stack_agency) structure is documented below.
+
+* `enable_auto_rollback` - (Optional, Bool) Specifies whether to enable automatic rollback.  
+  If enabled, the stack resources will rollback automatically to the last stable state with deployment failure.
+  The default value is **false**.
+
+* `enable_deletion_protection` - (Optional, Bool) Specifies whether to enable delete protection.  
+  The default value is **false**.
+
+-> For fields `description`, `agency`, `enable_auto_rollback`, and `enable_deletion_protection`, Editing operations have
+  the following limitations:
+  <br/>1. A stack cannot be updated if it is in a non-final state (ending with **IN_PROGRESS**). The states may include
+  **DEPLOYMENT_IN_PROGRESS**, **DELETION_IN_PROGRESS**, and **ROLLBACK_IN_PROGRESS**.
+  <br/>2. If the value of `enable_auto_rollback` is changed from **false** to **true**, the stack state is determined
+  more strictly. A stack cannot be updated if it is in a state ending with **FAILED**. The states may include
+  **DEPLOYMENT_FAILED**, **ROLLBACK_FAILED**, and **DELETION_FAILED**.
 
 * `template_body` - (Optional, String) Specifies the HCL/JSON template content for deployment resources.  
   This parameter and `template_uri` are alternative and required if `vars_body` is set.
@@ -145,26 +158,15 @@ The following arguments are supported:
 * `vars_uri` - (Optional, String) Specifies the OBS address where the variable (**.tfvars**) file corresponding to the
   HCL/JSON template located, which describes the target status of the deployment resources.
 
-* `enable_auto_rollback` - (Optional, Bool, ForceNew) Specifies whether to enable automatic rollback.  
-  If enabled, the stack resources will rollback automatically to the last stable state with deployment failure.
-  The default value is **false**.
-  Change this parameter will create a new resource.
-
-* `enable_deletion_protection` - (Optional, Bool, ForceNew) Specifies whether to enable delete protection.  
-  The default value is **false**.
-  Change this parameter will create a new resource.
-
 * `retain_all_resources` - (Optional, Bool) Specifies whether to reserve resources when deleting the resource stack.  
   The default value is **false**.
 
 <a name="stack_agency"></a>
 The `agency` block supports:
 
-* `name` - (Required, String, ForceNew) Specifies the name of IAM agency authorized to IAC account.  
-  Change this parameter will create a new resource.
+* `name` - (Required, String) Specifies the name of IAM agency authorized to IAC account.  
 
-* `provider_name` - (Required, String, ForceNew) Specifies the name of the provider corresponding to the IAM agency.  
-  Change this parameter will create a new resource.
+* `provider_name` - (Required, String) Specifies the name of the provider corresponding to the IAM agency.  
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_stack_test.go
+++ b/huaweicloud/services/acceptance/rfs/resource_huaweicloud_rfs_stack_test.go
@@ -54,6 +54,21 @@ func TestAccStack_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccStack_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Create by acc test update"),
+					resource.TestCheckResourceAttr(rName, "enable_auto_rollback", "true"),
+					resource.TestCheckResourceAttr(rName, "enable_deletion_protection", "false"),
+					resource.TestCheckResourceAttr(rName, "agency.0.provider_name", "huaweicloud"),
+					resource.TestCheckResourceAttr(rName, "agency.0.name", "rf_admin_trust"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -61,6 +76,8 @@ func TestAccStack_basic(t *testing.T) {
 					"agency",
 					"template_body",
 					"vars_body",
+					"enable_auto_rollback",
+					"enable_deletion_protection",
 				},
 			},
 		},
@@ -72,6 +89,22 @@ func testAccStack_basic(name string) string {
 resource "huaweicloud_rfs_stack" "test" {
   name        = "%[1]s"
   description = "Create by acc test"
+}
+`, name)
+}
+
+func testAccStack_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rfs_stack" "test" {
+  name                       = "%[1]s"
+  description                = "Create by acc test update"
+  enable_auto_rollback       = true
+  enable_deletion_protection = false
+
+  agency {
+    provider_name = "huaweicloud"
+    name          = "rf_admin_trust"
+  }
 }
 `, name)
 }

--- a/huaweicloud/services/rfs/resource_huaweicloud_rfs_stack.go
+++ b/huaweicloud/services/rfs/resource_huaweicloud_rfs_stack.go
@@ -2,6 +2,7 @@ package rfs
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -25,6 +26,7 @@ import (
 // @API RFS POST /v1/{project_id}/stacks/{stack_name}/deployments
 // @API RFS GET /v1/{project_id}/stacks/{stack_name}/events
 // @API RFS POST /v1/{project_id}/stacks/{stack_name}/deletion
+// @API RFS PATCH /v1/{project_id}/stacks/{stack_name}
 func ResourceStack() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceStackCreate,
@@ -59,19 +61,16 @@ func ResourceStack() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "The description of the resource stack.",
 			},
 			"agency": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"provider_name": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
 							Description: utils.SchemaDesc(
 								"The name of the provider corresponding to the IAM agency.",
 								utils.SchemaDescInput{
@@ -82,7 +81,6 @@ func ResourceStack() *schema.Resource {
 						"name": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
 							Description: utils.SchemaDesc(
 								"The name of IAM agency authorized to IAC account for resources modification.",
 								utils.SchemaDescInput{
@@ -124,13 +122,11 @@ func ResourceStack() *schema.Resource {
 			"enable_auto_rollback": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "Whether to enable automatic rollback.",
 			},
 			"enable_deletion_protection": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "Whether to enable delete protection.",
 			},
 			"retain_all_resources": {
@@ -446,7 +442,108 @@ func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 	}
 
+	if d.HasChanges("description", "enable_deletion_protection", "enable_auto_rollback", "agency") {
+		if err := updateStack(ctx, client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceStackRead(ctx, d, meta)
+}
+
+func buildUpdateStackAgenciesParams(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"provider_name": utils.ValueIgnoreEmpty(rawMap["provider_name"]),
+			"agency_name":   utils.ValueIgnoreEmpty(rawMap["name"]),
+		})
+	}
+	return rst
+}
+
+func buildUpdateStackBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"description":                utils.ValueIgnoreEmpty(d.Get("description")),
+		"stack_id":                   d.Id(),
+		"enable_deletion_protection": d.Get("enable_deletion_protection"),
+		"enable_auto_rollback":       d.Get("enable_auto_rollback"),
+		"agencies":                   buildUpdateStackAgenciesParams(d.Get("agency").([]interface{})),
+	}
+}
+
+func handleRetryUpdateStackError(err error) (bool, error) {
+	if err == nil {
+		// The operation was executed successfully and does not need to be executed again.
+		return false, nil
+	}
+	if errCode, ok := err.(golangsdk.ErrDefault403); ok {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)
+		}
+
+		errorCode := utils.PathSearch("error_code", apiError, "").(string)
+		if errorCode == "" {
+			return false, errors.New("unable to find error code from API response")
+		}
+
+		// Resource stacks in the "IN PROGRESS" state do not support modification operations and will report
+		// error code "RF.10012519".
+		if errorCode == "RF.10012519" {
+			return true, err
+		}
+	}
+	// Operation execution failed due to some resource or server issues, no need to try again.
+	return false, err
+}
+
+func updateStack(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		stackName    = d.Get("name").(string)
+		httpUrl      = "v1/{project_id}/stacks/{stack_name}"
+		requestId, _ = uuid.GenerateUUID()
+	)
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{stack_name}", stackName)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdateStackBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type":      "application/json",
+			"X-Language":        "en-us",
+			"Client-Request-Id": requestId,
+		},
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		_, err := client.Request("PATCH", requestPath, &requestOpt)
+		retry, err := handleRetryUpdateStackError(err)
+		return nil, retry, err
+	}
+
+	_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		PollInterval: 10 * time.Second,
+	})
+
+	if err != nil {
+		return fmt.Errorf("error updating RFS stack: %s", err)
+	}
+
+	return nil
 }
 
 func resourceStackDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

RFS stack resource support updating API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o rfs -f TestAccStack_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rfs" -v -coverprofile="./huaweicloud/services/acceptance/rfs/rfs_coverage.cov" -coverpkg="./huaweicloud/services/rfs" -run TestAccStack_ -timeout 360m -parallel 10      
=== RUN   TestAccStack_basic
=== PAUSE TestAccStack_basic
=== RUN   TestAccStack_withBody
=== PAUSE TestAccStack_withBody
=== RUN   TestAccStack_withUri
=== PAUSE TestAccStack_withUri
=== RUN   TestAccStack_archive
=== PAUSE TestAccStack_archive
=== CONT  TestAccStack_basic
=== CONT  TestAccStack_withUri
=== CONT  TestAccStack_archive
=== CONT  TestAccStack_withBody
=== NAME  TestAccStack_archive
    acceptance.go:2756: Skip the archive URI parameters acceptance test for RF resource stack.
--- SKIP: TestAccStack_archive (0.00s)
--- PASS: TestAccStack_basic (101.54s)
--- PASS: TestAccStack_withBody (182.43s)
--- PASS: TestAccStack_withUri (418.92s)
PASS
coverage: 8.0% of statements in ./huaweicloud/services/rfs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       419.053s        coverage: 8.0% of statements in ./huaweicloud/services/rfs
```
<img width="1341" height="82" alt="image" src="https://github.com/user-attachments/assets/3d81192c-e3be-4662-baea-525ac6ec928c" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
