### PR TITLE
feat(eip): add source to batch attach internet bandwidths

### DIFF
--- a/docs/resources/global_eip_batch_attach_internet_bandwidths.md
+++ b/docs/resources/global_eip_batch_attach_internet_bandwidths.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_global_batch_attach_internet_bandwidths"
+description: |-
+  Manages a resource to batch attach internet bandwidths to global EIPs within HuaweiCloud.
+---
+
+# huaweicloud_global_batch_attach_internet_bandwidths
+
+Manages a resource to batch attach internet bandwidths to global EIPs within HuaweiCloud.
+
+-> This resource is a one-time action resource used to batch attach internet bandwidths to global EIPs.
+  Deleting this resource will not clear the corresponding request record, but will only remove resource information from
+  the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "global_eip_configurations" {
+  type = list(object({
+    global_eip_id         = string
+    internet_bandwidth_id = string
+  }))
+}
+
+resource "huaweicloud_global_batch_attach_internet_bandwidths" "test" {
+  dynamic "global_eips" {
+    for_each = var.global_eip_configurations
+    content {
+      global_eip_id         = global_eips.value.global_eip_id
+      internet_bandwidth_id = global_eips.value.internet_bandwidth_id
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `global_eips` - (Required, List,NonUpdatable) Specifies the list of global EIPs and internet bandwidths to be attached
+  The [global_eips](#global_eips_struct) structure is documented below.
+
+<a name="global_eips_struct"></a>
+The `global_eips` block supports:
+
+* `global_eip_id` - (Required, String) Specifies the ID of the global EIP.
+
+* `internet_bandwidth_id` - (Required, String) Specifies the ID of the internet bandwidth.
+  All global EIPs in the list must be bound to the same bandwidth ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4265,9 +4265,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_eipv3_associate":     eip.ResourceEipv3Associate(),
 			"huaweicloud_vpc_internet_gateway":    eip.ResourceVPCInternetGateway(),
 
-			"huaweicloud_global_internet_bandwidth": eip.ResourceGlobalInternetBandwidth(),
-			"huaweicloud_global_eip":                eip.ResourceGlobalEIP(),
-			"huaweicloud_global_eip_associate":      eip.ResourceGlobalEIPAssociate(),
+			"huaweicloud_global_internet_bandwidth":               eip.ResourceGlobalInternetBandwidth(),
+			"huaweicloud_global_eip":                              eip.ResourceGlobalEIP(),
+			"huaweicloud_global_eip_associate":                    eip.ResourceGlobalEIPAssociate(),
+			"huaweicloud_global_batch_attach_internet_bandwidths": eip.ResourceBatchAttachInternetBandwidths(),
 
 			"huaweicloud_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),
 			"huaweicloud_vpc_peering_connection_accepter": vpc.ResourceVpcPeeringConnectionAccepterV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -440,6 +440,8 @@ var (
 	HW_DC_GLOBAL_GATEWAY_ID_HAS_PEER_LINK = os.Getenv("HW_DC_GLOBAL_GATEWAY_ID_HAS_PEER_LINK")
 	HW_DC_CONNECT_GATEWAY_ID              = os.Getenv("HW_DC_CONNECT_GATEWAY_ID")
 	HW_GLOBAL_EIP_ID                      = os.Getenv("HW_GLOBAL_EIP_ID")
+	HW_GLOBAL_EIP_IDS                     = os.Getenv("HW_GLOBAL_EIP_IDS")
+	HW_GLOBAL_INTERNET_BANDWIDTH_ID       = os.Getenv("HW_GLOBAL_INTERNET_BANDWIDTH_ID")
 
 	HW_DSC_INSTANCE_ID    = os.Getenv("HW_DSC_INSTANCE_ID")
 	HW_DSC_ALARM_TOPIC_ID = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
@@ -2813,6 +2815,20 @@ func TestAccPreCheckDcConnectGatewayId(t *testing.T) {
 func TestAccPreCheckGlobalEipId(t *testing.T) {
 	if HW_GLOBAL_EIP_ID == "" {
 		t.Skip("HW_GLOBAL_EIP_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckGlobalEipIds(t *testing.T) {
+	if HW_GLOBAL_EIP_IDS == "" {
+		t.Skip("HW_GLOBAL_EIP_IDS must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckGlobalInternetBandwidthId(t *testing.T) {
+	if HW_GLOBAL_INTERNET_BANDWIDTH_ID == "" {
+		t.Skip("HW_GLOBAL_INTERNET_BANDWIDTH_ID must be set for this acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_batch_attach_internet_bandwidths_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_batch_attach_internet_bandwidths_test.go
@@ -1,0 +1,45 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchAttachInternetBandwidths_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGlobalEipIds(t)
+			acceptance.TestAccPreCheckGlobalInternetBandwidthId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchAttachInternetBandwidthsBasic(),
+			},
+		},
+	})
+}
+
+func testBatchAttachInternetBandwidthsBasic() string {
+	return fmt.Sprintf(`
+locals {
+  global_eip_ids = split(",", "%[1]s")
+}
+
+resource "huaweicloud_global_batch_attach_internet_bandwidths" "test" {
+  dynamic "global_eips" {
+    for_each = local.global_eip_ids
+    content {
+      global_eip_id         = global_eips.value
+      internet_bandwidth_id = "%[2]s"
+    }
+  }
+}
+`, acceptance.HW_GLOBAL_EIP_IDS, acceptance.HW_GLOBAL_INTERNET_BANDWIDTH_ID)
+}

--- a/huaweicloud/services/eip/resource_huaweicloud_global_batch_attach_internet_bandwidths.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_global_batch_attach_internet_bandwidths.go
@@ -1,0 +1,203 @@
+package eip
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP POST /v3/{domain_id}/global-eips/batch-attach-internet-bandwidths
+// @API EIP GET /v3/{domain_id}/geip/jobs/{job_id}
+func ResourceBatchAttachInternetBandwidths() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBatchAttachInternetBandwidthsCreate,
+		ReadContext:   resourceBatchAttachInternetBandwidthsRead,
+		UpdateContext: resourceBatchAttachInternetBandwidthsUpdate,
+		DeleteContext: resourceBatchAttachInternetBandwidthsDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"global_eips": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     globalEipInternetBandwidthSchema(),
+			},
+		},
+	}
+}
+
+func globalEipInternetBandwidthSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"global_eip_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"internet_bandwidth_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildAttachInternetBandwidthsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	globalEipsRaw := d.Get("global_eips").([]interface{})
+	globalEips := make([]map[string]interface{}, 0, len(globalEipsRaw))
+
+	for _, item := range globalEipsRaw {
+		globalEips = append(globalEips, map[string]interface{}{
+			"global_eip_id":         utils.PathSearch("global_eip_id", item, nil),
+			"internet_bandwidth_id": utils.PathSearch("internet_bandwidth_id", item, nil),
+		})
+	}
+
+	bodyParams := map[string]interface{}{
+		"global_eips": globalEips,
+	}
+
+	return bodyParams
+}
+
+func resourceBatchAttachInternetBandwidthsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{domain_id}/global-eips/batch-attach-internet-bandwidths"
+	)
+
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", cfg.DomainID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildAttachInternetBandwidthsBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch attaching internet bandwidths to global EIPs: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find job_id from the API response")
+	}
+
+	err = waitForJobCompleted(ctx, d.Timeout(schema.TimeoutCreate), jobId, cfg.DomainID, client)
+	if err != nil {
+		return diag.Errorf("error waiting for batch attach internet bandwidths job completed: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate EIP request ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region))
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceBatchAttachInternetBandwidthsRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Read()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchAttachInternetBandwidthsUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Update()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchAttachInternetBandwidthsDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch attach internet bandwidths. 
+Deleting this resource will not clear of corresponding request record, but will only remove resource 
+information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func waitForJobCompleted(ctx context.Context, timeout time.Duration, jobId string, domainID string,
+	client *golangsdk.ServiceClient) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      refreshJobStatusFunc(client, jobId, domainID),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func refreshJobStatusFunc(client *golangsdk.ServiceClient, jobId, domainID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		getJobHttpUrl := "v3/{domain_id}/geip/jobs/{job_id}"
+		getJobPath := client.Endpoint + getJobHttpUrl
+		getJobPath = strings.ReplaceAll(getJobPath, "{domain_id}", domainID)
+		getJobPath = strings.ReplaceAll(getJobPath, "{job_id}", jobId)
+		getJobOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+
+		getJobResp, err := client.Request("GET", getJobPath, &getJobOpt)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		getJobRespBody, err := utils.FlattenResponse(getJobResp)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		status := utils.PathSearch("job.status", getJobRespBody, "").(string)
+		if status == "" {
+			return nil, "ERROR", errors.New("unable to find job status from the API response")
+		}
+
+		if status == "FINISH_ROLLBACK_SUCC" {
+			return nil, "FAILURE", fmt.Errorf("job fail: %s", utils.PathSearch("job.error_message", getJobRespBody, nil))
+		}
+		if status == "FINISH_SUCC" {
+			return getJobRespBody, "SUCCESS", nil
+		}
+		return getJobRespBody, "PENDING", nil
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add source to batch attach internet bandwidths

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add source to batch attach internet bandwidths
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o eip -f TestAccBatchAttachInternetBandwidths_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccBatchAttachInternetBandwidths_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchAttachInternetBandwidths_basic
=== PAUSE TestAccBatchAttachInternetBandwidths_basic
=== CONT  TestAccBatchAttachInternetBandwidths_basic
--- PASS: TestAccBatchAttachInternetBandwidths_basic (39.18s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       39.260s coverage: 3.9% of statements in ./huaweicloud/services/eip
```

<img width="1028" height="55" alt="Snipaste_2026-05-07_19-02-01" src="https://github.com/user-attachments/assets/c5cbc0be-00f1-4362-854c-68abb0fe84a3" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
