### PR TITLE
feat(eip): support `global_eip_segment_support_masks` data source

### DIFF
--- a/docs/data-sources/global_eip_segment_support_masks.md
+++ b/docs/data-sources/global_eip_segment_support_masks.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_global_eip_segment_support_masks"
+description: |-
+  Use this dataSource to get the list of supported masks for global EIP segment.
+---
+
+# huaweicloud_global_eip_segment_support_masks
+
+Use this dataSource to get the list of supported masks for global EIP segment.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_global_eip_segment_support_masks" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `page_reverse` - (Optional, String) Specifies the page direction.
+  The valid values are as follows:
+  + **true**: means the previous page.  
+  + **false**: means the next page.
+
+* `fields` - (Optional, List) Specifies the fields to return.
+  Supported values include **id**, **ip_version**, **mask**, **created_at**, and **updated_at**.
+
+* `sort_key` - (Optional, String) Specifies the sort fields.
+
+* `sort_dir` - (Optional, String) Specifies the sort directions.
+  Valid values are **asc** and **desc**.
+
+* `mask_ids` - (Optional, List) Specifies the mask IDs to filter.
+
+* `ip_version` - (Optional, List) Specifies the IP versions to filter.
+
+* `mask` - (Optional, Int) Specifies the mask length to filter. The value ranges from `1` to `128`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `support_masks` - The list of supported global EIP segment masks.
+
+  The [support_masks](#support_masks_struct) structure is documented below.
+
+<a name="support_masks_struct"></a>
+The `support_masks` block supports:
+
+* `id` - The mask record ID.
+
+* `ip_version` - The IP version. The range of values is `4` and `6`
+
+* `mask` - The mask length.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The update time.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2419,6 +2419,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_global_eip_quotas":                  eip.DataSourceGlobalEipQuotas(),
 			"huaweicloud_global_eip_pools":                   eip.DataSourceGlobalEIPPools(),
 			"huaweicloud_global_eip_bindings":                eip.DataSourceGlobalEipBindings(),
+			"huaweicloud_global_eip_segment_support_masks":   eip.DataSourceGlobalEipSegmentSupportMasks(),
 			"huaweicloud_global_eip_access_sites":            eip.DataSourceGlobalEIPAccessSites(),
 			"huaweicloud_global_internet_bandwidths":         eip.DataSourceGlobalInternetBandwidths(),
 			"huaweicloud_global_internet_bandwidth_tags":     eip.DataSourceGlobalInternetBandwidthTags(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_segment_support_masks_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_segment_support_masks_test.go
@@ -1,0 +1,108 @@
+package eip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGlobalEipSegmentSupportMasks_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_global_eip_segment_support_masks.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGlobalEipSegmentSupportMasks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "support_masks.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_masks.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_masks.0.ip_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_masks.0.mask"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_masks.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_masks.0.updated_at"),
+
+					resource.TestCheckOutput("is_mask_ids_filter_useful", "true"),
+					resource.TestCheckOutput("is_ip_version_filter_useful", "true"),
+					resource.TestCheckOutput("is_mask_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGlobalEipSegmentSupportMasks_basic() string {
+	return `
+data "huaweicloud_global_eip_segment_support_masks" "test" {
+  page_reverse = "true"
+  fields       = ["id", "mask", "ip_version", "created_at", "updated_at"]
+  sort_key     = "mask"
+  sort_dir     = "asc"
+}
+
+# Filter by mask_ids.
+locals {
+  mask_id = data.huaweicloud_global_eip_segment_support_masks.test.support_masks[0].id
+}
+
+data "huaweicloud_global_eip_segment_support_masks" "mask_ids_filter" {
+  mask_ids = [local.mask_id]
+}
+
+locals {
+  mask_ids_filter_result = [
+    for v in data.huaweicloud_global_eip_segment_support_masks.mask_ids_filter.support_masks[*].id : v == local.mask_id
+  ]
+}
+
+output "is_mask_ids_filter_useful" {
+  value = alltrue(local.mask_ids_filter_result) && length(local.mask_ids_filter_result) > 0
+}
+
+# Filter by ip_version.
+locals {
+  ip_version = data.huaweicloud_global_eip_segment_support_masks.test.support_masks[0].ip_version
+}
+
+data "huaweicloud_global_eip_segment_support_masks" "ip_version_filter" {
+  ip_version = [local.ip_version]
+}
+
+locals {
+  ip_version_filter_result = [
+    for v in data.huaweicloud_global_eip_segment_support_masks.ip_version_filter.support_masks[*].ip_version : v == local.ip_version
+  ]
+}
+
+output "is_ip_version_filter_useful" {
+  value = alltrue(local.ip_version_filter_result) && length(local.ip_version_filter_result) > 0
+}
+
+# Filter by mask.
+locals {
+  mask = data.huaweicloud_global_eip_segment_support_masks.test.support_masks[0].mask
+}
+
+data "huaweicloud_global_eip_segment_support_masks" "mask_filter" {
+  mask = local.mask
+}
+
+locals {
+  mask_filter_result = [
+    for v in data.huaweicloud_global_eip_segment_support_masks.mask_filter.support_masks[*].mask : v == local.mask
+  ]
+}
+
+output "is_mask_filter_useful" {
+  value = alltrue(local.mask_filter_result) && length(local.mask_filter_result) > 0
+}
+`
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_global_eip_segment_support_masks.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_global_eip_segment_support_masks.go
@@ -1,0 +1,219 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v3/{domain_id}/global-eip-segments/support-masks
+func DataSourceGlobalEipSegmentSupportMasks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGlobalEipSegmentSupportMasksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// This field is of boolean type in the API documentation,
+			// here it is modified to string to meet different scenarios.
+			"page_reverse": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+			},
+			"fields": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// The `sort_key` field in the API documentation is of type list, which is unnecessary.
+			// Here, it is modified to type string.
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// The `sort_dir` field in the API documentation is of type list, which is unnecessary.
+			// Here, it is modified to type string.
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// Named as `id` in the API documentation, now changed to `mask_ids`.
+			"mask_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"ip_version": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"mask": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"support_masks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_version": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"mask": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildGlobalEipSegmentSupportMasksQueryParams(d *schema.ResourceData, marker string) string {
+	queryParams := "?limit=2000"
+
+	if raw, ok := d.GetOk("page_reverse"); ok {
+		pageReverse, _ := strconv.ParseBool(raw.(string))
+		queryParams += fmt.Sprintf("&page_reverse=%v", pageReverse)
+	}
+	if raw, ok := d.GetOk("fields"); ok {
+		for _, f := range raw.([]interface{}) {
+			queryParams += fmt.Sprintf("&fields=%s", f)
+		}
+	}
+	if raw, ok := d.GetOk("sort_key"); ok {
+		queryParams += fmt.Sprintf("&sort_key=%s", raw)
+	}
+	if raw, ok := d.GetOk("sort_dir"); ok {
+		queryParams += fmt.Sprintf("&sort_dir=%s", raw)
+	}
+	if raw, ok := d.GetOk("mask_ids"); ok {
+		for _, id := range raw.([]interface{}) {
+			queryParams += fmt.Sprintf("&id=%s", id)
+		}
+	}
+	if raw, ok := d.GetOk("ip_version"); ok {
+		for _, v := range raw.([]interface{}) {
+			queryParams += fmt.Sprintf("&ip_version=%s", v)
+		}
+	}
+	if v, ok := d.GetOk("mask"); ok {
+		queryParams += fmt.Sprintf("&mask=%s", v)
+	}
+	if marker != "" {
+		queryParams += fmt.Sprintf("&marker=%s", marker)
+	}
+
+	return queryParams
+}
+
+func dataSourceGlobalEipSegmentSupportMasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "geip"
+		httpUrl    = "v3/{domain_id}/global-eip-segments/support-masks"
+		result     = make([]interface{}, 0)
+		nextMarker string
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", cfg.DomainID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithMarker := requestPath + buildGlobalEipSegmentSupportMasksQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithMarker, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving global EIP segment support masks: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		masksResp := utils.PathSearch("support_masks", respBody, make([]interface{}, 0)).([]interface{})
+		if len(masksResp) == 0 {
+			break
+		}
+
+		result = append(result, masksResp...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("support_masks", flattenGlobalEipSegmentSupportMasks(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGlobalEipSegmentSupportMasks(masks []interface{}) []interface{} {
+	if len(masks) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(masks))
+	for _, m := range masks {
+		rst = append(rst, map[string]interface{}{
+			"id":         utils.PathSearch("id", m, nil),
+			"ip_version": utils.PathSearch("ip_version", m, nil),
+			"mask":       utils.PathSearch("mask", m, nil),
+			"created_at": utils.PathSearch("created_at", m, nil),
+			"updated_at": utils.PathSearch("updated_at", m, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `global_eip_segment_support_masks` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `global_eip_segment_support_masks` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o eip -f TestAccDataSourceGlobalEipSegmentSupportMasks_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccDataSourceGlobalEipSegmentSupportMasks_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceGlobalEipSegmentSupportMasks_basic
=== PAUSE TestAccDataSourceGlobalEipSegmentSupportMasks_basic
=== CONT  TestAccDataSourceGlobalEipSegmentSupportMasks_basic
--- PASS: TestAccDataSourceGlobalEipSegmentSupportMasks_basic (22.43s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip  coverage: 3.8% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       22.600s coverage: 3.8% of statements in ./huaweicloud/services/eip
```
<img width="975" height="35" alt="image" src="https://github.com/user-attachments/assets/0226b59e-532a-4ea9-9aea-5c051478c8b4" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
