### PR TITLE
refactor(cbc): move cbc common function into cbc package

### DIFF
--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -381,26 +381,26 @@ func GetEipsbyAddresses(client *golangsdk.ServiceClient, addresses []string, eps
 	return allEips, nil
 }
 
-// GetResourceIDsByOrder returns resource IDs from an order.
-func GetResourceIDsByOrder(client *golangsdk.ServiceClient, orderId string, onlyMainResource int) ([]string, error) {
-	if strings.TrimSpace(orderId) == "" {
-		return nil, fmt.Errorf("order id is empty")
-	}
-	listOpts := resources.ListOpts{
-		OrderId:          orderId,
-		OnlyMainResource: onlyMainResource,
-	}
-	resp, err := resources.List(client, listOpts)
-	if err != nil {
-		return nil, fmt.Errorf("error getting order (%s) details: %s", orderId, err)
-	}
-	if resp == nil || resp.TotalCount < 1 {
-		return nil, fmt.Errorf("error getting order (%s) details: response empty", orderId)
-	}
+// // GetResourceIDsByOrder returns resource IDs from an order.
+// func GetResourceIDsByOrder(client *golangsdk.ServiceClient, orderId string, onlyMainResource int) ([]string, error) {
+// 	if strings.TrimSpace(orderId) == "" {
+// 		return nil, fmt.Errorf("order id is empty")
+// 	}
+// 	listOpts := resources.ListOpts{
+// 		OrderId:          orderId,
+// 		OnlyMainResource: onlyMainResource,
+// 	}
+// 	resp, err := resources.List(client, listOpts)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("error getting order (%s) details: %s", orderId, err)
+// 	}
+// 	if resp == nil || resp.TotalCount < 1 {
+// 		return nil, fmt.Errorf("error getting order (%s) details: response empty", orderId)
+// 	}
 
-	rst := make([]string, len(resp.Resources))
-	for i, v := range resp.Resources {
-		rst[i] = v.ResourceId
-	}
-	return rst, nil
-}
+// 	rst := make([]string, len(resp.Resources))
+// 	for i, v := range resp.Resources {
+// 		rst[i] = v.ResourceId
+// 	}
+// 	return rst, nil
+// }

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -268,20 +268,6 @@ func CaseInsensitiveFunc() schema.SchemaDiffSuppressFunc {
 	}
 }
 
-// GetAutoPay is a method to return whether order is auto pay according to the user input.
-// auto_pay parameter inputs and returns:
-//
-//	false: false
-//	true, empty: true
-//
-// Before using this function, make sure the parameter behavior is auto pay (the default value is "true").
-func GetAutoPay(d *schema.ResourceData) string {
-	if val, ok := d.GetOk("auto_pay"); ok && val.(string) == "false" {
-		return "false"
-	}
-	return "true"
-}
-
 func HasFilledOpt(d *schema.ResourceData, param string) bool {
 	_, b := d.GetOk(param)
 	return b

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -380,27 +380,3 @@ func GetEipsbyAddresses(client *golangsdk.ServiceClient, addresses []string, eps
 	}
 	return allEips, nil
 }
-
-// // GetResourceIDsByOrder returns resource IDs from an order.
-// func GetResourceIDsByOrder(client *golangsdk.ServiceClient, orderId string, onlyMainResource int) ([]string, error) {
-// 	if strings.TrimSpace(orderId) == "" {
-// 		return nil, fmt.Errorf("order id is empty")
-// 	}
-// 	listOpts := resources.ListOpts{
-// 		OrderId:          orderId,
-// 		OnlyMainResource: onlyMainResource,
-// 	}
-// 	resp, err := resources.List(client, listOpts)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("error getting order (%s) details: %s", orderId, err)
-// 	}
-// 	if resp == nil || resp.TotalCount < 1 {
-// 		return nil, fmt.Errorf("error getting order (%s) details: response empty", orderId)
-// 	}
-
-// 	rst := make([]string, len(resp.Resources))
-// 	for i, v := range resp.Resources {
-// 		rst[i] = v.ResourceId
-// 	}
-// 	return rst, nil
-// }

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -282,13 +282,6 @@ func GetAutoPay(d *schema.ResourceData) string {
 	return "true"
 }
 
