### PR TITLE
feat(modelarts): add new resource to manage training experiment

### DIFF
--- a/docs/resources/modelarts_training_experiment.md
+++ b/docs/resources/modelarts_training_experiment.md
@@ -1,0 +1,66 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_training_experiment"
+description: |-
+  Manages a ModelArts training experiment resource within HuaweiCloud.
+---
+
+# huaweicloud_modelarts_training_experiment
+
+Manages a ModelArts training experiment resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "training_experiment_name" {}
+
+resource "huaweicloud_modelarts_training_experiment" "test" {
+  metadata {
+    name = var.training_experiment_name
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the training experiment is located.  
+  If omitted, the provider-level region will be used.  
+  Changing this creates a new resource.
+
+* `metadata` - (Required, List) Specifies the configuration of the training experiment.  
+  The [metadata](#training_experiment_metadata_arg) structure is documented below.
+
+<a name="training_experiment_metadata_arg"></a>  
+  The `metadata` block supports:
+
+* `name` - (Required, String) Specifies the name of the training experiment.  
+  The valid length is limited from `1` to `64`, only letters, digits, underscores (_) and hyphens (-) are allowed.
+
+* `workspace_id` - (Optional, String, NonUpdatable) Specifies the ID of the workspace to which the training
+  experiment belongs.  
+  If omitted, the default workspace is used.
+
+* `description` - (Optional, String) Specifies the description of the training experiment.  
+  The maximum length is limited to `256` characters.  
+  Only letters, Chinese characters, digits, spaces, underscores (_), hyphens (-), dots (.) and commas (,) are allowed.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `create_time` - The creation time of the training experiment, in RFC3339 format.
+
+* `update_time` - The latest update time of the training experiment, in RFC3339 format.
+
+## Import
+
+The training experiment can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_modelarts_training_experiment.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3927,6 +3927,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_resource_pool":                   modelarts.ResourceModelartsResourcePool(),
 			"huaweicloud_modelarts_resource_pool_node_batch_resize": modelarts.ResourceResourcePoolNodeBatchResize(),
 			"huaweicloud_modelarts_service":                         modelarts.ResourceModelartsService(),
+			"huaweicloud_modelarts_training_experiment":             modelarts.ResourceTrainingExperiment(),
 			"huaweicloud_modelarts_workspace":                       modelarts.ResourceModelartsWorkspace(),
 			// Resource management via V2 APIs.
 			"huaweicloud_modelartsv2_node_batch_delete":      modelarts.ResourceV2NodeBatchDelete(),

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_training_experiment_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_training_experiment_test.go
@@ -1,0 +1,134 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
+)
+
+func getTrainingExperimentResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	return modelarts.GetTrainingExperimentById(client, state.Primary.ID)
+}
+
+func TestAccTrainingExperiment_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		obj   interface{}
+		rName = "huaweicloud_modelarts_training_experiment.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getTrainingExperimentResourceFunc)
+
+		rNameWithWorkspaceId = "huaweicloud_modelarts_training_experiment.test_with_workspace_id"
+		rcWithWorkspaceId    = acceptance.InitResourceCheck(rNameWithWorkspaceId, &obj, getTrainingExperimentResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rc.CheckResourceDestroy(),
+			rcWithWorkspaceId.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrainingExperiment_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet(rName, "metadata.0.workspace_id"),
+					resource.TestCheckResourceAttr(rName, "metadata.0.description", "acceptance test create"),
+					resource.TestMatchResourceAttr(rName, "create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					rcWithWorkspaceId.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rNameWithWorkspaceId, "metadata.0.workspace_id",
+						"huaweicloud_modelarts_workspace.test", "id"),
+					resource.TestCheckResourceAttr(rNameWithWorkspaceId, "metadata.0.description", ""),
+				),
+			},
+			{
+				Config: testAccTrainingExperiment_basic_step2(name, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "metadata.0.name", updateName),
+					resource.TestCheckResourceAttr(rName, "metadata.0.description", ""),
+					resource.TestMatchResourceAttr(rName, "update_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					rcWithWorkspaceId.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithWorkspaceId, "metadata.0.name", updateName),
+					resource.TestCheckResourceAttrPair(rNameWithWorkspaceId, "metadata.0.workspace_id",
+						"huaweicloud_modelarts_workspace.test", "id"),
+					resource.TestCheckResourceAttr(rNameWithWorkspaceId, "metadata.0.description", "Updated by terraform script"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccTrainingExperiment_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_modelarts_workspace" "test" {
+  name      = "%[1]s"
+  auth_type = "private"
+}
+`, name)
+}
+
+func testAccTrainingExperiment_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelarts_training_experiment" "test" {
+  metadata {
+    name        = "%[2]s"
+    description = "acceptance test create"
+  }
+}
+
+resource "huaweicloud_modelarts_training_experiment" "test_with_workspace_id" {
+  metadata {
+    name         = "%[2]s"
+    workspace_id = huaweicloud_modelarts_workspace.test.id
+  }
+}
+`, testAccTrainingExperiment_base(name), name)
+}
+
+func testAccTrainingExperiment_basic_step2(name, updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelarts_training_experiment" "test" {
+  metadata {
+    name = "%[2]s"
+  }
+}
+
+resource "huaweicloud_modelarts_training_experiment" "test_with_workspace_id" {
+  metadata {
+    name         = "%[2]s"
+    workspace_id = huaweicloud_modelarts_workspace.test.id
+    description  = "Updated by terraform script"
+  }
+}
+`, testAccTrainingExperiment_base(name), updateName)
+}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_training_experiment.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_training_experiment.go
@@ -1,0 +1,316 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	trainingExperimentNonUpdatableParams = []string{
+		"metadata.*.workspace_id",
+	}
+	trainingExperimentNotFoundErrCodes = []string{
+		"ModelArts.2842", // The resource does not exist.
+	}
+)
+
+// @API ModelArts POST /v2/{project_id}/training-experiments
+// @API ModelArts GET /v2/{project_id}/training-experiments/{experiment_id}
+// @API ModelArts PUT /v2/{project_id}/training-experiments/{experiment_id}
+// @API ModelArts DELETE /v2/{project_id}/training-experiments/{experiment_id}
+func ResourceTrainingExperiment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTrainingExperimentCreate,
+		ReadContext:   resourceTrainingExperimentRead,
+		UpdateContext: resourceTrainingExperimentUpdate,
+		DeleteContext: resourceTrainingExperimentDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(trainingExperimentNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the training experiment is located.`,
+			},
+
+			// Required parameters.
+			"metadata": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Required parameters.
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the training experiment.`,
+						},
+
+						// Optional parameters.
+						"workspace_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The ID of the workspace to which the training experiment belongs.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The description of the training experiment.`,
+						},
+					},
+				},
+				Description: `The configuration of the training experiment.`,
+			},
+
+			// Attributes.
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the training experiment, in RFC3339 format.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the training experiment, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true},
+				),
+			},
+		},
+	}
+}
+
+func buildTrainingExperimentCreateBodyParams(metadata []interface{}) map[string]interface{} {
+	if len(metadata) < 1 {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"metadata": utils.RemoveNil(map[string]interface{}{
+			"name":         utils.PathSearch("name", metadata[0], nil),
+			"description":  utils.ValueIgnoreEmpty(utils.PathSearch("description", metadata[0], nil)),
+			"workspace_id": utils.ValueIgnoreEmpty(utils.PathSearch("workspace_id", metadata[0], nil)),
+		}),
+	}
+}
+
+func createTrainingExperiment(client *golangsdk.ServiceClient, params map[string]interface{}) (interface{}, error) {
+	httpUrl := "v2/{project_id}/training-experiments"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(params),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceTrainingExperimentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("modelarts", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	resp, err := createTrainingExperiment(client, buildTrainingExperimentCreateBodyParams(d.Get("metadata").([]interface{})))
+	if err != nil {
+		return diag.Errorf("error creating training experiment: %s", err)
+	}
+
+	trainingExperimentId := utils.PathSearch("metadata.id", resp, "").(string)
+	if trainingExperimentId == "" {
+		return diag.Errorf("unable to find the ID of the training experiment from the API response")
+	}
+
+	d.SetId(trainingExperimentId)
+
+	return resourceTrainingExperimentRead(ctx, d, meta)
+}
+
+func GetTrainingExperimentById(client *golangsdk.ServiceClient, trainingExperimentId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/training-experiments/{experiment_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{experiment_id}", trainingExperimentId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceTrainingExperimentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                  = meta.(*config.Config)
+		region               = cfg.GetRegion(d)
+		trainingExperimentId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	resp, err := GetTrainingExperimentById(client, trainingExperimentId)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", trainingExperimentNotFoundErrCodes...),
+			fmt.Sprintf("error retrieving training experiment (%s)", trainingExperimentId),
+		)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("metadata", flattenTrainingExperimentMetadata(resp)),
+		// Attributes.
+		d.Set("create_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("metadata.create_time",
+			resp, float64(0)).(float64))/1000, false)),
+		d.Set("update_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("metadata.update_time",
+			resp, float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTrainingExperimentMetadata(resp interface{}) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"name":         utils.PathSearch("metadata.name", resp, nil),
+			"description":  utils.PathSearch("metadata.description", resp, nil),
+			"workspace_id": utils.PathSearch("metadata.workspace_id", resp, nil),
+		},
+	}
+}
+
+func buildTrainingExperimentUpdateBodyParams(metadata []interface{}) map[string]interface{} {
+	if len(metadata) < 1 {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"name":        utils.PathSearch("name", metadata[0], nil),
+		"description": utils.PathSearch("description", metadata[0], nil),
+	}
+}
+
+func updateTrainingExperiment(client *golangsdk.ServiceClient, trainingExperimentId string, params map[string]interface{}) error {
+	httpUrl := "v2/{project_id}/training-experiments/{experiment_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{experiment_id}", trainingExperimentId)
+
+	opt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(params),
+	}
+
+	_, err := client.Request("PUT", updatePath, &opt)
+	return err
+}
+
+func resourceTrainingExperimentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                  = meta.(*config.Config)
+		trainingExperimentId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	err = updateTrainingExperiment(client, trainingExperimentId, buildTrainingExperimentUpdateBodyParams(d.Get("metadata").([]interface{})))
+	if err != nil {
+		return diag.Errorf("error updating training experiment (%s): %s", trainingExperimentId, err)
+	}
+
+	return resourceTrainingExperimentRead(ctx, d, meta)
+}
+
+func deleteTrainingExperiment(client *golangsdk.ServiceClient, trainingExperimentId string) error {
+	httpUrl := "v2/{project_id}/training-experiments/{experiment_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{experiment_id}", trainingExperimentId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &opt)
+	return err
+}
+
+func resourceTrainingExperimentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                  = meta.(*config.Config)
+		trainingExperimentId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	err = deleteTrainingExperiment(client, trainingExperimentId)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", trainingExperimentNotFoundErrCodes...),
+			fmt.Sprintf("error deleting training experiment (%s)", trainingExperimentId),
+		)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new resource (`huaweicloud_modelarts_training_experiment`) to manage training experiment.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccTrainingExperiment_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccTrainingExperiment_basic -timeout 360m -parallel 10
=== RUN   TestAccTrainingExperiment_basic
=== PAUSE TestAccTrainingExperiment_basic
=== CONT  TestAccTrainingExperiment_basic
--- PASS: TestAccTrainingExperiment_basic (60.47s)
PASS
coverage: 7.9% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 60.572s coverage: 7.9% of statements in ./huaweicloud/services/modelarts

```
<img width="1092" height="33" alt="image" src="https://github.com/user-attachments/assets/67ca6e34-f91b-4375-950b-07a38988a78b" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1378" height="863" alt="image" src="https://github.com/user-attachments/assets/c084b14f-bc3d-4631-8126-fe3a78e1e52f" />
 
   <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
   
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1239" height="824" alt="image" src="https://github.com/user-attachments/assets/53faf80e-832c-49eb-8f23-d3591a92b6f5" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
