### PR TITLE
feat(eip): support `eip_bandwidth_batch_attach` resource

### DIFF
--- a/docs/resources/eip_bandwidth_batch_attach.md
+++ b/docs/resources/eip_bandwidth_batch_attach.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eip_bandwidth_batch_attach"
+description: |-
+  Manages a resource to batch attach EIPs to shared bandwidth within HuaweiCloud.
+---
+
+# huaweicloud_eip_bandwidth_batch_attach
+
+Manages a resource to batch attach EIPs to shared bandwidth within HuaweiCloud.
+
+-> This resource is a one-time action resource for batch attaching EIPs to shared bandwidth.
+Deleting this resource will not detach the EIPs from the shared bandwidth, but will only remove
+the resource information from the Terraform state file.
+
+## Example Usage
+
+```hcl
+variable "eip_bandwidth_attachments" {
+  type = list(object({
+    bandwidth_id = string
+    publicip_id  = string
+  }))
+}
+
+resource "huaweicloud_eip_bandwidth_batch_attach" "test" {
+  dynamic "publicips" {
+    for_each = var.eip_bandwidth_attachments
+    content {
+      bandwidth_id = publicips.value.bandwidth_id
+      publicip_id  = publicips.value.publicip_id
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the VPC EIP associate resource. If
+  omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `publicips` - (Required, List, NonUpdatable) Specifies the list of EIPs to attach to shared bandwidth.
+
+The [publicips](#publicips_struct) structure is documented below.
+
+<a name="publicips_struct"></a>
+The `publicips` block supports:
+
+* `bandwidth_id` - (Required, String, NonUpdatable) Specifies the shared bandwidth ID.
+
+* `publicip_id` - (Required, String, NonUpdatable) Specifies the EIP ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3506,6 +3506,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_eg_event_subscription_batch_action": eg.ResourceEventSubscriptionBatchAction(),
 			"huaweicloud_eg_event_subscription_target":       eg.ResourceEventSubscriptionTarget(),
 
+			"huaweicloud_eip_bandwidth_batch_attach": eip.ResourceEipBatchAttachShareBandwidth(),
+
 			"huaweicloud_elb_certificate":                      elb.ResourceCertificateV3(),
 			"huaweicloud_elb_domain_address":                   elb.ResourceDomainAddress(),
 			"huaweicloud_elb_certificate_private_key_echo":     elb.ResourceCertificatePrivateKeyEcho(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -77,6 +77,7 @@ var (
 	HW_CBR_DESTINATION_VAULT_ID   = os.Getenv("HW_CBR_DESTINATION_VAULT_ID")   // The destination vault ID.
 
 	HW_VPC_BANDWIDTH_ADDON_PACKAGE_ENABLED = os.Getenv("HW_VPC_BANDWIDTH_ADDON_PACKAGE_ENABLED")
+	HW_VPC_BANDWIDTH_ID                    = os.Getenv("HW_VPC_BANDWIDTH_ID")
 	HW_VPC_BANDWIDTH_NAME                  = os.Getenv("HW_VPC_BANDWIDTH_NAME")
 	HW_VPC_EIP_POOL_ENABLED                = os.Getenv("HW_VPC_EIP_POOL_ENABLED")
 	HW_VPC_EIP_PUBLICIP_POOL_ID            = os.Getenv("HW_VPC_EIP_PUBLICIP_POOL_ID")
@@ -447,6 +448,7 @@ var (
 
 	HW_EIP_ID      = os.Getenv("HW_EIP_ID")
 	HW_EIP_ADDRESS = os.Getenv("HW_EIP_ADDRESS")
+	HW_EIP_IDS     = os.Getenv("HW_EIP_IDS")
 
 	HW_CES_ALARM_TEMPLATE_ID = os.Getenv("HW_CES_ALARM_TEMPLATE_ID")
 	HW_CES_START_TIME        = os.Getenv("HW_CES_START_TIME")
@@ -4821,6 +4823,13 @@ func TestAccPreCheckVpcEipBandwidthAddOnPackageEnabled(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPreCheckVpcEipBandwidthId(t *testing.T) {
+	if HW_VPC_BANDWIDTH_ID == "" {
+		t.Skip("HW_VPC_BANDWIDTH_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
 func TestAccPreCheckVpcEipBandwidthName(t *testing.T) {
 	if HW_VPC_BANDWIDTH_NAME == "" {
 		t.Skip("HW_VPC_BANDWIDTH_NAME must be set for the acceptance test")
@@ -4975,6 +4984,13 @@ func TestAccPrecheckDscAlarmTopicID(t *testing.T) {
 func TestAccPrecheckEipIDAndIP(t *testing.T) {
 	if HW_EIP_ID == "" || HW_EIP_ADDRESS == "" {
 		t.Skip("HW_EIP_ID and HW_EIP_ADDRESS must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPrecheckEipIDS(t *testing.T) {
+	if HW_EIP_IDS == "" {
+		t.Skip("HW_EIP_IDS must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_eip_bandwidth_batch_attach_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_eip_bandwidth_batch_attach_test.go
@@ -1,0 +1,41 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccEipBatchAttachShareBandwidth_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckEipIDS(t)
+			acceptance.TestAccPreCheckVpcEipBandwidthId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEipBatchAttachShareBandwidth_basic(),
+			},
+		},
+	})
+}
+
+func testAccEipBatchAttachShareBandwidth_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_eip_bandwidth_batch_attach" "test" {
+  dynamic "publicips" {
+    for_each = split(",", "%s")
+    content {
+      bandwidth_id = "%s"
+      publicip_id  = publicips.value
+    }
+  }
+}
+`, acceptance.HW_EIP_IDS, acceptance.HW_VPC_BANDWIDTH_ID)
+}

