### PR TITLE
feat(RDS): add rds publication subscription profiles data source

### DIFF
--- a/docs/data-sources/rds_publication_publication_subscription_profiles.md
+++ b/docs/data-sources/rds_publication_publication_subscription_profiles.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Relational Database Service (RDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rds_publication_subscription_profiles"
+description: |-
+  Use this data source to query the list of RDS publication and subscription profiles within HuaweiCloud.
+---
+
+# huaweicloud_rds_publication_subscription_profiles
+
+Use this data source to query the list of RDS publication and subscription profiles within HuaweiCloud.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_rds_publication_subscription_profiles" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the replication profiles.  
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RDS instance.
+
+* `agent_type` - (Optional, String) Specifies the agent type to filter profiles.  
+  The valid values are as follows:
+  + **snapshot**: Snapshot agent.
+  + **log_reader**: Log reader agent.
+  + **distribution**: Distribution agent.
+  + **merge**: Merge agent.
+  + **queue_reader**: Queue reader agent.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `profiles` - The list of replication profiles.  
+  The [profiles](#replication_profiles_profiles) structure is documented below.
+
+<a name="replication_profiles_profiles"></a>
+The `profiles` block supports:
+
+* `profile_id` - The ID of the profile.
+
+* `profile_name` - The name of the profile.
+
+* `agent_type` - The agent type of the profile.  
+  The valid values are as follows:
+  + **snapshot**: Snapshot agent.
+  + **log_reader**: Log reader agent.
+  + **distribution**: Distribution agent.
+  + **merge**: Merge agent.
+  + **queue_reader**: Queue reader agent.
+
+* `description` - The description of the profile.
+
+* `is_def_profile` - Whether the profile is the default configuration.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2038,6 +2038,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_publication_monitor":                rds.DataSourceRdsPublicationMonitor(),
 			"huaweicloud_rds_subscriptions":                      rds.DataSourceRdsSubscriptions(),
 			"huaweicloud_rds_subscription_monitor":               rds.DataSourceRdsSubscriptionMonitor(),
+			"huaweicloud_rds_publication_subscription_profiles":  rds.DataSourceRdsPublicationSubscriptionProfiles(),
 			"huaweicloud_rds_configurable_distributor_instances": rds.DataSourceRdsConfigurableDistributorInstances(),
 			"huaweicloud_rds_configurable_subscriber_instances":  rds.DataSourceRdsConfigurableSubscriberInstances(),
 			"huaweicloud_rds_remote_databases":                   rds.DataSourceRemoteDatabases(),

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_publication_subscription_profiles_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_publication_subscription_profiles_test.go
@@ -1,0 +1,62 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRdsPublicationSubscriptionProfiles_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_rds_publication_subscription_profiles.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRdsInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRdsReplicationProfiles_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "profiles.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "profiles.0.profile_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "profiles.0.profile_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "profiles.0.agent_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "profiles.0.is_def_profile"),
+					resource.TestCheckOutput("agent_type_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRdsReplicationProfiles_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_rds_publication_subscription_profiles" "test" {
+  instance_id = "%[1]s"
+}
+
+data "huaweicloud_rds_publication_subscription_profiles" "agent_type_filter" {
+  depends_on = [data.huaweicloud_rds_publication_subscription_profiles.test]
+
+  instance_id = "%[1]s"
+  agent_type  = data.huaweicloud_rds_publication_subscription_profiles.test.profiles[0].agent_type
+}
+locals {
+  agent_type =data.huaweicloud_rds_publication_subscription_profiles.test.profiles[0].agent_type
+}
+
+output "agent_type_filter_is_useful" {
+  value = length(data.huaweicloud_rds_publication_subscription_profiles.agent_type_filter.profiles) > 0 && alltrue(
+    [for v in data.huaweicloud_rds_publication_subscription_profiles.agent_type_filter.profiles[*].agent_type :
+    v == local.agent_type]
+  )
+}
+`, acceptance.HW_RDS_INSTANCE_ID)
+}

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_publication_subscription_profiles.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_publication_subscription_profiles.go
@@ -1,0 +1,156 @@
+package rds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RDS GET /v3/{project_id}/instances/{instance_id}/replication/profiles
+func DataSourceRdsPublicationSubscriptionProfiles() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRdsPublicationSubscriptionProfilesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"agent_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"profiles": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     publicationSubscriptionProfilesSchema(),
+			},
+		},
+	}
+}
+
+func publicationSubscriptionProfilesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"profile_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"profile_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"agent_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_def_profile": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRdsPublicationSubscriptionProfilesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("rds", region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	httpUrl := "v3/{project_id}/instances/{instance_id}/replication/profiles"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+	listPath += buildListPublicationSubscriptionProfilesQueryParams(d)
+
+	listResp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		listPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return diag.Errorf("error retrieving RDS publication and subscription profiles: %s", err)
+	}
+
+	listRespJson, err := json.Marshal(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var listRespBody interface{}
+	err = json.Unmarshal(listRespJson, &listRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("profiles", flattenListPublicationSubscriptionProfilesBody(listRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildListPublicationSubscriptionProfilesQueryParams(d *schema.ResourceData) string {
+	queryParams := "?limit=100"
+	if v, ok := d.GetOk("agent_type"); ok {
+		queryParams += fmt.Sprintf("&agent_type=%v", v)
+	}
+	return queryParams
+}
+
+func flattenListPublicationSubscriptionProfilesBody(resp interface{}) []map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	profiles := utils.PathSearch("profiles", resp, make([]interface{}, 0)).([]interface{})
+	if len(profiles) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(profiles))
+	for i, profile := range profiles {
+		result[i] = map[string]interface{}{
+			"profile_id":     utils.PathSearch("profile_id", profile, nil),
+			"profile_name":   utils.PathSearch("profile_name", profile, nil),
+			"agent_type":     utils.PathSearch("agent_type", profile, nil),
+			"description":    utils.PathSearch("description", profile, nil),
+			"is_def_profile": utils.PathSearch("is_def_profile", profile, nil),
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add rds publication subscription profiles data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add rds publication subscription profiles data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TESt=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDataSourceRdsPublicationSubscriptionProfiles_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDataSourceRdsPublicationSubscriptionProfiles_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRdsPublicationSubscriptionProfiles_basic
=== PAUSE TestAccDataSourceRdsPublicationSubscriptionProfiles_basic
=== CONT  TestAccDataSourceRdsPublicationSubscriptionProfiles_basic
--- PASS: TestAccDataSourceRdsPublicationSubscriptionProfiles_basic (59.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       60.037s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