-func UpdateAutoRenew(c *golangsdk.ServiceClient, enabled, resourceId string) error {
-	if enabled == "true" {
-		return resources.EnableAutoRenew(c, resourceId)
-	}
-	return resources.DisableAutoRenew(c, resourceId)
-}
-
 func HasFilledOpt(d *schema.ResourceData, param string) bool {
 	_, b := d.GetOk(param)
 	return b

--- a/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
+++ b/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -753,7 +754,7 @@ func resourceBmsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the instance (%s): %s", instanceId, err)
 		}
 	}

--- a/huaweicloud/services/cbc/common.go
+++ b/huaweicloud/services/cbc/common.go
@@ -1,9 +1,20 @@
 package cbc
 
 import (
+	"fmt"
 	"strings"
 
+	// "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	// "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	// "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/chnsz/golangsdk"
+	// "github.com/chnsz/golangsdk/openstack/bss/v2/orders"
+	"github.com/chnsz/golangsdk/openstack/bss/v2/resources"
+	// "github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+	// "github.com/huaweicloud/huaweicloud-sdk-go-v3/core/sdkerr"
+	// "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	// "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 // PaySubscriptionOrder is a method used to pay for a subscription order.
@@ -30,4 +41,28 @@ func buildPaySubscriptionOrderBodyParams(orderId string) map[string]interface{} 
 		"use_coupon":   "NO",
 		"use_discount": "NO",
 	}
+}
+
+// GetResourceIDsByOrder returns resource IDs from an order.
+func GetResourceIDsByOrder(client *golangsdk.ServiceClient, orderId string, onlyMainResource int) ([]string, error) {
+	if strings.TrimSpace(orderId) == "" {
+		return nil, fmt.Errorf("order id is empty")
+	}
+	listOpts := resources.ListOpts{
+		OrderId:          orderId,
+		OnlyMainResource: onlyMainResource,
+	}
+	resp, err := resources.List(client, listOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error getting order (%s) details: %s", orderId, err)
+	}
+	if resp == nil || resp.TotalCount < 1 {
+		return nil, fmt.Errorf("error getting order (%s) details: response empty", orderId)
+	}
+
+	rst := make([]string, len(resp.Resources))
+	for i, v := range resp.Resources {
+		rst[i] = v.ResourceId
+	}
+	return rst, nil
 }

--- a/huaweicloud/services/cbc/common.go
+++ b/huaweicloud/services/cbc/common.go
@@ -43,6 +43,13 @@ func buildPaySubscriptionOrderBodyParams(orderId string) map[string]interface{} 
 	}
 }
 
+func UpdateAutoRenew(c *golangsdk.ServiceClient, enabled, resourceId string) error {
+	if enabled == "true" {
+		return resources.EnableAutoRenew(c, resourceId)
+	}
+	return resources.DisableAutoRenew(c, resourceId)
+}
+
 // GetResourceIDsByOrder returns resource IDs from an order.
 func GetResourceIDsByOrder(client *golangsdk.ServiceClient, orderId string, onlyMainResource int) ([]string, error) {
 	if strings.TrimSpace(orderId) == "" {

--- a/huaweicloud/services/cbc/common.go
+++ b/huaweicloud/services/cbc/common.go
@@ -1,20 +1,14 @@
 package cbc
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	// "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	// "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	// "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
-	// "github.com/chnsz/golangsdk/openstack/bss/v2/orders"
 	"github.com/chnsz/golangsdk/openstack/bss/v2/resources"
-	// "github.com/chnsz/golangsdk/openstack/networking/v1/eips"
-	// "github.com/huaweicloud/huaweicloud-sdk-go-v3/core/sdkerr"
-	// "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	// "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 // PaySubscriptionOrder is a method used to pay for a subscription order.
@@ -43,6 +37,20 @@ func buildPaySubscriptionOrderBodyParams(orderId string) map[string]interface{} 
 	}
 }
 
