### PR TITLE
feat(CSS): enhance css_log_setting to support log ingestion

### DIFF
--- a/docs/resources/css_log_setting.md
+++ b/docs/resources/css_log_setting.md
@@ -2,26 +2,47 @@
 subcategory: "Cloud Search Service (CSS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_css_log_setting"
-description: ""
+description: "Use this resource to manage log backup or log ingestion of a CSS cluster within HuaweiCloud."
 ---
 
 # huaweicloud_css_log_setting
 
-Manages CSS log setting resource within HuaweiCloud.
+Use this resource to manage log backup or log ingestion of a CSS cluster within HuaweiCloud.
 
 ## Example Usage
+
+### Manage Log Backup
 
 ```hcl
 variable "cluster_id" {}
 variable "agency" {}
 variable "base_path" {}
 variable "bucket" {}
+variable "period" {}
 
 resource "huaweicloud_css_log_setting" "test" {
   cluster_id = var.cluster_id
   agency     = var.agency
   base_path  = var.base_path
   bucket     = var.bucket
+  period     = var.period
+}
+```
+
+### Manage Log Ingestion
+
+```hcl
+variable "cluster_id" {}
+variable "index_prefix" {}
+variable "keep_days" {}
+variable "target_cluster_id" {}
+
+resource "huaweicloud_css_log_setting" "test" {
+  cluster_id        = var.cluster_id
+  action            = "real_time_log_collect"
+  index_prefix      = var.index_prefix
+  keep_days         = var.keep_days
+  target_cluster_id = var.target_cluster_id
 }
 ```
 
@@ -36,14 +57,38 @@ The following arguments are supported:
 * `cluster_id` - (Required, String, ForceNew) Specifies ID of the cluster whose log function you want to enable.
   Changing this creates a new resource.
 
-* `agency` - (Required, String) Specifies the agency name. You can create an agency to allow CSS to
-  call other cloud services.
+* `action` - (Optional, String, ForceNew) Specifies the log setting action type. Changing this creates a new resource.
+  Valid values are as follows:
+  + **base_log_collect**: Enables log backup.
+  + **real_time_log_collect**: Enable log ingestion.
+  
+  Defaults to **base_log_collect**.
 
-* `base_path` - (Required, String) Specifies the storage path of backed up logs in the OBS bucket.
+  -> **Note**: Log ingestion is only supported in the scenarios as follows:
+  The Elasticsearch cluster version is `7.10.2` and the image version is no earlier than `7.10.2_24.2.0_×.×.×`.
+  The OpenSearch cluster version is `1.3.6` or `2.19.0` and the image version is no earlier than `×.×.×_24.2.0_×.×.×`.
 
-* `bucket` - (Required, String) Specifies the name of the OBS bucket for storing logs.
+* `agency` - (Optional, String) Specifies the agency name. You can create an agency to allow CSS to
+  call other cloud services. This parameter is mandatory when `action` is set to **base_log_collect**.
 
-* `period` - (Optional, String) Specifies the backup start time. Format: GMT.
+* `base_path` - (Optional, String) Specifies the storage path of backed up logs in the OBS bucket.
+  This parameter is mandatory when `action` is set to **base_log_collect**.
+
+* `bucket` - (Optional, String) Specifies the name of the OBS bucket for storing logs.
+  This parameter is mandatory when `action` is set to **base_log_collect**.
+
+* `period` - (Optional, String) Specifies the start time of automatic backup.
+  The value must be in the format of **HH:MM GMT±HH:MM**, e.g., **01:00 GMT+08:00**.
+  This parameter is optional only when `action` is set to **base_log_collect**.
+
+* `index_prefix` - (Optional, String) Specifies the index prefix for real-time log ingestion.
+  This parameter is mandatory when `action` is set to **real_time_log_collect**.
+
+* `keep_days` - (Optional, Int) Specifies the number of days to keep real-time logs. The value ranges from 1 to 3650.
+  This parameter is mandatory when `action` is set to **real_time_log_collect**.
+
+* `target_cluster_id` - (Optional, String) Specifies the ID of the target cluster for real-time log ingestion.
+  This parameter is mandatory when `action` is set to **real_time_log_collect**.
 
 ## Attribute Reference
 
@@ -51,16 +96,59 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
 
-* `updated_at` - The update time.
+* `log_switch` - Whether the log backup is enabled.
+  + **true**: Log backup is enabled.
+  + **false**: Log backup is disabled.
 
-* `auto_enabled` - Whether to enable automatic backup.
+* `updated_at` - The update time of the log backup, in RFC3339 format.
 
