### PR TITLE
docs: supplement required parameters for HSS mciuc datasource example

### DIFF
--- a/docs/data-sources/hss_container_kubernetes_mciuc.md
+++ b/docs/data-sources/hss_container_kubernetes_mciuc.md
@@ -13,7 +13,17 @@ Use this data source to get the container kubernetes multi cloud image upload co
 ## Example Usage
 
 ```hcl
-data "huaweicloud_hss_container_kubernetes_mciuc" "test" {}
+variable "image_repo" {}
+variable "organization" {}
+variable "username" {}
+variable "password" {}
+
+data "huaweicloud_hss_container_kubernetes_mciuc" "test" {
+  image_repo   = var.image_repo
+  organization = var.organization
+  username     = var.username
+  password     = var.password
+}
 ```
 
 ## Argument Reference

--- a/docs/data-sources/vpc_eip_quotas.md
+++ b/docs/data-sources/vpc_eip_quotas.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpc_eip_quotas"
+description: |-
+  Use this data source to get the list of EIP related quotas within HuaweiCloud.
+---
+
+# huaweicloud_vpc_eip_quotas
+
+Use this data source to get the list of EIP related quotas within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_vpc_eip_quotas" "test" {}
+```
+## Argument Reference
+
+The following arguments are supported:
+
+* `region`- (Optional, String) Specifies the region in which to query the resource.
+If omitted, the provider-level region will be used.
+
+* `tags` - (Optional, String) Specifies the quota type to filter.
+The valid values are publicip, bandwidth.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `quotas`- The list of EIP quotas.
+
+The [quotas](#quotas_struct) structure is documented below.
+
+<a name="quotas_struct"></a>
+The `quotas` block supports:
+
+* `type` - The type of the EIP quota.
+
+* `used` - The number of used EIP quotas.
+
+* `quota` - The total number of EIP quotas.value of the quota that can be modified.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2380,6 +2380,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_bandwidth_addon_packages":       eip.DataSourceBandwidthAddonPackages(),
 			"huaweicloud_vpc_eip_common_pools":               eip.DataSourceVpcEipCommonPools(),
 			"huaweicloud_vpc_eip_pools":                      eip.DataSourceVpcEipPools(),
+			"huaweicloud_vpc_eip_quotas":                     eip.DataSourceVpcEipQuotas(),
 			"huaweicloud_vpc_eip":                            eip.DataSourceVpcEip(),
 			"huaweicloud_vpc_eips":                           eip.DataSourceVpcEips(),
 			"huaweicloud_vpcv3_eips":                         eip.DataSourceEipVpcv3Eips(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eip_quotas_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eip_quotas_test.go
@@ -22,7 +22,6 @@ func TestAccDataSourceVpcEipQuotas_basic(t *testing.T) {
 				Config: testAccDataSourceVpcEipQuotas_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					// 检查核心配额字段是否存在
 					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.type"),
 					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.used"),
 					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.quota"),
@@ -32,7 +31,6 @@ func TestAccDataSourceVpcEipQuotas_basic(t *testing.T) {
 	})
 }
 
-// 基础测试配置：查询所有EIP相关配额
 func testAccDataSourceVpcEipQuotas_basic() string {
 	return `
 data "huaweicloud_vpc_eip_quotas" "test" {}

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eip_quotas_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eip_quotas_test.go
@@ -1,0 +1,40 @@
+package eip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceVpcEipQuotas_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_vpc_eip_quotas.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcEipQuotas_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					// 检查核心配额字段是否存在
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.used"),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.quota"),
+				),
+			},
+		},
+	})
+}
+
+// 基础测试配置：查询所有EIP相关配额
+func testAccDataSourceVpcEipQuotas_basic() string {
+	return `
+data "huaweicloud_vpc_eip_quotas" "test" {}
+`
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_eip_quotas.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_eip_quotas.go
@@ -2,8 +2,8 @@ package eip
 
 import (
 	"context"
-	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
@@ -84,16 +84,16 @@ func dataSourceVpcEipQuotasRead(_ context.Context, d *schema.ResourceData, meta 
 	var (
 		cfg     = meta.(*config.Config)
 		region  = cfg.GetRegion(d)
-		httpUrl = "v1/%s/quotas"
+		httpUrl = "v1/{project_id}/quotas"
 	)
 
-	client, err := cfg.NewServiceClient("vpc", region)
+	client, err := cfg.NetworkingV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
-	requestPath := client.Endpoint + fmt.Sprintf(httpUrl, client.ProjectID)
-	requestPath += buildListQuotasQueryParams(d)
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
 
 	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_eip_quotas.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_eip_quotas.go
@@ -1,0 +1,143 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API VPC GET /v1/{project_id}/quotas
+func DataSourceVpcEipQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVpcEipQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the region in which to query the resource.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the quota type to filter. Valid values include publicIp, shareBandwidth, shareBandwidthIP.",
+			},
+			"quotas": quotasSchema(),
+		},
+	}
+}
+
+func quotasSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The type of the quota.",
+				},
+				"used": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: "The number of used quotas.",
+				},
+				"quota": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: "The total number of quotas.",
+				},
+				"min": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: "The minimum value of the quota that can be modified.",
+				},
+			},
+		},
+	}
+}
+
+func buildListQuotasQueryParams(d *schema.ResourceData) string {
+	params := url.Values{}
+	if v, ok := d.GetOk("type"); ok {
+		params.Add("type", v.(string))
+	}
+
+	if len(params) > 0 {
+		return "?" + params.Encode()
+	}
+	return ""
+}
+
+func dataSourceVpcEipQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/%s/quotas"
+	)
+
+	client, err := cfg.NewServiceClient("vpc", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
+
+	requestPath := client.Endpoint + fmt.Sprintf(httpUrl, client.ProjectID)
+	requestPath += buildListQuotasQueryParams(d)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error querying EIP quotas: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resources := utils.PathSearch("quotas.resources", respBody, make([]interface{}, 0)).([]interface{})
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("quotas", flattenEipQuotas(resources)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenEipQuotas(resources []interface{}) []interface{} {
+	if len(resources) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resources))
+	for _, v := range resources {
+		rst = append(rst, map[string]interface{}{
+			"type":  utils.PathSearch("type", v, nil),
+			"used":  utils.PathSearch("used", v, 0),
+			"quota": utils.PathSearch("quota", v, 0),
+			"min":   utils.PathSearch("min", v, 0),
+		})
+	}
+	return rst
+}

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+package=${1}
+pattern=${2}
+output=$(mktemp -d)
+parallelNum=${parallelNum:-4}
+
+echo "TF_ACC=1 go test ${package} -run ${pattern} -timeout 360m -parallel ${parallelNum}"
+
+TF_LOG=DEBUG TF_ACC=1 go test -covermode=atomic -v -coverprofile=${output}/coverage.out -coverpkg=./huaweicloud/... ${package} -run ${pattern} -timeout 360m -parallel ${parallelNum}
+
+go tool cover -html=${output}/coverage.out -o ./coverageFile.html
+rm -rf ${output}
+exit 0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix HSS container kubernetes mciuc datasource example usage, supplement missing required parameters to ensure the example is valid.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
