### PR TITLE
feat(obs): pfs support creating with encryption

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -163,6 +163,28 @@ resource "huaweicloud_obs_bucket" "bucket" {
 }
 ```
 
+### using parallel file system with encryption
+
+```hcl
+variable "kms_key_id" {}
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket              = "test-hang-3"
+  storage_class       = "STANDARD"
+  acl                 = "private"
+  parallel_fs         = true
+  encryption          = true
+  sse_algorithm       = "kms"
+  bucket_key_enabled  = "true"
+  kms_key_id          = var.kms_key_id
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -220,6 +242,10 @@ The following arguments are supported:
 
 * `parallel_fs` - (Optional, Bool, ForceNew) Whether enable a bucket as a parallel file system. Changing this will
   create a new bucket.
+
+  -> Currently, the parallel file system only supports KMS mode encryption. When configuring encryption for a parallel
+  file system, the following fields must be configured simultaneously: `encryption`, `sse_algorithm`, `kms_key_id`, and
+  `bucket_key_enabled`.
 
 * `multi_az` - (Optional, Bool, ForceNew) Whether enable the multi-AZ mode for the bucket. When the multi-AZ mode is
   enabled, data in the bucket is duplicated and stored in multiple AZs.

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
@@ -227,6 +227,51 @@ func TestAccObsBucket_encryption(t *testing.T) {
 	})
 }
 