-* `log_switch` - Whether to enable the log function.
+* `auto_enabled` - Whether log automatic backup is enabled.
+   + **true**: Automatic backup is enabled.
+   + **false**: Automatic backup is disabled.
+
+* `status` - The status of log ingestion task. The values are as follows:
+   + **100**: A real-time log ingestion task is being created.
+   + **150**: Real-time log ingestion is available.
+   + **200**: Real-time log ingestion task is activated.
+   + **300**: Real-time log ingestion failed.
+   + **302**: The real-time log ingestion task failed to be deleted.
+   + **303**: The real-time log ingestion task failed to be created.
+   + **304**: The real-time log ingestion task is being disabled.
+   + **400**: The real-time log ingestion task is disabled.
+
+* `log_ingestion_create_at` - The creation time of real-time log ingestion task, in RFC3339 format.
+
+* `log_ingestion_update_at` - The update time of real-time log ingestion task, in RFC3339 format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 
-The CSS log setting can be imported using `cluster_id`, e.g.
+### Import Log Backup
+
+The CSS log backup setting can be imported using `cluster_id` (defaults to **base_log_collect**)
+or explicitly specifying the action, e.g.
 
 ```bash
 $ terraform import huaweicloud_css_log_setting.test <cluster_id>
+```
+
+Or:
+
+```bash
+$ terraform import huaweicloud_css_log_setting.test <cluster_id>/base_log_collect
+```
+
+### Import Log Ingestion
+
+The CSS log ingestion setting can be imported using `cluster_id` and **real_time_log_collect**, e.g.
+
+```bash
+$ terraform import huaweicloud_css_log_setting.test <cluster_id>/real_time_log_collect
 ```

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -669,6 +669,7 @@ var (
 	HW_CSS_DATASTORE_ID        = os.Getenv("HW_CSS_DATASTORE_ID")
 	HW_CSS_AZ_MIGRATE_AGENCY   = os.Getenv("HW_CSS_AZ_MIGRATE_AGENCY")
 	HW_CSS_CLUSTER_ID          = os.Getenv("HW_CSS_CLUSTER_ID")
+	HW_CSS_TARGET_CLUSTER_ID   = os.Getenv("HW_CSS_TARGET_CLUSTER_ID")
 	HW_CSS_LOGSTASH_CLUSTER_ID = os.Getenv("HW_CSS_LOGSTASH_CLUSTER_ID")
 
 	HW_CERT_BATCH_PUSH_ID     = os.Getenv("HW_CERT_BATCH_PUSH_ID")
@@ -3932,6 +3933,13 @@ func TestAccPreCheckCSSClusterId(t *testing.T) {
 func TestAccPreCheckCSSLogStashClusterId(t *testing.T) {
 	if HW_CSS_LOGSTASH_CLUSTER_ID == "" {
 		t.Skip("HW_CSS_LOGSTASH_CLUSTER_ID must be set for the css logstash cluster acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCSSLogIngestionSetting(t *testing.T) {
+	if HW_CSS_CLUSTER_ID == "" || HW_CSS_TARGET_CLUSTER_ID == "" {
+		t.Skip("HW_CSS_CLUSTER_ID and HW_CSS_TARGET_CLUSTER_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_log_setting_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_log_setting_test.go
@@ -16,15 +16,20 @@ import (
 )
 
 func getLogSettingResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.CssV1Client(acceptance.HW_REGION_NAME)
+	var (
+		clusterID            = state.Primary.Attributes["cluster_id"]
+		action               = state.Primary.Attributes["action"]
+		getLogSettingHttpUrl = "v1.0/{project_id}/clusters/{cluster_id}/logs/settings"
+	)
+	client, err := cfg.NewServiceClient("css", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating CSS v1 client: %s", err)
 	}
 
-	getLogSettingHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/settings"
 	getLogSettingPath := client.Endpoint + getLogSettingHttpUrl
 	getLogSettingPath = strings.ReplaceAll(getLogSettingPath, "{project_id}", client.ProjectID)
-	getLogSettingPath = strings.ReplaceAll(getLogSettingPath, "{cluster_id}", state.Primary.ID)
+	getLogSettingPath = strings.ReplaceAll(getLogSettingPath, "{cluster_id}", clusterID)
+	getLogSettingPath = fmt.Sprintf("%s?action=%s", getLogSettingPath, action)
 
 	getLogSettingPathOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -33,15 +38,32 @@ func getLogSettingResourceFunc(cfg *config.Config, state *terraform.ResourceStat
 
 	getLogSettingResp, err := client.Request("GET", getLogSettingPath, &getLogSettingPathOpt)
 	if err != nil {
-		return getLogSettingResp, err
+		return nil, fmt.Errorf("error getting CSS cluster (%s) log setting: %s", clusterID, err)
 	}
 
 	getLogSettingRespBody, err := utils.FlattenResponse(getLogSettingResp)
 	if err != nil {
-		return nil, fmt.Errorf("erorr retrieving CSS cluster log setting: %s", err)
+		return nil, fmt.Errorf("erorr retrieving CSS cluster (%s) log setting: %s", clusterID, err)
 	}
 
-	return getLogSettingRespBody, nil
+	switch action {
+	case "real_time_log_collect":
+		logIngestionSetting := utils.PathSearch("realTimeLogCollectRecord", getLogSettingRespBody, nil)
+		if logIngestionSetting == nil {
+			return nil, golangsdk.ErrDefault404{}
+		}
+		return logIngestionSetting, nil
+	default:
+		logBackupSetting := utils.PathSearch("logConfiguration", getLogSettingRespBody, nil)
+		if logBackupSetting == nil {
+			return nil, golangsdk.ErrDefault404{}
+		}
+		logSwith := utils.PathSearch("logSwitch", logBackupSetting, false).(bool)
+		if !logSwith {
+			return nil, golangsdk.ErrDefault404{}
+		}
+		return logBackupSetting, nil
+	}
 }
 
 func TestAccLogSetting_elastic(t *testing.T) {
@@ -66,12 +88,14 @@ func TestAccLogSetting_elastic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "cluster_id", "huaweicloud_css_cluster.test", "id"),
+					resource.TestCheckResourceAttr(rName, "action", "base_log_collect"),
 					resource.TestCheckResourceAttrPair(rName, "bucket", "huaweicloud_obs_bucket.cssObs", "bucket"),
 					resource.TestCheckResourceAttr(rName, "base_path", "css_repository/css-log"),
 					resource.TestCheckResourceAttr(rName, "agency", "css_obs_agency"),
-					resource.TestCheckResourceAttr(rName, "auto_enabled", "false"),
 					resource.TestCheckResourceAttr(rName, "log_switch", "true"),
 					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttr(rName, "auto_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "period", "01:00 GMT+08:00"),
 				),
 			},
 			{
@@ -79,19 +103,27 @@ func TestAccLogSetting_elastic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "cluster_id", "huaweicloud_css_cluster.test", "id"),
+					resource.TestCheckResourceAttr(rName, "action", "base_log_collect"),
 					resource.TestCheckResourceAttrPair(rName, "bucket", "huaweicloud_obs_bucket.cssObs", "bucket"),
 					resource.TestCheckResourceAttr(rName, "base_path", "css_repository/css-log-update"),
 					resource.TestCheckResourceAttr(rName, "agency", "css_obs_agency"),
-					resource.TestCheckResourceAttr(rName, "auto_enabled", "true"),
-					resource.TestCheckResourceAttr(rName, "period", "00:00 GMT+08:00"),
 					resource.TestCheckResourceAttr(rName, "log_switch", "true"),
 					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttr(rName, "auto_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "period", "02:00 GMT+08:00"),
 				),
 			},
 			{
 				Config: testLogSetting_elastic_updateNull(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "cluster_id", "huaweicloud_css_cluster.test", "id"),
+					resource.TestCheckResourceAttr(rName, "action", "base_log_collect"),
+					resource.TestCheckResourceAttrPair(rName, "bucket", "huaweicloud_obs_bucket.cssObs", "bucket"),
+					resource.TestCheckResourceAttr(rName, "base_path", "css_repository/css-log-update"),
+					resource.TestCheckResourceAttr(rName, "agency", "css_obs_agency"),
+					resource.TestCheckResourceAttr(rName, "log_switch", "true"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 					resource.TestCheckResourceAttr(rName, "auto_enabled", "false"),
 				),
 			},
@@ -129,8 +161,9 @@ func TestAccLogSetting_logstash(t *testing.T) {
 					resource.TestCheckResourceAttrPair(rName, "bucket", "huaweicloud_obs_bucket.bucket1", "bucket"),
 					resource.TestCheckResourceAttr(rName, "base_path", "css_repository/logstash-log"),
 					resource.TestCheckResourceAttr(rName, "agency", "css_obs_agency"),
-					resource.TestCheckResourceAttr(rName, "auto_enabled", "false"),
 					resource.TestCheckResourceAttr(rName, "log_switch", "true"),
+					resource.TestCheckResourceAttr(rName, "auto_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "period", "01:00 GMT+08:00"),
 					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 				),
 			},
@@ -143,7 +176,7 @@ func TestAccLogSetting_logstash(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "base_path", "css_repository/logstash-log-2"),
 					resource.TestCheckResourceAttr(rName, "agency", "css_obs_agency"),
 					resource.TestCheckResourceAttr(rName, "auto_enabled", "true"),
-					resource.TestCheckResourceAttr(rName, "period", "00:00 GMT+08:00"),
+					resource.TestCheckResourceAttr(rName, "period", "02:00 GMT+08:00"),
 					resource.TestCheckResourceAttr(rName, "log_switch", "true"),
 					resource.TestCheckResourceAttrSet(rName, "updated_at"),
 				),
@@ -159,15 +192,72 @@ func TestAccLogSetting_logstash(t *testing.T) {
 	})
 }
 
+func TestAccLogSetting_elastic_logIngestion(t *testing.T) {
+	var obj interface{}
+
+	rName := "huaweicloud_css_log_setting.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getLogSettingResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCSSLogIngestionSetting(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testLogSetting_elastic_logIngestion(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_CSS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "action", "real_time_log_collect"),
+					resource.TestCheckResourceAttr(rName, "index_prefix", "index"),
+					resource.TestCheckResourceAttr(rName, "keep_days", "7"),
+					resource.TestCheckResourceAttr(rName, "target_cluster_id", acceptance.HW_CSS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "status", "200"),
+					resource.TestCheckResourceAttrSet(rName, "log_ingestion_create_at"),
+					resource.TestCheckResourceAttrSet(rName, "log_ingestion_update_at"),
+				),
+			},
+			{
+				Config: testLogSetting_elastic_logIngestion_update(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_CSS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "action", "real_time_log_collect"),
+					resource.TestCheckResourceAttr(rName, "index_prefix", "index"),
+					resource.TestCheckResourceAttr(rName, "keep_days", "10"),
+					resource.TestCheckResourceAttr(rName, "target_cluster_id", acceptance.HW_CSS_TARGET_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "status", "200"),
+					resource.TestCheckResourceAttrSet(rName, "log_ingestion_create_at"),
+					resource.TestCheckResourceAttrSet(rName, "log_ingestion_update_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testLogSetting_elastic(name string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "huaweicloud_css_log_setting" "test" {
   cluster_id = huaweicloud_css_cluster.test.id
+  bucket     = huaweicloud_obs_bucket.cssObs.bucket
   agency     = "css_obs_agency"
   base_path  = "css_repository/css-log"
-  bucket     = huaweicloud_obs_bucket.cssObs.bucket
+  period     = "01:00 GMT+08:00"
 }
 `, testAccCssCluster_basic(name, "Test@passw0rd", 1, "tag"))
 }
@@ -178,10 +268,10 @@ func testLogSetting_elastic_update(name string) string {
 
 resource "huaweicloud_css_log_setting" "test" {
   cluster_id = huaweicloud_css_cluster.test.id
+  bucket     = huaweicloud_obs_bucket.cssObs.bucket
   agency     = "css_obs_agency"
   base_path  = "css_repository/css-log-update"
-  bucket     = huaweicloud_obs_bucket.cssObs.bucket
-  period     = "00:00 GMT+08:00"
+  period     = "02:00 GMT+08:00"
 }
 `, testAccCssCluster_basic(name, "Test@passw0rd", 1, "tag"))
 }
