### PR TITLE
feat(cce): add skipped_check_item_list and is_only_upgrade to cluster…

### DIFF
--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_upgrade.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_upgrade.go
@@ -150,6 +150,44 @@ func ResourceClusterUpgrade() *schema.Resource {
 						},
 					}},
 			},
+			"skipped_check_item_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"resource_selector": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"operator": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"is_only_upgrade": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"is_snapshot": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -191,6 +229,7 @@ func buildClusterUpgradeCreateOpts(d *schema.ResourceData, targetVersion string)
 				"nodePoolOrder": d.Get("nodepool_order"),
 				"strategy":      buildClusterUpgradeStrategyOpts(d),
 				"targetVersion": targetVersion,
+				"isOnlyUpgrade": d.Get("is_only_upgrade"),
 			},
 		},
 	}
@@ -307,6 +346,35 @@ func buildClusterUpgradeInPlaceRollingUpdateOpts(inPlaceRollingUpdateRaw []inter
 	return nil
 }
 
+func buildClusterUpgradeSkippedCheckItemListOpts(d *schema.ResourceData) []map[string]interface{} {
+	raw := d.Get("skipped_check_item_list").([]interface{})
+	if len(raw) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(raw))
+	for _, v := range raw {
+		item, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		obj := map[string]interface{}{
+			"name": utils.ValueIgnoreEmpty(item["name"]),
+		}
+		rsRaw := item["resource_selector"].([]interface{})
+		if len(rsRaw) > 0 {
+			rs := rsRaw[0].(map[string]interface{})
+			obj["resourceSelector"] = map[string]interface{}{
+				"key":      rs["key"],
+				"values":   rs["values"],
+				"operator": rs["operator"],
+			}
+		}
+		result = append(result, obj)
+	}
+	return result
+}
+
 func resourceClusterUpgradeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.CceV3Client(cfg.GetRegion(d))
@@ -345,7 +413,8 @@ func resourceClusterUpgradeCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	// precheck
-	createPreCheckResp, err := createPreCheck(client, clusterID, exactCurrentVersion, exactTargetVersion)
+	createPreCheckResp, err := createPreCheck(client, clusterID, exactCurrentVersion, exactTargetVersion,
+		buildClusterUpgradeSkippedCheckItemListOpts(d))
 	if err != nil {
 		return diag.Errorf("error creating CCE cluster precheck: %s", err)
 	}
@@ -446,7 +515,8 @@ func createWorkflow(client *golangsdk.ServiceClient, clusterID, currentVersion, 
 	return utils.FlattenResponse(workflowResp)
 }
 
-func createPreCheck(client *golangsdk.ServiceClient, clusterID, currentVersion, targetVersion string) (interface{}, error) {
+func createPreCheck(client *golangsdk.ServiceClient, clusterID, currentVersion, targetVersion string,
+	skippedCheckItemList []map[string]interface{}) (interface{}, error) {
 	preCheckHttpUrl := "api/v3/projects/{project_id}/clusters/{cluster_id}/operation/precheck"
 	preCheckPath := client.Endpoint + preCheckHttpUrl
 	preCheckPath = strings.ReplaceAll(preCheckPath, "{project_id}", client.ProjectID)
@@ -458,9 +528,10 @@ func createPreCheck(client *golangsdk.ServiceClient, clusterID, currentVersion, 
 			"kind":       "PreCheckTask",
 			"apiVersion": "v3",
 			"spec": map[string]interface{}{
-				"clusterID":      clusterID,
-				"clusterVersion": currentVersion,
-				"targetVersion":  targetVersion,
+				"clusterID":            clusterID,
+				"clusterVersion":       currentVersion,
+				"targetVersion":        targetVersion,
+				"skippedCheckItemList": skippedCheckItemList,
 			},
 		},
 	}


### PR DESCRIPTION
```markdown
**What this PR does / why we need it**:

Add `skipped_check_item_list` and `is_only_upgrade` arguments to the `huaweicloud_cce_cluster_upgrade` resource.

- `skipped_check_item_list`: allows users to specify precheck items to skip during the cluster upgrade precheck phase.
  Each item supports an optional `resource_selector` block to target specific nodes by UID.
- `is_only_upgrade`: controls whether the upgrade action is performed exclusively, mapped to `isOnlyUpgrade` in the
  upgrade API request body.

**Which issue this PR fixes**: N/A

**Special notes for your reviewer**: N/A

**Release note**:
```release-note
* resource/huaweicloud_cce_cluster_upgrade: add `skipped_check_item_list` and `is_only_upgrade` arguments
```