### PR TITLE
feat(eip): support `global_eip_segments` data source

### DIFF
--- a/docs/data-sources/global_eip_segments.md
+++ b/docs/data-sources/global_eip_segments.md
@@ -1,0 +1,156 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_global_eip_segments"
+description: |-
+  Use this data source to get the list of global EIP segments.
+---
+
+# huaweicloud_global_eip_segments
+
+Use this data source to get the list of global EIP segments.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_global_eip_segments" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `page_reverse` - (Optional, String) Specifies the page direction.  
+  The valid values are as follows:
+  + **true**: means the previous page.
+  + **false**: means the next page.
+
+* `fields` - (Optional, List) Specifies the fields to return.  
+  Supported values include **id**, **name**, **description**, **domain_id**, **access_site**, **geip_pool_name**,
+  **isp**, **ip_version**, **cidr**, **cidr_v6**, **freezen**, **freezen_info**, **status**, **created_at**,
+  **updated_at**, **internet_bandwidth**, **associate_instance**, **is_pre_paid**, and **enterprise_project_id**.
+
+* `sort_key` - (Optional, String) Specifies the sort field.
+
+* `sort_dir` - (Optional, String) Specifies the sort directions.  
+  Valid values are **asc** and **desc**.
+
+* `segment_ids` - (Optional, List) Specifies the global EIP segment IDs to filter.
+
+* `internet_bandwidth_id` - (Optional, List) Specifies the global internet bandwidth IDs to filter.
+
+* `name` - (Optional, List) Specifies the segment names to filter.
+
+* `name_like` - (Optional, String) Specifies the fuzzy name match string to filter.
+
+* `access_site` - (Optional, List) Specifies the access sites to filter.
+
+* `geip_pool_name` - (Optional, List) Specifies the global EIP pool names to filter.
+
+* `isp` - (Optional, List) Specifies the ISP lines to filter.
+
+* `ip_address` - (Optional, List) Specifies the IPv4 addresses used to match CIDR to filter.
+
+* `ipv6_address` - (Optional, List) Specifies the IPv6 addresses used to match CIDR_V6 to filter.
+
+* `ip_version` - (Optional, List) Specifies the IP versions to filter.
+
+* `cidr` - (Optional, List) Specifies the IPv4 CIDR blocks to filter.
+
+* `cidr_v6` - (Optional, List) Specifies the IPv6 CIDR blocks to filter.
+
+* `freezen` - (Optional, List) Specifies whether the segments are frozen to filter.
+
+* `internet_bandwidth_is_null` - (Optional, List) Specifies whether the segments are bound to a global internet
+  bandwidth to filter.
+
+* `status` - (Optional, List) Specifies the segment statuses to filter.  
+  The valid values are as follows:
+  + **IDLE**: The global elastic public IP is not bound to an instance.
+  + **INUSE**: Global elastic public IP in use.
+  + **FREEZED**: The global elastic public IP has been frozen.
+  + **PENDING_CREATE**: Global elastic public IP is being created.
+  + **PENDING_UPDATE**: The global elastic public IP is being updated.
+
+* `associate_instance_region` - (Optional, List) Specifies the regions of bound instances to filter.
+
+* `associate_instance_instance_type` - (Optional, List) Specifies the bound instance types to filter.
+  Valid values include **DC-CONNECT-GATEWAY** and **IPV6-DC-CONNECT-GATEWAY**.
+
+* `associate_instance_public_border_group` - (Optional, List) Specifies the public border groups of bound instances to
+  filter.
+
+* `associate_instance_instance_site` - (Optional, List) Specifies the sites of bound instances to filter.
+
+* `associate_instance_instance_id` - (Optional, List) Specifies the bound instance IDs to filter.
+
+* `associate_instance_project_id` - (Optional, List) Specifies the project IDs of bound instances to filter.
+
+* `associate_instance_service_id` - (Optional, List) Specifies the service IDs of bound instances to filter.
+
+* `associate_instance_service_type` - (Optional, List) Specifies the service types of bound instances to filter.
+
+* `enterprise_project_id` - (Optional, List) Specifies the enterprise project IDs to filter.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `global_eip_segments` - The list of global EIP segments.
+
+  The [global_eip_segments](#global_eip_segments_struct) structure is documented below.
+
+<a name="global_eip_segments_struct"></a>
+The `global_eip_segments` block supports:
+
+* `id` - The global EIP segment ID.
+
+* `name` - The segment name.
+
+* `description` - The segment description.
+
+* `domain_id` - The domain ID.
+
+* `access_site` - The access site.
+
+* `geip_pool_name` - The global EIP pool name.
+
+* `isp` - The ISP line.
+
+* `ip_version` - The IP version.
+
+* `cidr` - The IPv4 CIDR block.
+
+* `cidr_v6` - The IPv6 CIDR block.
+
+* `freezen` - Whether the segment is frozen.
+
+* `freezen_info` - The freeze information.
+
+* `status` - The segment status.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The update time.
+
+* `internet_bandwidth` - The internet bandwidth bound to the segment.
+
+  The [internet_bandwidth](#internet_bandwidth_struct) structure is documented below.
+
+* `is_pre_paid` - Whether the segment is prepaid.
+
+* `is_charged` - Whether the segment is charged.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+<a name="internet_bandwidth_struct"></a>
+The `internet_bandwidth` block supports:
+
+* `id` - The internet bandwidth ID.
+
+* `size` - The bandwidth size.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2430,6 +2430,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_global_eip_quotas":                  eip.DataSourceGlobalEipQuotas(),
 			"huaweicloud_global_eip_pools":                   eip.DataSourceGlobalEIPPools(),
 			"huaweicloud_global_eip_bindings":                eip.DataSourceGlobalEipBindings(),
+			"huaweicloud_global_eip_segments":                eip.DataSourceGlobalEipSegments(),
 			"huaweicloud_global_eip_segment_support_masks":   eip.DataSourceGlobalEipSegmentSupportMasks(),
 			"huaweicloud_global_eip_access_sites":            eip.DataSourceGlobalEIPAccessSites(),
 			"huaweicloud_global_internet_bandwidths":         eip.DataSourceGlobalInternetBandwidths(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_segments_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_segments_test.go
@@ -1,0 +1,109 @@
+package eip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGlobalEipSegments_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_global_eip_segments.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGlobalEipSegments_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "global_eip_segments.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "global_eip_segments.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "global_eip_segments.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "global_eip_segments.0.ip_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "global_eip_segments.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "global_eip_segments.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "global_eip_segments.0.updated_at"),
+
+					resource.TestCheckOutput("is_segment_ids_filter_useful", "true"),
+					resource.TestCheckOutput("is_ip_version_filter_useful", "true"),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGlobalEipSegments_basic() string {
+	return `
+data "huaweicloud_global_eip_segments" "test" {
+  page_reverse = "true"
+  sort_key     = "id"
+  sort_dir     = "asc"
+}
+
+# Filter by segment_ids.
+locals {
+  segment_id = data.huaweicloud_global_eip_segments.test.global_eip_segments[0].id
+}
+
+data "huaweicloud_global_eip_segments" "segment_ids_filter" {
+  fields      = ["id"]
+  segment_ids = [local.segment_id]
+}
+
+locals {
+  segment_ids_filter_result = [
+    for v in data.huaweicloud_global_eip_segments.segment_ids_filter.global_eip_segments[*].id : v == local.segment_id
+  ]
+}
+
+output "is_segment_ids_filter_useful" {
+  value = alltrue(local.segment_ids_filter_result) && length(local.segment_ids_filter_result) > 0
+}
+
+# Filter by ip_version.
+locals {
+  ip_version = data.huaweicloud_global_eip_segments.test.global_eip_segments[0].ip_version
+}
+
+data "huaweicloud_global_eip_segments" "ip_version_filter" {
+  ip_version = [local.ip_version]
+}
+
+locals {
+  ip_version_filter_result = [
+    for v in data.huaweicloud_global_eip_segments.ip_version_filter.global_eip_segments[*].ip_version : v == local.ip_version
+  ]
+}
+
+output "is_ip_version_filter_useful" {
+  value = alltrue(local.ip_version_filter_result) && length(local.ip_version_filter_result) > 0
+}
+
+# Filter by name.
+locals {
+  segment_name = data.huaweicloud_global_eip_segments.test.global_eip_segments[0].name
+}
+
+data "huaweicloud_global_eip_segments" "name_filter" {
+  name = [local.segment_name]
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_global_eip_segments.name_filter.global_eip_segments[*].name : v == local.segment_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = alltrue(local.name_filter_result) && length(local.name_filter_result) > 0
+}
+`
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_global_eip_segments.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_global_eip_segments.go
@@ -1,0 +1,459 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v3/{domain_id}/global-eip-segments
+func DataSourceGlobalEipSegments() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGlobalEipSegmentsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// This field is of boolean type in the API documentation,
+			// here it is modified to string to meet different scenarios.
+			"page_reverse": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+			},
+			"fields": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// The `sort_key` field in the API documentation is of type list, which is unnecessary.
+			// Here, it is modified to type string.
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// The `sort_dir` field in the API documentation is of type list, which is unnecessary.
+			// Here, it is modified to type string.
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// Named as `id` in the API documentation, now changed to `segment_ids`.
+			"segment_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"internet_bandwidth_id": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"name": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"name_like": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"access_site": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"geip_pool_name": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"isp": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"ip_address": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"ipv6_address": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"ip_version": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"cidr": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"cidr_v6": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"freezen": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeBool},
+			},
+			"internet_bandwidth_is_null": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeBool},
+			},
+			"status": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// The field name in the API document is `gcbandwidth.id`, here it is named `gcbandwidth_id`.
+			"associate_instance_region": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// The field name in the API document is `gcbandwidth.id`, here it is named `gcbandwidth_id`.
+			"associate_instance_instance_type": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// The field name in the API document is `gcbandwidth.id`, here it is named `gcbandwidth_id`.
+			"associate_instance_public_border_group": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// The field name in the API document is `gcbandwidth.id`, here it is named `gcbandwidth_id`.
+			"associate_instance_instance_site": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// The field name in the API document is `gcbandwidth.id`, here it is named `gcbandwidth_id`.
+			"associate_instance_instance_id": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// The field name in the API document is `gcbandwidth.id`, here it is named `gcbandwidth_id`.
+			"associate_instance_project_id": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// The field name in the API document is `gcbandwidth.id`, here it is named `gcbandwidth_id`.
+			"associate_instance_service_id": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// The field name in the API document is `gcbandwidth.id`, here it is named `gcbandwidth_id`.
+			"associate_instance_service_type": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// There is no explanation of the field structure for response in the API documentation.
+			// The response field in the current schema is referenced from the response example section in the API
+			// documentation.
+			// The structure of some fields is unclear, so they were discarded in the schema, such as `tags`.
+			"global_eip_segments": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"access_site": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"geip_pool_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"isp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_version": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cidr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cidr_v6": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"freezen": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"freezen_info": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internet_bandwidth": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"size": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"is_pre_paid": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_charged": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildGlobalEipSegmentsQueryParams(d *schema.ResourceData, marker string) string {
+	values := url.Values{}
+	values.Set("limit", "2000")
+
+	add := func(name string, raw interface{}, useMulti bool) {
+		if !useMulti {
+			values.Set(name, fmt.Sprint(raw))
+			return
+		}
+		if arr, ok := raw.([]interface{}); ok {
+			for _, v := range arr {
+				values.Add(name, fmt.Sprint(v))
+			}
+		}
+	}
+
+	if marker != "" {
+		values.Set("marker", marker)
+	}
+
+	type param struct {
+		key      string
+		query    string
+		useMulti bool
+	}
+	params := []param{
+		{"page_reverse", "page_reverse", false},
+		{"fields", "fields", true},
+		{"sort_key", "sort_key", false},
+		{"sort_dir", "sort_dir", false},
+		{"segment_ids", "id", true},
+		{"internet_bandwidth_id", "internet_bandwidth_id", true},
+		{"name", "name", true},
+		{"name_like", "name_like", false},
+		{"access_site", "access_site", true},
+		{"geip_pool_name", "geip_pool_name", true},
+		{"isp", "isp", true},
+		{"ip_address", "ip_address", true},
+		{"ipv6_address", "ipv6_address", true},
+		{"ip_version", "ip_version", true},
+		{"cidr", "cidr", true},
+		{"cidr_v6", "cidr_v6", true},
+		{"freezen", "freezen", true},
+		{"internet_bandwidth_is_null", "internet_bandwidth_is_null", true},
+		{"status", "status", true},
+		{"associate_instance_region", "associate_instance.region", true},
+		{"associate_instance_instance_type", "associate_instance.instance_type", true},
+		{"associate_instance_public_border_group", "associate_instance.public_border_group", true},
+		{"associate_instance_instance_site", "associate_instance.instance_site", true},
+		{"associate_instance_instance_id", "associate_instance.instance_id", true},
+		{"associate_instance_project_id", "associate_instance.project_id", true},
+		{"associate_instance_service_id", "associate_instance.service_id", true},
+		{"associate_instance_service_type", "associate_instance.service_type", true},
+		{"enterprise_project_id", "enterprise_project_id", true},
+	}
+
+	for _, p := range params {
+		if raw, ok := d.GetOk(p.key); ok {
+			add(p.query, raw, p.useMulti)
+		}
+	}
+
+	return "?" + values.Encode()
+}
+
+func dataSourceGlobalEipSegmentsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "geip"
+		httpUrl    = "v3/{domain_id}/global-eip-segments"
+		result     = make([]interface{}, 0)
+		nextMarker string
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", cfg.DomainID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithMarker := requestPath + buildGlobalEipSegmentsQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithMarker, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving global EIP segments: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		segmentsResp := utils.PathSearch("global_eip_segments", respBody, make([]interface{}, 0)).([]interface{})
+		if len(segmentsResp) == 0 {
+			break
+		}
+
+		result = append(result, segmentsResp...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("global_eip_segments", flattenGlobalEipSegments(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGlobalEipSegments(segments []interface{}) []interface{} {
+	if len(segments) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(segments))
+	for _, seg := range segments {
+		rst = append(rst, map[string]interface{}{
+			"id":             utils.PathSearch("id", seg, nil),
+			"name":           utils.PathSearch("name", seg, nil),
+			"description":    utils.PathSearch("description", seg, nil),
+			"domain_id":      utils.PathSearch("domain_id", seg, nil),
+			"access_site":    utils.PathSearch("access_site", seg, nil),
+			"geip_pool_name": utils.PathSearch("geip_pool_name", seg, nil),
+			"isp":            utils.PathSearch("isp", seg, nil),
+			"ip_version":     int(utils.PathSearch("ip_version", seg, float64(0)).(float64)),
+			"cidr":           utils.PathSearch("cidr", seg, nil),
+			"cidr_v6":        utils.PathSearch("cidr_v6", seg, nil),
+			"freezen":        utils.PathSearch("freezen", seg, false),
+			"freezen_info":   utils.PathSearch("freezen_info", seg, nil),
+			"status":         utils.PathSearch("status", seg, nil),
+			"created_at":     utils.PathSearch("created_at", seg, nil),
+			"updated_at":     utils.PathSearch("updated_at", seg, nil),
+			"internet_bandwidth": flattenGlobalEipSegmentsInternetBandwidth(
+				utils.PathSearch("internet_bandwidth", seg, nil)),
+			"is_pre_paid":           utils.PathSearch("is_pre_paid", seg, false),
+			"is_charged":            utils.PathSearch("is_charged", seg, false),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", seg, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenGlobalEipSegmentsInternetBandwidth(raw interface{}) []interface{} {
+	if raw == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"id":   utils.PathSearch("id", raw, nil),
+			"size": int(utils.PathSearch("size", raw, float64(0)).(float64)),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `global_eip_segments` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `global_eip_segments` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o eip -f TestAccDataSourceGlobalEipSegments_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccDataSourceGlobalEipSegments_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceGlobalEipSegments_basic
=== PAUSE TestAccDataSourceGlobalEipSegments_basic
=== CONT  TestAccDataSourceGlobalEipSegments_basic
--- PASS: TestAccDataSourceGlobalEipSegments_basic (12.70s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip  coverage: 3.7% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       12.827s coverage: 3.7% of statements in ./huaweicloud/services/eip
```
<img width="863" height="34" alt="image" src="https://github.com/user-attachments/assets/40c1b259-eb22-46df-8976-f47fc47197a5" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
