### PR TITLE
fix(CCE): fix cce cluster upgrade resource

### DIFF
--- a/docs/resources/cce_cluster_upgrade.md
+++ b/docs/resources/cce_cluster_upgrade.md
@@ -124,6 +124,9 @@ The following arguments are supported:
 * `strategy` - (Required, List, NonUpdatable) Specifies the upgrade strategy.
   The [strategy](#strategy) structure is documented below.
 
+* `skipped_check_item_list` - (Optional, List, NonUpdatable) Specifies the skipped check items
+  The [skipped_check_item_list](#skipped_check_item_list) structure is documented below.
+
 * `addons` - (Optional, List, NonUpdatable) Specifies the add-on configuration list
   The [addons](#addons) structure is documented below.
 
@@ -135,6 +138,11 @@ The following arguments are supported:
   The key is the node pool ID, **DefaultPool** indicates the default pool.
   The value is the priority of the node pool. **0** indicating the lowest priority.
   A larger value indicates a higher priority.
+
+* `is_only_upgrade` - (Optional, String, NonUpdatable) Specifies whether to perform pre-upgrade checks during the cluster
+  upgrade process. The default is **false**, meaning pre-upgrade checks will be performed. If you called the pre-upgrade
+  check API in your cluster upgrade orchestration, setting this encapsulated field to **true** during the upgrade will
+  prevent an additional check from being performed. Value options: **true**, **false**.
 
 * `is_snapshot` - (Optional, Bool, NonUpdatable) Specifies whether the cluster is snapshotted.
 
@@ -176,6 +184,24 @@ The `strategy` block supports:
 * `in_place_rolling_update` - (Optional, List, NonUpdatable) Specifies the in-place upgrade settings.
   It's mandatory when the `type` is set to **inPlaceRollingUpdate**.
   The [in_place_rolling_update](#in_place_rolling_update) structure is documented below.
+
+<a name="skipped_check_item_list"></a>
+The `skipped_check_item_list` block supports:
+
+* `name` - (Optional, String, NonUpdatable) Specifies the name of the skipped checked item.
+
+* `resource_selector` - (Optional, List, NonUpdatable) Specifies the resource tag selector. This parameter is available
+  only for node check, but not for cluster check or add-on check.
+  The [resource_selector](#resource_selector) structure is documented below.
+
+<a name="resource_selector"></a>
+The `resource_selector` block supports:
+
+* `key` - (Required, String, NonUpdatable) Specifies the tag key.
+
+* `operator` - (Required, String, NonUpdatable) Specifies the logical operators of labels. Value options: **In**.
+
+* `values` - (Optional, String, NonUpdatable) Specifies the tag value list.
 
 <a name="in_place_rolling_update"></a>
 The `in_place_rolling_update` block supports:

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_upgrade.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_upgrade.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,6 +39,13 @@ var clusterUpgradeNonUpdatableParams = []string{"cluster_id", "target_version", 
 	"strategy.*.type",
 	"strategy.*.in_place_rolling_update",
 	"strategy.*.in_place_rolling_update.*.user_defined_step",
+	"skipped_check_item_list",
+	"skipped_check_item_list.*.name",
+	"skipped_check_item_list.*.resource_selector",
+	"skipped_check_item_list.*.resource_selector.*.key",
+	"skipped_check_item_list.*.resource_selector.*.values",
+	"skipped_check_item_list.*.resource_selector.*.operator",
+	"is_only_upgrade",
 }
 
 func ResourceClusterUpgrade() *schema.Resource {
@@ -185,8 +193,11 @@ func ResourceClusterUpgrade() *schema.Resource {
 				},
 			},
 			"is_only_upgrade": {
-				Type:     schema.TypeBool,
+				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"true", "false",
+				}, false),
 			},
 			"is_snapshot": {
 				Type:     schema.TypeBool,
@@ -229,9 +240,13 @@ func buildClusterUpgradeCreateOpts(d *schema.ResourceData, targetVersion string)
 				"nodePoolOrder": d.Get("nodepool_order"),
 				"strategy":      buildClusterUpgradeStrategyOpts(d),
 				"targetVersion": targetVersion,
-				"isOnlyUpgrade": d.Get("is_only_upgrade"),
 			},
 		},
+	}
+
+	if v, ok := d.GetOk("is_only_upgrade"); ok {
+		isOnlyUpgradeRaw, _ := strconv.ParseBool(v.(string))
+		result["spec"].(map[string]interface{})["clusterUpgradeAction"].(map[string]interface{})["isOnlyUpgrade"] = isOnlyUpgradeRaw
 	}
 	return result, nil
 }
@@ -524,7 +539,7 @@ func createPreCheck(client *golangsdk.ServiceClient, clusterID, currentVersion, 
 
 	preCheckOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody: map[string]interface{}{
+		JSONBody: utils.RemoveNil(map[string]interface{}{
 			"kind":       "PreCheckTask",
 			"apiVersion": "v3",
 			"spec": map[string]interface{}{
@@ -533,7 +548,7 @@ func createPreCheck(client *golangsdk.ServiceClient, clusterID, currentVersion, 
 				"targetVersion":        targetVersion,
 				"skippedCheckItemList": skippedCheckItemList,
 			},
-		},
+		}),
 	}
 	preCheckResp, err := client.Request("POST", preCheckPath, &preCheckOpt)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. fix cce culster upgrade resource
2. cce culster upgrade docs add params

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix cce culster upgrade resource
2. cce culster upgrade docs add params
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
