### PR TITLE
feat(geminidb): add datasource to query GeminiDB resource quotas

### DIFF
--- a/docs/data-sources/geminidb_quotas.md
+++ b/docs/data-sources/geminidb_quotas.md
@@ -1,0 +1,72 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_quotas"
+description: |-
+  Use this data source to query the GeminiDB resource quotas.
+---
+
+# huaweicloud_geminidb_quotas
+
+Use this data source to query the GeminiDB resource quotas.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_geminidb_quotas" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `datastore_type` - (Optional, String) Specifies the database type.
+  The valid values are as follows:
+  + **cassandra**: Indicates GeminiDB Cassandra.
+  + **mongodb**: Indicates GeminiDB Mongo.
+  + **influxdb**: Indicates GeminiDB Influx.
+  + **redis**: Indicates GeminiDB Redis.
+
+* `mode` - (Optional, String) Specifies the instance type.
+  The valid values are as follows:
+  + **Cluster**: Indicates proxy cluster GeminiDB Redis instance, cluster GeminiDB Cassandra or Influx instance
+  with classic storage.
+  + **CloudNativeCluster**: Indicates cluster GeminiDB Cassandra, Influx, or Redis instance with cloud native storage.
+  + **RedisCluster**: Indicates Redis Cluster GeminiDB Redis instance with classic storage.
+  + **Replication**: Indicates primary/standby GeminiDB Redis instance with classic storage.
+  + **InfluxdbSingle**: Indicates single-node GeminiDB Influx instance with classic storage.
+  + **EnhancedCluster**: Indicates GeminiDB Influx cluster (performance-enhanced) instance with classic storage.
+  + **ReplicaSet**: Indicates GeminiDB Mongo instance in a replica set.
+
+  -> If `datastore_type` is not transferred, this parameter is automatically ignored.
+    This parameter is mandatory when `datastore_type` is transferred.
+
+* `product_type` - (Optional, String) Specifies the product type.
+  The valid values are as follows:
+  + **Capacity**
+  + **Standard**
+  + **Performance**
+
+  -> This parameter is mandatory when you query a GeminiDB Redis cluster instance with cloud native storage.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `quotas` - The GeminiDB quotas.
+  The [quotas](#quotas_struct) structure is documented below.
+
+<a name="quotas_struct"></a>
+The `quotas` block supports:
+
+* `type` - The quota resource type.
+
+* `quota` - The current quota.
+  If this parameter is set to `0`, no quantity limit is set for resources.
+
+* `used` - The number of used resources.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1417,9 +1417,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_redis_flavors":                geminidb.DataSourceGaussDBRedisFlavors(),
 			"huaweicloud_gaussdb_influx_instances":             geminidb.DataSourceGaussDBInfluxInstances(),
 
-			"huaweicloud_geminidb_flavors":           geminidb.DataSourceGeminiDBFlavors(),
 			"huaweicloud_geminidb_accounts":          geminidb.DataSourceGeminiDbAccounts(),
 			"huaweicloud_geminidb_database_versions": geminidb.DataSourceDatabaseVersions(),
+			"huaweicloud_geminidb_flavors":           geminidb.DataSourceGeminiDBFlavors(),
+			"huaweicloud_geminidb_quotas":            geminidb.DataSourceQuotas(),
 
 			"huaweicloud_gaussdb_storage_types":             gaussdb.DataSourceGaussDbStorageTypes(),
 			"huaweicloud_gaussdb_datastores":                gaussdb.DataSourceGaussDbDatastores(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_quotas_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_quotas_test.go
@@ -1,0 +1,66 @@
+package geminidb
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceQuotas_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_geminidb_quotas.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceQuotas_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.quota"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.used"),
+
+					resource.TestCheckOutput("quotas_exist", "true"),
+					resource.TestCheckOutput("datastore_type_and_mode_filter_useful", "true"),
+					resource.TestCheckOutput("product_type_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceQuotas_basic = `
+data "huaweicloud_geminidb_quotas" "test" {}
+
+data "huaweicloud_geminidb_quotas" "datastore_type_and_mode_filter" {
+  datastore_type = "cassandra"
+  mode           = "Cluster"
+}
+
+data "huaweicloud_geminidb_quotas" "product_type_filter" {
+  datastore_type = "redis"
+  mode           = "CloudNativeCluster"
+  product_type   = "Capacity"
+}
+
+output "quotas_exist" {
+  value = length(data.huaweicloud_geminidb_quotas.test.quotas) > 0
+}
+
+output "datastore_type_and_mode_filter_useful" {
+  value = length(data.huaweicloud_geminidb_quotas.datastore_type_and_mode_filter.quotas) > 0
+}
+
+output "product_type_filter_useful" {
+  value = length(data.huaweicloud_geminidb_quotas.product_type_filter.quotas) > 0
+}
+`

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_quotas.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_quotas.go
@@ -1,0 +1,147 @@
+package geminidb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforNoSQL GET /v3/{project_id}/quotas
+func DataSourceQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"datastore_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"product_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"quotas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"quota": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"used": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildQuotasQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("datastore_type"); ok {
+		queryParams = fmt.Sprintf("%s&datastore_type=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("mode"); ok {
+		queryParams = fmt.Sprintf("%s&mode=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("product_type"); ok {
+		queryParams = fmt.Sprintf("%s&product_type=%v", queryParams, v)
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func dataSourceQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/quotas"
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildQuotasQueryParams(d)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving GeminiDB database quotas: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("quotas", flattenQuotas(utils.PathSearch("quotas.resources", getRespBody,
+			make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenQuotas(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"type":  utils.PathSearch("type", v, nil),
+			"quota": utils.PathSearch("quota", v, nil),
+			"used":  utils.PathSearch("used", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to query GeminiDB resource quotas.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to  query GeminiDB resource quotas.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccDataSourceQuotas_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccDataSourceQuotas_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceQuotas_basic
=== PAUSE TestAccDataSourceQuotas_basic
=== CONT  TestAccDataSourceQuotas_basic
--- PASS: TestAccDataSourceQuotas_basic (22.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  22.706s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/705d5d24-7ec4-4e41-a262-124e64f63778" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
