### PR TITLE
fix(eip): Delete the `Client-Request-Id`

### DIFF
--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip_bandwidth_rule.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip_bandwidth_rule.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -124,19 +123,13 @@ func resourceEipBandwidthRuleCreate(_ context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error creating VPC client: %s", err)
 	}
 
-	requestId, err := uuid.GenerateUUID()
-	if err != nil {
-		return diag.Errorf("unable to generate request ID: %s", err)
-	}
-
 	requestPath := client.Endpoint + httpUrl
 	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
 	requestPath = strings.ReplaceAll(requestPath, "{bandwidth_id}", bandwidthId)
 
 	opt := golangsdk.RequestOpts{
 		MoreHeaders: map[string]string{
-			"Content-Type":      "application/json",
-			"Client-Request-Id": requestId,
+			"Content-Type": "application/json",
 		},
 		KeepResponseBody: true,
 		JSONBody:         utils.RemoveNil(buildEipBandwidthRuleBodyParams(d)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Deiete the `Client-Request-Id`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Deiete the `Client-Request-Id`

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccEipBandwidthRule_basic'
...
=== RUN   TestAccEipBandwidthRule_basic
=== PAUSE TestAccEipBandwidthRule_basic
=== CONT  TestAccEipBandwidthRule_basic
--- PASS: TestAccEipBandwidthRule_basic (12.67s)
PASS
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
