### PR TITLE
feat(obs): new resource to manage bucket bpa

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -169,14 +169,14 @@ resource "huaweicloud_obs_bucket" "bucket" {
 variable "kms_key_id" {}
 
 resource "huaweicloud_obs_bucket" "test" {
-  bucket              = "test-hang-3"
-  storage_class       = "STANDARD"
-  acl                 = "private"
-  parallel_fs         = true
-  encryption          = true
-  sse_algorithm       = "kms"
-  bucket_key_enabled  = "true"
-  kms_key_id          = var.kms_key_id
+  bucket             = "test-hang-3"
+  storage_class      = "STANDARD"
+  acl                = "private"
+  parallel_fs        = true
+  encryption         = true
+  sse_algorithm      = "kms"
+  bucket_key_enabled = "true"
+  kms_key_id         = var.kms_key_id
 
   tags = {
     foo = "bar"

--- a/docs/resources/obs_bucket_bpa.md
+++ b/docs/resources/obs_bucket_bpa.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Object Storage Service (OBS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_obs_bucket_bpa"
+description: |-
+  Provides an OBS bucket public access block resource.
+---
+
+# huaweicloud_obs_bucket_bpa
+
+Provides an OBS bucket public access block resource.
+
+-> 1. Currently, the BPA capability of this bucket is only supported by some regions. Using this resource in regions that
+  do not support it may result in errors.<br/>2. Deleting this resource will set all BPA configurations to **false**.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_obs_bucket_bpa" "example" {
+  bucket                  = "your_bucket_name"
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `bucket` - (Required, String, NonUpdatable) Specifies the name of the bucket to set public access block.
+
+* `block_public_acls` - (Optional, Bool) Specifies whether to lock public ACLs. When set to true, uploading objects with
+  public ACLs is prohibited, and ACL modification APIs that set public ACLs are forbidden.
+  Defaults to **false**.
+
+* `ignore_public_acls` - (Optional, Bool) Specifies whether to ignore public ACLs. When set to true, public ACLs do not
+  take effect during all OBS OpenAPI permission checks.
+  Defaults to **false**.
+
+* `block_public_policy` - (Optional, Bool) Specifies whether to lock public policies. When set to true, bucket policy
+  modification APIs that set public policies are forbidden.
+  Defaults to **false**.
+
+* `restrict_public_buckets` - (Optional, Bool) Specifies whether to restrict account access. When set to true, during
+  all OBS OpenAPI permission checks, if the bucket policy status is public, only cloud service accounts and the current
+  account are allowed to access.
+  Defaults to **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the same as the bucket name.
+
+## Import
+
+OBS bucket public access block can be imported using the bucket name, e.g.
+
+```bash
+$ terraform import huaweicloud_obs_bucket_bpa.test <bucket>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3970,6 +3970,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_obs_bucket":             obs.ResourceObsBucket(),
 			"huaweicloud_obs_bucket_acl":         obs.ResourceOBSBucketAcl(),
+			"huaweicloud_obs_bucket_bpa":         obs.ResourceObsBucketBpa(),
 			"huaweicloud_obs_bucket_object":      obs.ResourceObsBucketObject(),
 			"huaweicloud_obs_bucket_object_acl":  obs.ResourceOBSBucketObjectAcl(),
 			"huaweicloud_obs_bucket_policy":      obs.ResourceObsBucketPolicy(),

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_bpa_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_bpa_test.go
@@ -1,0 +1,124 @@
+package obs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getOBSBucketBpaResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	obsClient, err := cfg.ObjectStorageClientWithSignature(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OBS Client: %s", err)
+	}
+
+	output, err := obsClient.GetBucketPublicAccessBlock(state.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	blockPublicAcls := output.BlockPublicAcls
+	ignorePublicAcls := output.IgnorePublicAcls
+	blockPublicPolicy := output.BlockPublicPolicy
+	restrictPublicBuckets := output.RestrictPublicBuckets
+	if !blockPublicAcls && !ignorePublicAcls && !blockPublicPolicy && !restrictPublicBuckets {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return output, nil
+}
+
+func TestAccObsBucketBpa_basic(t *testing.T) {
+	var obj interface{}
+
+	bucketName := acceptance.RandomAccResourceNameWithDash()
+	rName := "huaweicloud_obs_bucket_bpa.test"
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getOBSBucketBpaResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketBpa_basic(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "bucket", bucketName),
+					resource.TestCheckResourceAttr(rName, "block_public_acls", "true"),
+					resource.TestCheckResourceAttr(rName, "ignore_public_acls", "true"),
+					resource.TestCheckResourceAttr(rName, "block_public_policy", "true"),
+					resource.TestCheckResourceAttr(rName, "restrict_public_buckets", "true"),
+				),
+			},
+			{
+				Config: testAccObsBucketBpa_update(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "bucket", bucketName),
+					resource.TestCheckResourceAttr(rName, "block_public_acls", "true"),
+					resource.TestCheckResourceAttr(rName, "ignore_public_acls", "false"),
+					resource.TestCheckResourceAttr(rName, "block_public_policy", "true"),
+					resource.TestCheckResourceAttr(rName, "restrict_public_buckets", "false"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccObsBucketBpa_base(bucketName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%s"
+  storage_class = "STANDARD"
+  acl           = "private"
+}
+`, bucketName)
+}
+
+func testAccObsBucketBpa_basic(bucketName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket_bpa" "test" {
+  bucket                  = huaweicloud_obs_bucket.test.bucket
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+`, testAccObsBucketBpa_base(bucketName))
+}
+
+func testAccObsBucketBpa_update(bucketName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket_bpa" "test" {
+  bucket                  = huaweicloud_obs_bucket.test.bucket
+  block_public_acls       = true
+  ignore_public_acls      = false
+  block_public_policy     = true
+  restrict_public_buckets = false
+}
+`, testAccObsBucketBpa_base(bucketName))
+}

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_bpa.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_bpa.go
@@ -1,0 +1,184 @@
+package obs
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/obs"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API OBS PUT ?publicAccessBlock
+// @API OBS DELETE ?publicAccessBlock
+// @API OBS GET ?publicAccessBlock
+func ResourceObsBucketBpa() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceObsBucketBpaCreate,
+		UpdateContext: resourceObsBucketBpaUpdate,
+		ReadContext:   resourceObsBucketBpaRead,
+		DeleteContext: resourceObsBucketBpaDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{"bucket"}),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"block_public_acls": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"ignore_public_acls": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"block_public_policy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"restrict_public_buckets": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceObsBucketBpaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		bucket = d.Get("bucket").(string)
+	)
+
+	obsClient, err := cfg.ObjectStorageClientWithSignature(region)
+	if err != nil {
+		return diag.Errorf("error creating OBS Client: %s", err)
+	}
+
+	opts := &obs.PutBucketPublicAccessBlockInput{
+		Bucket: bucket,
+		PublicAccessBlockConfiguration: obs.PublicAccessBlockConfiguration{
+			BlockPublicAcls:       d.Get("block_public_acls").(bool),
+			IgnorePublicAcls:      d.Get("ignore_public_acls").(bool),
+			BlockPublicPolicy:     d.Get("block_public_policy").(bool),
+			RestrictPublicBuckets: d.Get("restrict_public_buckets").(bool),
+		},
+	}
+
+	_, err = obsClient.PutBucketPublicAccessBlock(opts)
+	if err != nil {
+		return diag.FromErr(getObsError("Error setting public access block of OBS bucket", bucket, err))
+	}
+
+	d.SetId(bucket)
+
+	return resourceObsBucketBpaRead(ctx, d, meta)
+}
+
+func resourceObsBucketBpaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		bucket = d.Get("bucket").(string)
+	)
+
+	obsClient, err := cfg.ObjectStorageClientWithSignature(region)
+	if err != nil {
+		return diag.Errorf("error creating OBS Client: %s", err)
+	}
+
+	opts := &obs.PutBucketPublicAccessBlockInput{
+		Bucket: bucket,
+		PublicAccessBlockConfiguration: obs.PublicAccessBlockConfiguration{
+			BlockPublicAcls:       d.Get("block_public_acls").(bool),
+			IgnorePublicAcls:      d.Get("ignore_public_acls").(bool),
+			BlockPublicPolicy:     d.Get("block_public_policy").(bool),
+			RestrictPublicBuckets: d.Get("restrict_public_buckets").(bool),
+		},
+	}
+
+	_, err = obsClient.PutBucketPublicAccessBlock(opts)
+	if err != nil {
+		return diag.FromErr(getObsError("Error updating public access block of OBS bucket", bucket, err))
+	}
+
+	return resourceObsBucketBpaRead(ctx, d, meta)
+}
+
+func resourceObsBucketBpaRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	obsClient, err := cfg.ObjectStorageClientWithSignature(region)
+	if err != nil {
+		return diag.Errorf("error creating OBS Client: %s", err)
+	}
+
+	// Deleting BPA is equivalent to setting all fields to false, so this resource does not provide checkDelete `404`.
+	output, err := obsClient.GetBucketPublicAccessBlock(d.Id())
+	if err != nil {
+		return diag.FromErr(getObsError("Error retrieving OBS bucket public access block", d.Id(), err))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("bucket", d.Id()),
+		d.Set("block_public_acls", output.BlockPublicAcls),
+		d.Set("ignore_public_acls", output.IgnorePublicAcls),
+		d.Set("block_public_policy", output.BlockPublicPolicy),
+		d.Set("restrict_public_buckets", output.RestrictPublicBuckets),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting OBS bucket public access block fields: %s", err)
+	}
+
+	return nil
+}
+
+func resourceObsBucketBpaDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	obsClient, err := cfg.ObjectStorageClientWithSignature(region)
+	if err != nil {
+		return diag.Errorf("error creating OBS Client: %s", err)
+	}
+
+	_, err = obsClient.DeleteBucketPublicAccessBlock(d.Id())
+	if err != nil {
+		return diag.FromErr(getObsError("Error deleting public access block of OBS bucket", d.Id(), err))
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage bucket bpa

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Due to the specific nature of the API, this resource does not support 404 checks for Deleted.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o obs -f TestAccObsBucketBpa_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccObsBucketBpa_basic -timeout 360m -parallel 10
=== RUN   TestAccObsBucketBpa_basic
=== PAUSE TestAccObsBucketBpa_basic
=== CONT  TestAccObsBucketBpa_basic
--- PASS: TestAccObsBucketBpa_basic (95.35s)
PASS
coverage: 16.7% of statements in ./huaweicloud/services/obs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       95.446s coverage: 16.7% of statements in ./huaweicloud/services/obs
```
<img width="1234" height="77" alt="image" src="https://github.com/user-attachments/assets/ffa1e848-7c8a-4343-86fa-1af955b31fa5" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