+func TestAccObsBucket_encryptionWithPfs(t *testing.T) {
+	resourceName := "huaweicloud_obs_bucket.test"
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+			acceptance.TestAccPreCheckProjectID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucket_encryptionWithPfs(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bucket", rName),
+					resource.TestCheckResourceAttr(resourceName, "bucket_key_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "kms_data_encryption", "SM4"),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_project_id", acceptance.HW_PROJECT_ID),
+					resource.TestCheckResourceAttr(resourceName, "parallel_fs", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sse_algorithm", "kms"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", "huaweicloud_kms_key.test", "id"),
+				),
+			},
+			{
+				Config: testAccObsBucket_encryptionWithPfs_update1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bucket", rName),
+					resource.TestCheckResourceAttr(resourceName, "bucket_key_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "kms_data_encryption", "SM4"),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_project_id", acceptance.HW_PROJECT_ID),
+					resource.TestCheckResourceAttr(resourceName, "parallel_fs", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sse_algorithm", "kms"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", "huaweicloud_kms_key.test_another", "id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccObsBucket_versioning(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "huaweicloud_obs_bucket.bucket"
@@ -651,6 +696,50 @@ resource "huaweicloud_obs_bucket" "test" {
   }
 }
 `, rName)
+}
+
+func testAccObsBucket_encryptionWithPfs(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_key" "test" {
+  key_alias    = "%[1]s"
+  pending_days = "7"
+}
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket              = "%[1]s"
+  storage_class       = "STANDARD"
+  acl                 = "private"
+  parallel_fs         = true
+  encryption          = true
+  sse_algorithm       = "kms"
+  bucket_key_enabled  = "true"
+  kms_key_id          = huaweicloud_kms_key.test.id
+  kms_key_project_id  = "%[2]s"
+  kms_data_encryption = "SM4"
+}
+`, rName, acceptance.HW_PROJECT_ID)
+}
+
+func testAccObsBucket_encryptionWithPfs_update1(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_key" "test_another" {
+  key_alias    = "%[1]s_another"
+  pending_days = "7"
+}
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket              = "%[1]s"
+  storage_class       = "STANDARD"
+  acl                 = "private"
+  parallel_fs         = true
+  encryption          = true
+  sse_algorithm       = "kms"
+  bucket_key_enabled  = "true"
+  kms_key_id          = huaweicloud_kms_key.test_another.id
+  kms_key_project_id  = "%[2]s"
+  kms_data_encryption = "SM4"
+}
+`, rName, acceptance.HW_PROJECT_ID)
 }
 
 func testAccObsBucket_epsId(randInt int, enterpriseProjectId string) string {

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -397,10 +397,70 @@ func ResourceObsBucket() *schema.Resource {
 	}
 }
 
+func buildSideEncryptParam(d *schema.ResourceData) string {
+	if !d.Get("encryption").(bool) {
+		return ""
+	}
+
+	// For compatibility reasons, its default value is configured to be "kms".
+	sseAlgorithm := d.Get("sse_algorithm").(string)
+	if sseAlgorithm == "" {
+		return obs.DEFAULT_SSE_KMS_ENCRYPTION_OBS
+	}
+
+	// Due to differences between the API and SDK, "AES256" needs to be converted to "obs".
+	if sseAlgorithm == "AES256" {
+		return "obs"
+	}
+
+	return sseAlgorithm
+}
+
+func buildSideDataEncryptParam(d *schema.ResourceData) string {
+	if !d.Get("encryption").(bool) {
+		return ""
+	}
+
+	// For compatibility reasons, its default value should be "AES256".
+	if v, ok := d.GetOk("kms_data_encryption"); ok {
+		return v.(string)
+	}
+
+	return "AES256"
+}
+
+func buildSideEncryptionKmsKeyIdParam(d *schema.ResourceData) string {
+	// For compatibility reasons, `kms_key_id` only participates in request construction under KMS type.
+	if buildSideEncryptParam(d) == obs.DEFAULT_SSE_KMS_ENCRYPTION_OBS {
+		return d.Get("kms_key_id").(string)
+	}
+
+	return ""
+}
+
+func buildSideEncryptionBucketKeyEnabledParam(d *schema.ResourceData) string {
+	// For compatibility reasons, `bucket_key_enabled` only participates in request construction under KMS type.
+	if buildSideEncryptParam(d) == obs.DEFAULT_SSE_KMS_ENCRYPTION_OBS {
+		return d.Get("bucket_key_enabled").(string)
+	}
+
+	return ""
+}
+
+func buildKmsKeyProjectIdParam(d *schema.ResourceData) string {
+	// For compatibility reasons, `kms_key_project_id` only participates in request construction under KMS type.
+	// The `kms_key_project_id` field can only be configured if the `kms_key_id` field has a value.
+	if buildSideEncryptionKmsKeyIdParam(d) != "" {
+		return d.Get("kms_key_project_id").(string)
+	}
+
+	return ""
+}
+
 func resourceObsBucketCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
-	obsClient, err := conf.ObjectStorageClient(region)
+	obsClient, err := conf.ObjectStorageClientWithSignature(region)
 	if err != nil {
 		return diag.Errorf("Error creating OBS client: %s", err)
 	}
@@ -421,7 +481,14 @@ func resourceObsBucketCreate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	log.Printf("[DEBUG] OBS bucket create opts: %#v", opts)
-	_, err = obsClient.CreateBucket(opts)
+	_, err = obsClient.CreateBucket(
+		opts,
+		obs.WithCustomHeader("x-obs-server-side-encryption", buildSideEncryptParam(d)),
+		obs.WithCustomHeader("x-obs-server-side-data-encryption", buildSideDataEncryptParam(d)),
+		obs.WithCustomHeader("x-obs-server-side-encryption-kms-key-id", buildSideEncryptionKmsKeyIdParam(d)),
+		obs.WithCustomHeader("x-obs-server-side-encryption-bucket-key-enabled", buildSideEncryptionBucketKeyEnabledParam(d)),
+		obs.WithCustomHeader("x-obs-sse-kms-key-project-id", buildKmsKeyProjectIdParam(d)),
+	)
 	if err != nil {
 		return diag.FromErr(getObsError("Error creating bucket", bucket, err))
 	}
@@ -487,7 +554,7 @@ func resourceObsBucketUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		"kms_data_encryption",
 		"bucket_key_enabled",
 	}
-	if d.HasChanges(encryptionChangeFields...) {
+	if !d.IsNewResource() && d.HasChanges(encryptionChangeFields...) {
 		if err := resourceObsBucketEncryptionUpdate(conf, obsClientWithSignature, d); err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

pfs support creating with encryption.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

This PR is for a specific requirement: when creating a parallel file system, encryption capabilities must be enabled synchronously via a header.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o obs -f TestAccObsBucket_encryptionWithPfs
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccObsBucket_encryptionWithPfs -timeout 360m -parallel 10
=== RUN   TestAccObsBucket_encryptionWithPfs
=== PAUSE TestAccObsBucket_encryptionWithPfs
=== CONT  TestAccObsBucket_encryptionWithPfs
--- PASS: TestAccObsBucket_encryptionWithPfs (50.37s)
PASS
coverage: 16.7% of statements in ./huaweicloud/services/obs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       50.466s coverage: 16.7% of statements in ./huaweicloud/services/obs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
