### PR TITLE
feat(geminidb): add datasource to get list of GeminiDB database versions

### DIFF
--- a/docs/data-sources/geminidb_database_versions.md
+++ b/docs/data-sources/geminidb_database_versions.md
@@ -1,0 +1,43 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_database_versions"
+description: |-
+  Use this data source to query the GeminiDB database version information within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_database_versions
+
+Use this data source to query the GeminiDB database version information within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "datastore_name" {}
+
+data "huaweicloud_geminidb_database_versions" "test" {
+  datastore_name = var.datastore_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `datastore_name` - (Required, String) Specifies the database type.
+  The valid values are as follows:
+  + **cassandra**: Indicates GeminiDB Cassandra.
+  + **mongodb**: Indicates GeminiDB Mongo.
+  + **influxdb**: Indicates GeminiDB Influx.
+  + **redis**: Indicates GeminiDB Redis.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `versions` - The list of database versions.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1415,8 +1415,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_redis_flavors":                geminidb.DataSourceGaussDBRedisFlavors(),
 			"huaweicloud_gaussdb_influx_instances":             geminidb.DataSourceGaussDBInfluxInstances(),
 
-			"huaweicloud_geminidb_flavors":  geminidb.DataSourceGeminiDBFlavors(),
-			"huaweicloud_geminidb_accounts": geminidb.DataSourceGeminiDbAccounts(),
+			"huaweicloud_geminidb_flavors":           geminidb.DataSourceGeminiDBFlavors(),
+			"huaweicloud_geminidb_accounts":          geminidb.DataSourceGeminiDbAccounts(),
+			"huaweicloud_geminidb_database_versions": geminidb.DataSourceDatabaseVersions(),
 
 			"huaweicloud_gaussdb_storage_types":             gaussdb.DataSourceGaussDbStorageTypes(),
 			"huaweicloud_gaussdb_datastores":                gaussdb.DataSourceGaussDbDatastores(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_database_versions_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_database_versions_test.go
@@ -1,0 +1,39 @@
+package geminidb
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDatabaseVersions_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_geminidb_database_versions.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDatabaseVersions_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "versions.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceDatabaseVersions_basic = `
+data "huaweicloud_geminidb_database_versions" "test" {
+  datastore_name = "redis"
+}
+`

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_database_versions.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_database_versions.go
@@ -1,0 +1,86 @@
+package geminidb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforNoSQL GET /v3/{project_id}/datastores/{datastore_name}/versions
+func DataSourceDatabaseVersions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDatabaseVersionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"datastore_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceDatabaseVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		datastoreName = d.Get("datastore_name").(string)
+		httpUrl       = "v3/{project_id}/datastores/{datastore_name}/versions"
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{datastore_name}", datastoreName)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving GeminiDB database versions: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("versions", utils.PathSearch("versions", getRespBody, make([]interface{}, 0)).([]interface{})),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to get list of GeminiDB database versions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to get the list of the GeminiDB database versions.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccDataSourceDatabaseVersions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccDataSourceDatabaseVersions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDatabaseVersions_basic
=== PAUSE TestAccDataSourceDatabaseVersions_basic
=== CONT  TestAccDataSourceDatabaseVersions_basic
--- PASS: TestAccDataSourceDatabaseVersions_basic (19.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  19.342s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/6d06436d-5389-42c9-82c7-4e2535ad932b" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
