### PR TITLE
feat(dds): add resource to manage DDS instance shard/config IP address

### DIFF
--- a/docs/resources/dds_ip_address.md
+++ b/docs/resources/dds_ip_address.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Document Database Service (DDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dds_ip_address"
+description: |-
+  Manages a shard/config IP address resource within HuaweiCloud.
+---
+
+# huaweicloud_dds_lts_log
+
+Manages a shard/config IP address resource within HuaweiCloud.
+
+-> 1. The frozen cluster DDS instance does not support add shard/config IP address.
+  <br/>2. The cluster DDS instance associated with the IPv6 subnet do not support add shard/config IP address.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "type" {}
+variable "password" {}
+
+resource "huaweicloud_dds_ip_address" "test" {
+  instance_id = var.instance_id
+  type        = var.type
+  password    = var.password
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the cluster DDS instance.
+
+* `type` - (Required, String, NonUpdatable) Specifies the node type of the cluster DDS instance.
+  The value can be **shard** or **config**.
+
+* `password` - (Required, String, NonUpdatable) Specifies the password for enabling this function
+  for a cluster DDS instance.
+  The value must be `8` to `32` characters in length and contain uppercase letters, lowercase letters,
+  digits and special characters, such as **~!@#%^*-_=+?**.
+
+* `target_ids` - (Optional, List) Specifies the shard group IDs.
+  This parameter only supports in update, creating resource does not support.
+  This parameter only supports add the shard group ID, does not support remove the shard group ID.
+  If the shard or config IP address is added for the first time, leave this parameter empty.
+  If a shard IP address has been added to a DDS instance, you need to specify this parameter to add an IP address
+  to the new shard group.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attribute is exported:
+
+* `id` - The resource ID, also is the DDS instance ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3321,6 +3321,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_audit_log_policy":              dds.ResourceDdsAuditLogPolicy(),
 			"huaweicloud_dds_audit_log_delete":              dds.ResourceDDSAuditLogDelete(),
 			"huaweicloud_dds_database_upgrade":              dds.ResourceDatabaseUpgrade(),
+			"huaweicloud_dds_ip_address":                    dds.ResourceIpAddress(),
 			"huaweicloud_dds_lts_log":                       dds.ResourceDdsLtsLog(),
 			"huaweicloud_dds_node_session_kill":             dds.ResourceNodeSessionKill(),
 			"huaweicloud_dds_instance_restart":              dds.ResourceDDSInstanceRestart(),

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_ip_address_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_ip_address_test.go
@@ -1,0 +1,64 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dds"
+)
+
+func getResourceIpAddressFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dds", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DDS client: %s", err)
+	}
+
+	return dds.GetInstanceInfo(client, state.Primary.ID)
+}
+
+func TestAccResourceIpAddress_basic(t *testing.T) {
+	var (
+		rName  = "huaweicloud_dds_ip_address.test"
+		object interface{}
+		rc     = acceptance.InitResourceCheck(
+			rName,
+			&object,
+			getResourceIpAddressFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDDSInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIpAddress_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "instance_id", acceptance.HW_DDS_INSTANCE_ID),
+					resource.TestCheckResourceAttr(rName, "type", "config"),
+					resource.TestCheckResourceAttr(rName, "password", "Test@1234"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIpAddress_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dds_ip_address" "test" {
+  instance_id = "%s"
+  type        = "config"
+  password    = "Test@1234"
+}
+`, acceptance.HW_DDS_INSTANCE_ID)
+}

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_ip_address.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_ip_address.go
@@ -1,0 +1,326 @@
+package dds
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var ipAddressNonUpdatableParams = []string{"instance_id", "type", "password"}
+
+// @API DDS POST /v3/{project_id}/instances/{instance_id}/create-ip
+// @API DDS DELETE /v3/{project_id}/instances/{instance_id}/ip
+// @API DDS GET /v3/{project_id}/instances
+// @API DDS GET /v3/{project_id}/jobs
+func ResourceIpAddress() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIpAddressCreate,
+		ReadContext:   resourceIpAddressRead,
+		UpdateContext: resourceIpAddressUpdate,
+		DeleteContext: resourceIpAddressDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(ipAddressNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"target_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildCreateIpAddressBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"type":     d.Get("type"),
+		"password": d.Get("password"),
+	}
+
+	return bodyParams
+}
+
+func resourceIpAddressCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		nodeType   = d.Get("type").(string)
+		targetIds  = d.Get("target_ids").(*schema.Set).List()
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/create-ip"
+	)
+
+	client, err := cfg.NewServiceClient("dds", region)
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s", err)
+	}
+
+	if len(targetIds) > 0 {
+		return diag.Errorf("error creating %s IP address: parameter `target_ids` does not support in creating", nodeType)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		KeepResponseBody: true,
+		JSONBody:         buildCreateIpAddressBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating %s IP address: %s", nodeType, err)
+	}
+
+	d.SetId(instanceId)
+
+	err = waitForAddIpAddressCompleted(ctx, client, d.Id(), d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceIpAddressRead(ctx, d, meta)
+}
+
+func waitForAddIpAddressCompleted(ctx context.Context, client *golangsdk.ServiceClient, instanceId string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"updating"},
+		Target:       []string{"normal"},
+		Refresh:      ddsInstanceStateRefreshFunc(client, instanceId),
+		Timeout:      timeout,
+		Delay:        15 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for adding IP address to complete: %s ", err)
+	}
+
+	return nil
+}
+
+func GetInstanceInfo(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	getHttpUrl := "v3/{project_id}/instances?id={instance_id}"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getOpts := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("instances|[0]", respBody, nil), nil
+}
+
+func resourceIpAddressRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		nodeType = d.Get("type").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dds", region)
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s", err)
+	}
+
+	instacneInfo, err := GetInstanceInfo(client, d.Id())
+	if err != nil {
+		// When the instance does not exist, the response HTTP status code of the query API is 400
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", instanceNotFoundCodes...),
+			fmt.Sprintf("error retrieving %s IP address", nodeType))
+	}
+
+	privateIpInfo := utils.PathSearch(fmt.Sprintf("groups[?type=='%s'].nodes[].private_ip", nodeType),
+		instacneInfo, make([]interface{}, 0)).([]interface{})
+	if len(privateIpInfo) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, fmt.Sprintf("error retrieving %s IP address", nodeType))
+	}
+
+	return diag.FromErr(d.Set("region", region))
+}
+
+func buildUpdateIpAddressBodyParams(d *schema.ResourceData, targetId string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"type":      d.Get("type"),
+		"target_id": targetId,
+		"password":  d.Get("password"),
+	}
+
+	return bodyParams
+}
+
+func resourceIpAddressUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		nodeType = d.Get("type").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dds", region)
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s", err)
+	}
+
+	if d.HasChanges("target_ids") {
+		oldTargetIds, newTargetIds := d.GetChange("target_ids")
+		removeTargetIds := oldTargetIds.(*schema.Set).Difference(newTargetIds.(*schema.Set))
+		if len(removeTargetIds.List()) > 0 {
+			return diag.Errorf("error updating %s IP address: remove the IP address operation does not support", nodeType)
+		}
+
+		targetIds := newTargetIds.(*schema.Set).Difference(oldTargetIds.(*schema.Set))
+		addTargetIds := utils.ExpandToStringList(targetIds.List())
+		for _, targetId := range addTargetIds {
+			err = updateIpAddress(ctx, client, d, d.Id(), targetId, nodeType)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	return resourceIpAddressRead(ctx, d, meta)
+}
+
+func updateIpAddress(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	instanceId, targetId, nodeType string) error {
+	httpUrl := "v3/{project_id}/instances/{instance_id}/create-ip"
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", instanceId)
+
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateIpAddressBodyParams(d, targetId),
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return fmt.Errorf("error updating %s IP address: %s", nodeType, err)
+	}
+
+	err = waitForAddIpAddressCompleted(ctx, client, d.Id(), d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func buildDeleteIpAddressBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"type": d.Get("type"),
+	}
+
+	return bodyParams
+}
+
+func resourceIpAddressDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		nodeType = d.Get("type").(string)
+		httpUrl  = "v3/{project_id}/instances/{instance_id}/ip"
+	)
+
+	client, err := cfg.NewServiceClient("dds", region)
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		KeepResponseBody: true,
+		JSONBody:         buildDeleteIpAddressBodyParams(d),
+	}
+
+	resp, err := client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting %s IP addresses: %s", nodeType, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("jobId", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error deleting %s IP addresses: unable to find job ID from the API response", nodeType)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"Running"},
+		Target:       []string{"Completed"},
+		Refresh:      JobStateRefreshFunc(client, jobId),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        60 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the job (%s) completed: %s ", jobId, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add resource to manage DDS instance shard/config IP address.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
The update operation
<img width="712" height="855" alt="s1" src="https://github.com/user-attachments/assets/d6d8b09f-cd13-4d9d-8bae-dbecc1f54543" />
<img width="989" height="702" alt="s2" src="https://github.com/user-attachments/assets/a7199b4e-c07a-449e-beaf-539059276bd9" />

```release-note
1.support a new resource to manage DDS instance shard/config IP address
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccResourceIpAddress_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccResourceIpAddress_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceIpAddress_basic
=== PAUSE TestAccResourceIpAddress_basic
=== CONT  TestAccResourceIpAddress_basic
--- PASS: TestAccResourceIpAddress_basic (181.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       181.815s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
<img width="723" height="207" alt="s3" src="https://github.com/user-attachments/assets/fe9d5049-46a3-421e-ae4e-b905d4bddd7a" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
