### PR TITLE
feat(eip): support `eip_bandwidth_associate` resource

### DIFF
--- a/docs/resources/eip_bandwidth_associate.md
+++ b/docs/resources/eip_bandwidth_associate.md
@@ -1,0 +1,89 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eip_bandwidth_associate"
+description: |-
+  Manages an EIP bandwidth associate resource to attach or detach an EIP from a shared bandwidth in HuaweiCloud.
+---
+
+# huaweicloud_eip_bandwidth_associate
+
+Manages an EIP bandwidth associate resource to attach or detach an EIP from a shared bandwidth in HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "bandwidth_id" {} 
+variable "eip_id" {}
+variable "bandwidth_charge_mode" {}
+variable "bandwidth_size" {}
+
+resource "huaweicloud_eip_bandwidth_associate" "test" { 
+  publicip_id  = var.eip_id 
+  bandwidth_id = var.bandwidth_id
+
+  bandwidth_charge_mode = var.bandwidth_charge_mode
+  bandwidth_size        = var.bandwidth_size
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the VPC EIP associate resource. If
+  omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `publicip_id` - (Required, String, NonUpdatable) Specifies the ID of the EIP to be associated with the shared bandwidth.
+
+* `bandwidth_id` - (Required, String, NonUpdatable) Specifies the ID of the shared bandwidth.
+
+* `bandwidth_charge_mode` - (Required, String, NonUpdatable) Specifies the charging mode for the bandwidth after the
+  EIP is removed from the shared bandwidth.
+
+* `bandwidth_size` - (Required, Int, NonUpdatable) Specifies the bandwidth size (Mbit/s) after the EIP is removed from the
+  shared bandwidth.
+
+* `bandwidth_name` - (Optional, String, NonUpdatable) Specifies the bandwidth name after the EIP is removed from the shared
+  bandwidth.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, the format is`<publicip_id>/<bandwidth_id>`.
+
+* `public_ip_address` - The IPv4 address of the EIP.
+
+* `public_ipv6_address` - The IPv6 address of the EIP.
+
+* `publicip_type` - The type of the EIP.
+
+* `ip_version` - The IP version of the EIP.
+
+## Import
+
+The EIP bandwidth associate can be imported using the `publicip_id` and `bandwidth_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_eip_bandwidth_associate.test <publicip_id>/<bandwidth_id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include `bandwidth_charge_mode`, `bandwidth_size` and `bandwidth_name`. It is generally
+recommended running `terraform plan` after importing a resource. You can then decide if changes should be applied to the
+resource, or the resource definition should be updated to align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_eip_bandwidth_associate" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      bandwidth_charge_mode,
+      bandwidth_size,
+      bandwidth_name,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3514,6 +3514,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_eg_event_subscription_batch_action": eg.ResourceEventSubscriptionBatchAction(),
 			"huaweicloud_eg_event_subscription_target":       eg.ResourceEventSubscriptionTarget(),
 
+			"huaweicloud_eip_bandwidth_associate": eip.ResourceEipBandwidthAssociate(),
+
 			"huaweicloud_elb_certificate":                      elb.ResourceCertificateV3(),
 			"huaweicloud_elb_domain_address":                   elb.ResourceDomainAddress(),
 			"huaweicloud_elb_certificate_private_key_echo":     elb.ResourceCertificatePrivateKeyEcho(),

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_eip_bandwidth_associate_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_eip_bandwidth_associate_test.go
@@ -1,0 +1,137 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
+)
+
+func getEipBandwidthAssociateResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region      = acceptance.HW_REGION_NAME
+		product     = "vpc"
+		publicipId  = state.Primary.Attributes["publicip_id"]
+		bandwidthId = state.Primary.Attributes["bandwidth_id"]
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating VPC EIP client: %s", err)
+	}
+
+	return eip.GetEipBandwidthAssociate(client, publicipId, bandwidthId)
+}
+
+func TestAccEipBandwidthAssociate_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_eip_bandwidth_associate.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getEipBandwidthAssociateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEipBandwidthAssociate_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "publicip_id", "huaweicloud_vpc_eip.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "bandwidth_id", "huaweicloud_vpc_bandwidth.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "public_ip_address", "huaweicloud_vpc_eip.test", "address"),
+					resource.TestCheckResourceAttrSet(rName, "publicip_type"),
+					resource.TestCheckResourceAttrSet(rName, "ip_version"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccEipBandwidthAssociateImportState(rName),
+				ImportStateVerifyIgnore: []string{
+					"bandwidth_charge_mode",
+					"bandwidth_size",
+					"bandwidth_name",
+				},
+			},
+		},
+	})
+}
+
+func testAccEipBandwidthAssociate_base(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "%[1]s"
+  size = 5
+}
+
+resource "huaweicloud_vpc_eip" "test" {
+  name = "%[1]s"
+
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    name        = "%[1]s-eip"
+    size        = 5
+    charge_mode = "traffic"
+  }
+
+  lifecycle {
+    ignore_changes = [bandwidth]
+  }
+}
+`, rName)
+}
+
+func testAccEipBandwidthAssociate_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_eip_bandwidth_associate" "test" {
+  publicip_id  = huaweicloud_vpc_eip.test.id
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.id
+
+  bandwidth_charge_mode = "bandwidth"
+  bandwidth_size        = 5
+
+  depends_on = [
+    huaweicloud_vpc_eip.test,
+    huaweicloud_vpc_bandwidth.test,
+  ]
+}
+`, testAccEipBandwidthAssociate_base(rName))
+}
+
+func testAccEipBandwidthAssociateImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		bandwidthId := rs.Primary.Attributes["bandwidth_id"]
+		publicipId := rs.Primary.Attributes["publicip_id"]
+		if bandwidthId == "" || publicipId == "" {
+			return "", fmt.Errorf("the bandwidth_id (%s) or publicip_id (%s) is nil", bandwidthId, publicipId)
+		}
+
+		return publicipId + "/" + bandwidthId, nil
+	}
+}

--- a/huaweicloud/services/eip/resource_huaweicloud_eip_bandwidth_associate.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_eip_bandwidth_associate.go
@@ -1,0 +1,278 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var eipBandwidthAssociateNonUpdatableParams = []string{
+	"publicip_id",
+	"bandwidth_id",
+	"bandwidth_charge_mode",
+	"bandwidth_size",
+	"bandwidth_name",
+}
+
+// @API EIP POST /v3/{project_id}/eip/publicips/{publicip_id}/attach-share-bandwidth
+// @API EIP GET /v3/{project_id}/eip/publicips/{publicip_id}
+// @API EIP POST /v3/{project_id}/eip/publicips/{publicip_id}/detach-share-bandwidth
+func ResourceEipBandwidthAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEipBandwidthAssociateCreate,
+		ReadContext:   resourceEipBandwidthAssociateRead,
+		UpdateContext: resourceEipBandwidthAssociateUpdate,
+		DeleteContext: resourceEipBandwidthAssociateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceEipBandwidthAssociateImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(eipBandwidthAssociateNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"publicip_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"bandwidth_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"bandwidth_charge_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: utils.SchemaDesc("", utils.SchemaDescInput{Required: true}),
+			},
+			"bandwidth_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: utils.SchemaDesc("", utils.SchemaDescInput{Required: true}),
+			},
+			"bandwidth_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"public_ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_ipv6_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"publicip_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip_version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildAttachShareBandwidthBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"publicip": map[string]interface{}{
+			"bandwidth_id": d.Get("bandwidth_id"),
+		},
+	}
+	return bodyParams
+}
+
+func buildDetachShareBandwidthBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"publicip": map[string]interface{}{
+			"bandwidth": map[string]interface{}{
+				"name":        d.Get("bandwidth_name"),
+				"size":        d.Get("bandwidth_size"),
+				"charge_mode": d.Get("bandwidth_charge_mode"),
+			},
+		},
+	}
+
+	return utils.RemoveNil(bodyParams)
+}
+
+func resourceEipBandwidthAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/eip/publicips/{publicip_id}/attach-share-bandwidth"
+		product    = "vpc"
+		publicipId = d.Get("publicip_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VPC EIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{publicip_id}", publicipId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildAttachShareBandwidthBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating VPC EIP bandwidth associate: %s", err)
+	}
+
+	resourceId := fmt.Sprintf("%s/%s", publicipId, d.Get("bandwidth_id").(string))
+	d.SetId(resourceId)
+
+	return resourceEipBandwidthAssociateRead(ctx, d, meta)
+}
+
+func GetEipBandwidthAssociate(client *golangsdk.ServiceClient, publicipId, expectedBandwidthId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/eip/publicips/{publicip_id}"
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{publicip_id}", publicipId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	publicip := utils.PathSearch("publicip", respBody, nil)
+	if publicip == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	bandwidthId := utils.PathSearch("bandwidth.id", publicip, "").(string)
+	shareType := utils.PathSearch("bandwidth.share_type", publicip, "").(string)
+
+	// The EIP must be bound to the expected bandwidth ID.
+	// The bandwidth type must be "WHOLE" (indicating shared bandwidth).
+	// If any condition is not met, it will be treated as a non-existent resource (404).
+	if bandwidthId != expectedBandwidthId || shareType != "WHOLE" {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return publicip, nil
+}
+
+func resourceEipBandwidthAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		product     = "vpc"
+		publicipId  = d.Get("publicip_id").(string)
+		bandwidthId = d.Get("bandwidth_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VPC EIP client: %s", err)
+	}
+
+	publicip, err := GetEipBandwidthAssociate(client, publicipId, bandwidthId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving VPC EIP bandwidth associate")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("public_ip_address", utils.PathSearch("public_ip_address", publicip, nil)),
+		d.Set("public_ipv6_address", utils.PathSearch("public_ipv6_address", publicip, nil)),
+		d.Set("publicip_type", utils.PathSearch("type", publicip, nil)),
+		d.Set("ip_version", utils.PathSearch("ip_version", publicip, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceEipBandwidthAssociateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in 'Update()' method because resource is a one-time action resource.
+	return nil
+}
+
+func resourceEipBandwidthAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/eip/publicips/{publicip_id}/detach-share-bandwidth"
+		product    = "vpc"
+		publicipId = d.Get("publicip_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VPC EIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{publicip_id}", publicipId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildDetachShareBandwidthBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "EIP.7902"),
+			"error deleting VPC EIP bandwidth associate")
+	}
+
+	return nil
+}
+
+func resourceEipBandwidthAssociateImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.SplitN(importedId, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID,"+
+			" want '<publicip_id>/<bandwidth_id>', but got '%s'", importedId)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("publicip_id", parts[0]),
+		d.Set("bandwidth_id", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `eip_bandwidth_associate` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `eip_bandwidth_associate` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccEipBandwidthAssociate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw-v -run TestAccEipBandwidthAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccEipBandwidthAssociate_basic
=== PAUSE TestAccEipBandwidthAssociate_basic
=== CONT  TestAccEipBandwidthAssociate_basic
--- PASS: TestAccEipBandwidthAssociate_basic (27.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       21.311s
```
<img width="617" height="41" alt="image" src="https://github.com/user-attachments/assets/08cb50e2-1bc1-4be3-8387-d7e4077f243f" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
 <img width="1205" height="376" alt="query" src="https://github.com/user-attachments/assets/958b6ab7-7d98-47f2-aaaf-b660232489a0" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1222" height="500" alt="delete" src="https://github.com/user-attachments/assets/ee7f81a7-eb6c-4f15-9671-e57b9cb8adf4" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
