### PR TITLE
feat(eip): add source to batch detach internet bandwidths

### DIFF
--- a/docs/resources/global_eip_batch_detach_internet_bandwidths.md
+++ b/docs/resources/global_eip_batch_detach_internet_bandwidths.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_global_batch_detach_internet_bandwidths"
+description: ""
+---
+
+# huaweicloud_global_batch_detach_internet_bandwidths
+
+Manages a resource to batch detach internet bandwidths from global EIPs within HuaweiCloud.
+
+-> **NOTE:** This resource is a one-time action resource used to batch detach internet bandwidths from global EIPs.
+Deleting this resource will not clear the corresponding request record, but will only remove resource information from
+the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "global_eip_id_1" {}
+variable "global_eip_id_2" {}
+
+resource "huaweicloud_global_batch_detach_internet_bandwidths" "test" {
+  global_eips {
+    global_eip_id         = var.global_eip_id_1
+  }
+
+  global_eips {
+    global_eip_id         = var.global_eip_id_2
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `global_eips` - (Required, List) Specifies the list of global EIPs to be detached from internet bandwidths.
+  The [global_eips](#global_eips_struct) structure is documented below.
+
+<a name="global_eips_struct"></a>
+The `global_eips` block supports:
+
+* `global_eip_id` - (Required, String) Specifies the ID of the global EIP.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `job_id` - The ID of the batch detach job.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4507,8 +4507,9 @@ func Provider() *schema.Provider {
 			// Legacy
 			"huaweicloud_apig_plugin_associate": apig.ResourcePluginBatchApisAssociate(),
 
-			"huaweicloud_networking_eip_associate": eip.ResourceEIPAssociate(),
-			"huaweicloud_dds_instance_recovery":    dds.ResourceDDSInstanceRestore(),
+			"huaweicloud_networking_eip_associate":                eip.ResourceEIPAssociate(),
+			"huaweicloud_global_batch_detach_internet_bandwidths": eip.ResourceBatchDetachInternetBandwidths(),
+			"huaweicloud_dds_instance_recovery":                   dds.ResourceDDSInstanceRestore(),
 
 			"huaweicloud_dws_public_domain_associate": dws.ResourceClusterPublicDomainAssociate(),
 

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_batch_detach_internet_bandwidths_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_batch_detach_internet_bandwidths_test.go
@@ -1,0 +1,41 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchDetachInternetBandwidths_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGlobalEipId(t)
+			acceptance.TestAccPreCheckGlobalEipId2(t)
+			acceptance.TestAccPreCheckGlobalInternetBandwidthId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchDetachInternetBandwidths_basic(),
+			},
+		},
+	})
+}
+
+func testBatchDetachInternetBandwidths_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_global_batch_detach_internet_bandwidths" "test" {
+  global_eips {
+    global_eip_id         = "%s"
+  }
+  global_eips {
+    global_eip_id         = "%s"
+  }
+}
+`, acceptance.HW_GLOBAL_EIP_ID, acceptance.HW_GLOBAL_EIP_ID2)
+}

--- a/huaweicloud/services/eip/resource_huaweicloud_global_batch_detach_internet_bandwidths.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_global_batch_detach_internet_bandwidths.go
@@ -1,0 +1,203 @@
+package eip
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP POST /v3/{domain_id}/global-eips/batch-detach-internet-bandwidths
+// @API EIP GET /v3/{domain_id}/geip/jobs/{job_id}
+func ResourceBatchDetachInternetBandwidths() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBatchDetachInternetBandwidthsCreate,
+		ReadContext:   resourceBatchDetachInternetBandwidthsRead,
+		UpdateContext: resourceBatchDetachInternetBandwidthsUpdate,
+		DeleteContext: resourceBatchDetachInternetBandwidthsDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"global_eips": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     globalEipInternetBandwidthSchema(),
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func globalEipInternetBandwidthSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"global_eip_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildDetachInternetBandwidthsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	globalEipsRaw := d.Get("global_eips").([]interface{})
+	globalEips := make([]map[string]interface{}, 0, len(globalEipsRaw))
+
+	for _, item := range globalEipsRaw {
+		v := item.(map[string]interface{})
+		globalEips = append(globalEips, map[string]interface{}{
+			"global_eip_id": v["global_eip_id"],
+		})
+	}
+
+	bodyParams := map[string]interface{}{
+		"global_eips": globalEips,
+	}
+
+	return bodyParams
+}
+
+func resourceBatchDetachInternetBandwidthsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{domain_id}/global-eips/batch-detach-internet-bandwidths"
+	)
+
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", cfg.DomainID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDetachInternetBandwidthsBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch detaching internet bandwidths from global EIPs: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find job_id from the API response")
+	}
+
+	err = waitForJobCompleted(ctx, d.Timeout(schema.TimeoutCreate), jobId, cfg.DomainID, client)
+	if err != nil {
+		return diag.Errorf("error waiting for batch detach internet bandwidths job completed: %s", err)
+	}
+
+	requestId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate EIP request ID: %s", err)
+	}
+
+	d.SetId(requestId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("job_id", jobId))
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceBatchDetachInternetBandwidthsRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Read()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchDetachInternetBandwidthsUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Update()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchDetachInternetBandwidthsDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch detach internet bandwidths. Deleting this
+    resource will not clear of corresponding request record, but will only remove resource information from the tf state
+    file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func waitForJobCompleted(ctx context.Context, timeout time.Duration, jobId string, domainID string,
+	client *golangsdk.ServiceClient) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      refreshJobStatusFunc(client, jobId, domainID),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func refreshJobStatusFunc(client *golangsdk.ServiceClient, jobId, domainID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		getJobHttpUrl := "v3/{domain_id}/geip/jobs/{job_id}"
+		getJobPath := client.Endpoint + getJobHttpUrl
+		getJobPath = strings.ReplaceAll(getJobPath, "{domain_id}", domainID)
+		getJobPath = strings.ReplaceAll(getJobPath, "{job_id}", jobId)
+		getJobOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+
+		getJobResp, err := client.Request("GET", getJobPath, &getJobOpt)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		getJobRespBody, err := utils.FlattenResponse(getJobResp)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		status := utils.PathSearch("job.status", getJobRespBody, "").(string)
+		if status == "" {
+			return nil, "ERROR", errors.New("unable to find job status from the API response")
+		}
+
+		if status == "FINISH_ROLLBACK_SUCC" {
+			return nil, "FAILURE", fmt.Errorf("job fail: %s", utils.PathSearch("job.error_message", getJobRespBody, nil))
+		} else if status == "FINISH_SUCC" {
+			return getJobRespBody, "SUCCESS", nil
+		}
+		return getJobRespBody, "PENDING", nil
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add source to batch detach internet bandwidths

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add source to batch detach internet bandwidths
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o eip -f TestAccBatchDetachInternetBandwidths_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccBatchDetachInternetBandwidths_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchDetachInternetBandwidths_basic
=== PAUSE TestAccBatchDetachInternetBandwidths_basic
=== CONT  TestAccBatchDetachInternetBandwidths_basic
--- PASS: TestAccBatchDetachInternetBandwidths_basic (35.85s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       35.925s coverage: 3.8% of statements in ./huaweicloud/services/eip
```

<img width="1184" height="143" alt="Snipaste_2026-05-07_20-17-59" src="https://github.com/user-attachments/assets/819afb5f-1845-4d25-956a-6de562de7af6" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