@@ -192,9 +282,10 @@ func testLogSetting_elastic_updateNull(name string) string {
 
 resource "huaweicloud_css_log_setting" "test" {
   cluster_id = huaweicloud_css_cluster.test.id
+  action     = "base_log_collect"
+  bucket     = huaweicloud_obs_bucket.cssObs.bucket
   agency     = "css_obs_agency"
   base_path  = "css_repository/css-log-update"
-  bucket     = huaweicloud_obs_bucket.cssObs.bucket
   period     = ""
 }
 `, testAccCssCluster_basic(name, "Test@passw0rd", 1, "tag"))
@@ -221,6 +312,7 @@ resource "huaweicloud_css_log_setting" "test" {
   agency     = "css_obs_agency"
   base_path  = "css_repository/logstash-log"
   bucket     = huaweicloud_obs_bucket.bucket1.bucket
+  period     = "01:00 GMT+08:00"
 }
 `, testAccLogstashCluster_basic(name, 1, "bar"))
 }
@@ -246,7 +338,7 @@ resource "huaweicloud_css_log_setting" "test" {
   agency     = "css_obs_agency"
   base_path  = "css_repository/logstash-log-2"
   bucket     = huaweicloud_obs_bucket.bucket2.bucket
-  period     = "00:00 GMT+08:00"
+  period     = "02:00 GMT+08:00"
 }
 `, testAccLogstashCluster_basic(name, 1, "bar"))
 }
@@ -275,4 +367,28 @@ resource "huaweicloud_css_log_setting" "test" {
   period     = ""
 }
 `, testAccLogstashCluster_basic(name, 1, "bar"))
+}
+
+func testLogSetting_elastic_logIngestion() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_css_log_setting" "test" {
+  cluster_id        = "%[1]s"
+  action            = "real_time_log_collect"
+  index_prefix      = "index"
+  keep_days         = 7
+  target_cluster_id = "%[2]s"
+}
+`, acceptance.HW_CSS_CLUSTER_ID, acceptance.HW_CSS_CLUSTER_ID)
+}
+
+func testLogSetting_elastic_logIngestion_update() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_css_log_setting" "test" {
+  cluster_id        = "%[1]s"
+  action            = "real_time_log_collect"
+  index_prefix      = "index"
+  keep_days         = 10
+  target_cluster_id = "%[2]s"
+}
+`, acceptance.HW_CSS_CLUSTER_ID, acceptance.HW_CSS_TARGET_CLUSTER_ID)
 }

