### PR TITLE
feat(dataarts): add new datasource for query the list of models in th…

### DIFF
--- a/docs/data-sources/dataarts_architecture_models.md
+++ b/docs/data-sources/dataarts_architecture_models.md
@@ -1,0 +1,96 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_architecture_models"
+description: |-
+  Use this data source to get the list of DataArts architecture models.
+---
+
+# huaweicloud_dataarts_architecture_models
+
+Use this data source to get the list of DataArts architecture models.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_architecture_models" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the architecture models are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace.
+
+* `workspace_type` - (Optional, String) Specifies the model workspace type.  
+  The valid values are as follows:
+  + **THIRD_NF**: relational modeling
+  + **DIMENSION**: dimensional modeling
+
+* `dw_type` - (Optional, String) Specifies the data connection type.  
+  The valid values are as follows:
+  + **DWS**
+  + **MRS_HIVE**
+  + **POSTGRESQL**
+  + **MRS_SPARK**
+  + **CLICKHOUSE**
+  + **MYSQL**
+  + **ORACLE**
+  + **DORIS**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `models` - The list of the architecture models that matched filter parameters.  
+  The [models](#dataarts_architecture_model) structure is documented below.
+
+<a name="dataarts_architecture_model"></a>
+The `models` block supports:
+
+* `id` - The ID of the model.
+
+* `name` - The name of the workspace.
+
+* `description` - The description of the model.
+
+* `is_physical` - Whether it is a physical table.
+
+* `frequent` - Whether it is frequently used.
+
+* `top` - Whether it is a top-level governance.
+
+* `level` - The data governance layer.  
+  + **SDI**
+  + **DWI**
+  + **DWR**
+  + **DM**
+
+* `dw_type` - The data connection type.
+
+* `create_time` - The creation time of the model, in RFC3339 format.
+
+* `update_time` - The update time of the model, in RFC3339 format.
+
+* `create_by` - The creator of the model.
+
+* `update_by` - The updater of the model.
+
+* `type` - The workspace type.  
+  + **THIRD_NF**
+  + **DIMENSION**
+
+* `biz_catalog_ids` - The associated business catalog IDs.
+
+* `databases` - The database name list.
+
+* `table_model_prefix` - The table model validation prefix.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1079,6 +1079,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_approvals":                        dataarts.DataSourceArchitectureApprovals(),
 			"huaweicloud_dataarts_architecture_data_standard_template_customs":   dataarts.DataSourceArchitectureDataStandardTemplateCustoms(),
 			"huaweicloud_dataarts_architecture_data_standard_template_optionals": dataarts.DataSourceArchitectureDataStandardTemplateOptionals(),
+			"huaweicloud_dataarts_architecture_models":                           dataarts.DataSourceArchitectureModels(),
 			"huaweicloud_dataarts_architecture_model_statistic":                  dataarts.DataSourceArchitectureModelStatistic(),
 			"huaweicloud_dataarts_architecture_processes":                        dataarts.DataSourceArchitectureProcesses(),
 			"huaweicloud_dataarts_architecture_table_models":                     dataarts.DataSourceArchitectureTableModels(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_models_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_models_test.go
@@ -1,0 +1,150 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataArchitectureModels_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_architecture_models.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		filterByType   = "data.huaweicloud_dataarts_architecture_models.filter_by_type"
+		dcFilterByType = acceptance.InitDataSourceCheck(filterByType)
+
+		filterByDwType   = "data.huaweicloud_dataarts_architecture_models.filter_by_dw_type"
+		dcFilterByDwType = acceptance.InitDataSourceCheck(filterByDwType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataArchitectureModels_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "models.#", regexp.MustCompile("^[1-9]([0-9]*)?$")),
+					resource.TestCheckResourceAttrSet(all, "models.0.id"),
+					resource.TestCheckResourceAttrSet(all, "models.0.name"),
+					resource.TestCheckResourceAttrSet(all, "models.0.type"),
+					resource.TestCheckResourceAttrSet(all, "models.0.dw_type"),
+					resource.TestCheckResourceAttrSet(all, "models.0.is_physical"),
+					resource.TestCheckResourceAttrSet(all, "models.0.create_time"),
+					resource.TestCheckResourceAttrSet(all, "models.0.update_time"),
+					resource.TestCheckResourceAttrSet(all, "models.0.create_by"),
+					resource.TestCheckResourceAttrSet(all, "models.0.update_by"),
+
+					// filter by type
+					dcFilterByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+
+					// filter by dw type
+					dcFilterByDwType.CheckResourceExists(),
+					resource.TestCheckOutput("is_dw_type_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataArchitectureModels_base(name string) string {
+	return fmt.Sprintf(`
+variable "models" {
+  type    = list(object({
+    name = string
+    type = string
+  }))
+  default = [
+    {
+      name = "%[1]s_third_nf"
+      type = "THIRD_NF"
+    },
+    {
+      name = "%[1]s_dimension"
+      type = "DIMENSION"
+    }
+  ]
+}
+
+resource "huaweicloud_dataarts_architecture_model" "test" {
+  count = length(var.models)
+
+  workspace_id = "%[2]s"
+  name         = var.models[count.index].name
+  type         = var.models[count.index].type
+  physical     = true
+  dw_type      = "DWS"
+}
+`, name, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func testAccDataArchitectureModels_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all models in the workspace.
+data "huaweicloud_dataarts_architecture_models" "test" {
+  workspace_id = "%[2]s"
+
+  depends_on = [huaweicloud_dataarts_architecture_model.test]
+}
+
+# Filter by workspace type.
+locals {
+  workspace_type = "THIRD_NF"
+}
+
+data "huaweicloud_dataarts_architecture_models" "filter_by_type" {
+  workspace_id   = "%[2]s"
+  workspace_type = local.workspace_type
+
+  depends_on = [huaweicloud_dataarts_architecture_model.test]
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_models.filter_by_type.models :
+	v.type == local.workspace_type
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+
+# Filter by dw type.
+locals {
+  dw_type = "DWS"
+}
+
+data "huaweicloud_dataarts_architecture_models" "filter_by_dw_type" {
+  workspace_id = "%[2]s"
+  dw_type      = local.dw_type
+
+  depends_on = [huaweicloud_dataarts_architecture_model.test]
+}
+
+locals {
+  dw_type_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_models.filter_by_dw_type.models :
+	v.dw_type == local.dw_type
+  ]
+}
+
+output "is_dw_type_filter_useful" {
+  value = length(local.dw_type_filter_result) > 0 && alltrue(local.dw_type_filter_result)
+}
+`, testAccDataArchitectureModels_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_models.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_models.go
@@ -1,0 +1,262 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/design/workspaces
+func DataSourceArchitectureModels() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceArchitectureModelsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the architecture models are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace.`,
+			},
+
+			// Optional parameters.
+			"workspace_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The model workspace type.`,
+			},
+			"dw_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The data connection type.`,
+			},
+
+			// Attributes.
+			"models": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        architectureModelSchema(),
+				Description: `The list of the architecture models that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func architectureModelSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the model.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the workspace.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the model.`,
+			},
+			"is_physical": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether it is a physical table.`,
+			},
+			"frequent": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether it is frequently used.`,
+			},
+			"top": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether it is a top-level governance.`,
+			},
+			"level": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data governance layer.`,
+			},
+			"dw_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data connection type.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the model, in RFC3339 format.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the model, in RFC3339 format.`,
+			},
+			"create_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the model.`,
+			},
+			"update_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The updater of the model.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The workspace type.`,
+			},
+			"biz_catalog_ids": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The associated business catalog IDs.`,
+			},
+			"databases": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The database name list.`,
+			},
+			"table_model_prefix": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The table model validation prefix.`,
+			},
+		},
+	}
+}
+
+func buildArchitectureModelsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("workspace_type"); ok {
+		res = fmt.Sprintf("%s&workspace_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("dw_type"); ok {
+		res = fmt.Sprintf("%s&dw_type=%v", res, v)
+	}
+
+	return res
+}
+
+func listArchitectureModels(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/design/workspaces?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildArchitectureModelsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildArchitectureMoreHeaders(d.Get("workspace_id").(string)),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		models := utils.PathSearch("data.value.records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, models...)
+		if len(models) < limit {
+			break
+		}
+		offset += len(models)
+	}
+
+	return result, nil
+}
+
+func flattenArchitectureModels(models []interface{}) []interface{} {
+	if len(models) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(models))
+	for _, model := range models {
+		result = append(result, map[string]interface{}{
+			"id":                 utils.PathSearch("id", model, nil),
+			"name":               utils.PathSearch("name", model, nil),
+			"description":        utils.PathSearch("description", model, nil),
+			"is_physical":        utils.PathSearch("is_physical", model, false),
+			"frequent":           utils.PathSearch("frequent", model, false),
+			"top":                utils.PathSearch("top", model, false),
+			"level":              utils.PathSearch("level", model, nil),
+			"dw_type":            utils.PathSearch("dw_type", model, nil),
+			"create_time":        utils.PathSearch("create_time", model, nil),
+			"update_time":        utils.PathSearch("update_time", model, nil),
+			"create_by":          utils.PathSearch("create_by", model, nil),
+			"update_by":          utils.PathSearch("update_by", model, nil),
+			"type":               utils.PathSearch("type", model, nil),
+			"biz_catalog_ids":    utils.PathSearch("biz_catalog_ids", model, nil),
+			"databases":          utils.PathSearch("databases", model, make([]interface{}, 0)),
+			"table_model_prefix": utils.PathSearch("table_model_prefix", model, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceArchitectureModelsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	models, err := listArchitectureModels(client, d)
+	if err != nil {
+		return diag.Errorf("error querying architecture models: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("models", flattenArchitectureModels(models)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a data source to query the list of models in the workspace.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataArchitectureModels_basic -timeout 360m -parallel 10
=== RUN   TestAccDataArchitectureModels_basic
=== PAUSE TestAccDataArchitectureModels_basic
=== CONT  TestAccDataArchitectureModels_basic
--- PASS: TestAccDataArchitectureModels_basic (21.66s)
PASS
coverage: 4.9% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  21.819s coverage: 4.9% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.