--- a/huaweicloud/services/eip/resource_huaweicloud_eip_bandwidth_batch_attach.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_eip_bandwidth_batch_attach.go
@@ -1,0 +1,154 @@
+package eip
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var eipBatchAttachShareBandwidthNonUpdatableParams = []string{
+	"publicips",
+	"publicips.*.bandwidth_id",
+	"publicips.*.publicip_id",
+}
+
+// @API EIP POST /v3/{project_id}/eip/publicips/attach-share-bandwidth
+func ResourceEipBatchAttachShareBandwidth() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEipBatchAttachShareBandwidthCreate,
+		ReadContext:   resourceEipBatchAttachShareBandwidthRead,
+		UpdateContext: resourceEipBatchAttachShareBandwidthUpdate,
+		DeleteContext: resourceEipBatchAttachShareBandwidthDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(eipBatchAttachShareBandwidthNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"publicips": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bandwidth_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"publicip_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceEipBatchAttachShareBandwidthCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/eip/publicips/attach-share-bandwidth"
+		product = "vpc"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VPC EIP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildBatchAttachShareBandwidthBodyParams(d),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error attaching EIPs to share bandwidth: %s", err)
+	}
+
+	_, err = utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildBatchAttachShareBandwidthBodyParams(d *schema.ResourceData) map[string]interface{} {
+	publicipsRaw := d.Get("publicips").([]interface{})
+
+	publicips := make([]map[string]interface{}, 0, len(publicipsRaw))
+	for _, item := range publicipsRaw {
+		publicip := item.(map[string]interface{})
+		publicips = append(publicips, map[string]interface{}{
+			"bandwidth_id": publicip["bandwidth_id"],
+			"publicip_id":  publicip["publicip_id"],
+		})
+	}
+
+	bodyParams := map[string]interface{}{
+		"publicips": publicips,
+	}
+
+	return bodyParams
+}
+
+func resourceEipBatchAttachShareBandwidthRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Read()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceEipBatchAttachShareBandwidthUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Update()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceEipBatchAttachShareBandwidthDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to attach EIPs to shared bandwidth. 
+Deleting this resource will not detach the EIPs from the shared bandwidth, but will only remove 
+the resource information from the Terraform state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `eip_bandwidth_batch_attach` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `eip_bandwidth_batch_attach` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccEipBatchAttachShareBandwidth_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip-v -run TestAccEipBatchAttachShareBandwidth_basic -timeout 360m -parallel 4
=== RUN   TestAccEipBatchAttachShareBandwidth_basic
=== PAUSE TestAccEipBatchAttachShareBandwidth_basic
=== CONT  TestAccEipBatchAttachShareBandwidth_basic
--- PASS: TestAccEipBatchAttachShareBandwidth_basic (12.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       21.311s
```
<img width="562" height="27" alt="image" src="https://github.com/user-attachments/assets/3b9a288d-a7d8-4da3-bdfa-33927383f2ac" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
