### PR TITLE
feat(rfs): new datasource to query stack sets

### DIFF
--- a/docs/data-sources/rfs_stack_sets.md
+++ b/docs/data-sources/rfs_stack_sets.md
@@ -1,0 +1,83 @@
+---
+subcategory: "Resource Formation (RFS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rfs_stack_sets"
+description: |-
+  Use this data source to list all RFS stack sets.
+---
+
+# huaweicloud_rfs_stack_sets
+
+Use this data source to list all RFS stack sets.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_rfs_stack_sets" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `filter` - (Optional, String) Specifies the filter condition.
+  + The AND operator is defined by commas (,), and the OR operator is defined by vertical bars (|).
+  + The OR operator has higher priority than the AND operator.
+  + Parentheses are not supported.
+  + Only double equal signs (==) are supported for filter operators.
+  + Filter parameter names and their values only support uppercase and lowercase English letters, numbers, and underscores.
+  + Semicolons are prohibited in filter conditions. If a semicolon is present, the filter will be ignored.
+  + A filter parameter can only be associated with one AND condition, and multiple OR conditions in an AND condition can
+  only be associated with one filter parameter.
+
+* `sort_key` - (Optional, String) Specifies the sorting field, only supports **create_time**.
+
+* `sort_dir` - (Optional, String) Specifies whether to sort in ascending or descending order.
+  Valid values are:
+  + **asc**: Ascending order
+  + **desc**: Descending order
+
+* `call_identity` - (Optional, String) Specifies the identity used to call the stack set.
+  This parameter is only supported when the permission model of the stack set is **SERVICE_MANAGED**.
+  Valid values are:
+  + **SELF**: Call as a management account.
+  + **DELEGATED_ADMIN**: Call as a delegated administrator.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `stack_sets` - The list of stack sets.
+
+  The [stack_sets](#stack_sets_struct) structure is documented below.
+
+<a name="stack_sets_struct"></a>
+The `stack_sets` block supports:
+
+* `stack_set_id` - The unique ID of the stack set.
+
+* `stack_set_name` - The name of the stack set.
+
+* `stack_set_description` - The description of the stack set.
+
+* `permission_model` - The permission model of the stack set.
+  Valid values are:
+  + **SELF_MANAGED**: Self-managed mode. Users need to manually create delegations in advance.
+  + **SERVICE_MANAGED**: Service-managed mode. RFS automatically creates all required IAM delegations.
+
+* `status` - The status of the stack set.
+  Valid values are:
+  + **IDLE**: The stack set is idle.
+  + **OPERATION_IN_PROGRESS**: The stack set is in operation.
+  + **DEACTIVATED**: The stack set is deactivated.
+
+* `create_time` - The creation time of the stack set, in RFC3339 format (yyyy-mm-ddTHH:MM:SSZ),
+  such as **1970-01-01T00:00:00.000Z**.
+
+* `update_time` - The update time of the stack set, in RFC3339 format (yyyy-mm-ddTHH:MM:SSZ),
+  such as **1970-01-01T00:00:00.000Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2087,6 +2087,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rfs_stacks":                       rfs.DataSourceStacks(),
 			"huaweicloud_rfs_stack_set_operation_metadata": rfs.DataSourceStackSetOperationMetadata(),
 			"huaweicloud_rfs_stack_set_operations":         rfs.DataSourceStackSetOperations(),
+			"huaweicloud_rfs_stack_sets":                   rfs.DataSourceRfsStackSets(),
 			"huaweicloud_rfs_private_providers":            rfs.DataSourcePrivateProviders(),
 			"huaweicloud_rfs_private_provider_versions":    rfs.DataSourcePrivateProviderVersions(),
 			"huaweicloud_rfs_templates":                    rfs.DataSourceRfsTemplates(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -860,6 +860,7 @@ var (
 	HW_RFS_STACK_SET_OPERATION_ID = os.Getenv("HW_RFS_STACK_SET_OPERATION_ID")
 	HW_RFS_MODULE_NAME            = os.Getenv("HW_RFS_MODULE_NAME")
 	HW_RFS_MODULE_URI             = os.Getenv("HW_RFS_MODULE_URI")
+	HW_RFS_ENABLE_FLAG            = os.Getenv("HW_RFS_ENABLE_FLAG")
 
 	HW_DMS_KAFKA_INSTANCE_ID         = os.Getenv("HW_DMS_KAFKA_INSTANCE_ID")
 	HW_DMS_KAFKA_TOPIC_NAME          = os.Getenv("HW_DMS_KAFKA_TOPIC_NAME")
@@ -4708,6 +4709,13 @@ func TestAccPreCheckRfsModuleName(t *testing.T) {
 func TestAccPreCheckRfsModuleURI(t *testing.T) {
 	if HW_RFS_MODULE_URI == "" {
 		t.Skip("HW_RFS_MODULE_URI must be set for RFS acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckRfsEnableFlag(t *testing.T) {
+	if HW_RFS_ENABLE_FLAG == "" {
+		t.Skip("HW_RFS_ENABLE_FLAG must be set for RFS acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_stack_sets_test.go
+++ b/huaweicloud/services/acceptance/rfs/data_source_huaweicloud_rfs_stack_sets_test.go
@@ -1,0 +1,42 @@
+package rfs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRfsStackSets_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_rfs_stack_sets.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRfsEnableFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRfsStackSets_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_sets.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_sets.0.stack_set_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_sets.0.stack_set_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_sets.0.permission_model"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_sets.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_sets.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "stack_sets.0.update_time"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceRfsStackSets_basic = `
+data "huaweicloud_rfs_stack_sets" "test" {}
+`

--- a/huaweicloud/services/rfs/data_source_huaweicloud_rfs_stack_sets.go
+++ b/huaweicloud/services/rfs/data_source_huaweicloud_rfs_stack_sets.go
@@ -1,0 +1,196 @@
+package rfs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RFS GET /v1/stack-sets
+func DataSourceRfsStackSets() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRfsStackSetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"call_identity": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"stack_sets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"stack_set_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"stack_set_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"stack_set_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"permission_model": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildStackSetsQueryParams(d *schema.ResourceData, marker string) string {
+	rst := ""
+
+	if v, ok := d.GetOk("filter"); ok {
+		rst += fmt.Sprintf("&filter=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%s", v.(string))
+	}
+
+	if v, ok := d.GetOk("call_identity"); ok {
+		rst += fmt.Sprintf("&call_identity=%s", v.(string))
+	}
+
+	if marker != "" {
+		rst += fmt.Sprintf("&marker=%s", marker)
+	}
+
+	if rst != "" {
+		rst = "?" + rst[1:]
+	}
+
+	return rst
+}
+
+func dataSourceRfsStackSetsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1/stack-sets"
+		allSets    = make([]interface{}, 0)
+		nextMarker string
+	)
+
+	client, err := cfg.NewServiceClient("rfs", region)
+	if err != nil {
+		return diag.Errorf("error creating RFS client: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Client-Request-Id": uuid,
+			"Content-Type":      "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithQueryParams := requestPath + buildStackSetsQueryParams(d, nextMarker)
+		resp, err := client.Request("GET", requestPathWithQueryParams, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RFS stack sets: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		sets := utils.PathSearch("stack_sets", respBody, make([]interface{}, 0)).([]interface{})
+		if len(sets) == 0 {
+			break
+		}
+
+		allSets = append(allSets, sets...)
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("stack_sets", flattenRfsStackSets(allSets)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRfsStackSets(sets []interface{}) []interface{} {
+	if len(sets) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(sets))
+	for _, set := range sets {
+		rst = append(rst, map[string]interface{}{
+			"stack_set_id":          utils.PathSearch("stack_set_id", set, nil),
+			"stack_set_name":        utils.PathSearch("stack_set_name", set, nil),
+			"stack_set_description": utils.PathSearch("stack_set_description", set, nil),
+			"permission_model":      utils.PathSearch("permission_model", set, nil),
+			"status":                utils.PathSearch("status", set, nil),
+			"create_time":           utils.PathSearch("create_time", set, nil),
+			"update_time":           utils.PathSearch("update_time", set, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query stack sets.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o rfs -f TestAccDataSourceRfsStackSets_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rfs" -v -coverprofile="./huaweicloud/services/acceptance/rfs/rfs_coverage.cov" -coverpkg="./huaweicloud/services/rfs" -run TestAccDataSourceRfsStackSets_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceRfsStackSets_basic
=== PAUSE TestAccDataSourceRfsStackSets_basic
=== CONT  TestAccDataSourceRfsStackSets_basic
--- PASS: TestAccDataSourceRfsStackSets_basic (14.51s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/rfs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rfs       14.625s coverage: 3.9% of statements in ./huaweicloud/services/rfs
```
<img width="1303" height="81" alt="image" src="https://github.com/user-attachments/assets/e741a473-6b8f-4384-90d9-be3931330627" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