+// GetAutoPay is a method to return whether order is auto pay according to the user input.
+// auto_pay parameter inputs and returns:
+//
+//	false: false
+//	true, empty: true
+//
+// Before using this function, make sure the parameter behavior is auto pay (the default value is "true").
+func GetAutoPay(d *schema.ResourceData) string {
+	if val, ok := d.GetOk("auto_pay"); ok && val.(string) == "false" {
+		return "false"
+	}
+	return "true"
+}
+
 func UpdateAutoRenew(c *golangsdk.ServiceClient, enabled, resourceId string) error {
 	if enabled == "true" {
 		return resources.EnableAutoRenew(c, resourceId)
@@ -53,7 +61,7 @@ func UpdateAutoRenew(c *golangsdk.ServiceClient, enabled, resourceId string) err
 // GetResourceIDsByOrder returns resource IDs from an order.
 func GetResourceIDsByOrder(client *golangsdk.ServiceClient, orderId string, onlyMainResource int) ([]string, error) {
 	if strings.TrimSpace(orderId) == "" {
-		return nil, fmt.Errorf("order id is empty")
+		return nil, errors.New("order id is empty")
 	}
 	listOpts := resources.ListOpts{
 		OrderId:          orderId,

--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_ha_instance.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_ha_instance.go
@@ -799,7 +799,7 @@ func resourceHAInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 				"master instance resource ID is not found in list API response", id)
 		}
 
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), masterResourceId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), masterResourceId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the CBH HA instance (%s): %s", id, err)
 		}
 	}

--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_ha_instance.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_ha_instance.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -259,7 +260,7 @@ func resourceHAInstanceCreate(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error waiting for CBH HA instance order (%s) complete: %s", orderId, err)
 	}
 
-	resourceIDs, err := common.GetResourceIDsByOrder(bssClient, orderId, 1)
+	resourceIDs, err := cbc.GetResourceIDsByOrder(bssClient, orderId, 1)
 	if err != nil {
 		return diag.Errorf("error retrieving resource IDs of CBH HA instance order (%s): %s", orderId, err)
 	}

--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -738,7 +739,7 @@ func resourceCBHInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 				"resource ID is not found in list API response", ID)
 		}
 
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), resourceId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), resourceId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the CBH instance (%s): %s", ID, err)
 		}
 	}

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
@@ -332,7 +332,7 @@ func buildBillingStructure(d *schema.ResourceData) map[string]interface{} {
 		billing["period_type"] = d.Get("period_unit").(string)
 		billing["period_num"] = d.Get("period").(int)
 		billing["is_auto_renew"], _ = strconv.ParseBool(d.Get("auto_renew").(string))
-		billing["is_auto_pay"], _ = strconv.ParseBool(common.GetAutoPay(d))
+		billing["is_auto_pay"], _ = strconv.ParseBool(cbc.GetAutoPay(d))
 	}
 
 	return utils.RemoveNil(billing)

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -1283,7 +1284,7 @@ func resourceVaultUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), vaultId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), vaultId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the vault (%s): %s", vaultId, err)
 		}
 	}