--- a/huaweicloud/services/css/resource_huaweicloud_css_log_setting.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_log_setting.go
@@ -2,12 +2,16 @@ package css
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -17,6 +21,7 @@ import (
 )
 
 // @API CSS POST /v1.0/{project_id}/clusters/{cluster_id}/logs/open
+// @API CSS POST /v1.0/{project_id}/clusters/{cluster_id}/logs/connectivity
 // @API CSS GET /v1.0/{project_id}/clusters/{cluster_id}/logs/settings
 // @API CSS POST /v1.0/{project_id}/clusters/{cluster_id}/logs/settings
 // @API CSS PUT /v1.0/{project_id}/clusters/{cluster_id}/logs/close
@@ -29,7 +34,13 @@ func ResourceLogSetting() *schema.Resource {
 		UpdateContext: resourceLogSettingUpdate,
 		DeleteContext: resourceLogSettingDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceLogSettingImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -44,32 +55,64 @@ func ResourceLogSetting() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"action": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "base_log_collect",
+				ValidateFunc: validation.StringInSlice([]string{"base_log_collect", "real_time_log_collect"}, false),
+			},
 			"agency": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"base_path": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"bucket": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"period": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"updated_at": {
+			"index_prefix": {
 				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"keep_days": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 3650),
+			},
+			"target_cluster_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"log_switch": {
+				Type:     schema.TypeBool,
 				Computed: true,
 			},
 			"auto_enabled": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"log_switch": {
-				Type:     schema.TypeBool,
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_ingestion_create_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_ingestion_update_at": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -80,170 +123,261 @@ func resourceLogSettingCreate(ctx context.Context, d *schema.ResourceData, meta 
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	clusterID := d.Get("cluster_id").(string)
-	cssV1Client, err := conf.CssV1Client(region)
+	cssClient, err := conf.NewServiceClient("css", region)
 	if err != nil {
-		return diag.Errorf("error creating CSS V1 client: %s", err)
+		return diag.Errorf("error creating CSS client: %s", err)
 	}
 
-	createLogSettingHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/open"
-	createLogSettingPath := cssV1Client.Endpoint + createLogSettingHttpUrl
-	createLogSettingPath = strings.ReplaceAll(createLogSettingPath, "{project_id}", cssV1Client.ProjectID)
-	createLogSettingPath = strings.ReplaceAll(createLogSettingPath, "{cluster_id}", clusterID)
-
-	createLogSettingOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
-	}
-	createLogSettingOpt.JSONBody = map[string]interface{}{
-		"agency":      d.Get("agency").(string),
-		"logBasePath": d.Get("base_path").(string),
-		"logBucket":   d.Get("bucket").(string),
-	}
-	_, err = cssV1Client.Request("POST", createLogSettingPath, &createLogSettingOpt)
-	if err != nil {
-		return diag.Errorf("error opening CSS cluster log function: %s", err)
-	}
-
-	d.SetId(clusterID)
-
-	if _, ok := d.GetOk("period"); ok {
-		err := openLogAutoBackup(d, cssV1Client)
+	action := d.Get("action").(string)
+	switch action {
+	case "real_time_log_collect":
+		err := openLogIngestion(ctx, d, cssClient)
 		if err != nil {
-			return diag.FromErr(err)
+			return diag.Errorf("error opening CSS cluster (%s) log ingestion: %s", clusterID, err)
+		}
+	default:
+		err = openLogBackup(ctx, d, cssClient)
+		if err != nil {
+			return diag.Errorf("error opening CSS cluster (%s) log backup: %s", clusterID, err)
+		}
+
+		if _, ok := d.GetOk("period"); ok {
+			err = openLogAutoBackup(d, cssClient)
+			if err != nil {
+				return diag.Errorf("error opening CSS cluster (%s) log auto backup: %s", clusterID, err)
+			}
 		}
 	}
 
+	d.SetId(fmt.Sprintf("%s/%s", clusterID, action))
 	return resourceLogSettingRead(ctx, d, meta)
 }
 
 func resourceLogSettingRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
-	cssV1Client, err := conf.CssV1Client(region)
+	cssClient, err := conf.NewServiceClient("css", region)
 	if err != nil {
-		return diag.Errorf("error creating CSS V1 client: %s", err)
+		return diag.Errorf("error creating CSS client: %s", err)
 	}
 
-	getLogSettingHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/settings"
-	getLogSettingPath := cssV1Client.Endpoint + getLogSettingHttpUrl
-	getLogSettingPath = strings.ReplaceAll(getLogSettingPath, "{project_id}", cssV1Client.ProjectID)
-	getLogSettingPath = strings.ReplaceAll(getLogSettingPath, "{cluster_id}", d.Id())
+	action := d.Get("action").(string)
+	clusterID := d.Get("cluster_id").(string)
 
-	getLogSettingPathOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	switch action {
+	case "real_time_log_collect":
+		logIngestionSetting, err := getLogIngestionSetting(clusterID, cssClient)
+		if err != nil {
+			// The cluster does not exist, http code is 403, key/value of error code is errCode/CSS.0015.
+			err = common.ConvertExpected403ErrInto404Err(err, "errCode", "CSS.0015")
+			return common.CheckDeletedDiag(d, err, "erorr retrieving CSS cluster log ingestion setting")
+		}
+		if logIngestionSetting == nil {
+			errorMsg := fmt.Sprintf("CSS cluster (%s) log ingestion is closed", clusterID)
+			return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, errorMsg)
+		}
+
+		realTimeLogCollectCreateAt := utils.PathSearch("createAt", logIngestionSetting, float64(0)).(float64)
+		realTimeLogCollectUpdateAt := utils.PathSearch("updateAt", logIngestionSetting, float64(0)).(float64)
+
+		mErr := multierror.Append(nil,
+			d.Set("region", region),
+			d.Set("cluster_id", clusterID),
+			d.Set("action", "real_time_log_collect"),
+			d.Set("index_prefix", utils.PathSearch("indexPrefix", logIngestionSetting, nil)),
+			d.Set("keep_days", utils.PathSearch("keepDays", logIngestionSetting, nil)),
+			d.Set("target_cluster_id", utils.PathSearch("targetClusterId", logIngestionSetting, nil)),
+			d.Set("status", utils.PathSearch("status", logIngestionSetting, nil)),
+			d.Set("log_ingestion_create_at", utils.FormatTimeStampRFC3339(int64(realTimeLogCollectCreateAt)/1000, false)),
+			d.Set("log_ingestion_update_at", utils.FormatTimeStampRFC3339(int64(realTimeLogCollectUpdateAt)/1000, false)),
+		)
+
+		return diag.FromErr(mErr.ErrorOrNil())
+	default:
+		logBackupSetting, err := getLogBackupSetting(clusterID, cssClient)
+		if err != nil {
+			// The cluster does not exist, http code is 403, key/value of error code is errCode/CSS.0015.
+			err = common.ConvertExpected403ErrInto404Err(err, "errCode", "CSS.0015")
+			return common.CheckDeletedDiag(d, err, "erorr retrieving CSS cluster log ingestion setting")
+		}
+		logBackupSwitch := utils.PathSearch("logSwitch", logBackupSetting, false).(bool)
+		if !logBackupSwitch {
+			errorMsg := fmt.Sprintf("CSS cluster (%s) log backup is closed", clusterID)
+			return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, errorMsg)
+		}
+
+		updateAt := utils.PathSearch("updateAt", logBackupSetting, float64(0)).(float64)
+		autoEnabled := utils.PathSearch("autoEnable", logBackupSetting, false).(bool)
+		var period string
+		if autoEnabled {
+			period = utils.PathSearch("period", logBackupSetting, false).(string)
+		}
+
+		mErr := multierror.Append(
+			nil,
+			d.Set("region", region),
+			d.Set("cluster_id", clusterID),
+			d.Set("action", "base_log_collect"),
+			d.Set("agency", utils.PathSearch("agency", logBackupSetting, nil)),
+			d.Set("base_path", utils.PathSearch("basePath", logBackupSetting, nil)),
+			d.Set("bucket", utils.PathSearch("obsBucket", logBackupSetting, nil)),
+			d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(updateAt)/1000, false)),
+			d.Set("auto_enabled", autoEnabled),
+			d.Set("period", period),
+			d.Set("log_switch", logBackupSwitch),
+		)
+
+		return diag.FromErr(mErr.ErrorOrNil())
 	}
