### PR TITLE
docs(cfw): update api to batch delete address groups

### DIFF
--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_batch_delete_address_groups.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_batch_delete_address_groups.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API CFW POST /v1/{project_id}/address-groups/batch-delete
+// @API CFW POST /v1/{project_id}/address-sets/batch-delete
 func ResourceBatchDeleteAddressGroups() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceBatchDeleteAddressGroupsCreate,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

update api to batch delete address groups

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
update api to batch delete address groups
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o cfw -f TestAccBatchDeleteAddressGroups_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cfw" -v -coverprofile="./huaweicloud/services/acceptance/cfw/cfw_coverage.cov" -coverpkg="./huaweicloud/services/cfw" -run TestAccBatchDeleteAddressGroups_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchDeleteAddressGroups_basic
=== PAUSE TestAccBatchDeleteAddressGroups_basic
=== CONT  TestAccBatchDeleteAddressGroups_basic
--- PASS: TestAccBatchDeleteAddressGroups_basic (42.96s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/cfw
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       43.052s coverage: 4.7% of statements in ./huaweicloud/services/cfw
```
<img width="1013" height="41" alt="Snipaste_2026-04-28_17-53-21" src="https://github.com/user-attachments/assets/ca4123d7-51b4-4c1c-8e34-5ff115a2fbca" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