--- a/huaweicloud/services/cce/common.go
+++ b/huaweicloud/services/cce/common.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/cce/v3/nodes"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -259,7 +259,7 @@ func buildExtendParams(d *schema.ResourceData) map[string]interface{} {
 	if isPrePaid || billingMode == 1 {
 		res["chargingMode"] = 1
 		res["isAutoRenew"] = "false"
-		res["isAutoPay"] = common.GetAutoPay(d)
+		res["isAutoPay"] = cbc.GetAutoPay(d)
 	}
 
 	if v, ok := d.GetOk("period_unit"); ok {

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
@@ -568,7 +568,7 @@ func buildResourceClusterExtendParams(d *schema.ResourceData, cfg *config.Config
 	}
 	if isPrePaid || billingMode == 1 {
 		res["isAutoRenew"] = "false"
-		res["isAutoPay"] = common.GetAutoPay(d)
+		res["isAutoPay"] = cbc.GetAutoPay(d)
 	}
 
 	if v, ok := d.GetOk("period_unit"); ok {
@@ -1344,7 +1344,7 @@ func resourceClusterResize(ctx context.Context, cfg *config.Config, d *schema.Re
 	}
 
 	if d.Get("charging_mode").(string) == "prePaid" {
-		opts.ExtendParam.IsAutoPay = common.GetAutoPay(d)
+		opts.ExtendParam.IsAutoPay = cbc.GetAutoPay(d)
 	}
 
 	resp, err := clusters.Resize(cceClient, clusterID, opts)

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -1152,7 +1153,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		if err != nil {
 			return diag.Errorf("error creating BSS v2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), clusterId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), clusterId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the CCE cluster (%s): %s", clusterId, err)
 		}
 	}

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -802,7 +803,7 @@ func resourceNodeUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Get("server_id").(string)); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Get("server_id").(string)); err != nil {
 			// Do not output the underlying ECS instance ID externally.
 			return diag.Errorf("error updating the auto-renew of the node (%s): %s", d.Id(), err)
 		}

--- a/huaweicloud/services/css/resource_huaweicloud_css_logstash_cluster.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_logstash_cluster.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -786,7 +787,7 @@ func updateChangingModeOrAutoRenew(ctx context.Context, d *schema.ResourceData, 
 			return err
 		}
 	} else if d.HasChange("auto_renew") {
-		if err := common.UpdateAutoRenew(bssClient, autoRenew, clusterID); err != nil {
+		if err := cbc.UpdateAutoRenew(bssClient, autoRenew, clusterID); err != nil {
 			return fmt.Errorf("error updating the auto-renew of the CSS cluster (%s): %s", clusterID, err)
 		}
 	}

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -1436,7 +1437,7 @@ func resourceDcsInstancesUpdate(ctx context.Context, d *schema.ResourceData, met
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the instance (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/ddm/resource_huaweicloud_ddm_instance.go
+++ b/huaweicloud/services/ddm/resource_huaweicloud_ddm_instance.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -417,7 +418,7 @@ func resourceDdmInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the DDM instance (%s): %s", instanceId, err)
 		}
 	}

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_readonly_node.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_readonly_node.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -266,7 +267,7 @@ func waitForPrePaidOrderCompleted(ctx context.Context, cfg *config.Config, d *sc
 		return "", err
 	}
 
-	resourceIds, err := common.GetResourceIDsByOrder(bssClient, orderId, 0)
+	resourceIds, err := cbc.GetResourceIDsByOrder(bssClient, orderId, 0)
 	if err != nil {
 		return "", fmt.Errorf("error retrieving resource IDs of DDS instance readonly node order (%s): %s", orderId, err)
 	}

--- a/huaweicloud/services/deh/resource_huaweicloud_deh_instance.go
+++ b/huaweicloud/services/deh/resource_huaweicloud_deh_instance.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -494,7 +495,7 @@ func resourceDehInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the DEH instance (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
@@ -506,7 +506,7 @@ func resourceElasticResourcePoolUpdate(ctx context.Context, d *schema.ResourceDa
 			return diag.Errorf("error creating BSS client: %s", err)
 		}
 
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), resourceId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), resourceId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the elastic resource pool (%s): %s", resourceId, err)
 		}
 	}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
