### PR TITLE
feat(eip): add source to internet bandwidth associate

### DIFF
--- a/docs/resources/global_eip_internet_bandwidth_associate.md
+++ b/docs/resources/global_eip_internet_bandwidth_associate.md
@@ -1,0 +1,60 @@
+---
+subcategory: "EIP (Elastic IP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_global_eip_internet_bandwidth_associate"
+description: |-
+  Manages a Global EIP associate internet bandwidth resource within HuaweiCloud.
+---
+
+# huaweicloud_global_eip_internet_bandwidth_associate
+
+Manages a Global EIP associate internet bandwidth resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "global_eip_id" {}
+variable "internet_bandwidth_id" {}
+
+resource "huaweicloud_global_eip_internet_bandwidth_associate" "test" {
+  global_eip_id         = var.global_eip_id
+  internet_bandwidth_id = var.internet_bandwidth_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the resource is located.
+  If omitted, the provider-level region will be used. Change this parameter will create a new resource.
+
+* `global_eip_id` - (Required, String, NonUpdatable) Specifies the ID of the global EIP to which the internet bandwidth
+  will be associated.
+
+* `internet_bandwidth_id` - (Required, String, NonUpdatable) Specifies the ID of the internet bandwidth to associate
+  to the global EIP.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in the format of `<global_eip_id>`.
+
+* `internet_bandwidth_info` - The information about the associated internet bandwidth.
+  The [internet_bandwidth_info](#block--internet_bandwidth_info) structure is documented below.
+
+<a name="block--internet_bandwidth_info"></a>
+The `internet_bandwidth_info` block exports:
+
+* `id` - The ID of the attached internet bandwidth.
+
+* `size` - The size of the attached internet bandwidth.
+
+## Import
+
+This resource can be imported using the `global_eip_id`, e.g.
+
+```bash
+$ terraform import huaweicloud_global_eip_internet_bandwidth_associate.test <global_eip_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4307,9 +4307,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_eipv3_associate":          eip.ResourceEipv3Associate(),
 			"huaweicloud_vpc_internet_gateway":         eip.ResourceVPCInternetGateway(),
 
-			"huaweicloud_global_internet_bandwidth": eip.ResourceGlobalInternetBandwidth(),
-			"huaweicloud_global_eip":                eip.ResourceGlobalEIP(),
-			"huaweicloud_global_eip_associate":      eip.ResourceGlobalEIPAssociate(),
+			"huaweicloud_global_internet_bandwidth":               eip.ResourceGlobalInternetBandwidth(),
+			"huaweicloud_global_eip":                              eip.ResourceGlobalEIP(),
+			"huaweicloud_global_eip_associate":                    eip.ResourceGlobalEIPAssociate(),
+			"huaweicloud_global_eip_internet_bandwidth_associate": eip.ResourceInternetBandwidthAssociate(),
 
 			"huaweicloud_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),
 			"huaweicloud_vpc_peering_connection_accepter": vpc.ResourceVpcPeeringConnectionAccepterV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -442,6 +442,7 @@ var (
 	HW_DC_GLOBAL_GATEWAY_ID_HAS_PEER_LINK = os.Getenv("HW_DC_GLOBAL_GATEWAY_ID_HAS_PEER_LINK")
 	HW_DC_CONNECT_GATEWAY_ID              = os.Getenv("HW_DC_CONNECT_GATEWAY_ID")
 	HW_GLOBAL_EIP_ID                      = os.Getenv("HW_GLOBAL_EIP_ID")
+	HW_GLOBAL_INTERNET_BANDWIDTH_ID       = os.Getenv("HW_GLOBAL_INTERNET_BANDWIDTH_ID")
 
 	HW_DSC_INSTANCE_ID    = os.Getenv("HW_DSC_INSTANCE_ID")
 	HW_DSC_ALARM_TOPIC_ID = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
@@ -2829,6 +2830,13 @@ func TestAccPreCheckDcConnectGatewayId(t *testing.T) {
 func TestAccPreCheckGlobalEipId(t *testing.T) {
 	if HW_GLOBAL_EIP_ID == "" {
 		t.Skip("HW_GLOBAL_EIP_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckGlobalInternetBandwidthId(t *testing.T) {
+	if HW_GLOBAL_INTERNET_BANDWIDTH_ID == "" {
+		t.Skip("HW_GLOBAL_INTERNET_BANDWIDTH_ID must be set for this acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_eip_internet_bandwidth_associate_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_eip_internet_bandwidth_associate_test.go
@@ -1,0 +1,66 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
+)
+
+func getGolbalEipFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region      = acceptance.HW_REGION_NAME
+		globalEipId = state.Primary.ID
+	)
+
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GEIP client: %s", err)
+	}
+
+	return eip.GetGlobalEIPWithInternetBandwidth(client, cfg.DomainID, globalEipId)
+}
+func TestAccInternetBandwidthAssociate_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_global_eip_internet_bandwidth_associate.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getGolbalEipFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGlobalEipId(t)
+			acceptance.TestAccPreCheckGlobalInternetBandwidthId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testGlobalInternetBandwidthAssociateBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testGlobalInternetBandwidthAssociateBasic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_global_eip_internet_bandwidth_associate" "test" {
+  global_eip_id         = "%s"
+  internet_bandwidth_id = "%s"
+}
+`, acceptance.HW_GLOBAL_EIP_ID, acceptance.HW_GLOBAL_INTERNET_BANDWIDTH_ID)
+}

