### PR TITLE
feat(modelarts): add new resource to manage workflow schedule

### DIFF
--- a/docs/resources/modelartsv2_workflow_schedule.md
+++ b/docs/resources/modelartsv2_workflow_schedule.md
@@ -1,0 +1,68 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelartsv2_workflow_schedule"
+description: |-
+  Manages a ModelArts workflow schedule configuration within HuaweiCloud.
+---
+
+# huaweicloud_modelartsv2_workflow_schedule
+
+Manages a ModelArts workflow schedule configuration within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workflow_id" {}
+
+resource "huaweicloud_modelartsv2_workflow_schedule" "test" {
+  workflow_id = var.workflow_id
+
+  content = jsonencode({
+    cron   = "0 0 0 * * Thu"
+    method = "fixed"
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the workflow schedule is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `workflow_id` - (Required, String, NonUpdatable) Specifies the ID of the workflow to which the schedule configuration
+  belongs.
+
+* `content` - (Required, String) Specifies the content of the workflow schedule, in JSON format.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `enable` - Whether the workflow schedule is enabled.
+
+* `policies` - The scheduling policies of the workflow schedule.  
+  The [policies](#modelartsv2_workflow_schedule_policies_attr) structure is documented below.
+
+* `user_id` - The user ID that created the workflow schedule.
+
+* `created_at` - The creation time of the workflow schedule, in RFC3339 format.
+
+<a name="modelartsv2_workflow_schedule_policies_attr"></a>
+The `policies` block supports:
+
+* `on_failure` - The policy action when the workflow execution fails.
+
+* `on_running` - The policy action when the workflow is already running.
+
+## Import
+
+Workflow schedules can be imported using `workflow_id` and `id`, separated by a slash, e.g.
+
+```bash
+terraform import huaweicloud_modelartsv2_workflow_schedule.test <workflow_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3901,6 +3901,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelartsv2_node_batch_unsubscribe": modelarts.ResourceV2NodeBatchUnsubscribe(),
 			"huaweicloud_modelartsv2_service":                modelarts.ResourceV2Service(),
 			"huaweicloud_modelartsv2_service_action":         modelarts.ResourceV2ServiceAction(),
+			"huaweicloud_modelartsv2_workflow_schedule":      modelarts.ResourceV2WorkflowSchedule(),
 
 			"huaweicloud_metastudio_instance": metastudio.ResourceMetaStudio(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -576,6 +576,7 @@ var (
 	HW_MODELARTS_DEVSERVER_IMAGE_ID                   = os.Getenv("HW_MODELARTS_DEVSERVER_IMAGE_ID")
 	HW_MODELARTS_RESOURCE_POOL_NAME                   = os.Getenv("HW_MODELARTS_RESOURCE_POOL_NAME")
 	HW_MODELARTS_RESOURCE_POOL_BATCH_RESIZE_NODE_NAME = os.Getenv("HW_MODELARTS_RESOURCE_POOL_BATCH_RESIZE_NODE_NAME")
+	HW_MODELARTS_WORKFLOW_ID                          = os.Getenv("HW_MODELARTS_WORKFLOW_ID")
 
 	HW_AOM_ALARM_EVENT_SN                        = os.Getenv("HW_AOM_ALARM_EVENT_SN")
 	HW_AOM_INSTALLER_AGENT_ID                    = os.Getenv("HW_AOM_INSTALLER_AGENT_ID")
@@ -3398,6 +3399,13 @@ func TestAccPreCheckModelArtsResourcePoolName(t *testing.T) {
 func TestAccPreCheckModelArtsResourcePoolBatchResize(t *testing.T) {
 	if HW_MODELARTS_RESOURCE_POOL_BATCH_RESIZE_NODE_NAME == "" {
 		t.Skip("HW_MODELARTS_RESOURCE_POOL_BATCH_RESIZE_NODE_NAME must be set for ModelArts resource pool acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckModelArtsWorkflowId(t *testing.T) {
+	if HW_MODELARTS_WORKFLOW_ID == "" {
+		t.Skip("HW_MODELARTS_WORKFLOW_ID must be set for ModelArts acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelartsv2_workflow_schedule_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelartsv2_workflow_schedule_test.go
@@ -1,0 +1,233 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
+)
+
+func getV2WorkflowScheduleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region     = acceptance.HW_REGION_NAME
+		workflowId = state.Primary.Attributes["workflow_id"]
+		scheduleId = state.Primary.ID
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	return modelarts.GetV2WorkflowScheduleById(client, workflowId, scheduleId)
+}
+
+func TestAccV2WorkflowSchedule_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName = "huaweicloud_modelartsv2_workflow_schedule.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getV2WorkflowScheduleResourceFunc)
+	)
+
+	// Each workflow can only manage one schedule resource, using serial testing instead.
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckModelArtsWorkflowId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccV2WorkflowSchedule_nonExistentWorkflow(),
+				ExpectError: regexp.MustCompile(`error creating ModelArts workflow schedule`),
+			},
+			{
+				Config: testAccV2WorkflowSchedule_basic_step1(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workflow_id", acceptance.HW_MODELARTS_WORKFLOW_ID),
+					resource.TestCheckResourceAttr(rName, "content", `{"cron":"0 0 12 * * ?","method":"fixed"}`),
+					resource.TestCheckResourceAttr(rName, "enable", "true"),
+					resource.TestCheckResourceAttr(rName, "policies.#", "1"),
+					resource.TestCheckResourceAttrSet(rName, "policies.0.on_failure"),
+					resource.TestCheckResourceAttrSet(rName, "policies.0.on_running"),
+					resource.TestCheckResourceAttrSet(rName, "user_id"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccV2WorkflowSchedule_basic_step2(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workflow_id", acceptance.HW_MODELARTS_WORKFLOW_ID),
+					resource.TestCheckResourceAttr(rName, "content", `{"cron":"0 0 13 * * Mon,Tue","method":"fixed"}`),
+					resource.TestCheckResourceAttr(rName, "enable", "true"),
+					resource.TestCheckResourceAttr(rName, "policies.#", "1"),
+					resource.TestCheckResourceAttrSet(rName, "policies.0.on_failure"),
+					resource.TestCheckResourceAttrSet(rName, "policies.0.on_running"),
+					resource.TestCheckResourceAttrSet(rName, "user_id"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccV2WorkflowScheduleImportStateIDFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccV2WorkflowScheduleImportStateIDFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		workflowID := rs.Primary.Attributes["workflow_id"]
+		if workflowID == "" {
+			return "", fmt.Errorf("attribute (workflow_id) of resource (%s) not found", name)
+		}
+		return fmt.Sprintf("%s/%s", workflowID, rs.Primary.ID), nil
+	}
+}
+
+func testAccV2WorkflowSchedule_nonExistentWorkflow() string {
+	randomUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_modelartsv2_workflow_schedule" "test" {
+  workflow_id = "%[1]s"
+  content     = jsonencode({
+    cron   = "0 0 12 * * ?"
+    method = "fixed"
+  })
+}
+`, randomUUID)
+}
+
+func testAccV2WorkflowSchedule_basic_step1() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_modelartsv2_workflow_schedule" "test" {
+  workflow_id = "%[1]s"
+  content     = jsonencode({
+    cron   = "0 0 12 * * ?"
+    method = "fixed"
+  })
+}
+`, acceptance.HW_MODELARTS_WORKFLOW_ID)
+}
+
+func testAccV2WorkflowSchedule_basic_step2() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_modelartsv2_workflow_schedule" "test" {
+  workflow_id = "%[1]s"
+  content     = jsonencode({
+    cron   = "0 0 13 * * Mon,Tue"
+    method = "fixed"
+  })
+}
+`, acceptance.HW_MODELARTS_WORKFLOW_ID)
+}
+
+func TestAccV2WorkflowSchedule_withPolicies(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName = "huaweicloud_modelartsv2_workflow_schedule.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getV2WorkflowScheduleResourceFunc)
+	)
+
+	// Each workflow can only manage one schedule resource, using serial testing instead.
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckModelArtsWorkflowId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV2WorkflowSchedule_withPolicies_step1(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workflow_id", acceptance.HW_MODELARTS_WORKFLOW_ID),
+					resource.TestCheckResourceAttr(rName, "content", `{"cron":"0 0 12 * * ?","method":"fixed"}`),
+					resource.TestCheckResourceAttr(rName, "enable", "true"),
+					resource.TestCheckResourceAttr(rName, "policies.#", "1"),
+					resource.TestCheckResourceAttrSet(rName, "policies.0.on_failure"),
+					resource.TestCheckResourceAttrSet(rName, "policies.0.on_running"),
+					resource.TestCheckResourceAttrSet(rName, "user_id"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccV2WorkflowSchedule_withPolicies_step2(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workflow_id", acceptance.HW_MODELARTS_WORKFLOW_ID),
+					resource.TestCheckResourceAttr(rName, "content", `{"cron":"0 0 13 * * Mon,Tue","method":"fixed"}`),
+					resource.TestCheckResourceAttr(rName, "enable", "true"),
+					resource.TestCheckResourceAttr(rName, "policies.#", "1"),
+					resource.TestCheckResourceAttrSet(rName, "policies.0.on_failure"),
+					resource.TestCheckResourceAttrSet(rName, "policies.0.on_running"),
+					resource.TestCheckResourceAttrSet(rName, "user_id"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccV2WorkflowScheduleImportStateIDFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccV2WorkflowSchedule_withPolicies_step1() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_modelartsv2_workflow_schedule" "test" {
+  workflow_id = "%[1]s"
+  content     = jsonencode({
+    cron   = "0 0 12 * * ?"
+    method = "fixed"
+  })
+  policies {
+    on_failure = "retry"
+    on_running = "cancel"
+  }
+}
+`, acceptance.HW_MODELARTS_WORKFLOW_ID)
+}
+
+func testAccV2WorkflowSchedule_withPolicies_step2() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_modelartsv2_workflow_schedule" "test" {
+  workflow_id = "%[1]s"
+  content     = jsonencode({
+    cron   = "0 0 13 * * Mon,Tue"
+    method = "fixed"
+  })
+  policies {
+    on_failure = "retry"
+    on_running = "cancel"
+  }
+}
+`, acceptance.HW_MODELARTS_WORKFLOW_ID)
+}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow_schedule.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow_schedule.go
@@ -1,0 +1,389 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	v2WorkflowScheduleNonUpdatableParams = []string{
+		"workflow_id",
+		"policies",
+		"policies.*.on_failure",
+		"policies.*.on_running",
+	}
+	v2WorkflowScheduleNotFoundErrCodes = []string{
+		"ModelArts.7512", // The workflow does not exist.
+		"ModelArts.7525", // The workflow schedule does not exist.
+	}
+)
+
+// @API ModelArts POST /v2/{project_id}/workflows/{workflow_id}/schedules
+// @API ModelArts GET /v2/{project_id}/workflows/{workflow_id}/schedules/{schedule_id}
+// @API ModelArts PUT /v2/{project_id}/workflows/{workflow_id}/schedules/{schedule_id}
+// @API ModelArts DELETE /v2/{project_id}/workflows/{workflow_id}/schedules/{schedule_id}
+func ResourceV2WorkflowSchedule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV2WorkflowScheduleCreate,
+		ReadContext:   resourceV2WorkflowScheduleRead,
+		UpdateContext: resourceV2WorkflowScheduleUpdate,
+		DeleteContext: resourceV2WorkflowScheduleDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceV2WorkflowScheduleImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(v2WorkflowScheduleNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the workflow schedule is located.`,
+			},
+
+			// Required parameters.
+			"workflow_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workflow to which the schedule configuration belongs.`,
+			},
+			"content": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Description:  `The content of the workflow schedule, in JSON format.`,
+			},
+			"policies": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"on_failure": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							Description: utils.SchemaDesc(
+								`The policy action when the workflow execution fails.`,
+								utils.SchemaDescInput{
+									Computed: true,
+								},
+							),
+						},
+						"on_running": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							Description: utils.SchemaDesc(
+								`The policy action when the workflow is already running.`,
+								utils.SchemaDescInput{
+									Computed: true,
+								},
+							),
+						},
+					},
+				},
+				Description: utils.SchemaDesc(
+					`The scheduling policies of the workflow schedule.`,
+					utils.SchemaDescInput{
+						Computed: true,
+					},
+				),
+			},
+
+			// Attributes.
+			"enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the workflow schedule is enabled.`,
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user ID that created the workflow schedule.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the workflow schedule, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true},
+				),
+			},
+		},
+	}
+}
+
+func buildV2WorkflowSchedulePolicies(policies []interface{}) map[string]interface{} {
+	if len(policies) < 1 {
+		return map[string]interface{}{
+			"on_failure": "retry",
+			"on_running": "cancel",
+		}
+	}
+
+	return map[string]interface{}{
+		"on_failure": utils.PathSearch("on_failure", policies[0], nil),
+		"on_running": utils.PathSearch("on_running", policies[0], nil),
+	}
+}
+
+func buildV2WorkflowScheduleCreateBodyParams(scheduleContent string, policies []interface{}) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		// Fixed values.
+		"action":   "run",
+		"type":     "time",
+		"policies": buildV2WorkflowSchedulePolicies(policies),
+		// Required parameters.
+		"content": utils.StringToJson(scheduleContent),
+	}
+	return bodyParams
+}
+
+func createV2WorkflowSchedule(client *golangsdk.ServiceClient, workflowId, scheduleContent string, policies []interface{}) (interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/workflows/{workflow_id}/schedules"
+	)
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{workflow_id}", workflowId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildV2WorkflowScheduleCreateBodyParams(scheduleContent, policies)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceV2WorkflowScheduleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg             = meta.(*config.Config)
+		region          = cfg.GetRegion(d)
+		workflowId      = d.Get("workflow_id").(string)
+		scheduleContent = d.Get("content").(string)
+		policies        = d.Get("policies").([]interface{})
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	resp, err := createV2WorkflowSchedule(client, workflowId, scheduleContent, policies)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts workflow schedule: %s", err)
+	}
+
+	scheduleId := utils.PathSearch("uuid", resp, "").(string)
+	if scheduleId == "" {
+		return diag.Errorf("unable to find the ModelArts workflow schedule ID from the API response")
+	}
+	d.SetId(scheduleId)
+
+	return resourceV2WorkflowScheduleRead(ctx, d, meta)
+}
+
+func flattenV2WorkflowSchedulePolicies(policies map[string]interface{}) []map[string]interface{} {
+	if len(policies) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"on_failure": utils.PathSearch("on_failure", policies, nil),
+			"on_running": utils.PathSearch("on_running", policies, nil),
+		},
+	}
+}
+
+func GetV2WorkflowScheduleById(client *golangsdk.ServiceClient, workflowId, scheduleId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/workflows/{workflow_id}/schedules/{schedule_id}"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{workflow_id}", workflowId)
+	getPath = strings.ReplaceAll(getPath, "{schedule_id}", scheduleId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceV2WorkflowScheduleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		workflowId = d.Get("workflow_id").(string)
+		scheduleId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	resp, err := GetV2WorkflowScheduleById(client, workflowId, scheduleId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", v2WorkflowScheduleNotFoundErrCodes...),
+			fmt.Sprintf("error retrieving ModelArts workflow schedule (%s)", scheduleId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("content", utils.JsonToString(utils.PathSearch("content", resp, nil))),
+		d.Set("enable", utils.PathSearch("enable", resp, nil)),
+		d.Set("policies", flattenV2WorkflowSchedulePolicies(utils.PathSearch("policies", resp,
+			make(map[string]interface{})).(map[string]interface{}))),
+		d.Set("user_id", utils.PathSearch("user_id", resp, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("created_at",
+			resp, "").(string))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildV2WorkflowScheduleUpdateBodyParams(scheduleContent string, isEnable bool) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"content": utils.StringToJson(scheduleContent),
+		"enable":  isEnable,
+	}
+	return bodyParams
+}
+
+func updateV2WorkflowScheduleContent(client *golangsdk.ServiceClient, workflowId, scheduleId, scheduleContent string, isEnable bool) error {
+	httpUrl := "v2/{project_id}/workflows/{workflow_id}/schedules/{schedule_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{workflow_id}", workflowId)
+	updatePath = strings.ReplaceAll(updatePath, "{schedule_id}", scheduleId)
+
+	opt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildV2WorkflowScheduleUpdateBodyParams(scheduleContent, isEnable)),
+	}
+
+	_, err := client.Request("PUT", updatePath, &opt)
+	return err
+}
+
+func resourceV2WorkflowScheduleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		workflowId = d.Get("workflow_id").(string)
+		scheduleId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	if d.HasChange("content") {
+		err := updateV2WorkflowScheduleContent(client, workflowId, scheduleId, d.Get("content").(string), d.Get("enable").(bool))
+		if err != nil {
+			return diag.Errorf("error updating ModelArts workflow schedule content: %s", err)
+		}
+	}
+
+	return resourceV2WorkflowScheduleRead(ctx, d, meta)
+}
+
+func deleteV2WorkflowSchedule(client *golangsdk.ServiceClient, workflowId, scheduleId string) error {
+	httpUrl := "v2/{project_id}/workflows/{workflow_id}/schedules/{schedule_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{workflow_id}", workflowId)
+	deletePath = strings.ReplaceAll(deletePath, "{schedule_id}", scheduleId)
+
+	opt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &opt)
+	return err
+}
+
+func resourceV2WorkflowScheduleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		workflowId = d.Get("workflow_id").(string)
+		scheduleId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	err = deleteV2WorkflowSchedule(client, workflowId, scheduleId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", v2WorkflowScheduleNotFoundErrCodes...),
+			fmt.Sprintf("error deleting ModelArts workflow schedule (%s)", scheduleId))
+	}
+
+	return nil
+}
+
+func resourceV2WorkflowScheduleImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.SplitN(importedId, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workflow_id>/<id>', but got '%s'", importedId)
+	}
+
+	d.SetId(parts[1])
+	mErr := multierror.Append(nil,
+		d.Set("workflow_id", parts[0]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource to manage workflow schedule of ModelArts service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance test:
<img width="1038" height="320" alt="image" src="https://github.com/user-attachments/assets/78fca78d-abfb-4bd3-baf1-e79ef8239e20" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage workflow schedule.
2. supports corresponding documentation and tests.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccV2WorkflowSchedule_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccV2WorkflowSchedule_ -timeout 360m -parallel 10
=== RUN   TestAccV2WorkflowSchedule_basic
--- PASS: TestAccV2WorkflowSchedule_basic (29.70s)
=== RUN   TestAccV2WorkflowSchedule_withPolicies
--- PASS: TestAccV2WorkflowSchedule_withPolicies (25.67s)
PASS
coverage: 6.4% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 55.478s coverage: 6.4% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1935" height="1060" alt="image" src="https://github.com/user-attachments/assets/9e77a89c-a2cd-4f71-8d52-63bff4e19431" />

    ab. Related resources (parent resources) not found
    <img width="1961" height="1103" alt="image" src="https://github.com/user-attachments/assets/5c9cbd0a-507f-477c-83b2-4debc5996acb" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1979" height="1079" alt="image" src="https://github.com/user-attachments/assets/dea997b9-672e-46ea-8f39-48d1777880e1" />

    bb. Related resources (parent resources) not found
    <img width="1960" height="1108" alt="image" src="https://github.com/user-attachments/assets/3fba6b35-66e7-422e-b301-1fb3be36d9b5" />

