### PR TITLE
feat(eip): support `global_eip_support_regions` data source

### DIFF
--- a/docs/data-sources/global_eip_support_regions.md
+++ b/docs/data-sources/global_eip_support_regions.md
@@ -1,0 +1,105 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_global_eip_support_regions"
+description: |-
+  Use this data source to get the list of regions that global EIPs can bind to.
+---
+
+# huaweicloud_global_eip_support_regions
+
+Use this data source to get the list of regions that global EIPs can bind to.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_global_eip_support_regions" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `page_reverse` - (Optional, String) Specifies the page direction.  
+  The valid values are as follows:
+  + **true**: means the previous page.
+  + **false**: means the next page.
+
+* `fields` - (Optional, List) Specifies the fields to return.
+  Supported values include **id**, **instance_type**, **access_site**, **region_id**, **public_border_group**,
+  **remote_endpoint**, **status**, **created_at**, and **updated_at**.
+
+* `sort_key` - (Optional, String) Specifies the sort fields.
+
+* `sort_dir` - (Optional, String) Specifies the sort directions.
+  Valid values are **asc** and **desc**.
+
+* `support_region_ids` - (Optional, List) Specifies the support region record IDs to filter.
+
+* `instance_type` - (Optional, List) Specifies the supported instance types to filter.  
+  The valid values are as follows:
+  + **DC-CONNECT-GATEWAY**
+  + **IPV6-DC-CONNECT-GATEWAY**
+  + **ECS**
+  + **IPV6-ECS**
+  + **PORT**
+  + **IPV6-PORT**
+  + **VIP**
+  + **IPV6-VIP**
+  + **ELB**
+  + **IPV6-ELB**
+  + **NATGW**
+
+* `public_border_group` - (Optional, List) Specifies the public border groups to filter. Valid value is **center** or an
+  edge site name.
+
+* `access_site` - (Optional, List) Specifies the access sites to filter.
+
+* `region_id` - (Optional, List) Specifies the region IDs to filter.
+
+* `remote_endpoint` - (Optional, List) Specifies the remote endpoints to filter.
+
+* `status` - (Optional, List) Specifies the values used to filter by EIP or site status in the query.  
+  The valid values are as follows:
+  + **IDLE**: The global elastic public IP is not bound to an instance.
+  + **INUSE**: Global elastic public IP in use.
+  + **FREEZED**: The global elastic public IP has been frozen.
+  + **PENDING_CREATE**: Global elastic public IP is being created.
+  + **PENDING_UPDATE**: The global elastic public IP is being updated.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `support_regions` - The list of global EIP support region objects.
+
+  The [support_regions](#support_regions_struct) structure is documented below.
+
+<a name="support_regions_struct"></a>
+The `support_regions` block supports:
+
+* `id` - The support region record ID.
+
+* `instance_type` - The supported instance type.
+
+* `access_site` - The access site.
+
+* `region_id` - The region ID.
+
+* `public_border_group` - The public border group.
+
+* `remote_endpoint` - The next-hop address.
+
+* `status` - The status.  
+  The valid values are as follows:
+  + **ACTIVE**: Already online.
+  + **INACTIVE**: Offline.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The update time.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2426,6 +2426,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_global_eip_pools":                   eip.DataSourceGlobalEIPPools(),
 			"huaweicloud_global_eip_bindings":                eip.DataSourceGlobalEipBindings(),
 			"huaweicloud_global_eip_segment_support_masks":   eip.DataSourceGlobalEipSegmentSupportMasks(),
+			"huaweicloud_global_eip_support_regions":         eip.DataSourceGlobalEipSupportRegions(),
 			"huaweicloud_global_eip_access_sites":            eip.DataSourceGlobalEIPAccessSites(),
 			"huaweicloud_global_internet_bandwidths":         eip.DataSourceGlobalInternetBandwidths(),
 			"huaweicloud_global_internet_bandwidth_tags":     eip.DataSourceGlobalInternetBandwidthTags(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_support_regions_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_support_regions_test.go
@@ -1,0 +1,134 @@
+package eip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGlobalEipSupportRegions_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_global_eip_support_regions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGlobalEipSupportRegions_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.instance_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.region_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.public_border_group"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.access_site"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.remote_endpoint"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.status"),
+
+					resource.TestCheckOutput("is_support_region_ids_filter_useful", "true"),
+					resource.TestCheckOutput("is_instance_type_filter_useful", "true"),
+					resource.TestCheckOutput("is_public_border_group_filter_useful", "true"),
+					resource.TestCheckOutput("is_region_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGlobalEipSupportRegions_basic() string {
+	return `
+data "huaweicloud_global_eip_support_regions" "test" {
+  page_reverse = "true"
+  fields       = ["id", "instance_type", "access_site", "region_id", "public_border_group", "remote_endpoint", "status"]
+  sort_key     = "region_id"
+  sort_dir     = "asc"
+}
+
+# Filter by support_region_ids.
+locals {
+  support_region_id = data.huaweicloud_global_eip_support_regions.test.support_regions[0].id
+}
+
+data "huaweicloud_global_eip_support_regions" "support_region_ids_filter" {
+  support_region_ids = [local.support_region_id]
+}
+
+locals {
+  support_region_ids_filter_result = [
+    for v in data.huaweicloud_global_eip_support_regions.support_region_ids_filter.support_regions[*].id : v
+    == local.support_region_id
+  ]
+}
+
+output "is_support_region_ids_filter_useful" {
+  value = alltrue(local.support_region_ids_filter_result) && length(local.support_region_ids_filter_result) > 0
+}
+
+# Filter by instance_type.
+locals {
+  instance_type = data.huaweicloud_global_eip_support_regions.test.support_regions[0].instance_type
+}
+
+data "huaweicloud_global_eip_support_regions" "instance_type_filter" {
+  instance_type = [local.instance_type]
+}
+
+locals {
+  instance_type_filter_result = [
+    for v in data.huaweicloud_global_eip_support_regions.instance_type_filter.support_regions[*].instance_type : v
+    == local.instance_type
+  ]
+}
+
+output "is_instance_type_filter_useful" {
+  value = alltrue(local.instance_type_filter_result) && length(local.instance_type_filter_result) > 0
+}
+
+# Filter by public_border_group.
+locals {
+  public_border_group = data.huaweicloud_global_eip_support_regions.test.support_regions[0].public_border_group
+}
+
+data "huaweicloud_global_eip_support_regions" "public_border_group_filter" {
+  public_border_group = [local.public_border_group]
+}
+
+locals {
+  public_border_group_filter_result = [
+    for v in data.huaweicloud_global_eip_support_regions.public_border_group_filter.support_regions[*].public_border_group
+    : v == local.public_border_group
+  ]
+}
+
+output "is_public_border_group_filter_useful" {
+  value = alltrue(local.public_border_group_filter_result) && length(local.public_border_group_filter_result) > 0
+}
+
+# Filter by region_id.
+locals {
+  region_id = data.huaweicloud_global_eip_support_regions.test.support_regions[0].region_id
+}
+
+data "huaweicloud_global_eip_support_regions" "region_id_filter" {
+  region_id = [local.region_id]
+}
+
+locals {
+  region_id_filter_result = [
+    for v in data.huaweicloud_global_eip_support_regions.region_id_filter.support_regions[*].region_id : v
+    == local.region_id
+  ]
+}
+
+output "is_region_id_filter_useful" {
+  value = alltrue(local.region_id_filter_result) && length(local.region_id_filter_result) > 0
+}
+`
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_global_eip_support_regions.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_global_eip_support_regions.go
@@ -1,0 +1,282 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v3/{domain_id}/geip/support-regions
+func DataSourceGlobalEipSupportRegions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGlobalEipSupportRegionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// This field is of boolean type in the API documentation,
+			// here it is modified to string to meet different scenarios.
+			"page_reverse": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+			},
+			"fields": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// The `sort_key` field in the API documentation is of type list, which is unnecessary.
+			// Here, it is modified to type string.
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// The `sort_dir` field in the API documentation is of type list, which is unnecessary.
+			// Here, it is modified to type string.
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// Named as `id` in the API documentation, now changed to `support_region_ids`.
+			"support_region_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"instance_type": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"public_border_group": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"access_site": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"region_id": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"remote_endpoint": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"support_regions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"access_site": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_border_group": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"remote_endpoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildGlobalEipSupportRegionsQueryParams(d *schema.ResourceData, marker string) string {
+	values := url.Values{}
+	values.Set("limit", "2000")
+
+	if raw, ok := d.GetOk("page_reverse"); ok {
+		if b, err := strconv.ParseBool(raw.(string)); err == nil {
+			values.Set("page_reverse", fmt.Sprint(b))
+		}
+	}
+
+	type param struct {
+		key      string
+		query    string
+		useMulti bool
+	}
+
+	params := []param{
+		{"fields", "fields", true},
+		{"sort_key", "sort_key", false},
+		{"sort_dir", "sort_dir", false},
+		{"support_region_ids", "id", true},
+		{"instance_type", "instance_type", true},
+		{"public_border_group", "public_border_group", true},
+		{"access_site", "access_site", true},
+		{"region_id", "region_id", true},
+		{"remote_endpoint", "remote_endpoint", true},
+		{"status", "status", true},
+	}
+
+	for _, p := range params {
+		if raw, ok := d.GetOk(p.key); ok {
+			if !p.useMulti {
+				values.Set(p.query, fmt.Sprint(raw))
+				continue
+			}
+
+			arr, ok := raw.([]interface{})
+			if !ok {
+				values.Add(p.query, fmt.Sprint(raw))
+				continue
+			}
+			for _, v := range arr {
+				values.Add(p.query, fmt.Sprint(v))
+			}
+		}
+	}
+
+	if marker != "" {
+		values.Set("marker", marker)
+	}
+
+	enc := values.Encode()
+	if enc == "" {
+		return ""
+	}
+
+	return "?" + enc
+}
+
+func dataSourceGlobalEipSupportRegionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "geip"
+		httpUrl    = "v3/{domain_id}/geip/support-regions"
+		result     = make([]interface{}, 0)
+		nextMarker string
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", cfg.DomainID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithMarker := requestPath + buildGlobalEipSupportRegionsQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithMarker, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving global EIP support regions: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		regionsResp := utils.PathSearch("support_regions", respBody, make([]interface{}, 0)).([]interface{})
+		if len(regionsResp) == 0 {
+			break
+		}
+
+		result = append(result, regionsResp...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("support_regions", flattenGlobalEipSupportRegions(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGlobalEipSupportRegions(regions []interface{}) []interface{} {
+	if len(regions) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(regions))
+	for _, r := range regions {
+		rst = append(rst, map[string]interface{}{
+			"id":                  utils.PathSearch("id", r, nil),
+			"instance_type":       utils.PathSearch("instance_type", r, nil),
+			"access_site":         utils.PathSearch("access_site", r, nil),
+			"region_id":           utils.PathSearch("region_id", r, nil),
+			"public_border_group": utils.PathSearch("public_border_group", r, nil),
+			"remote_endpoint":     utils.PathSearch("remote_endpoint", r, nil),
+			"status":              utils.PathSearch("status", r, nil),
+			"created_at":          utils.PathSearch("created_at", r, nil),
+			"updated_at":          utils.PathSearch("updated_at", r, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `global_eip_support_regions` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `global_eip_support_regions` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o eip -f TestAccDataSourceGlobalEipSupportRegions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccDataSourceGlobalEipSupportRegions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceGlobalEipSupportRegions_basic
=== PAUSE TestAccDataSourceGlobalEipSupportRegions_basic
=== CONT  TestAccDataSourceGlobalEipSupportRegions_basic
--- PASS: TestAccDataSourceGlobalEipSupportRegions_basic (121.35s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip  coverage: 4.0% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       121.462s        coverage: 4.0% of statements in ./huaweicloud/services/eip
```
<img width="916" height="35" alt="image" src="https://github.com/user-attachments/assets/997cfb6f-9caf-47c5-b5b1-6b6f6849ff3a" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