-
-	getLogSettingResp, err := cssV1Client.Request("GET", getLogSettingPath, &getLogSettingPathOpt)
-	if err != nil {
-		// The cluster does not exist, http code is 403, key/value of error code is errCode/CSS.0015.
-		err = common.ConvertExpected403ErrInto404Err(err, "errCode", "CSS.0015")
-		return common.CheckDeletedDiag(d, err, "erorr retrieving CSS cluster log setting")
-	}
-
-	getLogSettingRespBody, err := utils.FlattenResponse(getLogSettingResp)
-	if err != nil {
-		return diag.Errorf("erorr retrieving CSS cluster log setting: %s", err)
-	}
-
-	logSetting := utils.PathSearch("logConfiguration", getLogSettingRespBody, nil)
-	updateAt := utils.PathSearch("updateAt", logSetting, float64(0)).(float64)
-	autoEnabled := utils.PathSearch("autoEnable", logSetting, false).(bool)
-	var period string
-	if autoEnabled {
-		period = utils.PathSearch("period", logSetting, nil).(string)
-	}
-	mErr := multierror.Append(
-		nil,
-		d.Set("region", region),
-		d.Set("cluster_id", d.Id()),
-		d.Set("agency", utils.PathSearch("agency", logSetting, nil)),
-		d.Set("base_path", utils.PathSearch("basePath", logSetting, nil)),
-		d.Set("bucket", utils.PathSearch("obsBucket", logSetting, nil)),
-		d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(updateAt)/1000, false)),
-		d.Set("auto_enabled", autoEnabled),
-		d.Set("period", period),
-		d.Set("log_switch", utils.PathSearch("logSwitch", logSetting, false)),
-	)
-
-	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func resourceLogSettingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
-	cssV1Client, err := conf.CssV1Client(region)
+	cssClient, err := conf.NewServiceClient("css", region)
 	if err != nil {
-		return diag.Errorf("error creating CSS V1 client: %s", err)
+		return diag.Errorf("error creating CSS client: %s", err)
 	}
 
-	logBaseSettingChanges := []string{
-		"agency",
-		"base_path",
-		"bucket",
-	}
+	clusterID := d.Get("cluster_id").(string)
+	action := d.Get("action").(string)
 
-	if d.HasChanges(logBaseSettingChanges...) {
-		err = updateLogBaseSetting(d, cssV1Client)
-		if err != nil {
-			return diag.FromErr(err)
+	switch action {
+	case "real_time_log_collect":
+		logIngestionSettingChanges := []string{
+			"index_prefix",
+			"keep_days",
+			"target_cluster_id",
 		}
-	}
-
-	if d.HasChange("period") {
-		if _, ok := d.GetOk("period"); ok {
-			err = openLogAutoBackup(d, cssV1Client)
+		if d.HasChanges(logIngestionSettingChanges...) {
+			err := updateLogIngestionSetting(ctx, d, cssClient)
 			if err != nil {
-				return diag.FromErr(err)
-			}
-		} else {
-			err = closeLogAutoBackup(d.Id(), cssV1Client)
-			if err != nil {
-				return diag.FromErr(err)
+				return diag.Errorf("error updating CSS cluster (%s) log ingestion setting: %s", clusterID, err)
 			}
 		}
-	}
+		return resourceLogSettingRead(ctx, d, meta)
+	default:
+		logBackupSettingChanges := []string{
+			"agency",
+			"base_path",
+			"bucket",
+		}
 
-	return resourceLogSettingRead(ctx, d, meta)
+		if d.HasChanges(logBackupSettingChanges...) {
+			err := updateLogBackupSetting(d, cssClient)
+			if err != nil {
+				return diag.Errorf("error updating CSS cluster (%s) log backup setting: %s", clusterID, err)
+			}
+		}
+
+		if d.HasChange("period") {
+			period := d.Get("period").(string)
+			var err error
+			if period != "" {
+				err = openLogAutoBackup(d, cssClient)
+				if err != nil {
+					return diag.Errorf("error updating CSS cluster (%s) log auto backup setting: %s", clusterID, err)
+				}
+			} else {
+				err = closeLogAutoBackup(clusterID, cssClient)
+				if err != nil {
+					return diag.Errorf("error closing CSS cluster (%s) log auto backup: %s", clusterID, err)
+				}
+			}
+		}
+		return resourceLogSettingRead(ctx, d, meta)
+	}
 }
 
-func resourceLogSettingDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLogSettingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 
-	cssV1Client, err := conf.CssV1Client(region)
+	cssClient, err := conf.NewServiceClient("css", region)
 	if err != nil {
-		return diag.Errorf("error creating CSS V1 client: %s", err)
+		return diag.Errorf("error creating CSS client: %s", err)
 	}
+	clusterID := d.Get("cluster_id").(string)
+	action := d.Get("action").(string)
 
-	deleteLogSettingUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/close"
-	deleteLogSettingPath := cssV1Client.Endpoint + deleteLogSettingUrl
-	deleteLogSettingPath = strings.ReplaceAll(deleteLogSettingPath, "{project_id}", cssV1Client.ProjectID)
-	deleteLogSettingPath = strings.ReplaceAll(deleteLogSettingPath, "{cluster_id}", d.Id())
+	switch action {
+	case "real_time_log_collect":
+		err := closeLogIngestion(ctx, d, cssClient)
+		if err != nil {
+			// "CSS.0015": The cluster does not exist. Status code is 403.
+			err = common.ConvertExpected403ErrInto404Err(err, "errCode", "CSS.0015")
+			// "CSS.0004": Invalid operation. Status code is 415.
+			// {"errCode":"CSS.0004","externalMessage":"CSS.0004 : Invalid operation. (Illegal operation)"}
+			err = common.ConvertUndefinedErrInto404Err(err, 415, "errCode", "CSS.0004")
+			return common.CheckDeletedDiag(d, err, fmt.Sprintf("error close the CSS cluser (%s) log ingestion", clusterID))
+		}
+		return nil
+	default:
+		err := closeLogBackup(clusterID, cssClient)
+		if err != nil {
+			// "CSS.0015": The cluster does not exist. Status code is 403.
+			err = common.ConvertExpected403ErrInto404Err(err, "errCode", "CSS.0015")
+			// "CSS.0004": Invalid operation. Status code is 415.
+			// {"errCode":"CSS.0004","externalMessage":"CSS.0004 : Invalid operation. (Illegal operation)"}
+			err = common.ConvertUndefinedErrInto404Err(err, 415, "errCode", "CSS.0004")
+			return common.CheckDeletedDiag(d, err, fmt.Sprintf("error close the CSS cluser (%s) log backup", clusterID))
+		}
+		return nil
+	}
+}
 
