### PR TITLE
feat(obs): obs bucket encryption support new fields

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -228,19 +228,40 @@ The following arguments are supported:
   bucket, but the name of a deleted bucket can be reused for another bucket at least 30 minutes after the deletion.
   Exercise caution when changing this field.
 
-* `encryption` - (Optional, Bool) Whether to enable default server-side encryption of the bucket.
+* `encryption` - (Optional, Bool) Specifies whether to enable default server-side encryption of the bucket.
+
+  -> Fields `sse_algorithm`, `kms_key_id`, `kms_key_project_id`, `kms_data_encryption`, and `bucket_key_enabled` are
+  valid only when `encryption` is set to **true**.
 
 * `sse_algorithm` - (Optional, String) Specifies the mode of encryption algorithm. The valid values are:
-  + **kms**: Server-side encryption with keys hosted by KMS are used to encrypt your objects.
-  + **AES256**: Server-side encryption with keys managed by OBS are used to encrypt your objects.
+  + **kms**: SSE-KMS encryption and the AES256 algorithm are used. If you need to use the SM4 encryption algorithm, you
+    also need to configure `kms_data_encryption`.
+  + **AES256**: SSE-OBS encryption and the AES256 algorithm are used.
 
   Defaults to **kms**.
 
-* `kms_key_id` - (Optional, String) Specifies the ID of a KMS key. If omitted, the default master key will be used. This
-  field is used only when `sse_algorithm` value is **kms**.
+* `kms_key_id` - (Optional, String) Specifies the KMS master key ID used in SSE-KMS encryption.
+  This field is used only when `sse_algorithm` value is **kms**.
+  
+  -> 1. If this parameter is not specified, the default master key will be used.
+  <br/>2. If `kms_key_enabled` is set to **true**, the value of `kms_key_id` is the ID of the master key created on KMS.
 
-* `kms_key_project_id` - (Optional, String) Specifies the project ID to which the KMS key belongs. This field is valid
-  only when `kms_key_id` is specified.
+* `kms_key_project_id` - (Optional, String) Specifies the ID of the project where the KMS master key belongs when
+  SSE-KMS is used. This field is valid only when `kms_key_id` is specified.
+
+  -> 1. If the project is not the default one, you must use this parameter to specify the project ID.
+  <br/>2. If `kms_key_id` is not specified, do not set the project ID.
+  <br/>3. If a custom key in a non-default IAM project is used to encrypt objects, only the key owner can upload or
+  download the encrypted objects.
+
+* `kms_data_encryption` - (Optional, String) Specifies the data encryption algorithm under SSE-KMS encryption method.
+  Valid value is **SM4**, which means the Chinese national cryptographic algorithm SM4.
+
+* `bucket_key_enabled` - (Optional, String) Specifies whether to enable the OBS bucket key feature.
+  Valid values are **true** and **false**.
+
+  -> 1. This parameter is only supported when `sse_algorithm` is set to **kms**.
+  <br/>2. When configuring a POSIX bucket, this parameter should be set to **true**, and `kms_key_id` is required.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the OBS bucket.
   Defaults to `0`.

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
@@ -168,8 +168,8 @@ func TestAccObsBucket_parallelFS(t *testing.T) {
 }
 
 func TestAccObsBucket_encryption(t *testing.T) {
-	rInt := acctest.RandInt()
-	resourceName := "huaweicloud_obs_bucket.bucket"
+	resourceName := "huaweicloud_obs_bucket.test"
+	rName := acceptance.RandomAccResourceNameWithDash()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -180,58 +180,47 @@ func TestAccObsBucket_encryption(t *testing.T) {
 		CheckDestroy:      testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObsBucket_basic(rInt),
+				Config: testAccObsBucket_encryption(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObsBucketExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "bucket", testAccObsBucketName(rInt)),
-					resource.TestCheckResourceAttr(resourceName, "bucket_domain_name", testAccObsBucketDomainName(rInt)),
+					resource.TestCheckResourceAttr(resourceName, "bucket", rName),
 					resource.TestCheckResourceAttr(resourceName, "acl", "private"),
+					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "kms_data_encryption", "SM4"),
+					resource.TestCheckResourceAttr(resourceName, "sse_algorithm", "kms"),
 					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
-					resource.TestCheckResourceAttr(resourceName, "encryption", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "bucket_domain_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "bucket_version"),
 				),
 			},
 			{
-				Config: testAccObsBucket_encryption(rInt),
+				Config: testAccObsBucket_encryption_update1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bucket", rName),
+					resource.TestCheckResourceAttr(resourceName, "acl", "private"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_key_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
-					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
-				),
-			},
-			{
-				Config: testAccObsBucket_encryptionByDefaultKMSMasterKey(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObsBucketExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
-					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
-				),
-			},
-			{
-				Config: testAccObsBucket_encryptionBySSEObsMode(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObsBucketExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
-					resource.TestCheckResourceAttr(resourceName, "sse_algorithm", "AES256"),
-				),
-			},
-			{
-				Config: testAccObsBucket_updateEncryptionToSSEKMSMode(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObsBucketExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "kms_data_encryption", "SM4"),
 					resource.TestCheckResourceAttr(resourceName, "sse_algorithm", "kms"),
 				),
 			},
 			{
-				Config: testAccObsBucket_basic(rInt),
+				Config: testAccObsBucket_encryption_update2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObsBucketExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "bucket", testAccObsBucketName(rInt)),
-					resource.TestCheckResourceAttr(resourceName, "bucket_domain_name", testAccObsBucketDomainName(rInt)),
-					resource.TestCheckResourceAttr(resourceName, "acl", "private"),
-					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
-					resource.TestCheckResourceAttr(resourceName, "encryption", "false"),
-					resource.TestCheckResourceAttr(resourceName, "sse_algorithm", ""),
+					resource.TestCheckResourceAttr(resourceName, "bucket_key_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "kms_data_encryption", ""),
+					resource.TestCheckResourceAttr(resourceName, "sse_algorithm", "AES256"),
+				),
+			},
+			{
+				Config: testAccObsBucket_encryption_update3(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sse_algorithm", "kms"),
 				),
 			},
 		},
