### PR TITLE
feat(eip): new datasource to query publicip count

### DIFF
--- a/docs/data-sources/eip_publicip_count.md
+++ b/docs/data-sources/eip_publicip_count.md
@@ -1,0 +1,32 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eip_publicip_count"
+description: |-
+  Use this data source to get the count of elastic public IPs.
+---
+
+# huaweicloud_eip_publicip_count
+
+Use this data source to get the count of elastic public IPs.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_eip_publicip_count" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `elasticip_size` - Indicates the number of elastic public IPs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2398,6 +2398,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpcv3_eips":                         eip.DataSourceEipVpcv3Eips(),
 			"huaweicloud_vpc_eip_tags":                       eip.DataSourceVpcEipTags(),
 			"huaweicloud_vpc_internet_gateways":              eip.DataSourceVPCInternetGateways(),
+			"huaweicloud_eip_publicip_count":                 eip.DataSourceEipPublicipCount(),
 			"huaweicloud_global_eip_quotas":                  eip.DataSourceGlobalEipQuotas(),
 			"huaweicloud_global_eip_pools":                   eip.DataSourceGlobalEIPPools(),
 			"huaweicloud_global_eip_bindings":                eip.DataSourceGlobalEipBindings(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_eip_publicip_count_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_eip_publicip_count_test.go
@@ -1,0 +1,35 @@
+package eip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceEipPublicipCount_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_eip_publicip_count.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceEipPublicipCount_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "elasticip_size"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceEipPublicipCount_basic = `
+data "huaweicloud_eip_publicip_count" "test" {}
+`

--- a/huaweicloud/services/eip/data_source_huaweicloud_eip_publicip_count.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_eip_publicip_count.go
@@ -1,0 +1,78 @@
+package eip
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v2/{project_id}/elasticips
+func DataSourceEipPublicipCount() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEipPublicipCountRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"elasticip_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceEipPublicipCountRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "vpc"
+		httpUrl = "v2/{project_id}/elasticips"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VPC EIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving EIP public IP count: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate UUID: %s", err)
+	}
+	d.SetId(generateId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("elasticip_size", utils.PathSearch("elasticip_size", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query publicip count.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o eip -f TestAccDataSourceEipPublicipCount_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccDataSourceEipPublicipCount_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceEipPublicipCount_basic
=== PAUSE TestAccDataSourceEipPublicipCount_basic
=== CONT  TestAccDataSourceEipPublicipCount_basic
--- PASS: TestAccDataSourceEipPublicipCount_basic (12.01s)
PASS
coverage: 2.3% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       12.099s coverage: 2.3% of statements in ./huaweicloud/services/eip
```
<img width="1331" height="74" alt="image" src="https://github.com/user-attachments/assets/6dd68e02-2b8a-40fd-97d3-09db336c2eec" />



* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
