### PR TITLE
feat(drs): new datasource to query job monitor data

### DIFF
--- a/docs/data-sources/drs_job_monitor_data.md
+++ b/docs/data-sources/drs_job_monitor_data.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_job_monitor_data"
+description: |-
+  Use this data source to get monitoring data for a specified DRS job within HuaweiCloud.
+---
+
+# huaweicloud_drs_job_monitor_data
+
+Use this data source to get monitoring data for a specified DRS job within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+data "huaweicloud_drs_job_monitor_data" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the ID of the DRS job.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `bandwidth` - The EIP bandwidth. Unit: MB/s.
+
+* `is_src_normal` - Whether the source database connection is normal.
+
+* `is_dst_normal` - Whether the destination database connection is normal.
+
+* `src_offset` - The source database offset position.
+
+* `node_offset` - The migration instance offset position.
+
+* `dst_offset` - The destination database offset position.
+
+* `src_delay` - The source database delay.
+
+* `dst_delay` - The destination database delay.
+
+* `src_rps` - The source database RPS.
+
+* `src_io` - The source database IO.
+
+* `dst_rps` - The destination database RPS.
+
+* `dst_io` - The destination database IO.
+
+* `trans_data` - The amount of migrated data. Unit: MB.
+
+* `trans_lines` - The number of migrated data rows.
+
+* `used_volumes` - The disk usage. Unit: GB.
+
+* `used_memory` - The memory usage. Unit: MB.
+
+* `used_cpu_percent` - The CPU usage percentage.
+
+* `node_volume_size` - The total node disk size. Unit: GB.
+
+* `node_memory_size` - The total node memory size. Unit: MB.
+
+* `update_time` - The update time.
+
+* `apply_rate` - The synchronization speed. Unit: byte/s.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1303,6 +1303,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_drs_availability_zones": drs.DataSourceAvailabilityZones(),
 			"huaweicloud_drs_job_links":          drs.DataSourceJobLinks(),
+			"huaweicloud_drs_job_monitor_data":   drs.DataSourceDrsJobMonitorData(),
 			"huaweicloud_drs_node_types":         drs.DataSourceNodeTypes(),
 			"huaweicloud_drs_job_configurations": drs.DataSourceDrsJobConfigurations(),
 

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_job_monitor_data_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_job_monitor_data_test.go
@@ -1,0 +1,42 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsJobMonitorData_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_drs_job_monitor_data.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDrsJobMonitorData_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "bandwidth"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "update_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "node_volume_size"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDrsJobMonitorData_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_job_monitor_data" "test" {
+  job_id = "%s"
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_job_monitor_data.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_job_monitor_data.go
@@ -1,0 +1,184 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v5/{project_id}/jobs/{job_id}/monitor-data
+func DataSourceDrsJobMonitorData() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsJobMonitorDataRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"bandwidth": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_src_normal": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"is_dst_normal": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"src_offset": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"node_offset": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_offset": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"src_delay": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"dst_delay": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"src_rps": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"src_io": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_rps": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_io": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"trans_data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"trans_lines": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"used_volumes": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"used_memory": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"used_cpu_percent": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"node_volume_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"node_memory_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"apply_rate": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDrsJobMonitorDataRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v5/{project_id}/jobs/{job_id}/monitor-data"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{job_id}", d.Get("job_id").(string))
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &reqOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DRS job monitor data: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("bandwidth", utils.PathSearch("bandwidth", respBody, nil)),
+		d.Set("is_src_normal", utils.PathSearch("is_src_normal", respBody, nil)),
+		d.Set("is_dst_normal", utils.PathSearch("is_dst_normal", respBody, nil)),
+		d.Set("src_offset", utils.PathSearch("src_offset", respBody, nil)),
+		d.Set("node_offset", utils.PathSearch("node_offset", respBody, nil)),
+		d.Set("dst_offset", utils.PathSearch("dst_offset", respBody, nil)),
+		d.Set("src_delay", utils.PathSearch("src_delay", respBody, nil)),
+		d.Set("dst_delay", utils.PathSearch("dst_delay", respBody, nil)),
+		d.Set("src_rps", utils.PathSearch("src_rps", respBody, nil)),
+		d.Set("src_io", utils.PathSearch("src_io", respBody, nil)),
+		d.Set("dst_rps", utils.PathSearch("dst_rps", respBody, nil)),
+		d.Set("dst_io", utils.PathSearch("dst_io", respBody, nil)),
+		d.Set("trans_data", utils.PathSearch("trans_data", respBody, nil)),
+		d.Set("trans_lines", utils.PathSearch("trans_lines", respBody, nil)),
+		d.Set("used_volumes", utils.PathSearch("used_volumes", respBody, nil)),
+		d.Set("used_memory", utils.PathSearch("used_memory", respBody, nil)),
+		d.Set("used_cpu_percent", utils.PathSearch("used_cpu_percent", respBody, nil)),
+		d.Set("node_volume_size", utils.PathSearch("node_volume_size", respBody, nil)),
+		d.Set("node_memory_size", utils.PathSearch("node_memory_size", respBody, nil)),
+		d.Set("update_time", utils.PathSearch("update_time", respBody, nil)),
+		d.Set("apply_rate", utils.PathSearch("apply_rate", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query job monitor data

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o drs -f TestAccDataSourceDrsJobMonitorData_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsJobMonitorData_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsJobMonitorData_basic
=== PAUSE TestAccDataSourceDrsJobMonitorData_basic
=== CONT  TestAccDataSourceDrsJobMonitorData_basic
--- PASS: TestAccDataSourceDrsJobMonitorData_basic (21.67s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       21.758s coverage: 3.7% of statements in ./huaweicloud/services/drs
```
<img width="1315" height="82" alt="image" src="https://github.com/user-attachments/assets/7b75fc3a-6cd9-4b98-b898-224d645be638" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