@@ -587,48 +576,53 @@ resource "huaweicloud_obs_bucket" "bucket" {
 `, randInt)
 }
 
-func testAccObsBucket_encryption(randInt int) string {
+func testAccObsBucket_encryption(rName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_kms_key" "key_1" {
-  key_alias    = "kms-%d"
+resource "huaweicloud_obs_bucket" "test" {
+  bucket              = "%s"
+  storage_class       = "STANDARD"
+  acl                 = "private"
+  encryption          = true
+  sse_algorithm       = "kms"
+  kms_data_encryption = "SM4"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, rName)
+}
+
+func testAccObsBucket_encryption_update1(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_key" "test" {
+  key_alias    = "%[1]s"
   pending_days = "7"
 }
 
-resource "huaweicloud_obs_bucket" "bucket" {
-  bucket        = "tf-test-bucket-%d"
-  storage_class = "STANDARD"
-  acl           = "private"
-  encryption    = true
-  kms_key_id    = huaweicloud_kms_key.key_1.id
+resource "huaweicloud_obs_bucket" "test" {
+  bucket              = "%[1]s"
+  storage_class       = "STANDARD"
+  acl                 = "private"
+  encryption          = true
+  sse_algorithm       = "kms"
+  kms_key_id          = huaweicloud_kms_key.test.id
+  kms_data_encryption = "SM4"
+  bucket_key_enabled  = "true"
 
   tags = {
     foo = "bar"
     key = "value"
   }
 }
-`, randInt, randInt)
+`, rName)
 }
 
-func testAccObsBucket_encryptionByDefaultKMSMasterKey(randInt int) string {
+func testAccObsBucket_encryption_update2(rName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_obs_bucket" "bucket" {
-  bucket        = "tf-test-bucket-%d"
-  storage_class = "STANDARD"
-  acl           = "private"
-  encryption    = true
-
-  tags = {
-    foo = "bar"
-    key = "value"
-  }
-}
-`, randInt)
-}
-
-func testAccObsBucket_encryptionBySSEObsMode(randInt int) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_obs_bucket" "bucket" {
-  bucket        = "tf-test-bucket-%d"
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[1]s"
   storage_class = "STANDARD"
   acl           = "private"
   encryption    = true
