### PR TITLE
feat(eip): support `eip_publicip_instances_count` data source

### DIFF
--- a/docs/data-sources/eip_publicip_instances_count.md
+++ b/docs/data-sources/eip_publicip_instances_count.md
@@ -1,0 +1,32 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eip_publicip_instances_count"
+description: |-
+  Use this dataSource to get the number of public IP instances.
+---
+
+# huaweicloud_eip_publicip_instances_count
+
+Use this dataSource to get the number of public IP instances.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_eip_publicip_instances_count" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instance_num` - The number of public IP instances.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2403,6 +2403,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_internet_gateways":              eip.DataSourceVPCInternetGateways(),
 			"huaweicloud_eip_publicip_count":                 eip.DataSourceEipPublicipCount(),
 			"huaweicloud_eip_publicip_types":                 eip.DataSourceEipPublicipTypes(),
+			"huaweicloud_eip_publicip_instances_count":       eip.DataSourcePublicipInstancesCount(),
 			"huaweicloud_global_eip_quotas":                  eip.DataSourceGlobalEipQuotas(),
 			"huaweicloud_global_eip_pools":                   eip.DataSourceGlobalEIPPools(),
 			"huaweicloud_global_eip_bindings":                eip.DataSourceGlobalEipBindings(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_eip_publicip_instances_count_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_eip_publicip_instances_count_test.go
@@ -1,0 +1,37 @@
+package eip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcePublicipInstancesCount_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_eip_publicip_instances_count.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourcePublicipInstancesCount_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_num"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourcePublicipInstancesCount_basic() string {
+	return `
+data "huaweicloud_eip_publicip_instances_count" "test" {}
+`
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_eip_publicip_instances_count.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_eip_publicip_instances_count.go
@@ -1,0 +1,79 @@
+package eip
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v2/{project_id}/publicip/instances
+func DataSourcePublicipInstancesCount() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePublicipInstancesCountRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePublicipInstancesCountRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "vpc"
+		httpUrl = "v2/{project_id}/publicip/instances"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VPC EIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving EIP public IP instances count: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("instance_num", utils.PathSearch("instance_num", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `eip_publicip_instances_count` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `eip_publicip_instances_count` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccDataSourcePublicipInstancesCount_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccDataSourcePublicipInstancesCount_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePublicipInstancesCount_basic
=== PAUSE TestAccDataSourcePublicipInstancesCount_basic
=== CONT  TestAccDataSourcePublicipInstancesCount_basic
--- PASS: TestAccDataSourcePublicipInstancesCount_basic (16.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       16.506s
```
<img width="929" height="31" alt="image" src="https://github.com/user-attachments/assets/83432de5-8543-4b6f-bf55-9ce07b98d507" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
