### PR TITLE
feat(RDS): add rds standby instance rebuild resource

### DIFF
--- a/docs/resources/rds_standby_instance_rebuild.md
+++ b/docs/resources/rds_standby_instance_rebuild.md
@@ -1,0 +1,56 @@
+---
+subcategory: "RDS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rds_standby_instance_rebuild"
+description: |-
+  Manages an RDS standby instance rebuild resource within HuaweiCloud.
+---
+
+# huaweicloud_rds_standby_instance_rebuild
+
+Manages an RDS standby instance rebuild resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_rds_standby_instance_rebuild" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the RDS instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the instance ID.
+
+* `workflow_id` - The task flow ID.
+
+* `last_rebuild_time` - The last rebuilding time.
+
+* `next_rebuild_time` - The time when the next rebuilding is allowed
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+
+## Import
+
+The RDS standby instance rebuild can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_rds_standby_instance_rebuild.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4059,6 +4059,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_instance":                        rds.ResourceRdsInstance(),
 			"huaweicloud_rds_instance_restart":                rds.ResourceInstanceRestart(),
 			"huaweicloud_rds_instance_eip_associate":          rds.ResourceRdsInstanceEipAssociate(),
+			"huaweicloud_rds_standby_instance_rebuild":        rds.ResourceStandbyInstanceRebuild(),
 			"huaweicloud_rds_parametergroup":                  rds.ResourceRdsConfiguration(),
 			"huaweicloud_rds_parametergroup_apply":            rds.ResourceConfigurationApply(),
 			"huaweicloud_rds_parametergroup_copy":             rds.ResourceRdsConfigurationCopy(),

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_standby_instance_rebuild_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_standby_instance_rebuild_test.go
@@ -1,0 +1,47 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRdsStandbyInstanceRebuild_basic(t *testing.T) {
+	rName := "huaweicloud_rds_standby_instance_rebuild.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRdsInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsStandbyInstanceRebuild_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "instance_id", acceptance.HW_RDS_INSTANCE_ID),
+					resource.TestCheckResourceAttrSet(rName, "workflow_id"),
+					resource.TestCheckResourceAttrSet(rName, "last_rebuild_time"),
+					resource.TestCheckResourceAttrSet(rName, "next_rebuild_time"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccRdsStandbyInstanceRebuild_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rds_standby_instance_rebuild" "test" {
+  instance_id = "%s"
+}
+`, acceptance.HW_RDS_INSTANCE_ID)
+}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_standby_instance_rebuild.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_standby_instance_rebuild.go
@@ -1,0 +1,198 @@
+package rds
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var rebuildSlaveNonUpdatableParams = []string{
+	"instance_id",
+}
+
+// @API RDS PUT /v3/{project_id}/instances/{instance_id}/rebuild
+// @API RDS GET /v3/{project_id}/instances/{instance_id}/rebuild
+// @API RDS GET /v3/{project_id}/instances
+func ResourceStandbyInstanceRebuild() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStandbyInstanceRebuildCreate,
+		ReadContext:   resourceStandbyInstanceRebuildRead,
+		UpdateContext: resourceStandbyInstanceRebuildUpdate,
+		DeleteContext: resourceStandbyInstanceRebuildDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(rebuildSlaveNonUpdatableParams),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"workflow_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_rebuild_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"next_rebuild_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceStandbyInstanceRebuildCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/rebuild"
+		product = "rds"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		res, err := client.Request("PUT", createPath, &createOpt)
+		retry, err := handleMultiOperationsError(err)
+		return res, retry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     rdsInstanceStateRefreshFunc(client, instanceId),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return diag.Errorf("error creating RDS standby instance rebuild:(%s): %s", instanceId, err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(r.(*http.Response))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	workflowID := utils.PathSearch("workflow_id", createRespBody, "").(string)
+	if workflowID == "" {
+		return diag.Errorf("error creating RDS standby instance rebuild: workflow_id not found in the response")
+	}
+	err = checkRDSInstanceJobFinish(client, workflowID, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(instanceId)
+
+	return resourceStandbyInstanceRebuildRead(ctx, d, meta)
+}
+
+func resourceStandbyInstanceRebuildRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/rebuild"
+		product = "rds"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	instanceID := d.Id()
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving RDS standby instance rebuild")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	workflowId := utils.PathSearch("workflow_id", getRespBody, "").(string)
+	if workflowId == "" {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving RDS standby instance rebuild")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("instance_id", utils.PathSearch("instance_id", getRespBody, nil)),
+		d.Set("workflow_id", utils.PathSearch("workflow_id", getRespBody, nil)),
+		d.Set("last_rebuild_time", utils.PathSearch("last_rebuild_time", getRespBody, nil)),
+		d.Set("next_rebuild_time", utils.PathSearch("next_rebuild_time", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceStandbyInstanceRebuildUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceStandbyInstanceRebuildDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting RDS standby instance rebuild resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add rds standby instance rebuild resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add rds standby instance rebuild resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
