### PR TITLE
feat(eip): new datasource to query publicip types

### DIFF
--- a/docs/data-sources/eip_publicip_types.md
+++ b/docs/data-sources/eip_publicip_types.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eip_publicip_types"
+description: |-
+  Use this data source to get a list of EIP public IP types.
+---
+
+# huaweicloud_eip_publicip_types
+
+Use this data source to get a list of EIP public IP types.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_eip_publicip_types" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `publicip_types` - Indicates the public IP types.
+
+  The [publicip_types](#publicip_types_struct) structure is documented below.
+
+<a name="publicip_types_struct"></a>
+The `publicip_types` block supports:
+
+* `id` - Indicates the elastic public IP pool ID.
+
+* `type` - Indicates the elastic public IP pool type. Valid values are:
+  + **5_bgp**: Dynamic BGP public IP pool.
+  + **5_sbgp**: Static BGP public IP pool.
+  + **5_testbgp**: IP test pool.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2402,6 +2402,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_eip_tags":                       eip.DataSourceVpcEipTags(),
 			"huaweicloud_vpc_internet_gateways":              eip.DataSourceVPCInternetGateways(),
 			"huaweicloud_eip_publicip_count":                 eip.DataSourceEipPublicipCount(),
+			"huaweicloud_eip_publicip_types":                 eip.DataSourceEipPublicipTypes(),
 			"huaweicloud_global_eip_quotas":                  eip.DataSourceGlobalEipQuotas(),
 			"huaweicloud_global_eip_pools":                   eip.DataSourceGlobalEIPPools(),
 			"huaweicloud_global_eip_bindings":                eip.DataSourceGlobalEipBindings(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_eip_publicip_types_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_eip_publicip_types_test.go
@@ -1,0 +1,35 @@
+package eip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEipPublicipTypes_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_eip_publicip_types.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceEipPublicipTypes_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "publicip_types.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceEipPublicipTypes_basic = `
+data "huaweicloud_eip_publicip_types" "test" {}
+`

--- a/huaweicloud/services/eip/data_source_huaweicloud_eip_publicip_types.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_eip_publicip_types.go
@@ -1,0 +1,109 @@
+package eip
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v2/{project_id}/publicip_types
+func DataSourceEipPublicipTypes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEipPublicipTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"publicip_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceEipPublicipTypesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "vpc"
+		httpUrl = "v2/{project_id}/publicip_types"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VPC EIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving EIP public IP types: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate UUID: %s", err)
+	}
+	d.SetId(generateId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("publicip_types", flattenPublicipTypes(
+			utils.PathSearch("publicip_types", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+// The API documentation indicates that field `publicip_types` is of type object, but actual testing revealed that its
+// type is array.
+func flattenPublicipTypes(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"id":   utils.PathSearch("id", v, nil),
+			"type": utils.PathSearch("type", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query publicip types.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o eip -f TestAccDataSourceEipPublicipTypes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccDataSourceEipPublicipTypes_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceEipPublicipTypes_basic
=== PAUSE TestAccDataSourceEipPublicipTypes_basic
=== CONT  TestAccDataSourceEipPublicipTypes_basic
--- PASS: TestAccDataSourceEipPublicipTypes_basic (14.97s)
PASS
coverage: 2.5% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       15.065s coverage: 2.5% of statements in ./huaweicloud/services/eip
```
<img width="1291" height="69" alt="image" src="https://github.com/user-attachments/assets/571a291b-e36d-4458-8cf9-b61b5625a57f" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