-	deleteLogSettingOpt := golangsdk.RequestOpts{
+func openLogBackup(_ context.Context, d *schema.ResourceData, cssClient *golangsdk.ServiceClient) error {
+	clusterID := d.Get("cluster_id").(string)
+	openLogBackupHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/open"
+	openLogBackupPath := cssClient.Endpoint + openLogBackupHttpUrl
+	openLogBackupPath = strings.ReplaceAll(openLogBackupPath, "{project_id}", cssClient.ProjectID)
+	openLogBackupPath = strings.ReplaceAll(openLogBackupPath, "{cluster_id}", clusterID)
+
+	openLogBackupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	openLogBackupOpt.JSONBody = map[string]interface{}{
+		"agency":      d.Get("agency").(string),
+		"logBasePath": d.Get("base_path").(string),
+		"logBucket":   d.Get("bucket").(string),
+	}
+	_, err := cssClient.Request("POST", openLogBackupPath, &openLogBackupOpt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func getLogBackupSetting(clusterID string, cssClient *golangsdk.ServiceClient) (interface{}, error) {
+	getLogBackupSettingHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/settings"
+	getLogBackupSettingPath := cssClient.Endpoint + getLogBackupSettingHttpUrl
+	getLogBackupSettingPath = strings.ReplaceAll(getLogBackupSettingPath, "{project_id}", cssClient.ProjectID)
+	getLogBackupSettingPath = strings.ReplaceAll(getLogBackupSettingPath, "{cluster_id}", clusterID)
+
+	getLogBackupSettingPathOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
 
-	_, err = cssV1Client.Request("PUT", deleteLogSettingPath, &deleteLogSettingOpt)
+	getLogBackupSettingResp, err := cssClient.Request("GET", getLogBackupSettingPath, &getLogBackupSettingPathOpt)
 	if err != nil {
-		// "CSS.0015": The cluster does not exist. Status code is 403.
-		err = common.ConvertExpected403ErrInto404Err(err, "errCode", "CSS.0015")
-		// "CSS.0004": Invalid operation. Status code is 415.
-		// {"errCode":"CSS.0004","externalMessage":"CSS.0004 : Invalid operation. (Illegal operation)"}
-		err = common.ConvertUndefinedErrInto404Err(err, 415, "errCode", "CSS.0004")
-		return common.CheckDeletedDiag(d, err, "error closing CSS cluster log function")
+		return nil, err
 	}
 
-	return nil
+	getLogBackupSettingRespBody, err := utils.FlattenResponse(getLogBackupSettingResp)
+	if err != nil {
+		return nil, err
+	}
+	return utils.PathSearch("logConfiguration", getLogBackupSettingRespBody, nil), nil
 }
 
-func updateLogBaseSetting(d *schema.ResourceData, cssV1Client *golangsdk.ServiceClient) error {
+func updateLogBackupSetting(d *schema.ResourceData, cssClient *golangsdk.ServiceClient) error {
+	clusterID := d.Get("cluster_id").(string)
 	updateLogSettingHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/settings"
-	updateLogSettingPath := cssV1Client.Endpoint + updateLogSettingHttpUrl
-	updateLogSettingPath = strings.ReplaceAll(updateLogSettingPath, "{project_id}", cssV1Client.ProjectID)
-	updateLogSettingPath = strings.ReplaceAll(updateLogSettingPath, "{cluster_id}", d.Id())
+	updateLogSettingPath := cssClient.Endpoint + updateLogSettingHttpUrl
+	updateLogSettingPath = strings.ReplaceAll(updateLogSettingPath, "{project_id}", cssClient.ProjectID)
+	updateLogSettingPath = strings.ReplaceAll(updateLogSettingPath, "{cluster_id}", clusterID)
 
 	updateLogSettingOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -254,18 +388,36 @@ func updateLogBaseSetting(d *schema.ResourceData, cssV1Client *golangsdk.Service
 		"logBasePath": d.Get("base_path").(string),
 		"logBucket":   d.Get("bucket").(string),
 	}
-	_, err := cssV1Client.Request("POST", updateLogSettingPath, &updateLogSettingOpt)
+	_, err := cssClient.Request("POST", updateLogSettingPath, &updateLogSettingOpt)
 	if err != nil {
-		return fmt.Errorf("error updating CSS cluster log setting: %s", err)
+		return err
 	}
 	return nil
 }
 
-func openLogAutoBackup(d *schema.ResourceData, cssV1Client *golangsdk.ServiceClient) error {
+func closeLogBackup(clusterID string, cssClient *golangsdk.ServiceClient) error {
+	closeLogBackupUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/close"
+	closeLogBackupPath := cssClient.Endpoint + closeLogBackupUrl
+	closeLogBackupPath = strings.ReplaceAll(closeLogBackupPath, "{project_id}", cssClient.ProjectID)
+	closeLogBackupPath = strings.ReplaceAll(closeLogBackupPath, "{cluster_id}", clusterID)
+
+	closeLogBackupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	_, err := cssClient.Request("PUT", closeLogBackupPath, &closeLogBackupOpt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func openLogAutoBackup(d *schema.ResourceData, cssClient *golangsdk.ServiceClient) error {
+	clusterID := d.Get("cluster_id").(string)
 	openLogAutoBackupHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/policy/update"
-	openLogAutoBackupPath := cssV1Client.Endpoint + openLogAutoBackupHttpUrl
-	openLogAutoBackupPath = strings.ReplaceAll(openLogAutoBackupPath, "{project_id}", cssV1Client.ProjectID)
-	openLogAutoBackupPath = strings.ReplaceAll(openLogAutoBackupPath, "{cluster_id}", d.Id())
+	openLogAutoBackupPath := cssClient.Endpoint + openLogAutoBackupHttpUrl
+	openLogAutoBackupPath = strings.ReplaceAll(openLogAutoBackupPath, "{project_id}", cssClient.ProjectID)
+	openLogAutoBackupPath = strings.ReplaceAll(openLogAutoBackupPath, "{cluster_id}", clusterID)
 
 	openLogAutoBackupOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -276,17 +428,17 @@ func openLogAutoBackup(d *schema.ResourceData, cssV1Client *golangsdk.ServiceCli
 		"period": d.Get("period"),
 	}
 
-	_, err := cssV1Client.Request("POST", openLogAutoBackupPath, &openLogAutoBackupOpt)
+	_, err := cssClient.Request("POST", openLogAutoBackupPath, &openLogAutoBackupOpt)
 	if err != nil {
-		return fmt.Errorf("error opening CSS cluster log auto backup policy: %s", err)
+		return err
 	}
 	return nil
 }
 
-func closeLogAutoBackup(clusterID string, cssV1Client *golangsdk.ServiceClient) error {
+func closeLogAutoBackup(clusterID string, cssClient *golangsdk.ServiceClient) error {
 	closeLogAutoBackupHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/policy/close"
-	closeLogAutoBackupPath := cssV1Client.Endpoint + closeLogAutoBackupHttpUrl
-	closeLogAutoBackupPath = strings.ReplaceAll(closeLogAutoBackupPath, "{project_id}", cssV1Client.ProjectID)
+	closeLogAutoBackupPath := cssClient.Endpoint + closeLogAutoBackupHttpUrl
+	closeLogAutoBackupPath = strings.ReplaceAll(closeLogAutoBackupPath, "{project_id}", cssClient.ProjectID)
 	closeLogAutoBackupPath = strings.ReplaceAll(closeLogAutoBackupPath, "{cluster_id}", clusterID)
 
 	closeLogAutoBackupOpt := golangsdk.RequestOpts{
@@ -294,9 +446,229 @@ func closeLogAutoBackup(clusterID string, cssV1Client *golangsdk.ServiceClient) 
 		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
 
-	_, err := cssV1Client.Request("PUT", closeLogAutoBackupPath, &closeLogAutoBackupOpt)
+	_, err := cssClient.Request("PUT", closeLogAutoBackupPath, &closeLogAutoBackupOpt)
 	if err != nil {
-		return fmt.Errorf("error closing CSS cluster log auto backup policy: %s", err)
+		return err
 	}
 	return nil
+}
+
+func openLogIngestion(ctx context.Context, d *schema.ResourceData, cssClient *golangsdk.ServiceClient) error {
+	clusterID := d.Get("cluster_id").(string)
+	targetClusterID := d.Get("target_cluster_id").(string)
+	openLogIngestionHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/open"
+	openLogIngestionPath := cssClient.Endpoint + openLogIngestionHttpUrl
+
+	openLogIngestionPath = strings.ReplaceAll(openLogIngestionPath, "{project_id}", cssClient.ProjectID)
+	openLogIngestionPath = strings.ReplaceAll(openLogIngestionPath, "{cluster_id}", clusterID)
+	openLogIngestionPath = fmt.Sprintf("%s?action=real_time_log_collect", openLogIngestionPath)
+
+	err := checkTargetClusterConnectivity(clusterID, targetClusterID, cssClient)
+	if err != nil {
+		return err
+	}
+
+	openLogIngestionOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	openLogIngestionOpt.JSONBody = map[string]interface{}{
+		"index_prefix":      d.Get("index_prefix").(string),
+		"keep_days":         d.Get("keep_days").(int),
+		"target_cluster_id": d.Get("target_cluster_id").(string),
+	}
+	_, err = cssClient.Request("POST", openLogIngestionPath, &openLogIngestionOpt)
+	if err != nil {
+		return err
+	}
+
+	err = configLogIngestionWaitingForCompleted(ctx, clusterID, cssClient, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkTargetClusterConnectivity(clusterID string, targetClusterID string, client *golangsdk.ServiceClient) error {
+	// Check the connection between two clusters when they are different
+	if targetClusterID == clusterID {
+		return nil
+	}
+	connectivityTestHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/connectivity"
+	connectivityTestPath := client.Endpoint + connectivityTestHttpUrl
+	connectivityTestPath = strings.ReplaceAll(connectivityTestPath, "{project_id}", client.ProjectID)
+	connectivityTestPath = strings.ReplaceAll(connectivityTestPath, "{cluster_id}", clusterID)
+	connectivityTestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"target_cluster_id": targetClusterID,
+		},
+	}
+	_, err := client.Request("POST", connectivityTestPath, &connectivityTestOpt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func configLogIngestionWaitingForCompleted(ctx context.Context, clusterID string, client *golangsdk.ServiceClient, timeout time.Duration) error {
+	targetStatus := []string{"200"}
+	failedStatus := []string{"300", "302", "303"}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			logIngestionSetting, err := getLogIngestionSetting(clusterID, client)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch(`status`, logIngestionSetting, "").(string)
+			if utils.StrSliceContains(targetStatus, status) {
+				return logIngestionSetting, "COMPLETED", nil
+			}
+
+			// Check for permanent failure states
+			if utils.StrSliceContains(failedStatus, status) {
+				return logIngestionSetting, status, fmt.Errorf("log ingestion failed with status: %s", status)
+			}
+
+			// For other statuses (including 100, 150, 304, 400, 920), continue waiting
+			return logIngestionSetting, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func getLogIngestionSetting(clusterID string, cssClient *golangsdk.ServiceClient) (interface{}, error) {
+	getLogSettingHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/settings"
+	getLogSettingPath := cssClient.Endpoint + getLogSettingHttpUrl
+	getLogSettingPath = strings.ReplaceAll(getLogSettingPath, "{project_id}", cssClient.ProjectID)
+	getLogSettingPath = strings.ReplaceAll(getLogSettingPath, "{cluster_id}", clusterID)
+
+	getLogIngestionSettingPath := fmt.Sprintf("%s?action=real_time_log_collect", getLogSettingPath)
+
+	getLogIngestionSettingOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	getLogIngestionSettingResp, err := cssClient.Request("GET", getLogIngestionSettingPath, &getLogIngestionSettingOpt)
+	if err != nil {
+		return nil, err
+	}
+	getLogIngestionSettingRespBody, err := utils.FlattenResponse(getLogIngestionSettingResp)
+	if err != nil {
+		return nil, err
+	}
+	return utils.PathSearch("realTimeLogCollectRecord", getLogIngestionSettingRespBody, nil), nil
+}
+
+func updateLogIngestionSetting(ctx context.Context, d *schema.ResourceData, cssClient *golangsdk.ServiceClient) error {
+	clusterID := d.Get("cluster_id").(string)
+	updateLogIngestionHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/settings"
+	updateLogIngestionPath := cssClient.Endpoint + updateLogIngestionHttpUrl
+	updateLogIngestionPath = strings.ReplaceAll(updateLogIngestionPath, "{project_id}", cssClient.ProjectID)
+	updateLogIngestionPath = strings.ReplaceAll(updateLogIngestionPath, "{cluster_id}", clusterID)
+	updateLogIngestionPath = fmt.Sprintf("%s?action=real_time_log_collect", updateLogIngestionPath)
+
+	if d.HasChange("target_cluster_id") {
+		targetClusterID := d.Get("target_cluster_id").(string)
+		err := checkTargetClusterConnectivity(clusterID, targetClusterID, cssClient)
+		if err != nil {
+			return err
+		}
+	}
+
+	updateLogIngestionSettingOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	updateLogIngestionSettingOpt.JSONBody = map[string]interface{}{
+		"index_prefix":      d.Get("index_prefix").(string),
+		"keep_days":         d.Get("keep_days").(int),
+		"target_cluster_id": d.Get("target_cluster_id").(string),
+	}
+	_, err := cssClient.Request("POST", updateLogIngestionPath, &updateLogIngestionSettingOpt)
+	if err != nil {
+		return err
+	}
+	err = configLogIngestionWaitingForCompleted(ctx, clusterID, cssClient, d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func closeLogIngestion(ctx context.Context, d *schema.ResourceData, cssClient *golangsdk.ServiceClient) error {
+	clusterID := d.Get("cluster_id").(string)
+	closeLogIngestionHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/close"
+	closeLogIngestionPath := cssClient.Endpoint + closeLogIngestionHttpUrl
+	closeLogIngestionPath = strings.ReplaceAll(closeLogIngestionPath, "{project_id}", cssClient.ProjectID)
+	closeLogIngestionPath = strings.ReplaceAll(closeLogIngestionPath, "{cluster_id}", clusterID)
+
+	closeLogIngestionPath = fmt.Sprintf("%s?action=real_time_log_collect", closeLogIngestionPath)
+
+	closeLogIngestionOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err := cssClient.Request("PUT", closeLogIngestionPath, &closeLogIngestionOpt)
+	if err != nil {
+		return err
+	}
+	err = closeLogIngestionWaitingForCompleted(ctx, clusterID, cssClient, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func closeLogIngestionWaitingForCompleted(ctx context.Context, clusterID string, client *golangsdk.ServiceClient, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			setting, err := getLogIngestionSetting(clusterID, client)
+			if err != nil {
+				return setting, "ERROR", err
+			}
+			// When log ingestion is closed, the setting will be nil
+			if setting == nil {
+				return "closed", "COMPLETED", nil
+			}
+			return setting, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceLogSettingImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+
+	switch len(parts) {
+	case 1:
+		d.SetId(parts[0] + "/base_log_collect")
+		d.Set("cluster_id", parts[0])
+		d.Set("action", "base_log_collect")
+	case 2:
+		d.SetId(d.Id())
+		d.Set("cluster_id", parts[0])
+		d.Set("action", parts[1])
+	default:
+		return nil, errors.New("invalid format of import ID, must be <cluster_id> or <cluster_id>/<action>")
+	}
+
+	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
enhance css_log_setting to support log ingestion

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
enhance css_log_setting to support log ingestion
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
$ make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run=TestAccLogSetting'
=== RUN   TestAccLogSetting_elastic
=== PAUSE TestAccLogSetting_elastic
=== RUN   TestAccLogSetting_logstash
=== PAUSE TestAccLogSetting_logstash
=== RUN   TestAccLogSetting_elastic_logIngestion
=== PAUSE TestAccLogSetting_elastic_logIngestion
=== CONT  TestAccLogSetting_elastic
=== CONT  TestAccLogSetting_elastic_logIngestion
=== CONT  TestAccLogSetting_logstash
--- PASS: TestAccLogSetting_elastic_logIngestion (121.90s)
--- PASS: TestAccLogSetting_elastic (624.59s)
--- PASS: TestAccLogSetting_logstash (832.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       832.748s
```
<img width="1154" height="42" alt="image" src="https://github.com/user-attachments/assets/71a7353a-f7ba-4af3-9ec1-a02ca922a62a" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

    - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> <img width="1021" height="225" alt="image" src="https://github.com/user-attachments/assets/5652ca26-e65b-4bef-8765-4ffa63bd4330" /> <<<<<<

  
    ab. Related resources (parent resources) not found
    \>>>>>> <img width="1073" height="246" alt="image" src="https://github.com/user-attachments/assets/d843ae08-35f8-41c9-b92e-d5f453f2bd35" /><<<<<<

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> <img width="956" height="98" alt="image" src="https://github.com/user-attachments/assets/e6462f6f-e509-4532-a8d5-3431829fc08d" /> <<<<<<

    bb. Related resources (parent resources) not found
    \>>>>>><img width="1004" height="98" alt="image" src="https://github.com/user-attachments/assets/ac2d7262-e50c-49c9-a348-0fc4e1549554" /><<<<<<

