### PR TITLE
feat(modelarts): supports new data source to query workflow schedules

### DIFF
--- a/docs/data-sources/modelartsv2_workflow_schedules.md
+++ b/docs/data-sources/modelartsv2_workflow_schedules.md
@@ -1,0 +1,68 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelartsv2_workflow_schedules"
+description: |-
+  Use this data source to get the list of workflow schedules within HuaweiCloud.
+---
+
+# huaweicloud_modelartsv2_workflow_schedules
+
+Use this data source to get the list of workflow schedules within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workflow_id" {}
+
+data "huaweicloud_modelartsv2_workflow_schedules" "test" {
+  workflow_id = var.workflow_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the workflow schedules are located.  
+  If omitted, the provider-level region will be used.
+
+* `workflow_id` - (Required, String) Specifies the ID of the workflow to which the schedule configurations belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `schedules` - The list of the workflow schedules.  
+  The [schedules](#modelartsv2_workflow_schedules_attr) structure is documented below.
+
+<a name="modelartsv2_workflow_schedules_attr"></a>
+The `schedules` block supports:
+
+* `id` - The ID of the workflow schedule.
+
+* `type` - The type of the workflow schedule.
+
+* `content` - The content of the workflow schedule, in JSON format.
+
+* `action` - The action of the workflow schedule.
+
+* `workflow_id` - The ID of the workflow to which the schedule belongs.
+
+* `user_id` - The user ID that created the workflow schedule.
+
+* `enable` - Whether the workflow schedule is enabled.
+
+* `policies` - The scheduling policies of the workflow schedule.  
+  The [policies](#modelartsv2_workflow_schedules_policies_attr) structure is documented below.
+
+* `created_at` - The creation time of the workflow schedule, in RFC3339 format.
+
+<a name="modelartsv2_workflow_schedules_policies_attr"></a>
+The `policies` block supports:
+
+* `on_failure` - The policy action when the workflow execution fails.
+
+* `on_running` - The policy action when the workflow is already running.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1927,6 +1927,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelartsv2_node_pool_nodes":     modelarts.DataSourceV2NodePoolNodes(),
 			"huaweicloud_modelartsv2_resource_pool_nodes": modelarts.DataSourceV2ResourcePoolNodes(),
 			"huaweicloud_modelartsv2_resource_pools":      modelarts.DataSourceV2ResourcePools(),
+			"huaweicloud_modelartsv2_workflow_schedules":  modelarts.DataSourceV2WorkflowSchedules(),
 
 			"huaweicloud_mapreduce_availability_zones":               mrs.DataSourceAvailabilityZones(),
 			"huaweicloud_mapreduce_available_flavors":                mrs.DataSourceAvailableFlavors(),

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelartsv2_workflow_schedules_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelartsv2_workflow_schedules_test.go
@@ -1,0 +1,85 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceV2WorkflowSchedules_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_modelartsv2_workflow_schedules.test"
+		dc     = acceptance.InitDataSourceCheck(dcName)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckModelArtsWorkflowId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceV2WorkflowSchedules_nonExistentWorkflow(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dcName, "schedules.#", "0"),
+				),
+			},
+			{
+				Config: testAccDatasourceV2WorkflowSchedules_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_created_schedule_found", "true"),
+					resource.TestCheckResourceAttrSet(dcName, "schedules.0.id"),
+					resource.TestCheckResourceAttr(dcName, "schedules.0.workflow_id", acceptance.HW_MODELARTS_WORKFLOW_ID),
+					resource.TestCheckResourceAttrSet(dcName, "schedules.0.content"),
+					resource.TestCheckResourceAttrSet(dcName, "schedules.0.enable"),
+					resource.TestCheckResourceAttrSet(dcName, "schedules.0.type"),
+					resource.TestCheckResourceAttr(dcName, "schedules.0.action", "run"),
+					resource.TestCheckResourceAttr(dcName, "schedules.0.policies.#", "1"),
+					resource.TestCheckResourceAttrSet(dcName, "schedules.0.policies.0.on_failure"),
+					resource.TestCheckResourceAttrSet(dcName, "schedules.0.policies.0.on_running"),
+					resource.TestCheckResourceAttrSet(dcName, "schedules.0.user_id"),
+					resource.TestMatchResourceAttr(dcName, "schedules.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceV2WorkflowSchedules_nonExistentWorkflow() string {
+	return fmt.Sprintf(`
+data "huaweicloud_modelartsv2_workflow_schedules" "test" {
+  workflow_id = "%[1]s"
+}
+`, acceptance.HW_MODELARTS_WORKFLOW_ID)
+}
+
+func testAccDatasourceV2WorkflowSchedules_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_modelartsv2_workflow_schedule" "test" {
+  workflow_id = "%[1]s"
+  content     = jsonencode({
+    cron   = "0 0 12 * * ?"
+    method = "fixed"
+  })
+}
+
+data "huaweicloud_modelartsv2_workflow_schedules" "test" {
+  depends_on = [huaweicloud_modelartsv2_workflow_schedule.test]
+
+  workflow_id = "%[1]s"
+}
+
+output "is_created_schedule_found" {
+  value = length([for v in data.huaweicloud_modelartsv2_workflow_schedules.test.schedules : v if
+    v.id == huaweicloud_modelartsv2_workflow_schedule.test.id]) > 0
+}
+`, acceptance.HW_MODELARTS_WORKFLOW_ID)
+}

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_workflow_schedules.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_workflow_schedules.go
@@ -1,0 +1,199 @@
+package modelarts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ModelArts GET /v2/{project_id}/workflows/{workflow_id}/schedules
+func DataSourceV2WorkflowSchedules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV2WorkflowSchedulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the workflow schedules are located.`,
+			},
+
+			// Required parameters.
+			"workflow_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workflow to which the schedule configurations belong.`,
+			},
+
+			// Attributes.
+			"schedules": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2WorkflowSchedulesElemSchema(),
+				Description: `The list of the workflow schedules.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2WorkflowSchedulePoliciesElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"on_failure": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The policy action when the workflow execution fails.`,
+			},
+			"on_running": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The policy action when the workflow is already running.`,
+			},
+		},
+	}
+}
+
+func dataSourceV2WorkflowSchedulesElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the workflow schedule.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the workflow schedule.`,
+			},
+			"content": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The content of the workflow schedule, in JSON format.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The action of the workflow schedule.`,
+			},
+			"workflow_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the workflow to which the schedule belongs.`,
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user ID that created the workflow schedule.`,
+			},
+			"enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the workflow schedule is enabled.`,
+			},
+			"policies": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceV2WorkflowSchedulePoliciesElemSchema(),
+				Description: `The scheduling policies of the workflow schedule.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the workflow schedule, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func listV2WorkflowSchedules(client *golangsdk.ServiceClient, workflowId string) ([]interface{}, error) {
+	var httpUrl = "v2/{project_id}/workflows/{workflow_id}/schedules"
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{workflow_id}", workflowId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("schedules", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenV2WorkflowSchedules(items []interface{}) []map[string]interface{} {
+	if len(items) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("uuid", item, nil),
+			"type":        utils.PathSearch("type", item, nil),
+			"content":     utils.JsonToString(utils.PathSearch("content", item, nil)),
+			"action":      utils.PathSearch("action", item, nil),
+			"workflow_id": utils.PathSearch("workflow_id", item, nil),
+			"user_id":     utils.PathSearch("user_id", item, nil),
+			"enable":      utils.PathSearch("enable", item, nil),
+			"policies": flattenV2WorkflowSchedulePolicies(utils.PathSearch("policies", item,
+				make(map[string]interface{})).(map[string]interface{})),
+			"created_at": utils.FormatTimeStampRFC3339(
+				utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("created_at", item, "").(string))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceV2WorkflowSchedulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		workflowId = d.Get("workflow_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	schedules, err := listV2WorkflowSchedules(client, workflowId)
+	if err != nil {
+		return diag.Errorf("error querying ModelArts workflow schedules: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("schedules", flattenV2WorkflowSchedules(schedules)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source to query workflow schedules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1065" height="279" alt="image" src="https://github.com/user-attachments/assets/cff0c792-800b-4fc4-9826-9cb80f90ed15" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query workflow schedules.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDatasourceV2WorkflowSchedules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDatasourceV2WorkflowSchedules_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceV2WorkflowSchedules_basic
--- PASS: TestAccDatasourceV2WorkflowSchedules_basic (24.28s)
PASS
coverage: 6.3% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 24.379s coverage: 6.3% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