@@ -1256,7 +1256,7 @@ func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		if err != nil || len(resourceIDs) == 0 {
 			return diag.Errorf("error getting resource IDs: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), resourceIDs[0]); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), resourceIDs[0]); err != nil {
 			return diag.Errorf("error updating the auto-renew of DRS job (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -1251,7 +1252,7 @@ func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	if d.HasChange("auto_renew") {
 		// resource_id is different from job_id
-		resourceIDs, err := common.GetResourceIDsByOrder(bssClient, d.Get("order_id").(string), 1)
+		resourceIDs, err := cbc.GetResourceIDsByOrder(bssClient, d.Get("order_id").(string), 1)
 		if err != nil || len(resourceIDs) == 0 {
 			return diag.Errorf("error getting resource IDs: %s", err)
 		}
@@ -1408,7 +1409,7 @@ func waitForOrderDetail(ctx context.Context, bssV2Client *golangsdk.ServiceClien
 		Pending: []string{"pending"},
 		Target:  []string{"complete"},
 		Refresh: func() (interface{}, string, error) {
-			resourceIDs, err := common.GetResourceIDsByOrder(bssV2Client, orderId, 1)
+			resourceIDs, err := cbc.GetResourceIDsByOrder(bssV2Client, orderId, 1)
 			if err != nil {
 				if strings.Contains(err.Error(), "response empty") {
 					return resourceIDs, "pending", nil
@@ -1461,7 +1462,7 @@ func resourceJobDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		resourceIDs, err := common.GetResourceIDsByOrder(bssV2Client, orderId, 1)
+		resourceIDs, err := cbc.GetResourceIDsByOrder(bssV2Client, orderId, 1)
 		if err != nil {
 			return diag.Errorf("error getting resource IDs: %s", err)
 		}

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -726,7 +726,7 @@ func resourceComputeInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 		extendParam.PeriodType = d.Get("period_unit").(string)
 		extendParam.PeriodNum = d.Get("period").(int)
 		extendParam.IsAutoRenew = d.Get("auto_renew").(string)
-		extendParam.IsAutoPay = common.GetAutoPay(d)
+		extendParam.IsAutoPay = cbc.GetAutoPay(d)
 	} else if chargingMode == "spot" {
 		extendParam.MarketType = "spot"
 		extendParam.SpotPrice = d.Get("spot_maximum_price").(string)
@@ -1264,7 +1264,7 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 
 		extendParam := &cloudservers.ResizeExtendParam{
-			AutoPay: common.GetAutoPay(d),
+			AutoPay: cbc.GetAutoPay(d),
 		}
 		resizeOpts := &cloudservers.ResizeOpts{
 			FlavorRef:   newFlavorId,
@@ -1322,7 +1322,7 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		if strings.EqualFold(d.Get("charging_mode").(string), "prePaid") {
 			extendOpts.ChargeInfo = &cloudvolumes.ExtendChargeOpts{
-				IsAutoPay: common.GetAutoPay(d),
+				IsAutoPay: cbc.GetAutoPay(d),
 			}
 		}
 

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -1148,7 +1149,7 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 			return diag.FromErr(err)
 		}
 	} else if d.HasChange("auto_renew") {
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), serverID); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), serverID); err != nil {
 			return diag.Errorf("error updating the auto-renew of the instance (%s): %s", serverID, err)
 		}
 	}

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 )
 
 // @API EIP POST /v2.0/{project_id}/bandwidths/change-to-period
@@ -278,7 +279,7 @@ func resourceVpcBandWidthV2Update(ctx context.Context, d *schema.ResourceData, m
 			return err
 		}
 	} else if d.HasChange("auto_renew") {
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), bwID); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), bwID); err != nil {
 			return diag.Errorf("error updating the auto-renew of the bandwidth (%s): %s", bwID, err)
 		}
 	}

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
@@ -306,7 +306,7 @@ func buildVpcEipCreateOpts(cfg *config.Config, d *schema.ResourceData, isPrePaid
 			PeriodType:  d.Get("period_unit").(string),
 			PeriodNum:   d.Get("period").(int),
 			IsAutoRenew: d.Get("auto_renew").(string),
-			IsAutoPay:   common.GetAutoPay(d),
+			IsAutoPay:   cbc.GetAutoPay(d),
 		}
 	}
 	return result, nil
