### PR TITLE
feat(eip): support `vpc_eip_public_ip_pool_types` data source

### DIFF
--- a/docs/data-sources/vpc_eip_public_ip_pool_types.md
+++ b/docs/data-sources/vpc_eip_public_ip_pool_types.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpc_eip_public_ip_pool_types"
+description: |-
+  Use this dataSource to get the list of public IP pool types.
+---
+
+# huaweicloud_vpc_eip_public_ip_pool_types
+
+Use this dataSource to get the list of public IP pool types.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_vpc_eip_public_ip_pool_types" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `fields` - (Optional, List) Specifies the fields returned by the query.  
+  The supported field names include: **id**, **name**, **size**, **used**, **project_id**, **status**,
+  **billing_info**, **created_at**, **updated_at**, **type**, **shared**, **is_common**,
+  **description**, **tags**, **enterprise_project_id**, **allow_share_bandwidth_types**, and **public_border_group**.
+
+* `sort_key` - (Optional, String) Specifies the sort key. The supported field names are **id**, **name**,
+  **created_at**, **updated_at**, and **public_border_group**.
+
+* `sort_dir` - (Optional, String) Specifies the sort order. Valid values are **asc** and **desc**.
+
+* `type_id` - (Optional, String) Specifies the type ID.
+
+* `name` - (Optional, String) Specifies the name
+
+* `size` - (Optional, Int) Specifies the size
+
+* `status` - (Optional, String) Specifies the status.
+
+* `type` - (Optional, String) Specifies the type.
+
+* `description` - (Optional, String) Specifies the description.
+
+* `public_border_group` - (Optional, String) Specifies the public_border_group.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `public_ip_pool_types` - The list of public IP pool type objects.
+
+  The [public_ip_pool_types](#public_ip_pool_types_struct) structure is documented below.
+
+<a name="public_ip_pool_types_struct"></a>
+The `public_ip_pool_types` block supports:
+
+* `id` - The public IP pool type ID.
+
+* `type` - The public IP pool type.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2379,6 +2379,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpcv3_bandwidths":                   eip.DataSourceEipVpcv3Bandwidths(),
 			"huaweicloud_vpc_bandwidth_addon_packages":       eip.DataSourceBandwidthAddonPackages(),
 			"huaweicloud_vpc_eip_common_pools":               eip.DataSourceVpcEipCommonPools(),
+			"huaweicloud_vpc_eip_public_ip_pool_types":       eip.DataSourceVpcEipPublicIpPoolTypes(),
 			"huaweicloud_vpc_eip_pools":                      eip.DataSourceVpcEipPools(),
 			"huaweicloud_vpc_eip":                            eip.DataSourceVpcEip(),
 			"huaweicloud_vpc_eips":                           eip.DataSourceVpcEips(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eip_public_ip_pool_types_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eip_public_ip_pool_types_test.go
@@ -1,0 +1,84 @@
+package eip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceVpcEipPublicIpPoolTypes_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_vpc_eip_public_ip_pool_types.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceVpcEipPublicIpPoolTypes_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "public_ip_pool_types.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "public_ip_pool_types.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "public_ip_pool_types.0.type"),
+
+					resource.TestCheckOutput("is_type_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceVpcEipPublicIpPoolTypes_basic() string {
+	return `
+data "huaweicloud_vpc_eip_public_ip_pool_types" "test" {
+  fields   = ["id", "type"]
+  sort_key = "id"
+  sort_dir = "asc"
+}
+
+# Filter by type_id.
+locals {
+  type_id = data.huaweicloud_vpc_eip_public_ip_pool_types.test.public_ip_pool_types[0].id
+}
+
+data "huaweicloud_vpc_eip_public_ip_pool_types" "type_id_filter" {
+  type_id = local.type_id
+}
+
+locals {
+  type_id_filter_result = [
+    for v in data.huaweicloud_vpc_eip_public_ip_pool_types.type_id_filter.public_ip_pool_types[*].id : v == local.type_id
+  ]
+}
+
+output "is_type_id_filter_useful" {
+  value = alltrue(local.type_id_filter_result) && length(local.type_id_filter_result) > 0
+}
+
+# Filter by type.
+locals {
+  type = data.huaweicloud_vpc_eip_public_ip_pool_types.test.public_ip_pool_types[0].type
+}
+
+data "huaweicloud_vpc_eip_public_ip_pool_types" "type_filter" {
+  type = local.type
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_vpc_eip_public_ip_pool_types.type_id_filter.public_ip_pool_types[*].type : v == local.type
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = alltrue(local.type_filter_result) && length(local.type_filter_result) > 0
+}
+`
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_eip_public_ip_pool_types.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_eip_public_ip_pool_types.go
@@ -1,0 +1,228 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v3/{project_id}/eip/publicip-pool-types
+func DataSourceVpcEipPublicIpPoolTypes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVpcEipPublicIpPoolTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// The `fields` field is of type string in the API documentation,
+			// but according to its field description, it should be a list.
+			"fields": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// The field name in the API document is `id`, here it is named `type_id`.
+			"type_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"public_border_group": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// The field name in the API document is `publicip-pool-types`, object type.
+			// But the actual return is `publicip_pool_types`, list type, here it is named `public_ip_pool_types`.
+			"public_ip_pool_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildVpcEipPublicIpPoolTypesQueryParams(d *schema.ResourceData, marker string) string {
+	rst := ""
+
+	rawArray, ok := d.Get("fields").([]interface{})
+	if ok && len(rawArray) > 0 {
+		for _, v := range rawArray {
+			rst += fmt.Sprintf("&fields=%s", v.(string))
+		}
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%s", v)
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%s", v)
+	}
+
+	if v, ok := d.GetOk("type_id"); ok {
+		rst += fmt.Sprintf("&id=%s", v)
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		rst += fmt.Sprintf("&name=%s", v)
+	}
+
+	if v, ok := d.GetOk("size"); ok {
+		rst += fmt.Sprintf("&size=%d", v)
+	}
+
+	if v, ok := d.GetOk("status"); ok {
+		rst += fmt.Sprintf("&status=%s", v)
+	}
+
+	if v, ok := d.GetOk("type"); ok {
+		rst += fmt.Sprintf("&type=%s", v)
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		rst += fmt.Sprintf("&description=%s", v)
+	}
+
+	if v, ok := d.GetOk("public_border_group"); ok {
+		rst += fmt.Sprintf("&public_border_group=%s", v)
+	}
+
+	if marker != "" {
+		rst += fmt.Sprintf("&marker=%s", marker)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourceVpcEipPublicIpPoolTypesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/eip/publicip-pool-types"
+		result     = make([]interface{}, 0)
+		nextMarker string
+	)
+
+	client, err := cfg.NetworkingV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating EIP v3 client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildVpcEipPublicIpPoolTypesQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving EIP public IP pool types: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		types := utils.PathSearch("publicip_pool_types", respBody, make([]interface{}, 0)).([]interface{})
+		if len(types) == 0 {
+			break
+		}
+
+		result = append(result, types...)
+
+		// There is no return for the `page_info` field in the API documentation, but it actually exists.
+		nextMarker = utils.PathSearch("page_info.previous_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("public_ip_pool_types", flattenVpcEipPublicIpPoolTypes(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenVpcEipPublicIpPoolTypes(typesResp []interface{}) []interface{} {
+	if len(typesResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(typesResp))
+	for _, v := range typesResp {
+		rst = append(rst, map[string]interface{}{
+			"id":   utils.PathSearch("id", v, nil),
+			"type": utils.PathSearch("type", v, nil),
+		})
+	}
+
+	return rst
+}

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+package=${1}
+pattern=${2}
+output=$(mktemp -d)
+parallelNum=${parallelNum:-4}
+
+echo "TF_ACC=1 go test ${package} -run ${pattern} -timeout 360m -parallel ${parallelNum}"
+
+TF_LOG=DEBUG TF_ACC=1 go test -covermode=atomic -v -coverprofile=${output}/coverage.out -coverpkg=./huaweicloud/... ${package} -run ${pattern} -timeout 360m -parallel ${parallelNum}
+
+go tool cover -html=${output}/coverage.out -o ./coverageFile.html
+rm -rf ${output}
+exit 0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `vpc_eip_public_ip_pool_types` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `vpc_eip_public_ip_pool_types` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccDataSourceVpcEipPublicIpPoolTypes_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccDataSourceVpcEipPublicIpPoolTypes_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceVpcEipPublicIpPoolTypes_basic
=== PAUSE TestAccDataSourceVpcEipPublicIpPoolTypes_basic
=== CONT  TestAccDataSourceVpcEipPublicIpPoolTypes_basic
--- PASS: TestAccDataSourceVpcEipPublicIpPoolTypes_basic (13.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       13.450s
```
<img width="927" height="35" alt="image" src="https://github.com/user-attachments/assets/76e9b2a0-a318-4b53-81c2-227826c1710c" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