--- a/huaweicloud/services/eip/resource_huaweicloud_global_eip_internet_bandwidth_associate.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_global_eip_internet_bandwidth_associate.go
@@ -1,0 +1,210 @@
+package eip
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP POST /v3/{domain_id}/global-eips/{global_eip_id}/attach-internet-bandwidth
+// @API EIP POST /v3/{domain_id}/global-eips/{global_eip_id}/detach-internet-bandwidth
+// @API EIP GET /v3/{domain_id}/global-eips/{global_eip_id}
+func ResourceInternetBandwidthAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInternetBandwidthAssociateCreate,
+		ReadContext:   resourceInternetBandwidthAssociateRead,
+		UpdateContext: resourceInternetBandwidthAssociateUpdate,
+		DeleteContext: resourceInternetBandwidthAssociateDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"global_eip_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"internet_bandwidth_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"internet_bandwidth_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     globalEipInternetBandwidthInfoSchema(),
+			},
+		},
+	}
+}
+
+func globalEipInternetBandwidthInfoSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildAttachInternetBandwidthBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"global_eip": map[string]interface{}{
+			"internet_bandwidth_id": d.Get("internet_bandwidth_id").(string),
+		},
+	}
+
+	return bodyParams
+}
+
+func resourceInternetBandwidthAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v3/{domain_id}/global-eips/{global_eip_id}/attach-internet-bandwidth"
+		globalEipId = d.Get("global_eip_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", cfg.DomainID)
+	requestPath = strings.ReplaceAll(requestPath, "{global_eip_id}", globalEipId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildAttachInternetBandwidthBodyParams(d),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating global EIP internet bandwidth associate: %s", err)
+	}
+
+	d.SetId(globalEipId)
+
+	return resourceInternetBandwidthAssociateRead(ctx, d, meta)
+}
+
+func GetGlobalEIPWithInternetBandwidth(client *golangsdk.ServiceClient, domainID, globalEipId string) (interface{}, error) {
+	getGEIPHttpUrl := "v3/{domain_id}/global-eips/{global_eip_id}"
+	getGEIPPath := client.Endpoint + getGEIPHttpUrl
+	getGEIPPath = strings.ReplaceAll(getGEIPPath, "{domain_id}", domainID)
+	getGEIPPath = strings.ReplaceAll(getGEIPPath, "{global_eip_id}", globalEipId)
+	getGEIPOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getGEIPResp, err := client.Request("GET", getGEIPPath, &getGEIPOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	getGEIPRespBody, err := utils.FlattenResponse(getGEIPResp)
+	if err != nil {
+		return nil, err
+	}
+
+	target := utils.PathSearch("global_eip.internet_bandwidth_info", getGEIPRespBody, nil)
+	if target == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return utils.PathSearch("global_eip", getGEIPRespBody, nil), nil
+}
+
+func resourceInternetBandwidthAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	globalEIPRaw, err := GetGlobalEIPWithInternetBandwidth(client, cfg.DomainID, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving global EIP internet bandwidth info")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("global_eip_id", utils.PathSearch("id", globalEIPRaw, nil)),
+		d.Set("internet_bandwidth_info", flattenInternetBandwidthInfo(globalEIPRaw)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInternetBandwidthInfo(geip interface{}) []interface{} {
+	if geip == nil {
+		return nil
+	}
+
+	internetBandwidthInfo := utils.PathSearch("internet_bandwidth_info", geip, nil)
+	if internetBandwidthInfo == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"id":   utils.PathSearch("id", internetBandwidthInfo, nil),
+			"size": utils.PathSearch("size", internetBandwidthInfo, nil),
+		},
+	}
+}
+
+func resourceInternetBandwidthAssociateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInternetBandwidthAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	deleteGEIPHttpUrl := "v3/{domain_id}/global-eips/{global_eip_id}/detach-internet-bandwidth"
+	deleteGEIPPath := client.Endpoint + deleteGEIPHttpUrl
+	deleteGEIPPath = strings.ReplaceAll(deleteGEIPPath, "{domain_id}", cfg.DomainID)
+	deleteGEIPPath = strings.ReplaceAll(deleteGEIPPath, "{global_eip_id}", d.Id())
+
+	deleteGEIPOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("POST", deleteGEIPPath, &deleteGEIPOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "GEIP.5001"),
+			"error deleting internet bandwidth associate")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add source to internet bandwidth associate

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add source to internet bandwidth associate
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o eip -f TestAccInternetBandwidthAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccInternetBandwidthAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccInternetBandwidthAssociate_basic
=== PAUSE TestAccInternetBandwidthAssociate_basic
=== CONT  TestAccInternetBandwidthAssociate_basic
--- PASS: TestAccInternetBandwidthAssociate_basic (27.85s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       27.931s coverage: 4.1% of statements in ./huaweicloud/services/eip
```
<img width="1018" height="61" alt="Snipaste_2026-05-12_21-30-48" src="https://github.com/user-attachments/assets/432d4b78-eee7-4810-b100-d66acb47d30c" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> 
<img width="1208" height="685" alt="Snipaste_2026-05-12_21-32-29" src="https://github.com/user-attachments/assets/2bb04067-be83-42fd-8b52-2f41ba004839" />

 <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> 
<img width="1238" height="783" alt="Snipaste_2026-05-12_21-33-27" src="https://github.com/user-attachments/assets/082932df-2885-42bd-9b2a-7159955a4ac9" />


 <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
