### PR TITLE
feat(modelarts): add new data source to query notebooks

### DIFF
--- a/docs/data-sources/modelarts_notebooks.md
+++ b/docs/data-sources/modelarts_notebooks.md
@@ -1,0 +1,178 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_notebooks"
+description: |-
+  Use this data source to get the list of ModelArts Notebook instances within HuaweiCloud.
+---
+
+# huaweicloud_modelarts_notebooks
+
+Use this data source to get the list of ModelArts Notebook instances within HuaweiCloud.
+
+## Example Usage
+
+### Query all notebooks without any filter
+
+```hcl
+data "huaweicloud_modelarts_notebooks" "test" {}
+```
+
+### Query the notebooks and using notebook name to filter
+
+```hcl
+variable "notebook_name" {}
+
+data "huaweicloud_modelarts_notebooks" "test" {
+  name = var.notebook_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the notebooks are located.  
+  If omitted, the provider-level region will be used.
+
+* `feature` - (Optional, String) Specifies the feature type of the notebooks to be queried.
+
+* `notebook_id` - (Optional, String) Specifies the notebook instance ID to be queried.
+
+* `name` - (Optional, String) Specifies the name of the notebooks to be queried. Fuzzy match is supported.
+
+* `status` - (Optional, String) Specifies the status of the notebooks to be queried.
+
+* `workspace_id` - (Optional, String) Specifies the workspace ID of the notebooks to be queried.
+
+* `flavor_id` - (Optional, String) Specifies the flavor of the notebooks to be queried.
+
+* `image_id` - (Optional, String) Specifies the image ID of the notebooks to be queried.
+
+* `billing` - (Optional, String) Specifies the billing type of the notebooks to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `notebooks` - The list of notebooks that match the filter parameters.  
+  The [notebooks](#modelarts_notebooks_attr) structure is documented below.
+
+<a name="modelarts_notebooks_attr"></a>
+The `notebooks` block supports:
+
+* `id` - The ID of the notebook instance.
+
+* `name` - The name of the notebook instance.
+
+* `description` - The description of the notebook instance.
+
+* `status` - The status of the notebook instance.
+
+* `feature` - The feature type of the notebook instance.
+
+* `flavor_id` - The flavor of the notebook instance.
+
+* `workspace_id` - The workspace ID to which the notebook belongs.
+
+* `pool_id` - The dedicated resource pool ID of the notebook instance.
+
+* `pool_name` - The dedicated resource pool name of the notebook instance.
+
+* `image_id` - The image ID of the notebook instance.
+
+* `image_name` - The image name of the notebook instance.
+
+* `image_type` - The image type of the notebook instance.
+
+* `image_swr_path` - The SWR path of the image of the notebook instance.
+
+* `url` - The access URL of the notebook instance.
+
+* `fail_reason` - The failure reason of the notebook instance.
+
+* `auto_stop_enabled` - Whether the auto stop feature is enabled for the notebook instance.
+
+* `lease_duration` - The lease duration of the notebook instance, in milliseconds.
+
+* `lease_type` - The auto stop type of the notebook instance.
+
+* `key_pair` - The SSH key pair name when SSH access is configured.
+
+* `ssh_uri` - The SSH access URI when SSH access is configured.
+
+* `allowed_access_ips` - The allowed access IP list for SSH when SSH access is configured.
+
+* `user_id` - The user ID of the notebook instance.
+
+* `ip` - The IP address of the node where the notebook instance is located.
+
+* `jupyter_version` - The JupyterLab version of the notebook instance.
+
+* `billing_items` - The billing resource types of the notebook instance.
+
+* `custom_spec` - The custom specification of the notebook instance, in JSON format.
+
+* `user_vpc` - The user VPC configuration of the notebook instance, in JSON format.
+
+* `volume` - The system volume configuration of the notebook instance.  
+  The [volume](#modelarts_notebooks_volume_attr) structure is documented below.
+
+* `data_volumes` - The extended storage list of the notebook instance.  
+  The [data_volumes](#modelarts_notebooks_data_volumes_attr) structure is documented below.
+
+* `action_progress` - The initialization progress of the notebook instance.  
+  The [action_progress](#modelarts_notebooks_action_progress_attr) structure is documented below.
+
+* `tags` - The tags of the notebook instance.  
+  The [tags](#modelarts_notebooks_tags_attr) structure is documented below.
+
+* `created_at` - The creation time of the notebook instance.
+
+* `updated_at` - The last update time of the notebook instance.
+
+<a name="modelarts_notebooks_volume_attr"></a>
+The `volume` block supports:
+
+* `type` - The storage category of the notebook instance.
+
+* `ownership` - The ownership type of the storage.
+
+* `size` - The storage capacity.
+
+* `uri` - The storage URI.
+
+* `id` - The storage ID.
+
+* `mount_path` - The mount path of the storage.
+
+<a name="modelarts_notebooks_data_volumes_attr"></a>
+The `data_volumes` block supports:
+
+* `type` - The extended storage category.
+
+* `mount_path` - The mount path of the extended storage.
+
+* `path` - The source path of the extended storage.
+
+* `status` - The status of the extended storage.
+
+* `mount_type` - The mount type of the extended storage.
+
+<a name="modelarts_notebooks_action_progress_attr"></a>
+The `action_progress` block supports:
+
+* `status` - The status of the step.
+
+* `step` - The step number.
+
+* `description` - The description of the step.
+
+<a name="modelarts_notebooks_tags_attr"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `value` - The value of the tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1923,6 +1923,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_models":            modelarts.DataSourceModels(),
 			"huaweicloud_modelarts_notebook_flavors":  modelarts.DataSourceNotebookFlavors(),
 			"huaweicloud_modelarts_notebook_images":   modelarts.DataSourceNotebookImages(),
+			"huaweicloud_modelarts_notebooks":         modelarts.DataSourceNotebooks(),
 			"huaweicloud_modelarts_resource_flavors":  modelarts.DataSourceResourceFlavors(),
 			"huaweicloud_modelarts_service_flavors":   modelarts.DataSourceServiceFlavors(),
 			"huaweicloud_modelarts_services":          modelarts.DataSourceServices(),

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_notebooks_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_notebooks_test.go
@@ -1,0 +1,314 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataNotebooks_basic(t *testing.T) {
+	var (
+		rName = "huaweicloud_modelarts_notebook.test"
+
+		all   = "data.huaweicloud_modelarts_notebooks.all"
+		dcAll = acceptance.InitDataSourceCheck(all)
+
+		byFeature   = "data.huaweicloud_modelarts_notebooks.filter_by_feature"
+		dcByFeature = acceptance.InitDataSourceCheck(byFeature)
+
+		byNotebookId   = "data.huaweicloud_modelarts_notebooks.filter_by_notebook_id"
+		dcByNotebookId = acceptance.InitDataSourceCheck(byNotebookId)
+
+		byName   = "data.huaweicloud_modelarts_notebooks.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byStatus   = "data.huaweicloud_modelarts_notebooks.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byWorkspaceId   = "data.huaweicloud_modelarts_notebooks.filter_by_workspace_id"
+		dcByWorkspaceId = acceptance.InitDataSourceCheck(byWorkspaceId)
+
+		byFlavor   = "data.huaweicloud_modelarts_notebooks.filter_by_flavor"
+		dcByFlavor = acceptance.InitDataSourceCheck(byFlavor)
+
+		byImageId   = "data.huaweicloud_modelarts_notebooks.filter_by_image_id"
+		dcByImageId = acceptance.InitDataSourceCheck(byImageId)
+
+		byBilling   = "data.huaweicloud_modelarts_notebooks.filter_by_billing"
+		dcByBilling = acceptance.InitDataSourceCheck(byBilling)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRunnerPublicIPs(t, 1)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataNotebooks_nonExistentNotebook(),
+				Check: resource.ComposeTestCheckFunc(
+					dcAll.CheckResourceExists(),
+					resource.TestCheckResourceAttr(all, "notebooks.#", "0"),
+				),
+			},
+			{
+				Config: testAccDataNotebooks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dcAll.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "notebooks.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByFeature.CheckResourceExists(),
+					resource.TestCheckOutput("is_feature_filter_useful", "true"),
+					dcByNotebookId.CheckResourceExists(),
+					resource.TestCheckOutput("is_notebook_id_filter_useful", "true"),
+					resource.TestCheckResourceAttr(byNotebookId, "notebooks.0.status", "RUNNING"),
+					resource.TestCheckResourceAttrPair(byNotebookId, "notebooks.0.id", rName, "id"),
+					resource.TestCheckResourceAttrPair(byNotebookId, "notebooks.0.name", rName, "name"),
+					resource.TestCheckResourceAttrPair(byNotebookId, "notebooks.0.flavor_id", rName, "flavor_id"),
+					resource.TestCheckResourceAttrPair(byNotebookId, "notebooks.0.image_id", rName, "image_id"),
+					resource.TestCheckResourceAttrPair(byNotebookId, "notebooks.0.image_type", rName, "image_type"),
+					resource.TestCheckResourceAttrPair(byNotebookId, "notebooks.0.image_swr_path", rName, "image_swr_path"),
+					resource.TestCheckResourceAttrPair(byNotebookId, "notebooks.0.image_name", rName, "image_name"),
+					resource.TestCheckResourceAttrPair(byNotebookId, "notebooks.0.description", rName, "description"),
+					resource.TestCheckResourceAttrPair(byNotebookId, "notebooks.0.key_pair", rName, "key_pair"),
+					resource.TestCheckResourceAttrPair(byNotebookId, "notebooks.0.workspace_id", rName, "workspace_id"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					dcByWorkspaceId.CheckResourceExists(),
+					resource.TestCheckOutput("is_workspace_id_filter_useful", "true"),
+					dcByFlavor.CheckResourceExists(),
+					resource.TestCheckOutput("is_flavor_filter_useful", "true"),
+					dcByImageId.CheckResourceExists(),
+					resource.TestCheckOutput("is_image_id_filter_useful", "true"),
+					dcByBilling.CheckResourceExists(),
+					resource.TestCheckOutput("is_billing_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataNotebooks_nonExistentNotebook() string {
+	name := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+// Create a new workspace to make sure no notebook exists in the workspace.
+resource "huaweicloud_modelarts_workspace" "test" {
+  name = "%[1]s"
+}
+
+data "huaweicloud_modelarts_notebooks" "all" {
+  workspace_id = huaweicloud_modelarts_workspace.test.id
+}
+`, name)
+}
+
+func testAccDataNotebooks_basic_base() string {
+	name := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+data "huaweicloud_modelarts_notebook_flavors" "test" {
+  type     = "MANAGED"
+  category = "CPU"
+}
+
+data "huaweicloud_modelarts_notebook_images" "test" {
+  type     = "BUILD_IN"
+  cpu_arch = try(data.huaweicloud_modelarts_notebook_flavors.test.flavors[0].arch, "x86_64")
+}
+
+resource "huaweicloud_kps_keypair" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_modelarts_notebook" "test" {
+  depends_on = [huaweicloud_kps_keypair.test]
+
+  name               = "%[1]s"
+  flavor_id          = data.huaweicloud_modelarts_notebook_flavors.test.flavors[0].id
+  image_id           = data.huaweicloud_modelarts_notebook_images.test.images[0].id
+  description        = "Created by Terraform"
+  key_pair           = huaweicloud_kps_keypair.test.name
+  allowed_access_ips = split(",", "%[2]s")
+  workspace_id       = "0"
+
+  volume {
+    type = "EVS"
+    size = 100
+  }
+}
+`, name, acceptance.HW_RUNNER_PUBLIC_IPS)
+}
+
+func testAccDataNotebooks_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query without any filter.
+data "huaweicloud_modelarts_notebooks" "all" {
+  depends_on = [huaweicloud_modelarts_notebook.test]
+}
+
+# Filter by 'feature' parameter.
+locals {
+  notebook_feature = "NOTEBOOK"
+}
+
+data "huaweicloud_modelarts_notebooks" "filter_by_feature" {
+  depends_on = [huaweicloud_modelarts_notebook.test]
+
+  feature = local.notebook_feature
+}
+
+locals {
+  feature_filter_result = [for v in data.huaweicloud_modelarts_notebooks.filter_by_feature.notebooks :
+    v.feature == local.notebook_feature]
+}
+
+output "is_feature_filter_useful" {
+  value = length(local.feature_filter_result) > 0 && alltrue(local.feature_filter_result)
+}
+
+# Filter by 'name' parameter.
+data "huaweicloud_modelarts_notebooks" "filter_by_name" {
+  depends_on = [huaweicloud_modelarts_notebook.test]
+
+  name = huaweicloud_modelarts_notebook.test.name
+}
+
+locals {
+  name_filter_result = [for v in data.huaweicloud_modelarts_notebooks.filter_by_name.notebooks :
+    v.name == huaweicloud_modelarts_notebook.test.name]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by 'notebook_id' parameter.
+locals {
+  notebook_id = huaweicloud_modelarts_notebook.test.id
+}
+
+data "huaweicloud_modelarts_notebooks" "filter_by_notebook_id" {
+  depends_on = [huaweicloud_modelarts_notebook.test]
+
+  notebook_id = local.notebook_id
+}
+
+locals {
+  notebook_id_filter_result = [for v in data.huaweicloud_modelarts_notebooks.filter_by_notebook_id.notebooks :
+    v.id == local.notebook_id]
+}
+
+output "is_notebook_id_filter_useful" {
+  value = length(local.notebook_id_filter_result) > 0 && alltrue(local.notebook_id_filter_result)
+}
+
+# Filter by 'status' parameter.
+locals {
+  notebook_status = huaweicloud_modelarts_notebook.test.status
+}
+
+data "huaweicloud_modelarts_notebooks" "filter_by_status" {
+  depends_on = [huaweicloud_modelarts_notebook.test]
+
+  status = local.notebook_status
+}
+
+locals {
+  status_filter_result = [for v in data.huaweicloud_modelarts_notebooks.filter_by_status.notebooks :
+    v.status == local.notebook_status]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+# Filter by 'workspace_id' parameter.
+locals {
+  workspace_id = huaweicloud_modelarts_notebook.test.workspace_id
+}
+
+data "huaweicloud_modelarts_notebooks" "filter_by_workspace_id" {
+  depends_on = [huaweicloud_modelarts_notebook.test]
+
+  workspace_id = local.workspace_id
+}
+
+locals {
+  workspace_id_filter_result = [for v in data.huaweicloud_modelarts_notebooks.filter_by_workspace_id.notebooks :
+    v.workspace_id == local.workspace_id]
+}
+
+output "is_workspace_id_filter_useful" {
+  value = length(local.workspace_id_filter_result) > 0 && alltrue(local.workspace_id_filter_result)
+}
+
+# Filter by 'flavor_id' parameter.
+locals {
+  notebook_flavor_id = huaweicloud_modelarts_notebook.test.flavor_id
+}
+
+data "huaweicloud_modelarts_notebooks" "filter_by_flavor" {
+  depends_on = [huaweicloud_modelarts_notebook.test]
+
+  flavor_id = local.notebook_flavor_id
+}
+
+locals {
+  flavor_filter_result = [for v in data.huaweicloud_modelarts_notebooks.filter_by_flavor.notebooks :
+    v.flavor_id == local.notebook_flavor_id]
+}
+
+output "is_flavor_filter_useful" {
+  value = length(local.flavor_filter_result) > 0 && alltrue(local.flavor_filter_result)
+}
+
+# Filter by 'image_id' parameter.
+locals {
+  notebook_image_id = huaweicloud_modelarts_notebook.test.image_id
+}
+
+data "huaweicloud_modelarts_notebooks" "filter_by_image_id" {
+  depends_on = [huaweicloud_modelarts_notebook.test]
+
+  image_id = local.notebook_image_id
+}
+
+locals {
+  image_id_filter_result = [for v in data.huaweicloud_modelarts_notebooks.filter_by_image_id.notebooks :
+    v.image_id == local.notebook_image_id]
+}
+
+output "is_image_id_filter_useful" {
+  value = length(local.image_id_filter_result) > 0 && alltrue(local.image_id_filter_result)
+}
+
+# Filter by 'billing' parameter.
+locals {
+  notebook_billing = "STORAGE"
+}
+
+data "huaweicloud_modelarts_notebooks" "filter_by_billing" {
+  depends_on = [huaweicloud_modelarts_notebook.test]
+
+  billing = local.notebook_billing
+}
+
+locals {
+  billing_filter_result = [for v in data.huaweicloud_modelarts_notebooks.filter_by_billing.notebooks :
+    contains(v.billing_items, local.notebook_billing)]
+}
+
+output "is_billing_filter_useful" {
+  value = length(local.billing_filter_result) > 0 && anytrue(local.billing_filter_result)
+}
+`, testAccDataNotebooks_basic_base())
+}

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_notebooks.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_notebooks.go
@@ -1,0 +1,515 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ModelArts GET /v1/{project_id}/notebooks
+func DataSourceNotebooks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNotebooksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the notebooks are located.`,
+			},
+
+			// Optional parameters.
+			"feature": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The feature type of the notebooks to be queried.`,
+			},
+			"notebook_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The notebook instance ID to be queried.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the notebooks to be queried. Fuzzy match is supported.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The status of the notebooks to be queried.`,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The workspace ID of the notebooks to be queried.`,
+			},
+			"flavor_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The flavor of the notebooks to be queried.`,
+			},
+			"image_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The image ID of the notebooks to be queried.`,
+			},
+			"billing": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The billing type of the notebooks to be queried.`,
+			},
+
+			// Attributes.
+			"notebooks": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataSourceNotebooksNotebookElemSchema(),
+				Description: `The list of notebooks that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataSourceNotebooksNotebookElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the notebook instance.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the notebook instance.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the notebook instance.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the notebook instance.`,
+			},
+			"feature": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The feature type of the notebook instance.`,
+			},
+			"flavor_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor of the notebook instance.`,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The workspace ID to which the notebook belongs.`,
+			},
+			"pool_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The dedicated resource pool ID of the notebook instance.`,
+			},
+			"pool_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The dedicated resource pool name of the notebook instance.`,
+			},
+			"image_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The image ID of the notebook instance.`,
+			},
+			"image_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The image name of the notebook instance.`,
+			},
+			"image_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The image type of the notebook instance.`,
+			},
+			"image_swr_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The SWR path of the image of the notebook instance.`,
+			},
+			"url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The access URL of the notebook instance.`,
+			},
+			"fail_reason": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The failure reason of the notebook instance.`,
+			},
+			"auto_stop_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the auto stop feature is enabled for the notebook instance.`,
+			},
+			"lease_duration": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The lease duration of the notebook instance, in milliseconds.`,
+			},
+			"lease_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The auto stop type of the notebook instance.`,
+			},
+			"key_pair": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The SSH key pair name when SSH access is configured.`,
+			},
+			"ssh_uri": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The SSH access URI when SSH access is configured.`,
+			},
+			"allowed_access_ips": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The allowed access IP list for SSH when SSH access is configured.`,
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user ID of the notebook instance.`,
+			},
+			"ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The IP address of the node where the notebook instance is located.`,
+			},
+			"jupyter_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The JupyterLab version of the notebook instance.`,
+			},
+			"billing_items": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The billing resource types of the notebook instance.`,
+			},
+			"custom_spec": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The custom specification of the notebook instance, in JSON format.`,
+			},
+			"user_vpc": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user VPC configuration of the notebook instance, in JSON format.`,
+			},
+			"volume": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The storage category of the notebook instance.`,
+						},
+						"ownership": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ownership type of the storage.`,
+						},
+						"size": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The storage capacity.`,
+						},
+						"uri": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The storage URI.`,
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The storage ID.`,
+						},
+						"mount_path": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The mount path of the storage.`,
+						},
+					},
+				},
+				Description: `The system volume configuration of the notebook instance.`,
+			},
+			"data_volumes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The extended storage category.`,
+						},
+						"mount_path": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The mount path of the extended storage.`,
+						},
+						"path": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The source path of the extended storage.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the extended storage.`,
+						},
+						"mount_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The mount type of the extended storage.`,
+						},
+					},
+				},
+				Description: `The extended storage list of the notebook instance.`,
+			},
+			"tags": common.TagsComputedSchema(`The tags of the notebook instance.`),
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the notebook instance.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The last update time of the notebook instance.`,
+			},
+		},
+	}
+}
+
+func buildNotebooksQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("billing"); ok {
+		res = fmt.Sprintf("%s&billing=%v", res, v)
+	}
+	if v, ok := d.GetOk("feature"); ok {
+		res = fmt.Sprintf("%s&feature=%v", res, v)
+	}
+	if v, ok := d.GetOk("flavor_id"); ok {
+		res = fmt.Sprintf("%s&flavor=%v", res, v)
+	}
+	if v, ok := d.GetOk("image_id"); ok {
+		res = fmt.Sprintf("%s&image_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("notebook_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("workspace_id"); ok {
+		res = fmt.Sprintf("%s&workspace_id=%v", res, v)
+	}
+
+	return res
+}
+
+func listNotebooks(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	// The ListNotebooks API allows 10, 20 or 50 for limit; use the maximum to reduce requests.
+	var (
+		httpUrl = "v1/{project_id}/notebooks?limit={limit}"
+		limit   = 50
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildNotebooksQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"X-Language":   "en-us",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		notebooks := utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, notebooks...)
+
+		if len(notebooks) < limit {
+			break
+		}
+		offset += len(notebooks)
+	}
+
+	return result, nil
+}
+
+func flattenNotebookEndpointsAccess(endpoints []interface{}) (keyPair, sshURI string, ips []interface{}) {
+	for _, ep := range endpoints {
+		if fmt.Sprint(utils.PathSearch("service", ep, "")) != "SSH" {
+			continue
+		}
+		keyPair = utils.PathSearch("key_pair_names[0]", ep, "").(string)
+		sshURI = fmt.Sprint(utils.PathSearch("uri", ep, ""))
+		ips = utils.PathSearch("allowed_access_ips", ep, make([]interface{}, 0)).([]interface{})
+		break
+	}
+	return
+}
+
+func flattenNotebookVolumeForList(volume map[string]interface{}) []map[string]interface{} {
+	if len(volume) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"type":       utils.PathSearch("category", volume, nil),
+			"ownership":  utils.PathSearch("ownership", volume, nil),
+			"size":       utils.PathSearch("capacity", volume, nil),
+			"uri":        utils.PathSearch("uri", volume, nil),
+			"id":         utils.PathSearch("id", volume, nil),
+			"mount_path": utils.PathSearch("mount_path", volume, nil),
+		},
+	}
+}
+
+func flattenNotebookDataVolumes(dataVolumes []interface{}) []map[string]interface{} {
+	if len(dataVolumes) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(dataVolumes))
+	for _, dataVolume := range dataVolumes {
+		result = append(result, map[string]interface{}{
+			"type":       utils.PathSearch("category", dataVolume, nil),
+			"mount_path": utils.PathSearch("mount_path", dataVolume, nil),
+			"path":       utils.PathSearch("url", dataVolume, nil),
+			"status":     utils.PathSearch("status", dataVolume, nil),
+			"mount_type": utils.PathSearch("mount_type", dataVolume, nil),
+		})
+	}
+	return result
+}
+
+func flattenNotebooks(notebooks []interface{}) []map[string]interface{} {
+	if len(notebooks) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(notebooks))
+	for _, notebook := range notebooks {
+		keyPair, sshURI, ips := flattenNotebookEndpointsAccess(utils.PathSearch("endpoints", notebook, make([]interface{}, 0)).([]interface{}))
+
+		result = append(result, map[string]interface{}{
+			"id":                 utils.PathSearch("id", notebook, nil),
+			"name":               utils.PathSearch("name", notebook, nil),
+			"description":        utils.PathSearch("description", notebook, nil),
+			"status":             utils.PathSearch("status", notebook, nil),
+			"feature":            utils.PathSearch("feature", notebook, nil),
+			"flavor_id":          utils.PathSearch("flavor", notebook, nil),
+			"workspace_id":       utils.PathSearch("workspace_id", notebook, nil),
+			"pool_id":            utils.PathSearch("pool.id", notebook, nil),
+			"pool_name":          utils.PathSearch("pool.name", notebook, nil),
+			"image_id":           utils.PathSearch("image.id", notebook, nil),
+			"image_name":         utils.PathSearch("image.name", notebook, nil),
+			"image_type":         utils.PathSearch("image.type", notebook, nil),
+			"image_swr_path":     utils.PathSearch("image.swr_path", notebook, nil),
+			"url":                utils.PathSearch("url", notebook, nil),
+			"fail_reason":        utils.PathSearch("fail_reason", notebook, nil),
+			"auto_stop_enabled":  utils.PathSearch("lease.enable", notebook, nil),
+			"lease_duration":     utils.PathSearch("lease.duration", notebook, nil),
+			"lease_type":         utils.PathSearch("lease.type", notebook, nil),
+			"key_pair":           keyPair,
+			"ssh_uri":            sshURI,
+			"allowed_access_ips": ips,
+			"user_id":            utils.PathSearch("user_id", notebook, nil),
+			"ip":                 utils.PathSearch("ip", notebook, nil),
+			"jupyter_version":    utils.PathSearch("jupyter_version", notebook, nil),
+			"billing_items":      utils.PathSearch("billing_items", notebook, make([]interface{}, 0)).([]interface{}),
+			"custom_spec":        utils.JsonToString(utils.PathSearch("custom_spec", notebook, nil)),
+			"user_vpc":           utils.JsonToString(utils.PathSearch("user_vpc", notebook, nil)),
+			"volume": flattenNotebookVolumeForList(utils.PathSearch("volume",
+				notebook, make(map[string]interface{})).(map[string]interface{})),
+			"data_volumes": flattenNotebookDataVolumes(utils.PathSearch("data_volumes", notebook, make([]interface{}, 0)).([]interface{})),
+			"tags":         utils.FlattenTagsToMap(utils.PathSearch("tags", notebook, nil)),
+			"created_at":   utils.FormatTimeStampRFC3339(int64(utils.PathSearch("lease.create_at", notebook, float64(0)).(float64))/1000, false),
+			"updated_at":   utils.FormatTimeStampRFC3339(int64(utils.PathSearch("lease.update_at", notebook, float64(0)).(float64))/1000, false),
+		})
+	}
+	return result
+}
+
+func dataSourceNotebooksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	notebooks, err := listNotebooks(client, d)
+	if err != nil {
+		return diag.Errorf("error querying ModelArts notebooks: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("notebooks", flattenNotebooks(notebooks)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source to query notebooks for ModelArts Service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance test:
<img width="1017" height="52" alt="image" src="https://github.com/user-attachments/assets/0cbe5345-77bf-495b-86be-51b66507337a" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query notebooks
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDataNotebooks_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataNotebooks_basic -timeout 360m -parallel 10
=== RUN   TestAccDataNotebooks_basic
=== PAUSE TestAccDataNotebooks_basic
=== CONT  TestAccDataNotebooks_basic
--- PASS: TestAccDataNotebooks_basic (208.06s)
PASS
coverage: 12.1% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 208.156s        coverage: 12.1% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
