### PR TITLE
feat(eip): add eip quotas datasource

### DIFF
--- a/docs/data-sources/eip_quotas.md
+++ b/docs/data-sources/eip_quotas.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eip_quotas"
+description: |-
+  Use this data source to get the list of EIP related quotas within HuaweiCloud.
+---
+
+# huaweicloud_eip_quotas
+
+Use this data source to get the list of EIP related quotas within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_eip_quotas" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Optional, String) Specifies the quota type to filter.
+  The valid values are **vpc**, **subnet**, **securityGroup**, **securityGroupRule**,
+  **vpn**, **vpcPeer**, **loadbalancer**, **listener**, **physicalConnect**,
+  **virtualInterface**, **firewall**, **address_group**, **flow_log**,
+  **vpcContainRoutetable**, **routetableContainRoutes**, **publicip**,
+  **shareBandwidth** and **shareBandwidthIP**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `quotas` - The quota objects.
+
+  The [quotas](#quotas_struct) structure is documented below.
+
+<a name="quotas_struct"></a>
+The `quotas` block supports:
+
+* `resources` - The resource objects.
+
+  The [resources](#quotas_resources_struct) structure is documented below.
+
+<a name="quotas_resources_struct"></a>
+The `resources` block supports:
+
+* `type` - The type of the EIP quota.
+
+* `used` - The number of used EIP quotas.
+
+* `quota` - The total number of EIP quotas.
+
+* `min` - The minimum quota.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2387,6 +2387,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_eip_common_pools":               eip.DataSourceVpcEipCommonPools(),
 			"huaweicloud_vpc_eip_public_ip_pool_types":       eip.DataSourceVpcEipPublicIpPoolTypes(),
 			"huaweicloud_vpc_eip_pools":                      eip.DataSourceVpcEipPools(),
+			"huaweicloud_eip_quotas":                         eip.DataSourceEipQuotas(),
 			"huaweicloud_vpc_eip":                            eip.DataSourceVpcEip(),
 			"huaweicloud_vpc_eips":                           eip.DataSourceVpcEips(),
 			"huaweicloud_vpcv3_eips":                         eip.DataSourceEipVpcv3Eips(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_eip_quotas_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_eip_quotas_test.go
@@ -1,0 +1,36 @@
+package eip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEipQuotas_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_eip_quotas.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceEipQuotas_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.resources.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.resources.0.used"),
+					resource.TestCheckResourceAttrSet(dataSource, "quotas.0.resources.0.quota"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceEipQuotas_basic = `
+data "huaweicloud_eip_quotas" "test" {}
+`

--- a/huaweicloud/services/eip/data_source_huaweicloud_eip_quotas.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_eip_quotas.go
@@ -1,0 +1,164 @@
+package eip
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v1/{project_id}/quotas
+func DataSourceEipQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEipQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the region in which to query the resource.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the quota type to filter. Valid values include publicIp, shareBandwidth, shareBandwidthIP.",
+			},
+			"quotas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resources": quotasSchema(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func quotasSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The type of the quota.",
+				},
+				"used": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: "The number of used quotas.",
+				},
+				"quota": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: "The total number of quotas.",
+				},
+				"min": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: "The minimum value of the quota that can be modified.",
+				},
+			},
+		},
+	}
+}
+
+func buildListQuotasQueryParams(d *schema.ResourceData) string {
+	params := url.Values{}
+	if v, ok := d.GetOk("type"); ok {
+		params.Add("type", v.(string))
+	}
+
+	if len(params) > 0 {
+		return "?" + params.Encode()
+	}
+	return ""
+}
+
+func dataSourceEipQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/quotas"
+	)
+
+	client, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC EIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildListQuotasQueryParams(d)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error querying EIP quotas: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("quotas", flattenQuotasWrapper(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenQuotasWrapper(respBody interface{}) []interface{} {
+	quotasObj := utils.PathSearch("quotas", respBody, nil)
+	if quotasObj == nil {
+		return nil
+	}
+
+	resources := utils.PathSearch("resources", quotasObj, make([]interface{}, 0)).([]interface{})
+	return []interface{}{
+		map[string]interface{}{
+			"resources": flattenEipQuotas(resources),
+		},
+	}
+}
+
+func flattenEipQuotas(resources []interface{}) []interface{} {
+	if len(resources) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resources))
+	for _, v := range resources {
+		rst = append(rst, map[string]interface{}{
+			"type":  utils.PathSearch("type", v, nil),
+			"used":  utils.PathSearch("used", v, 0),
+			"quota": utils.PathSearch("quota", v, 0),
+			"min":   utils.PathSearch("min", v, 0),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source `huaweicloud_vpc_eip_quotas` to query the EIP related quotas, including publicIp, shareBandwidth and shareBandwidthIP. Users can obtain the total quota and used quota of EIP resources through this data source.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
The code complies with the project specifications, the unit tests have passed, and the documentation is complete.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
new datasource: huaweicloud_vpc_eip_quotas
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run=TestAccDataSourceEipQuotas_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run=TestAccDataSourceEipQuotas_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceEipQuotas_basic
=== PAUSE TestAccDataSourceEipQuotas_basic
=== CONT  TestAccDataSourceEipQuotas_basic
--- PASS: TestAccDataSourceEipQuotas_basic (24.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       24.328s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
