### PR TITLE
docs(dataarts/architecture): update docs for approvals batch action resource

### DIFF
--- a/docs/resources/dataarts_architecture_approvals_batch_action.md
+++ b/docs/resources/dataarts_architecture_approvals_batch_action.md
@@ -11,8 +11,7 @@ description: |-
 Use this resource to operate a DataArts Architecture approvals batch action within HuaweiCloud.
 
 -> This resource is only a one-time action resource for operating approvals. Deleting this resource will not
-   clear the corresponding request record, but will only remove the resource information from the tfstate file,
-   but will only remove the resource information from the tfstate file.
+   clear the corresponding request record, but will only remove the resource information from the tfstate file.
 
 ## Example Usage
 

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_approvals_batch_action.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_approvals_batch_action.go
@@ -183,8 +183,7 @@ func resourceArchitectureApprovalsBatchActionUpdate(_ context.Context, _ *schema
 
 func resourceArchitectureApprovalsBatchActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	msg := `This resource is only a one-time action resource for operating approvals. Deleting this resource will not
-clear the corresponding request record, but will only remove the resource information from the tfstate file,
-but will only remove the resource information from the tfstate file.`
+clear the corresponding request record, but will only remove the resource information from the tfstate file.`
 	return diag.Diagnostics{
 		diag.Diagnostic{
 			Severity: diag.Warning,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
update docs for approvals batch action resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
update docs for approvals batch action resource
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
 update docs for approvals batch action resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
