### PR TITLE
feat(modelarts): add new action resource to batch locking and unlocking nodes of a resource pool

### DIFF
--- a/docs/resources/modelartsv2_node_batch_lock.md
+++ b/docs/resources/modelartsv2_node_batch_lock.md
@@ -1,0 +1,46 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelartsv2_node_batch_lock"
+description: |-
+  Use this resource to batch lock nodes in a resource pool within HuaweiCloud.
+---
+
+# huaweicloud_modelartsv2_node_batch_lock
+
+Use this resource to batch lock nodes in a resource pool within HuaweiCloud.
+
+-> This resource is only a one-time action resource for batch locking the ModelArts nodes. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "resource_pool_id" {}
+variable "node_names" {
+  type = list(string)
+}
+
+resource "huaweicloud_modelartsv2_node_batch_lock" "test" {
+  pool_id    = var.resource_pool_id
+  node_names = var.node_names
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the resource nodes are located.  
+  If omitted, the provider-level region will be used.  
+  Changing this parameter will create a new resource.
+
+* `pool_id` - (Required, String, NonUpdatable) Specifies the resource pool ID to which the resource nodes belong.
+
+* `node_names` - (Required, List, NonUpdatable) Specifies the name list of resource nodes to be locked.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/docs/resources/modelartsv2_node_batch_unlock.md
+++ b/docs/resources/modelartsv2_node_batch_unlock.md
@@ -1,0 +1,46 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelartsv2_node_batch_unlock"
+description: |-
+  Use this resource to batch unlock nodes in a resource pool within HuaweiCloud.
+---
+
+# huaweicloud_modelartsv2_node_batch_unlock
+
+Use this resource to batch unlock nodes in a resource pool within HuaweiCloud.
+
+-> This resource is only a one-time action resource for batch unlocking the ModelArts nodes. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "resource_pool_id" {}
+variable "node_names" {
+  type = list(string)
+}
+
+resource "huaweicloud_modelartsv2_node_batch_unlock" "test" {
+  pool_id    = var.resource_pool_id
+  node_names = var.node_names
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the resource nodes are located.  
+  If omitted, the provider-level region will be used.  
+  Changing this parameter will create a new resource.
+
+* `pool_id` - (Required, String, NonUpdatable) Specifies the resource pool ID to which the resource nodes belong.
+
+* `node_names` - (Required, List, NonUpdatable) Specifies the name list of resource nodes to be unlocked.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3924,7 +3924,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_workspace":                       modelarts.ResourceModelartsWorkspace(),
 			// Resource management via V2 APIs.
 			"huaweicloud_modelartsv2_node_batch_delete":      modelarts.ResourceV2NodeBatchDelete(),
+			"huaweicloud_modelartsv2_node_batch_lock":        modelarts.ResourceV2NodeBatchLock(),
 			"huaweicloud_modelartsv2_node_batch_reboot":      modelarts.ResourceV2NodeBatchReboot(),
+			"huaweicloud_modelartsv2_node_batch_unlock":      modelarts.ResourceV2NodeBatchUnlock(),
 			"huaweicloud_modelartsv2_node_batch_unsubscribe": modelarts.ResourceV2NodeBatchUnsubscribe(),
 			"huaweicloud_modelartsv2_service":                modelarts.ResourceV2Service(),
 			"huaweicloud_modelartsv2_service_action":         modelarts.ResourceV2ServiceAction(),

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelartsv2_node_batch_lock_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelartsv2_node_batch_lock_test.go
@@ -1,0 +1,50 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceV2NodeBatchLock_basic(t *testing.T) {
+	var (
+		rName = "huaweicloud_modelartsv2_node_batch_lock.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceV2NodeBatchLock_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(rName, "node_names.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceV2NodeBatchLock_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_modelartsv2_resource_pool_nodes" "test" {
+  resource_pool_name = "%[1]s"
+}
+
+locals {
+  node_names = try(slice([for o in data.huaweicloud_modelartsv2_resource_pool_nodes.test.nodes:
+    o.metadata[0].name], 0, 1), [])
+}
+
+resource "huaweicloud_modelartsv2_node_batch_lock" "test" {
+  pool_id    = "%[1]s"
+  node_names = local.node_names
+}`, acceptance.HW_MODELARTS_RESOURCE_POOL_ID)
+}

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelartsv2_node_batch_unlock_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelartsv2_node_batch_unlock_test.go
@@ -1,0 +1,59 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceV2NodeBatchUnlock_basic(t *testing.T) {
+	var (
+		rName = "huaweicloud_modelartsv2_node_batch_unlock.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceV2NodeBatchUnlock_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(rName, "node_names.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceV2NodeBatchUnlock_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_modelartsv2_resource_pool_nodes" "test" {
+  resource_pool_name = "%[1]s"
+}
+
+locals {
+  node_names = try(slice([for o in data.huaweicloud_modelartsv2_resource_pool_nodes.test.nodes:
+    o.metadata[0].name], 0, 1), [])
+}
+
+resource "huaweicloud_modelartsv2_node_batch_lock" "test" {
+  pool_id    = "%[1]s"
+  node_names = local.node_names
+}
+
+resource "huaweicloud_modelartsv2_node_batch_unlock" "test" {
+  pool_id    = "%[1]s"
+  node_names = local.node_names
+
+  depends_on = [
+    huaweicloud_modelartsv2_node_batch_lock.test
+  ]
+}`, acceptance.HW_MODELARTS_RESOURCE_POOL_ID)
+}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_node_batch_lock.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_node_batch_lock.go
@@ -1,0 +1,135 @@
+package modelarts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var v2NodeBatchLockNonUpdatableParams = []string{
+	"pool_id",
+	"node_names",
+}
+
+// @API ModelArts POST /v2/{project_id}/pools/{pool_name}/nodes/batch-lock
+func ResourceV2NodeBatchLock() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV2NodeBatchLockCreate,
+		ReadContext:   resourceV2NodeBatchLockRead,
+		UpdateContext: resourceV2NodeBatchLockUpdate,
+		DeleteContext: resourceV2NodeBatchLockDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(v2NodeBatchLockNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the resource nodes are located.`,
+			},
+
+			// Required parameters.
+			"pool_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource pool ID to which the resource nodes belong.`,
+			},
+			"node_names": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The name list of resource nodes to be locked.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
+			},
+		},
+	}
+}
+
+func buildNodeBatchLockBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"nodeNames": d.Get("node_names").([]interface{}),
+		// Whether locking or unlocking, the `actions` parameter must be an array.
+		// And the array must contain only one element named `delete`.
+		"actions": []interface{}{"delete"},
+	}
+}
+
+func resourceV2NodeBatchLockCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/pools/{pool_name}/nodes/batch-lock"
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{pool_name}", d.Get("pool_id").(string))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildNodeBatchLockBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating node batch lock: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceV2NodeBatchLockRead(ctx, d, meta)
+}
+
+func resourceV2NodeBatchLockRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV2NodeBatchLockUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV2NodeBatchLockDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for batch locking the ModelArts nodes. Deleting this
+resource will not clear the corresponding request record, but will only remove the resource information from the
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_node_batch_unlock.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_node_batch_unlock.go
@@ -1,0 +1,135 @@
+package modelarts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var v2NodeBatchUnlockNonUpdatableParams = []string{
+	"pool_id",
+	"node_names",
+}
+
+// @API ModelArts POST /v2/{project_id}/pools/{pool_name}/nodes/batch-unlock
+func ResourceV2NodeBatchUnlock() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV2NodeBatchUnlockCreate,
+		ReadContext:   resourceV2NodeBatchUnlockRead,
+		UpdateContext: resourceV2NodeBatchUnlockUpdate,
+		DeleteContext: resourceV2NodeBatchUnlockDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(v2NodeBatchUnlockNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the resource nodes are located.`,
+			},
+
+			// Required parameters.
+			"pool_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource pool ID to which the resource nodes belong.`,
+			},
+			"node_names": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The name list of resource nodes to be unlocked.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
+			},
+		},
+	}
+}
+
+func buildNodeBatchUnlockBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"nodeNames": d.Get("node_names").([]interface{}),
+		// Whether locking or unlocking, the `actions` parameter must be an array.
+		// And the array must contain only one element named `delete`.
+		"actions": []interface{}{"delete"},
+	}
+}
+
+func resourceV2NodeBatchUnlockCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/pools/{pool_name}/nodes/batch-unlock"
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{pool_name}", d.Get("pool_id").(string))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildNodeBatchUnlockBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating node batch unlock: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	return resourceV2NodeBatchUnlockRead(ctx, d, meta)
+}
+
+func resourceV2NodeBatchUnlockRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV2NodeBatchUnlockUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceV2NodeBatchUnlockDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for batch unlocking the ModelArts nodes. Deleting this
+resource will not clear the corresponding request record, but will only remove the resource information from the
+tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new action resource to batch locking and unlocking nodes of a resource pool

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.add new action resource to batch locking and unlocking nodes of a resource pool
```

## PR Checklist
#### 1.lock
<img width="2560" height="1390" alt="lock" src="https://github.com/user-attachments/assets/d08f674e-ed21-4f7e-a4a6-9776b962fa96" />


#### 2.unlock
<img width="2560" height="1390" alt="unlock" src="https://github.com/user-attachments/assets/cbf3ff04-b26f-4e8d-9be5-257a3e22f0b9" />
