### PR TITLE
fix(obs): fix the wrong replication test case

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -113,6 +113,7 @@ var (
 	HW_CNAD_PROJECT_OBJECT_ID = os.Getenv("HW_CNAD_PROJECT_OBJECT_ID")
 
 	HW_OBS_DESTINATION_BUCKET  = os.Getenv("HW_OBS_DESTINATION_BUCKET")
+	HW_OBS_AGENCY_NAME         = os.Getenv("HW_OBS_AGENCY_NAME")
 	HW_OBS_ENDPOINT            = os.Getenv("HW_OBS_ENDPOINT")
 	HW_OBS_OBJECT_STORAGE_PATH = os.Getenv("HW_OBS_OBJECT_STORAGE_PATH")
 	HW_OBS_USER_DOMAIN_NAME1   = os.Getenv("HW_OBS_USER_DOMAIN_NAME1")
@@ -1774,6 +1775,13 @@ func TestAccPreCheckOBS(t *testing.T) {
 func TestAccPreCheckOBSDestinationBucket(t *testing.T) {
 	if HW_OBS_DESTINATION_BUCKET == "" {
 		t.Skip("HW_OBS_DESTINATION_BUCKET must be set for OBS destination tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckOBSAgencyName(t *testing.T) {
+	if HW_OBS_AGENCY_NAME == "" {
+		t.Skip("HW_OBS_AGENCY_NAME must be set for OBS tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_replication_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_replication_test.go
@@ -29,7 +29,6 @@ func TestAccObsBucketReplication_basic(t *testing.T) {
 	var obj interface{}
 
 	bucketName := acceptance.RandomAccResourceNameWithDash()
-	agencyName := acceptance.RandomAccResourceName()
 	rName := "huaweicloud_obs_bucket_replication.replica"
 	rc := acceptance.InitResourceCheck(
 		rName,
@@ -43,16 +42,17 @@ func TestAccObsBucketReplication_basic(t *testing.T) {
 			// The source bucket and target bucket must belong to different regions of the same account.
 			// https://support.huaweicloud.com/intl/en-us/ugobs-obs/obs_41_0034.html
 			acceptance.TestAccPreCheckOBSDestinationBucket(t)
+			acceptance.TestAccPreCheckOBSAgencyName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObsBucketReplication_basic(agencyName, bucketName, acceptance.HW_OBS_DESTINATION_BUCKET),
+				Config: testAccObsBucketReplication_basic(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "bucket", bucketName),
-					resource.TestCheckResourceAttr(rName, "agency", agencyName),
+					resource.TestCheckResourceAttr(rName, "agency", acceptance.HW_OBS_AGENCY_NAME),
 					resource.TestCheckResourceAttr(rName, "destination_bucket", acceptance.HW_OBS_DESTINATION_BUCKET),
 					resource.TestCheckResourceAttr(rName, "rule.#", "1"),
 					resource.TestCheckResourceAttr(rName, "rule.0.enabled", "true"),
@@ -61,7 +61,7 @@ func TestAccObsBucketReplication_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccObsBucketReplication_update_1(agencyName, bucketName, acceptance.HW_OBS_DESTINATION_BUCKET),
+				Config: testAccObsBucketReplication_update_1(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "rule.#", "2"),
@@ -76,7 +76,7 @@ func TestAccObsBucketReplication_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccObsBucketReplication_update_2(agencyName, bucketName, acceptance.HW_OBS_DESTINATION_BUCKET),
+				Config: testAccObsBucketReplication_update_2(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "rule.#", "1"),
@@ -94,50 +94,40 @@ func TestAccObsBucketReplication_basic(t *testing.T) {
 	})
 }
 
-func testAccObsBucketReplication_base(agencyName, bucketName string) string {
+func testAccObsBucketReplication_base(bucketName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_identity_agency" "agency" {
-  name                   = "%s"
-  description            = "This is an iam agency for obs bucket replication"
-  delegated_service_name = "op_svc_obs"
-
-  domain_roles = [
-    "OBS Administrator",
-  ]
-}
-
 resource "huaweicloud_obs_bucket" "source" {
   bucket        = "%s"
   storage_class = "STANDARD"
   acl           = "private"
 }
-`, agencyName, bucketName)
+`, bucketName)
 }
 
-func testAccObsBucketReplication_basic(agencyName, bucketName, destinationName string) string {
+func testAccObsBucketReplication_basic(bucketName string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_obs_bucket_replication" "replica" {
   bucket             = huaweicloud_obs_bucket.source.bucket
-  destination_bucket = "%s"
-  agency             = huaweicloud_identity_agency.agency.name
+  destination_bucket = "%[2]s"
+  agency             = "%[3]s"
 
   rule {
     prefix = "abc"
   }
 }
-`, testAccObsBucketReplication_base(agencyName, bucketName), destinationName)
+`, testAccObsBucketReplication_base(bucketName), acceptance.HW_OBS_DESTINATION_BUCKET, acceptance.HW_OBS_AGENCY_NAME)
 }
 
-func testAccObsBucketReplication_update_1(agencyName, bucketName, destinationName string) string {
+func testAccObsBucketReplication_update_1(bucketName string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_obs_bucket_replication" "replica" {
   bucket             = huaweicloud_obs_bucket.source.bucket
-  destination_bucket = "%s"
-  agency             = huaweicloud_identity_agency.agency.name
+  destination_bucket = "%[2]s"
+  agency             = "%[3]s"
 
   rule {
     prefix = "imgs/"
@@ -149,19 +139,19 @@ resource "huaweicloud_obs_bucket_replication" "replica" {
     history_enabled = true
   }
 }
-`, testAccObsBucketReplication_base(agencyName, bucketName), destinationName)
+`, testAccObsBucketReplication_base(bucketName), acceptance.HW_OBS_DESTINATION_BUCKET, acceptance.HW_OBS_AGENCY_NAME)
 }
 
-func testAccObsBucketReplication_update_2(agencyName, bucketName, destinationName string) string {
+func testAccObsBucketReplication_update_2(bucketName string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_obs_bucket_replication" "replica" {
   bucket             = huaweicloud_obs_bucket.source.bucket
-  destination_bucket = "%s"
-  agency             = huaweicloud_identity_agency.agency.name
+  destination_bucket = "%[2]s"
+  agency             = "%[3]s"
 
   rule {}
 }
-`, testAccObsBucketReplication_base(agencyName, bucketName), destinationName)
+`, testAccObsBucketReplication_base(bucketName), acceptance.HW_OBS_DESTINATION_BUCKET, acceptance.HW_OBS_AGENCY_NAME)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix the wrong replication test case.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The test case error was fixed because the delegate must be created through the console to be used.
Before fixing:
```
./scripts/coverage.sh -o obs -f TestAccObsBucketReplication_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccObsBucketReplication_basic -timeout 360m -parallel 10
=== RUN   TestAccObsBucketReplication_basic
=== PAUSE TestAccObsBucketReplication_basic
=== CONT  TestAccObsBucketReplication_basic
    resource_huaweicloud_obs_bucket_replication_test.go:40: Step 1/4 error: Error running apply: exit status 1

        Error: Error creating cross-region replication of OBS bucket tf-test-6ewak: obs: service returned error: Status=403 Forbidden, Code=500 INTERNAL_SERVER_ERROR, Message=INNER ERROR, RequestId=0000019DCEC2729344C58BDD6B07F87C

          with huaweicloud_obs_bucket_replication.replica,
          on terraform_plugin_test.tf line 20, in resource "huaweicloud_obs_bucket_replication" "replica":
          20: resource "huaweicloud_obs_bucket_replication" "replica" {

--- FAIL: TestAccObsBucketReplication_basic (17.55s)
FAIL
coverage: 16.7% of statements in ./huaweicloud/services/obs
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       17.644s
FAIL
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o obs -f TestAccObsBucketReplication_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccObsBucketReplication_basic -timeout 360m -parallel 10
=== RUN   TestAccObsBucketReplication_basic
=== PAUSE TestAccObsBucketReplication_basic
=== CONT  TestAccObsBucketReplication_basic
--- PASS: TestAccObsBucketReplication_basic (43.99s)
PASS
coverage: 18.8% of statements in ./huaweicloud/services/obs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       44.108s coverage: 18.8% of statements in ./huaweicloud/services/obs
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
