### PR TITLE
feat(eip): support `vpc_eip_bandwidth_rule` resource

### DIFF
--- a/docs/resources/vpc_eip_bandwidth_rule.md
+++ b/docs/resources/vpc_eip_bandwidth_rule.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpc_eip_bandwidth_rule"
+description: |-
+  Manages a VPC EIP bandwidth rule resource within HuaweiCloud.
+---
+
+# huaweicloud_vpc_eip_bandwidth_rule
+
+Manages a VPC EIP bandwidth rule resource within HuaweiCloud.
+
+-> This resource is a one-time action resource used to create a bandwidth rule for shared bandwidth.
+Please enable the enterprise-level QoS feature before creating the bandwidth rule.
+Deleting this resource will not delete the actual bandwidth rule on the cloud, but will only remove the resource
+information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "bandwidth_id" {}
+variable "publicip_id" {}
+variable "name" {}
+
+resource "huaweicloud_vpc_eip_bandwidth_rule" "test" {
+  bandwidth_id          = var.bandwidth_id 
+  name                  = var.name 
+  egress_size           = 20 
+  egress_guarented_size = 10
+  
+  publicip_info { 
+    publicip_id = var.publicip_id 
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the VPC EIP associate resource. If
+  omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `bandwidth_id` - (Required, String, NonUpdatable) Specifies the ID of the shared bandwidth to which the rule belongs.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the bandwidth rule.  
+  The value can contain 1 to 64 characters, including letters, digits, Chinese characters, underscores (_), hyphens (-),
+  and periods (.).
+
+* `egress_size` - (Required, Int, NonUpdatable) Specifies the outbound bandwidth size (Mbit/s) for the bandwidth rule.
+
+* `egress_guarented_size` - (Required, Int, NonUpdatable) Specifies the guarented outbound bandwidth size (Mbit/s) for the
+  bandwidth rule. This value must be less than or equal to `egress_size`.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the bandwidth rule.
+
+* `publicip_info` - (Required, List, NonUpdatable) Specifies the public IP information associated with the bandwidth rule.
+
+The [publicip_info](#publicip_info_struct) structure is documented below.
+
+<a name="publicip_info_struct"></a>
+The `publicip_info` block supports:
+
+* `publicip_id` - (Required, String, ForceNew) Specifies the ID of the public IP address to be associated with the
+  bandwidth rule.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4232,6 +4232,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_vpc_bandwidth":           eip.ResourceVpcBandWidthV2(),
 			"huaweicloud_vpc_bandwidth_associate": eip.ResourceBandWidthAssociate(),
+			"huaweicloud_vpc_eip_bandwidth_rule":  eip.ResourceEipBandwidthRule(),
 			"huaweicloud_vpc_eip":                 eip.ResourceVpcEIPV1(),
 			"huaweicloud_vpc_eip_associate":       eip.ResourceEIPAssociate(),
 			"huaweicloud_vpc_eipv3_associate":     eip.ResourceEipv3Associate(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -77,6 +77,7 @@ var (
 	HW_CBR_DESTINATION_VAULT_ID   = os.Getenv("HW_CBR_DESTINATION_VAULT_ID")   // The destination vault ID.
 
 	HW_VPC_BANDWIDTH_ADDON_PACKAGE_ENABLED = os.Getenv("HW_VPC_BANDWIDTH_ADDON_PACKAGE_ENABLED")
+	HW_VPC_BANDWIDTH_NAME                  = os.Getenv("HW_VPC_BANDWIDTH_NAME")
 	HW_VPC_EIP_POOL_ENABLED                = os.Getenv("HW_VPC_EIP_POOL_ENABLED")
 
 	HW_APIG_DEDICATED_INSTANCE_ID             = os.Getenv("HW_APIG_DEDICATED_INSTANCE_ID")
@@ -4726,6 +4727,13 @@ func TestAccPreCheckVpcEipPoolEnabled(t *testing.T) {
 func TestAccPreCheckVpcEipBandwidthAddOnPackageEnabled(t *testing.T) {
 	if HW_VPC_BANDWIDTH_ADDON_PACKAGE_ENABLED == "" {
 		t.Skip("HW_VPC_BANDWIDTH_ADDON_PACKAGE_ENABLED must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckVpcEipBandwidthName(t *testing.T) {
+	if HW_VPC_BANDWIDTH_NAME == "" {
+		t.Skip("HW_VPC_BANDWIDTH_NAME must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_bandwidth_rule_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_bandwidth_rule_test.go
@@ -1,0 +1,54 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccEipBandwidthRule_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_vpc_eip_bandwidth_rule.test"
+		rName        = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckVpcEipBandwidthName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEipBandwidthRule_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEipBandwidthRule_basic(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_vpc_bandwidth" "test" {
+  name = "%s"
+}
+
+resource "huaweicloud_vpc_eip_bandwidth_rule" "test" {
+  bandwidth_id           = data.huaweicloud_vpc_bandwidth.test.id
+  name                   = "%s"
+  egress_size            = 10
+  egress_guarented_size  = 10
+  description            = "test bandwidth rule with public IP"
+  
+  publicip_info {
+    publicip_id = data.huaweicloud_vpc_bandwidth.test.publicips[0].id
+  }
+}
+`, acceptance.HW_VPC_BANDWIDTH_NAME, rName)
+}

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip_bandwidth_rule.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip_bandwidth_rule.go
@@ -1,0 +1,186 @@
+package eip
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var eipBandwidthRuleNonUpdatableParams = []string{
+	"bandwidth_id",
+	"name",
+	"egress_size",
+	"egress_guarented_size",
+	"description",
+	"publicip_info",
+	"publicip_info.*.publicip_id",
+}
+
+// Currently, only the API creation and deployment are complete.
+// We're doing a one-time resource allocation; further improvements will be needed
+// after the three subsequent APIs are deployed.
+// @API EIP POST /v3/{project_id}/eip/bandwidths/{bandwidth_id}/bandwidth-rules
+func ResourceEipBandwidthRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEipBandwidthRuleCreate,
+		ReadContext:   resourceEipBandwidthRuleRead,
+		UpdateContext: resourceEipBandwidthRuleUpdate,
+		DeleteContext: resourceEipBandwidthRuleDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(eipBandwidthRuleNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"bandwidth_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"egress_size": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"egress_guarented_size": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"publicip_info": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"publicip_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildEipBandwidthRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	publicIpInfoRaw := d.Get("publicip_info").([]interface{})
+
+	var publicIpInfoList []map[string]interface{}
+	for _, v := range publicIpInfoRaw {
+		if item, ok := v.(map[string]interface{}); ok {
+			publicIpInfoList = append(publicIpInfoList, map[string]interface{}{
+				"publicip_id": item["publicip_id"],
+			})
+		}
+	}
+
+	bodyParams := map[string]interface{}{
+		"bandwidth_rule": map[string]interface{}{
+			"name":                  d.Get("name"),
+			"egress_size":           d.Get("egress_size"),
+			"egress_guarented_size": d.Get("egress_guarented_size"),
+			"description":           utils.ValueIgnoreEmpty(d.Get("description")),
+			"publicip_info":         publicIpInfoList,
+		},
+	}
+	return bodyParams
+}
+
+func resourceEipBandwidthRuleCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		product     = "vpc"
+		bandwidthId = d.Get("bandwidth_id").(string)
+		httpUrl     = "v3/{project_id}/eip/bandwidths/{bandwidth_id}/bandwidth-rules"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate request ID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{bandwidth_id}", bandwidthId)
+
+	opt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type":      "application/json",
+			"Client-Request-Id": requestId,
+		},
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildEipBandwidthRuleBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating EIP bandwidth rule: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	ruleId := utils.PathSearch("bandwidth_rule.id", respBody, "").(string)
+	if ruleId == "" {
+		return diag.Errorf("unable to find the bandwidth rule ID from the API response")
+	}
+
+	d.SetId(ruleId)
+
+	return nil
+}
+
+func resourceEipBandwidthRuleRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Read()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceEipBandwidthRuleUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Update()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceEipBandwidthRuleDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to create a bandwidth rule for shared bandwidth. 
+Please enable the enterprise-level QoS feature before creating the bandwidth rule.
+Deleting this resource will not delete the actual bandwidth rule on the cloud, but will only remove the resource 
+information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `vpc_eip_bandwidth_rule` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `vpc_eip_bandwidth_rule` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccEipBandwidthRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw-v -run TestAccEipBandwidthRule_basic -timeout 360m -parallel 4
=== RUN   TestAccEipBandwidthRule_basic
=== PAUSE TestAccEipBandwidthRule_basic
=== CONT  TestAccEipBandwidthRule_basic
--- PASS: TestAccEipBandwidthRule_basic (12.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       21.311s
```
<img width="924" height="31" alt="image" src="https://github.com/user-attachments/assets/68d1caa9-0d2d-4957-9b92-2beb92a3bdf9" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