@@ -639,13 +633,13 @@ resource "huaweicloud_obs_bucket" "bucket" {
     key = "value"
   }
 }
-`, randInt)
+`, rName)
 }
 
-func testAccObsBucket_updateEncryptionToSSEKMSMode(randInt int) string {
+func testAccObsBucket_encryption_update3(rName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_obs_bucket" "bucket" {
-  bucket        = "tf-test-bucket-%d"
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[1]s"
   storage_class = "STANDARD"
   acl           = "private"
   encryption    = true
@@ -656,7 +650,7 @@ resource "huaweicloud_obs_bucket" "bucket" {
     key = "value"
   }
 }
-`, randInt)
+`, rName)
 }
 
 func testAccObsBucket_epsId(randInt int, enterpriseProjectId string) string {

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -362,6 +363,16 @@ func ResourceObsBucket() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"kms_data_encryption": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"bucket_key_enabled": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -468,7 +479,15 @@ func resourceObsBucketUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
-	if d.HasChanges("encryption", "sse_algorithm", "kms_key_id", "kms_key_project_id") {
+	encryptionChangeFields := []string{
+		"encryption",
+		"sse_algorithm",
+		"kms_key_id",
+		"kms_key_project_id",
+		"kms_data_encryption",
+		"bucket_key_enabled",
+	}
+	if d.HasChanges(encryptionChangeFields...) {
 		if err := resourceObsBucketEncryptionUpdate(conf, obsClientWithSignature, d); err != nil {
 			return diag.FromErr(err)
 		}
@@ -796,6 +815,14 @@ func resourceObsBucketEncryptionUpdate(config *config.Config, obsClient *obs.Obs
 			if raw, ok := d.GetOk("kms_key_id"); ok {
 				input.KMSMasterKeyID = raw.(string)
 				input.ProjectID = d.Get("kms_key_project_id").(string)
+			}
+
+			if raw, ok := d.GetOk("kms_data_encryption"); ok {
+				input.KMSDataEncryption = raw.(string)
+			}
+
+			if raw, ok := d.GetOk("bucket_key_enabled"); ok {
+				input.BucketKeyEnabled = raw.(string) == "true"
 			}
 		}
 
@@ -1326,6 +1353,8 @@ func setObsBucketEncryption(obsClient *obs.ObsClient, d *schema.ResourceData) er
 					d.Set("kms_key_id", nil),
 					d.Set("kms_key_project_id", nil),
 					d.Set("sse_algorithm", nil),
+					d.Set("kms_data_encryption", nil),
+					d.Set("bucket_key_enabled", nil),
 				)
 				if mErr.ErrorOrNil() != nil {
 					return fmt.Errorf("error saving encryption of OBS bucket %s: %s", bucket, mErr)
@@ -1345,6 +1374,8 @@ func setObsBucketEncryption(obsClient *obs.ObsClient, d *schema.ResourceData) er
 			d.Set("kms_key_id", output.KMSMasterKeyID),
 			d.Set("kms_key_project_id", output.ProjectID),
 			d.Set("sse_algorithm", sseAlgorithm),
+			d.Set("kms_data_encryption", output.KMSDataEncryption),
+			d.Set("bucket_key_enabled", strconv.FormatBool(output.BucketKeyEnabled)),
 		)
 	} else {
 		mErr = multierror.Append(mErr,
@@ -1352,6 +1383,8 @@ func setObsBucketEncryption(obsClient *obs.ObsClient, d *schema.ResourceData) er
 			d.Set("kms_key_id", nil),
 			d.Set("kms_key_project_id", nil),
 			d.Set("sse_algorithm", nil),
+			d.Set("kms_data_encryption", nil),
+			d.Set("bucket_key_enabled", nil),
 		)
 	}
 	if mErr.ErrorOrNil() != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

obs bucket encryption support new fields

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o obs -f TestAccObsBucket_encryption
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccObsBucket_encryption -timeout 360m -parallel 10
=== RUN   TestAccObsBucket_encryption
=== PAUSE TestAccObsBucket_encryption
=== CONT  TestAccObsBucket_encryption
--- PASS: TestAccObsBucket_encryption (61.49s)
PASS
coverage: 17.1% of statements in ./huaweicloud/services/obs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       61.596s coverage: 17.1% of statements in ./huaweicloud/services/obs
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
