### PR TITLE
feat(eip): support `eip_publicips_by_tags` data source

### DIFF
--- a/docs/data-sources/eip_publicips_by_tags.md
+++ b/docs/data-sources/eip_publicips_by_tags.md
@@ -1,0 +1,91 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eip_publicips_by_tags"
+description: |-
+  Use this data source to get the list of EIP public IPs filtered by tags.
+---
+
+# huaweicloud_eip_publicips_by_tags
+
+Use this data source to get the list of EIP public IPs filtered by tags.
+
+## Example Usage
+
+```hcl
+variable "action" {}
+
+data "huaweicloud_eip_publicips_by_tags" "test" {
+  action = var.action
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `action` - (Required, String) Specifies the operation type. The valid values are **filter** and **count**.
+  + If `action` is **filter**, resources are queried with pagination.
+  + If `action` is **count**, only the total number of resources matching the conditions is returned.
+
+* `tags` - (Optional, List) Specifies the tag filter conditions. It can contain up to `10` keys.
+  + The maximum number of values under each key is `10`, and the structure cannot be missing. The key cannot be empty
+    or an empty string.
+  + Keys cannot be duplicated, and values within the same key cannot be duplicated.
+
+  The [tags](#query_tags) structure is documented below.
+
+* `matches` - (Optional, List) Specifies the search fields.
+  + The `key` is the field to be matched, currently only **resource_name** is supported.
+  + The `value` is the matching value. This field is a fixed dictionary value.
+
+  The [matches](#query_matches) structure is documented below.
+
+<a name="query_tags"></a>
+The `tags` block supports:
+
+* `key` - (Required, String) Specifies the tag key.
+
+* `values` - (Required, List) Specifies the list of tag values.
+
+<a name="query_matches"></a>
+The `matches` block supports:
+
+* `key` - (Required, String) Specifies the field to match. The valid value is **resource_name**.
+
+* `value` - (Required, String) Specifies the match value. Currently limited to EIP addresses only.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resources` - The list of resources.
+
+  The [resources](#resources_struct) structure is documented below.
+
+* `total_count` - The total number of resources.
+
+<a name="resources_struct"></a>
+The `resources` block supports:
+
+* `resource_detail` - The resource detail object.
+
+* `resource_id` - The resource ID.
+
+* `resource_name` - The resource name.
+
+* `tags` - The tag list associated with the resource.
+
+  The [tags](#tags_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `value` - The value of the tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2405,6 +2405,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_eips":                           eip.DataSourceVpcEips(),
 			"huaweicloud_vpcv3_eips":                         eip.DataSourceEipVpcv3Eips(),
 			"huaweicloud_vpc_eip_tags":                       eip.DataSourceVpcEipTags(),
+			"huaweicloud_eip_publicips_by_tags":              eip.DataSourcePublicipsByTags(),
 			"huaweicloud_vpc_internet_gateways":              eip.DataSourceVPCInternetGateways(),
 			"huaweicloud_eip_publicip_count":                 eip.DataSourceEipPublicipCount(),
 			"huaweicloud_eip_publicip_types":                 eip.DataSourceEipPublicipTypes(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_eip_publicips_by_tags_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_eip_publicips_by_tags_test.go
@@ -1,0 +1,84 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcePublicipsByTags_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_eip_publicips_by_tags.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Need to ensure that the set EIP resource have created labels.
+			acceptance.TestAccPrecheckEipIDAndIP(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourcePublicipsByTags_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.tags.#"),
+
+					resource.TestCheckOutput("results_is_not_empty", "true"),
+					resource.TestCheckOutput("matches_filter_is_useful", "true"),
+					resource.TestCheckOutput("tags_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourcePublicipsByTags_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_eip_publicips_by_tags" "test" {
+  action = "filter"
+}
+
+data "huaweicloud_eip_publicips_by_tags" "filter_by_count" {
+  action = "count"
+}
+
+data "huaweicloud_eip_publicips_by_tags" "filter_by_matches" {
+  action = "filter"
+
+  matches {
+    key   = "resource_name"
+    value = "%[1]s"
+  }
+}
+
+data "huaweicloud_eip_publicips_by_tags" "filter_by_tags" {
+  action = "filter"
+
+  tags {
+    key    = data.huaweicloud_eip_publicips_by_tags.test.resources.0.tags.0.key
+    values = [data.huaweicloud_eip_publicips_by_tags.test.resources.0.tags.0.value]
+  }
+}
+
+output "results_is_not_empty" {
+  value = data.huaweicloud_eip_publicips_by_tags.filter_by_count.total_count > 0
+}
+
+output "matches_filter_is_useful" {
+  value = length(data.huaweicloud_eip_publicips_by_tags.filter_by_matches.resources) > 0
+}
+
+output "tags_filter_is_useful" {
+  value = length(data.huaweicloud_eip_publicips_by_tags.filter_by_tags.resources) > 0
+}
+`, acceptance.HW_EIP_ADDRESS)
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_eip_publicips_by_tags.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_eip_publicips_by_tags.go
@@ -1,0 +1,264 @@
+package eip
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP POST /v2.0/{project_id}/publicips/resource_instances/action
+func DataSourcePublicipsByTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePublicipsByTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// In the API documentation, it is of type `Object`,
+						// but here it has been changed to type `string`.
+						"resource_detail": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"total_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildPublicipsByTagsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	action := d.Get("action").(string)
+	bodyParams := map[string]interface{}{
+		"action":  action,
+		"tags":    buildPublicipsFilterTagsBodyParams(d.Get("tags").([]interface{})),
+		"matches": buildPublicipsFilterMatchesBodyParams(d.Get("matches").([]interface{})),
+	}
+
+	return bodyParams
+}
+
+func buildPublicipsFilterTagsBodyParams(tags []interface{}) []map[string]interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	res := make([]map[string]interface{}, len(tags))
+	for i, tagRaw := range tags {
+		if tag, ok := tagRaw.(map[string]interface{}); ok {
+			res[i] = map[string]interface{}{
+				"key": utils.PathSearch("key", tag, nil),
+				"values": utils.ExpandToStringList(
+					utils.PathSearch("values", tag, make([]interface{}, 0)).([]interface{})),
+			}
+		}
+	}
+
+	return res
+}
+
+func buildPublicipsFilterMatchesBodyParams(matches []interface{}) []map[string]interface{} {
+	if len(matches) == 0 {
+		return nil
+	}
+
+	res := make([]map[string]interface{}, len(matches))
+	for i, matchRaw := range matches {
+		if match, ok := matchRaw.(map[string]interface{}); ok {
+			res[i] = map[string]interface{}{
+				"key":   utils.PathSearch("key", match, nil),
+				"value": utils.PathSearch("value", match, nil),
+			}
+		}
+	}
+
+	return res
+}
+
+func dataSourcePublicipsByTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "vpc"
+		httpUrl    = "v2.0/{project_id}/publicips/resource_instances/action"
+		tagsAction = d.Get("action").(string)
+		offset     = 0
+		result     = make([]interface{}, 0)
+		totalCount float64
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VPC EIP client: %s", err)
+	}
+
+	reqBodyParams := buildPublicipsByTagsBodyParams(d)
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		if tagsAction == "filter" {
+			reqBodyParams["offset"] = offset
+		}
+
+		requestOpt.JSONBody = utils.RemoveNil(reqBodyParams)
+		resp, err := client.Request("POST", requestPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving EIP public IPs by tags: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalCount = utils.PathSearch("total_count", respBody, float64(0)).(float64)
+		if tagsAction == "count" {
+			break
+		}
+
+		resourcesResp := utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{})
+		if len(resourcesResp) == 0 {
+			break
+		}
+
+		result = append(result, resourcesResp...)
+
+		offset += len(resourcesResp)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("resources", flattenPublicipsByTags(result)),
+		d.Set("total_count", totalCount),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPublicipsByTags(resourcesResp []interface{}) []interface{} {
+	if len(resourcesResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(resourcesResp))
+	for i, v := range resourcesResp {
+		rst[i] = map[string]interface{}{
+			"resource_detail": utils.JsonToString(utils.PathSearch("resource_detail", v, nil)),
+			"resource_id":     utils.PathSearch("resource_id", v, nil),
+			"resource_name":   utils.PathSearch("resource_name", v, nil),
+			"tags": flattenPublicipsTagsResp(
+				utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})),
+		}
+	}
+
+	return rst
+}
+
+func flattenPublicipsTagsResp(tagsResp []interface{}) []interface{} {
+	if len(tagsResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(tagsResp))
+	for i, tag := range tagsResp {
+		rst[i] = map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.PathSearch("value", tag, nil),
+		}
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `eip_publicips_by_tags` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `eip_publicips_by_tags` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o eip -f TestAccDataSourcePublicipsByTags_basic                                     Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccDataSourcePublicipsByTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourcePublicipsByTags_basic
=== PAUSE TestAccDataSourcePublicipsByTags_basic
=== CONT  TestAccDataSourcePublicipsByTags_basic
--- PASS: TestAccDataSourcePublicipsByTags_basic (25.92s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip  coverage: 4.1% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       26.353s coverage: 4.1% of statements in ./huaweicloud/services/eip
```
<img width="872" height="40" alt="image" src="https://github.com/user-attachments/assets/68e8acd6-e305-4b70-98ca-aead0f0b574f" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
