### PR TITLE
feat(drs): support `stop_job` resource

### DIFF
--- a/docs/resources/drs_stop_job.md
+++ b/docs/resources/drs_stop_job.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_stop_job"
+description: |-
+  Manages a resource to stop a DRS job within HuaweiCloud.
+---
+
+# huaweicloud_drs_stop_job
+
+Manages a resource to stop a DRS job within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource used to stop a DRS job. Deleting this resource will not restore the
+  job or undo the stop action, but will only remove the resource information from the tf state file.
+  <br/>2. You must specify an existing DRS job ID. If the job does not exist or has already ended,
+  the operation may fail.<br/>3. The execution result of this operation is based on the value of the `status` field.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+resource "huaweicloud_drs_stop_job" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `job_id` - (Required, String, NonUpdatable) Specifies the job ID.
+
+* `is_force_stop` - (Optional, Bool, NonUpdatable) Specifies whether to force stop the job.
+  The value can be **true** or **false**. Defaults to **false**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `job_id`.
+
+* `name` - The name of the job.
+
+* `status` - The status of the job.  
+  The valid values are as follows:
+  + **success**.
+  + **failed**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3441,6 +3441,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_job":                            drs.ResourceDrsJob(),
 			"huaweicloud_drs_job_primary_standby_switch":     drs.ResourceDRSPrimaryStandbySwitch(),
 			"huaweicloud_drs_download_batch_create_template": drs.ResourceDownloadBatchCreateTemplate(),
+			"huaweicloud_drs_stop_job":                       drs.ResourceStopJob(),
 
 			"huaweicloud_dws_alarm_subscription":              dws.ResourceDwsAlarmSubs(),
 			"huaweicloud_dws_cluster":                         dws.ResourceDwsCluster(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -478,6 +478,8 @@ var (
 	HW_CFW_SERVICE_GROUP_ID          = os.Getenv("HW_CFW_SERVICE_GROUP_ID")
 	HW_CFW_SERVICE_GROUP_MEMBER_ID   = os.Getenv("HW_CFW_SERVICE_GROUP_MEMBER_ID")
 
+	HW_DRS_JOB_ID = os.Getenv("HW_DRS_JOB_ID")
+
 	HW_CTS_START_TIME = os.Getenv("HW_CTS_START_TIME")
 	HW_CTS_END_TIME   = os.Getenv("HW_CTS_END_TIME")
 
@@ -2870,6 +2872,13 @@ func TestAccPreCheckCesAlarmRuleWithTags(t *testing.T) {
 func TestAccPreCheckCfw(t *testing.T) {
 	if HW_CFW_INSTANCE_ID == "" {
 		t.Skip("HW_CFW_INSTANCE_ID must be set for CFW acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDrsJobId(t *testing.T) {
+	if HW_DRS_JOB_ID == "" {
+		t.Skip("HW_DRS_JOB_ID must be set for DRS acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_stop_job_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_stop_job_test.go
@@ -1,0 +1,35 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccStopJob_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testStopJob_basic(),
+			},
+		},
+	})
+}
+
+func testStopJob_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_drs_stop_job" "test" {
+  job_id        = "%s"
+  is_force_stop = true
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_stop_job.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_stop_job.go
@@ -1,0 +1,133 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var stopJobNonUpdatableParams = []string{"job_id", "is_force_stop"}
+
+// @API DRS POST /v5/{project_id}/jobs/{job_id}/stop
+func ResourceStopJob() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStopJobCreate,
+		ReadContext:   resourceStopJobRead,
+		UpdateContext: resourceStopJobUpdate,
+		DeleteContext: resourceStopJobDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(stopJobNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"is_force_stop": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildStopJobBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"is_force_stop": utils.GetNestedObjectFromRawConfig(d.GetRawConfig(), "is_force_stop"),
+	}
+}
+
+func resourceStopJobCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/jobs/{job_id}/stop"
+	)
+
+	client, err := cfg.DrsV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DRS v5 client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", d.Get("job_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildStopJobBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error stopping DRS job: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(d.Get("job_id").(string))
+
+	mErr := multierror.Append(nil,
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting stop DRS job fields: %s", mErr)
+	}
+
+	return nil
+}
+
+func resourceStopJobRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceStopJobUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceStopJobDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to stop a DRS job. Deleting this resource will not
+    restore the job or undo the stop action, but will only remove the resource information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `stop_job` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `stop_job` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccStopJob_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run TestAccStopJob_basic -timeout 360m -parallel 4
=== RUN   TestAccStopJob_basic
=== PAUSE TestAccStopJob_basic
=== CONT  TestAccStopJob_basic
--- PASS: TestAccStopJob_basic (13.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       13.847s
```
<img width="798" height="35" alt="image" src="https://github.com/user-attachments/assets/b6cc9856-8d4f-42de-a0a4-a0b713b2d134" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