@@ -626,7 +626,7 @@ func updateEipBandwidth(vpcV1Client *golangsdk.ServiceClient, cfg *config.Config
 				Size: newMap["size"].(int),
 			},
 			ExtendParam: &bandwidthsv2.ExtendParam{
-				IsAutoPay: common.GetAutoPay(d),
+				IsAutoPay: cbc.GetAutoPay(d),
 			},
 		}
 		log.Printf("[DEBUG] Bandwidth Update Options: %#v", updateOpts)

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -731,7 +732,7 @@ func resourceVpcEipUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			return diag.FromErr(err)
 		}
 	} else if d.HasChange("auto_renew") {
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the EIP (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -611,7 +612,7 @@ func resourceLoadBalancerV3Update(ctx context.Context, d *schema.ResourceData, m
 			return diag.FromErr(err)
 		}
 	} else if d.HasChange("auto_renew") {
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the load balancer (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer_copy.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer_copy.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -491,7 +492,7 @@ func resourceLoadBalancerCopyUpdate(ctx context.Context, d *schema.ResourceData,
 			return diag.FromErr(err)
 		}
 	} else if d.HasChange("auto_renew") {
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the load-balancer (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
@@ -370,7 +370,7 @@ func buildBssParamBodyParams(d *schema.ResourceData) map[string]interface{} {
 			"periodType":   utils.ValueIgnoreEmpty(d.Get("period_unit")),
 			"periodNum":    utils.ValueIgnoreEmpty(d.Get("period")),
 			"isAutoRenew":  utils.ValueIgnoreEmpty(d.Get("auto_renew")),
-			"isAutoPay":    utils.ValueIgnoreEmpty(common.GetAutoPay(d)),
+			"isAutoPay":    utils.ValueIgnoreEmpty(cbc.GetAutoPay(d)),
 		}
 	}
 
@@ -733,7 +733,7 @@ func buildUpdateVolumeSizeBodyParams(d *schema.ResourceData) map[string]interfac
 
 	if d.Get("charging_mode").(string) == "prePaid" {
 		bodyParams["bssParam"] = map[string]interface{}{
-			"isAutoPay": common.GetAutoPay(d),
+			"isAutoPay": cbc.GetAutoPay(d),
 		}
 	}
 
@@ -805,7 +805,7 @@ func buildUpdateVolumeTypeBodyParams(d *schema.ResourceData) map[string]interfac
 
 	if d.Get("charging_mode").(string) == "prePaid" {
 		bodyParams["bssParam"] = map[string]interface{}{
-			"isAutoPay": common.GetAutoPay(d),
+			"isAutoPay": cbc.GetAutoPay(d),
 		}
 	}
 

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
@@ -20,6 +20,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -955,7 +956,7 @@ func resourceEvsVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the volume (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_instance.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -1240,7 +1241,7 @@ func resourceOpenGaussInstanceUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if d.HasChange("auto_renew") {
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the instance (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_gaussdb_cassandra_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_gaussdb_cassandra_instance.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -1072,7 +1073,7 @@ func resourceGeminiDBInstanceV3Update(ctx context.Context, d *schema.ResourceDat
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the instance (%s): %s", instanceId, err)
 		}
 	}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_gaussdb_redis_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_gaussdb_redis_instance.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -713,7 +714,7 @@ func resourceGaussRedisInstanceV3Update(ctx context.Context, d *schema.ResourceD
 	}
 
 	if d.HasChange("auto_renew") {
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the instance (%s): %s", instanceId, err)
 		}
 	}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_gaussdb_redis_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_gaussdb_redis_instance.go
@@ -427,7 +427,7 @@ func resourceGaussRedisInstanceV3Create(ctx context.Context, d *schema.ResourceD
 			ChargingMode: d.Get("charging_mode").(string),
 			PeriodType:   d.Get("period_unit").(string),
 			PeriodNum:    d.Get("period").(int),
-			IsAutoPay:    common.GetAutoPay(d),
+			IsAutoPay:    cbc.GetAutoPay(d),
 			IsAutoRenew:  d.Get("auto_renew").(string),
 		}
 		createOpts.ChargeInfo = chargeInfo
@@ -786,7 +786,7 @@ func gaussRedisInstanceUpdateVolumeSize(ctx context.Context, d *schema.ResourceD
 		Size: d.Get("volume_size").(int),
 	}
 	if d.Get("charging_mode") == "prePaid" {
-		extendOpts.IsAutoPay = common.GetAutoPay(d)
+		extendOpts.IsAutoPay = cbc.GetAutoPay(d)
 	}
 
 	var res *instances.ExtendResponse
@@ -888,7 +888,7 @@ func gaussRedisInstanceEnlargeNodeNum(ctx context.Context, d *schema.ResourceDat
 		Num: expandSize,
 	}
 	if d.Get("charging_mode") == "prePaid" {
-		enlargeNodeOpts.IsAutoPay = common.GetAutoPay(d)
+		enlargeNodeOpts.IsAutoPay = cbc.GetAutoPay(d)
 	}
 	log.Printf("[DEBUG] enlarge node options: %+v", enlargeNodeOpts)
 
@@ -1038,7 +1038,7 @@ func gaussRedisInstanceUpdateFlavor(ctx context.Context, d *schema.ResourceData,
 		},
 	}
 	if d.Get("charging_mode") == "prePaid" {
-		resizeOpts.IsAutoPay = common.GetAutoPay(d)
+		resizeOpts.IsAutoPay = cbc.GetAutoPay(d)
 	}
 
 	var res *instances.ExtendResponse

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -909,7 +910,7 @@ func resourceGeminiDbInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if d.HasChange("auto_renew") {
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the GeminiDB instance (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_quota.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_quota.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -319,7 +320,7 @@ func resourceQuotaUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
 
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), quotaId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), quotaId); err != nil {
 			return diag.Errorf("error updating the auto_renew of the HSS quota (%s): %s", quotaId, err)
 		}
 	}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_instance.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -1656,7 +1657,7 @@ func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the Kafka instance (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -501,7 +502,7 @@ func resourceLoadBalancerV2Update(ctx context.Context, d *schema.ResourceData, m
 			return diag.FromErr(err)
 		}
 	} else if d.HasChange("auto_renew") {
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the load-balancer (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -506,7 +507,7 @@ func resourceDevServerUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		if err != nil {
 			return diag.Errorf("error creating BSS client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), devServerId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), devServerId); err != nil {
 			return diag.Errorf("error updating the auto_renew of the DevServer (%s): %s", devServerId, err)
 		}
 	}

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_cluster.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -1435,7 +1436,7 @@ func resourceMRSClusterV2Update(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if d.HasChange("auto_renew") {
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), clusterId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), clusterId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the cluster (%s): %s", clusterId, err)
 		}
 	}

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -456,7 +457,7 @@ func resourcePublicGatewayUpdate(ctx context.Context, d *schema.ResourceData, me
 			return diag.FromErr(err)
 		}
 	} else if d.HasChange("auto_renew") {
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the NAT gateway (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/nat/resource_huaweicloud_natv3_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_natv3_gateway.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -497,7 +498,7 @@ func resourcePublicGatewayV3Update(ctx context.Context, d *schema.ResourceData, 
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the NAT gateway (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
@@ -23,6 +23,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -1408,7 +1409,7 @@ func resourceRdsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceID); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceID); err != nil {
 			return diag.Errorf("error updating the auto-renew of the instance (%s): %s", instanceID, err)
 		}
 	}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -582,7 +583,7 @@ func updateRdsInstanceAutoRenew(d *schema.ResourceData, config *config.Config) e
 		if err != nil {
 			return fmt.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return fmt.Errorf("error updating the auto-renew of the instance (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/rocketmq/resource_huaweicloud_dms_rocketmq_instance.go
+++ b/huaweicloud/services/rocketmq/resource_huaweicloud_dms_rocketmq_instance.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/kafka"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -695,7 +696,7 @@ func resourceDmsRocketMQInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the RocketMQ instance (%s): %s", instanceId, err)
 		}
 	}

