### PR TITLE
feat(vpc): add new data source to query peering connections

### DIFF
--- a/docs/data-sources/vpc_peering_connections.md
+++ b/docs/data-sources/vpc_peering_connections.md
@@ -1,0 +1,98 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpc_peering_connections"
+description: |-
+  Use this data source to get the list of VPC peering connections.
+---
+
+# huaweicloud_vpc_peering_connections
+
+Use this data source to get the list of VPC peering connections in the current tenant.
+
+~> Currently, the maximum of 2000 peering connections can be queried.
+
+## Example Usage
+
+### Query all peering connections and without any filter
+
+```hcl
+data "huaweicloud_vpc_peering_connections" "all" {}
+```
+
+### Query the peering connections and using name filter
+
+```hcl
+variable "peering_connection_name" {}
+
+data "huaweicloud_vpc_peering_connections" "by_vpc" {
+  name = var.peering_connection_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the peering connections are located.  
+  If omitted, the provider-level region will be used.
+
+* `connection_id` - (Optional, String) Specifies the ID of the VPC peering connection to be queried.
+
+* `name` - (Optional, String) Specifies the name of the VPC peering connection to be queried.
+
+* `status` - (Optional, String) Specifies the status of the VPC peering connection to be queried.  
+  The valid values are as follows:
+  + **PENDING_ACCEPTANCE**
+  + **REJECTED**
+  + **EXPIRED**
+  + **DELETED**
+  + **ACTIVE**
+
+* `project_id` - (Optional, String) Specifies the project ID of the VPC to be queried.
+
+* `vpc_id` - (Optional, String) Specifies the ID of the requester's VPC to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `connections` - The list of peering connections that matched the filter parameters.  
+  The [connections](#vpc_peering_connections_attr) structure is documented below.
+
+<a name="vpc_peering_connections_attr"></a>
+The `connections` block supports:
+
+* `id` - The ID of the peering connection.
+
+* `name` - The name of the peering connection.
+
+* `status` - The status of the peering connection.
+
+* `description` - The description of the peering connection.
+
+* `request_vpc_info` - The information of the requester's VPC.  
+  The [request_vpc_info](#vpc_peering_connections_request_vpc_info_attr) structure is documented below.
+
+* `accept_vpc_info` - The information of the accepter's VPC.  
+  The [accept_vpc_info](#vpc_peering_connections_accept_vpc_info_attr) structure is documented below.
+
+* `created_at` - The creation time of the peering connection, in RFC3339 format.
+
+* `updated_at` - The latest update time of the peering connection, in RFC3339 format.
+
+<a name="vpc_peering_connections_request_vpc_info_attr"></a>
+The `request_vpc_info` block supports:
+
+* `vpc_id` - The ID of the requester's VPC.
+
+* `project_id` - The project ID of the requester to which the VPC of peering connection belongs.
+
+<a name="vpc_peering_connections_accept_vpc_info_attr"></a>
+The `accept_vpc_info` block supports:
+
+* `vpc_id` - The ID of the accepter's VPC.
+
+* `project_id` - The project ID of the accepter to which the VPC of peering connection belongs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2434,6 +2434,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_network_acl_tags":                   vpc.DataSourceVpcNetworkAclTags(),
 			"huaweicloud_vpc_network_acls_by_tags":               vpc.DataSourceNetworkAclsByTags(),
 			"huaweicloud_vpc_peering_connection":                 vpc.DataSourceVpcPeeringConnectionV2(),
+			"huaweicloud_vpc_peering_connections":                vpc.DataSourcePeeringConnections(),
 			"huaweicloud_vpc_route_table":                        vpc.DataSourceVPCRouteTable(),
 			"huaweicloud_vpc_routes":                             vpc.DataSourceVpcRoutes(),
 			"huaweicloud_vpc_sub_network_interfaces":             vpc.DataSourceVpcSubNetworkInterfaces(),

--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_peering_connections_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_peering_connections_test.go
@@ -1,0 +1,226 @@
+package vpc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataPeeringConnections_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_vpc_peering_connections.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byConnectionId   = "data.huaweicloud_vpc_peering_connections.filter_by_connection_id"
+		dcByConnectionId = acceptance.InitDataSourceCheck(byConnectionId)
+
+		byName   = "data.huaweicloud_vpc_peering_connections.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byStatus   = "data.huaweicloud_vpc_peering_connections.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byProjectId   = "data.huaweicloud_vpc_peering_connections.filter_by_project_id"
+		dcByProjectId = acceptance.InitDataSourceCheck(byProjectId)
+
+		byVpcId   = "data.huaweicloud_vpc_peering_connections.filter_by_vpc_id"
+		dcByVpcId = acceptance.InitDataSourceCheck(byVpcId)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataPeeringConnections_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameter.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "connections.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'connection_id' parameter.
+					dcByConnectionId.CheckResourceExists(),
+					resource.TestCheckOutput("is_connection_id_filter_useful", "true"),
+					resource.TestCheckResourceAttr(byConnectionId, "connections.#", "1"),
+					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.id"),
+					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.name"),
+					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.status"),
+					resource.TestCheckResourceAttr(byConnectionId, "connections.0.request_vpc_info.#", "1"),
+					resource.TestCheckResourceAttrPair(byConnectionId, "connections.0.request_vpc_info.0.vpc_id",
+						"huaweicloud_vpc.test.0", "id"),
+					resource.TestCheckResourceAttrPair(byConnectionId, "connections.0.request_vpc_info.0.project_id",
+						"data.huaweicloud_identity_projects.test", "projects.0.id"),
+					resource.TestCheckResourceAttr(byConnectionId, "connections.0.accept_vpc_info.#", "1"),
+					resource.TestCheckResourceAttrPair(byConnectionId, "connections.0.accept_vpc_info.0.vpc_id",
+						"huaweicloud_vpc.test.1", "id"),
+					resource.TestCheckResourceAttrPair(byConnectionId, "connections.0.accept_vpc_info.0.project_id",
+						"data.huaweicloud_identity_projects.test", "projects.0.id"),
+					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.description"),
+					resource.TestMatchResourceAttr(byConnectionId, "connections.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byConnectionId, "connections.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|([+-]\d{2}:\d{2}))$`)),
+					// Filter by 'name' parameter.
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					// Filter by 'status' parameter.
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					// Filter by 'project_id' parameter.
+					dcByProjectId.CheckResourceExists(),
+					resource.TestCheckOutput("is_project_id_filter_useful", "true"),
+					// Filter by 'vpc_id' parameter.
+					dcByVpcId.CheckResourceExists(),
+					resource.TestCheckOutput("is_vpc_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataPeeringConnections_basic_base(name string) string {
+	return fmt.Sprintf(`
+locals {
+  basic_cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc" "test" {
+  count = 2
+
+  name = format("%[1]s_%%d", count.index)
+  cidr = cidrsubnet(local.basic_cidr, 4, count.index)
+}
+
+resource "huaweicloud_vpc_peering_connection" "test" {
+  name        = "%[1]s"
+  vpc_id      = huaweicloud_vpc.test[0].id
+  peer_vpc_id = huaweicloud_vpc.test[1].id
+  description = "Created by acceptance test"
+}
+`, name)
+}
+
+func testAccDataPeeringConnections_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameter.
+data "huaweicloud_vpc_peering_connections" "all" {
+  depends_on = [huaweicloud_vpc_peering_connection.test]
+}
+
+# Filter by 'connection_id' parameter.
+locals {
+  connection_id = huaweicloud_vpc_peering_connection.test.id
+}
+
+data "huaweicloud_vpc_peering_connections" "filter_by_connection_id" {
+  depends_on = [huaweicloud_vpc_peering_connection.test]
+
+  connection_id = huaweicloud_vpc_peering_connection.test.id
+}
+
+locals {
+  connection_id_filter_result = [
+    for v in data.huaweicloud_vpc_peering_connections.filter_by_connection_id.connections[*].id : v == local.connection_id
+  ]
+}
+
+output "is_connection_id_filter_useful" {
+  value = length(local.connection_id_filter_result) > 0 && alltrue(local.connection_id_filter_result)
+}
+
+# Filter by 'name' parameter.
+locals {
+  connection_name = huaweicloud_vpc_peering_connection.test.name
+}
+
+data "huaweicloud_vpc_peering_connections" "filter_by_name" {
+  depends_on = [huaweicloud_vpc_peering_connection.test]
+
+  name = local.connection_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_vpc_peering_connections.filter_by_name.connections[*].name : v == local.connection_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by 'status' parameter.
+locals {
+  connection_status = huaweicloud_vpc_peering_connection.test.status
+}
+
+data "huaweicloud_vpc_peering_connections" "filter_by_status" {
+  depends_on = [huaweicloud_vpc_peering_connection.test]
+
+  status = local.connection_status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_vpc_peering_connections.filter_by_status.connections[*].status : v == local.connection_status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+# Filter by 'project_id' parameter.
+data "huaweicloud_identity_projects" "test" {
+  name = "%[2]s"
+}
+
+locals {
+  project_id = data.huaweicloud_identity_projects.test.projects[0].id
+}
+
+data "huaweicloud_vpc_peering_connections" "filter_by_project_id" {
+  depends_on = [huaweicloud_vpc_peering_connection.test]
+
+  project_id = local.project_id
+}
+
+locals {
+  project_id_filter_result = [
+    for v in data.huaweicloud_vpc_peering_connections.filter_by_project_id.connections[*].accept_vpc_info[0].project_id : v == local.project_id
+  ]
+}
+
+output "is_project_id_filter_useful" {
+  value = length(local.project_id_filter_result) > 0 && alltrue(local.project_id_filter_result)
+}
+
+# Filter by 'vpc_id' parameter.
+locals {
+  vpc_id = huaweicloud_vpc_peering_connection.test.vpc_id
+}
+
+data "huaweicloud_vpc_peering_connections" "filter_by_vpc_id" {
+  depends_on = [huaweicloud_vpc_peering_connection.test]
+
+  vpc_id = local.vpc_id
+}
+
+locals {
+  vpc_id_filter_result = [
+    for v in data.huaweicloud_vpc_peering_connections.filter_by_vpc_id.connections[*].request_vpc_info[0].vpc_id : v == local.vpc_id
+  ]
+}
+
+output "is_vpc_id_filter_useful" {
+  value = length(local.vpc_id_filter_result) > 0 && alltrue(local.vpc_id_filter_result)
+}
+`, testAccDataPeeringConnections_basic_base(name), acceptance.HW_REGION_NAME)
+}

--- a/huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connections.go
+++ b/huaweicloud/services/vpc/data_source_huaweicloud_vpc_peering_connections.go
@@ -1,0 +1,268 @@
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API VPC GET /v2.0/vpc/peerings
+func DataSourcePeeringConnections() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePeeringConnectionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the peering connections are located.`,
+			},
+
+			// Optional parameters.
+			"connection_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the VPC peering connection to be queried.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the VPC peering connection to be queried.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The status of the VPC peering connection to be queried.`,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The project ID of the VPC to be queried.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the requester's VPC to be queried.`,
+			},
+
+			// Attributes.
+			"connections": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the peering connection.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the peering connection.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the peering connection.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the peering connection.`,
+						},
+						"request_vpc_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"vpc_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the requester's VPC.`,
+									},
+									"project_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The project ID of the requester to which the VPC of peering connection belongs.`,
+									},
+								},
+							},
+							Description: `The information of the requester's VPC.`,
+						},
+						"accept_vpc_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"vpc_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the accepter's VPC.`,
+									},
+									"project_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The project ID of the accepter to which the VPC of peering connection belongs.`,
+									},
+								},
+							},
+							Description: `The information of the accepter's VPC.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the peering connection, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the peering connection, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `The list of peering connections that matched the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildListPeeringConnectionsQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("connection_id"); ok {
+		queryParams = fmt.Sprintf("%s&id=%s", queryParams, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		queryParams = fmt.Sprintf("%s&name=%s", queryParams, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		queryParams = fmt.Sprintf("%s&status=%s", queryParams, v)
+	}
+	if v, ok := d.GetOk("project_id"); ok {
+		queryParams = fmt.Sprintf("%s&tenant_id=%s", queryParams, v)
+	}
+	if v, ok := d.GetOk("vpc_id"); ok {
+		queryParams = fmt.Sprintf("%s&vpc_id=%s", queryParams, v)
+	}
+	return queryParams
+}
+
+func listPeeringConnections(client *golangsdk.ServiceClient, queryParams string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2.0/vpc/peerings?limit={limit}"
+		limit   = 2000
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += queryParams
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	// Unfortunately, the API does not return the next marker, so just the first page can be queried.
+	requestResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("peerings", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenPeeringConnectionRequestVpcInfo(requestVpcInfo map[string]interface{}) []map[string]interface{} {
+	if len(requestVpcInfo) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"vpc_id":     utils.PathSearch("vpc_id", requestVpcInfo, nil),
+			"project_id": utils.PathSearch("tenant_id", requestVpcInfo, nil),
+		},
+	}
+}
+
+func flattenPeeringConnectionAcceptVpcInfo(acceptVpcInfo map[string]interface{}) []map[string]interface{} {
+	if len(acceptVpcInfo) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"vpc_id":     utils.PathSearch("vpc_id", acceptVpcInfo, nil),
+			"project_id": utils.PathSearch("tenant_id", acceptVpcInfo, nil),
+		},
+	}
+}
+
+func flattenPeeringConnections(peerings []interface{}) []map[string]interface{} {
+	if len(peerings) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(peerings))
+	for _, peering := range peerings {
+		result = append(result, map[string]interface{}{
+			"id":     utils.PathSearch("id", peering, nil),
+			"name":   utils.PathSearch("name", peering, nil),
+			"status": utils.PathSearch("status", peering, nil),
+			"request_vpc_info": flattenPeeringConnectionRequestVpcInfo(utils.PathSearch("request_vpc_info",
+				peering, make(map[string]interface{})).(map[string]interface{})),
+			"accept_vpc_info": flattenPeeringConnectionAcceptVpcInfo(utils.PathSearch("accept_vpc_info",
+				peering, make(map[string]interface{})).(map[string]interface{})),
+			"description": utils.PathSearch("description", peering, nil),
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("created_at",
+				peering, "").(string), "2006-01-02T15:04:05")/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("updated_at",
+				peering, "").(string), "2006-01-02T15:04:05")/1000, false),
+		})
+	}
+	return result
+}
+
+func dataSourcePeeringConnectionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("vpc", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC peering connection client: %s", err)
+	}
+
+	perringConnections, err := listPeeringConnections(client, buildListPeeringConnectionsQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error querying VPC peering connections: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("connections", flattenPeeringConnections(perringConnections)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source that used to query VPC peering connections and which supports following filters:
- connection_id
- name
- status
- project_id
- vpc_id

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1022" height="239" alt="image" src="https://github.com/user-attachments/assets/769ea787-a218-4766-b9f7-b9db9f3ab9b5" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query peering connections.
2. supplement the corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o vpc -f TestAccDataPeeringConnections_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/vpc" -v -coverprofile="./huaweicloud/services/acceptance/vpc/vpc_coverage.cov" -coverpkg="./huaweicloud/services/vpc" -run TestAccDataPeeringConnections_basic -timeout 360m -parallel 10
=== RUN   TestAccDataPeeringConnections_basic
=== PAUSE TestAccDataPeeringConnections_basic
=== CONT  TestAccDataPeeringConnections_basic
--- PASS: TestAccDataPeeringConnections_basic (45.31s)
PASS
coverage: 6.6% of statements in ./huaweicloud/services/vpc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       45.408s coverage: 6.6% of statements in ./huaweicloud/services/vpc
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