--- a/huaweicloud/services/sfsturbo/resource_huaweicloud_sfs_turbo.go
+++ b/huaweicloud/services/sfsturbo/resource_huaweicloud_sfs_turbo.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -655,7 +656,7 @@ func resourceSFSTurboUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), d.Id()); err != nil {
 			return diag.Errorf("error updating the auto-renew of the SFS Turbo (%s): %s", d.Id(), err)
 		}
 	}

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_instance.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_instance.go
@@ -714,7 +714,7 @@ func resourceGaussDBInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 			PeriodType:   d.Get("period_unit").(string),
 			PeriodNum:    d.Get("period").(int),
 			IsAutoRenew:  d.Get("auto_renew").(string),
-			IsAutoPay:    common.GetAutoPay(d),
+			IsAutoPay:    cbc.GetAutoPay(d),
 		}
 		createOpts.ChargeInfo = chargeInfo
 	}
@@ -1613,7 +1613,7 @@ func updateInstanceFlavor(ctx context.Context, client, bssClient *golangsdk.Serv
 		},
 	}
 	if d.Get("charging_mode") == "prePaid" {
-		resizeOpts.IsAutoPay = common.GetAutoPay(d)
+		resizeOpts.IsAutoPay = cbc.GetAutoPay(d)
 	}
 	retryFunc := func() (interface{}, bool, error) {
 		res, err := instances.Resize(client, d.Id(), resizeOpts).ExtractJobResponse()
@@ -1691,7 +1691,7 @@ func createInstanceReadReplica(ctx context.Context, client, bssClient *golangsdk
 		Priorities: priorities,
 	}
 	if d.Get("charging_mode") == "prePaid" {
-		createReplicaOpts.IsAutoPay = common.GetAutoPay(d)
+		createReplicaOpts.IsAutoPay = cbc.GetAutoPay(d)
 	}
 	retryFunc := func() (interface{}, bool, error) {
 		res, err := instances.CreateReplica(client, d.Id(), createReplicaOpts).ExtractJobResponse()
@@ -1816,7 +1816,7 @@ func deleteInstanceReadReplica(ctx context.Context, client, bssClient *golangsdk
 func updateInstanceVolumeSize(ctx context.Context, client, bssClient *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	extendOpts := instances.ExtendVolumeOpts{
 		Size:      d.Get("volume_size").(int),
-		IsAutoPay: common.GetAutoPay(d),
+		IsAutoPay: cbc.GetAutoPay(d),
 	}
 	retryFunc := func() (interface{}, bool, error) {
 		res, err := instances.ExtendVolume(client, d.Id(), extendOpts).ExtractJobResponse()

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_instance.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_instance.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -1490,7 +1491,7 @@ func resourceGaussDBInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if d.HasChange("auto_renew") {
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the instance (%s): %s", instanceId, err)
 		}
 	}

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -524,7 +525,7 @@ func resourceCloudInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), instanceId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the cloud WAF (%s): %s", instanceId, err)
 		}
 	}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_server.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -466,7 +467,7 @@ func resourceAppServerUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
-		if err = common.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), serverId); err != nil {
+		if err = cbc.UpdateAutoRenew(bssClient, d.Get("auto_renew").(string), serverId); err != nil {
 			return diag.Errorf("error updating the auto-renew of the server (%s): %s", serverId, err)
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Move cbc common function into cbc package

**Which issue this PR fixes**:

**Special notes for your reviewer**:
To verify the function relocation between files, you can use the go build command. If any references are broken, the compilation will fail with the following error messages:

<img width="1760" height="196" alt="32e05903-7198-43d7-9f1b-a77c1c74a664" src="https://github.com/user-attachments/assets/d7373019-cb3a-434c-9acf-f8436aa91335" />

**Release note**:

```release-note
1. change file `common/common.go`
2. change file `services/cbc/common.go`
3. change import files.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.