### PR TITLE
feat(dataarts): add new data source for query the list of  table model relations

### DIFF
--- a/docs/data-sources/dataarts_architecture_table_model_relations.md
+++ b/docs/data-sources/dataarts_architecture_table_model_relations.md
@@ -1,0 +1,71 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_architecture_table_model_relations"
+description: |-
+  Use this data source to get the list of DataArts architecture table model relations.
+---
+
+# huaweicloud_dataarts_architecture_table_model_relations
+
+Use this data source to get the list of DataArts architecture table model relations.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "model_id" {}
+
+data "huaweicloud_dataarts_architecture_table_model_relations" "test" {
+  workspace_id = var.workspace_id
+  model_id     = var.model_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the table model relations are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID to which the table model belongs.
+
+* `model_id` - (Required, String) Specifies the model ID to which the table model relations belong.
+
+* `biz_type` - (Optional, String) Specifies the business type.  
+  The valid values are as follows:
+  + **TABLE_MODEL**
+  + **FACT_LOGIC_TABLE**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `relations` - The list of the table model relations matched filter parameters.  
+  The [relations](#dataarts_architecture_table_model_relation) structure is documented below.
+
+<a name="dataarts_architecture_table_model_relation"></a>
+The `relations` block supports:
+
+* `id` - The ID of the relation.
+
+* `relation_type` - The type of the relation.
+
+* `source_table_id` - The ID of the source table.
+
+* `source_table_name` - The name of the source table.
+
+* `target_table_id` - The ID of the target table.
+
+* `target_table_name` - The name of the target table.
+
+* `created_at` - The creation time of the relation, in RFC3339 format.
+
+* `updated_at` - The update time of the relation, in RFC3339 format.
+
+* `created_by` - The creator of the relation.
+
+* `updated_by` - The updater of the relation.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1083,6 +1083,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_model_statistic":                  dataarts.DataSourceArchitectureModelStatistic(),
 			"huaweicloud_dataarts_architecture_processes":                        dataarts.DataSourceArchitectureProcesses(),
 			"huaweicloud_dataarts_architecture_table_models":                     dataarts.DataSourceArchitectureTableModels(),
+			"huaweicloud_dataarts_architecture_table_model_relations":            dataarts.DataSourceArchitectureTableModelRelations(),
 			// DataArts DataService
 			"huaweicloud_dataarts_dataservice_api_authorized_apps": dataarts.DataSourceDataServiceApiAuthorizedApps(),
 			"huaweicloud_dataarts_dataservice_apis":                dataarts.DataSourceDataServiceApis(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -688,6 +688,7 @@ var (
 	HW_DATAARTS_INSTANCE_ID    = os.Getenv("HW_DATAARTS_INSTANCE_ID")
 	HW_DATAARTS_CDM_NAME       = os.Getenv("HW_DATAARTS_CDM_NAME")
 	HW_DATAARTS_MANAGER_ID     = os.Getenv("HW_DATAARTS_MANAGER_ID")
+	HW_DATAARTS_MODEL_ID       = os.Getenv("HW_DATAARTS_MODEL_ID")
 	HW_DATAARTS_BIZ_CATALOG_ID = os.Getenv("HW_DATAARTS_BIZ_CATALOG_ID")
 	HW_DATAARTS_SUBJECT_ID     = os.Getenv("HW_DATAARTS_SUBJECT_ID")
 	// Architecture
@@ -4035,6 +4036,13 @@ func TestAccPreCheckDataArtsDataServiceApigInstanceId(t *testing.T) {
 func TestAccPreCheckDataArtsManagerID(t *testing.T) {
 	if HW_DATAARTS_MANAGER_ID == "" {
 		t.Skip("This environment does not support DataArts Studio permission set tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDataArtsModelID(t *testing.T) {
+	if HW_DATAARTS_MODEL_ID == "" {
+		t.Skip("HW_DATAARTS_MODEL_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_table_model_relations_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_table_model_relations_test.go
@@ -1,0 +1,70 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataArchitectureTableModelRelations_basic(t *testing.T) {
+	var (
+		dcName = "data.huaweicloud_dataarts_architecture_table_model_relations.test"
+		all    = acceptance.InitDataSourceCheck(dcName)
+
+		byBizTypeNotFound   = "data.huaweicloud_dataarts_architecture_table_model_relations.filter_by_biz_not_found"
+		dcbyBizTypeNotFound = acceptance.InitDataSourceCheck(byBizTypeNotFound)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsModelID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataArchitectureTableModelRelations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					all.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dcName, "relations.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dcName, "relations.#"),
+					resource.TestCheckResourceAttrSet(dcName, "relations.0.id"),
+					resource.TestCheckResourceAttrSet(dcName, "relations.0.source_table_id"),
+					resource.TestCheckResourceAttrSet(dcName, "relations.0.source_table_name"),
+					resource.TestCheckResourceAttrSet(dcName, "relations.0.target_table_id"),
+					resource.TestCheckResourceAttrSet(dcName, "relations.0.target_table_name"),
+					resource.TestCheckResourceAttrSet(dcName, "relations.0.created_at"),
+					resource.TestCheckResourceAttrSet(dcName, "relations.0.updated_at"),
+					dcbyBizTypeNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_biz_type_filter_useful_not_found", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataArchitectureTableModelRelations_basic() string {
+	return fmt.Sprintf(`
+# Query all relations and without any filter
+data "huaweicloud_dataarts_architecture_table_model_relations" "test" {
+  workspace_id = "%[1]s"
+  model_id     = "%[2]s"
+}
+
+# Test filter by biz type not found
+data "huaweicloud_dataarts_architecture_table_model_relations" "filter_by_biz_not_found" {
+  workspace_id = "%[1]s"
+  model_id     = "%[2]s"
+  biz_type     = "FACT_LOGIC_TABLE"
+}
+
+output "is_biz_type_filter_useful_not_found" {
+  value = length(data.huaweicloud_dataarts_architecture_table_model_relations.filter_by_biz_not_found.relations) == 0
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_MODEL_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_table_model_relations.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_table_model_relations.go
@@ -1,0 +1,219 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/design/{model_id}/table-model/relation
+func DataSourceArchitectureTableModelRelations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceArchitectureTableModelRelationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the table model relations are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The workspace ID to which the table model belongs.`,
+			},
+			"model_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The model ID to which the table model relations belong.`,
+			},
+
+			// Optional parameters.
+			"biz_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The business type.`,
+			},
+
+			// Attributes.
+			"relations": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        architectureTableModelRelationSchema(),
+				Description: `The list of the table model relations matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func architectureTableModelRelationSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the relation.`,
+			},
+			"relation_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the relation.`,
+			},
+			"source_table_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the source table.`,
+			},
+			"source_table_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the source table.`,
+			},
+			"target_table_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the target table.`,
+			},
+			"target_table_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the target table.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the relation, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the relation, in RFC3339 format.`,
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the relation.`,
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The updater of the relation.`,
+			},
+		},
+	}
+}
+
+func buildArchitectureTableModelRelationsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("biz_type"); ok {
+		res = fmt.Sprintf("%s&biz_type=%v", res, v)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+
+	return res
+}
+
+func listArchitectureTableModelRelations(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/design/{model_id}/table-model/relation"
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{model_id}", d.Get("model_id").(string))
+	listPath += buildArchitectureTableModelRelationsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildArchitectureMoreHeaders(d.Get("workspace_id").(string)),
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	records := utils.PathSearch("data.value.records", respBody, make([]interface{}, 0)).([]interface{})
+	for _, record := range records {
+		relations := utils.PathSearch("relations", record, make([]interface{}, 0)).([]interface{})
+		result = append(result, relations...)
+	}
+
+	return result, nil
+}
+
+func flattenArchitectureTableModelRelations(relations []interface{}) []interface{} {
+	if len(relations) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(relations))
+	for _, relation := range relations {
+		result = append(result, map[string]interface{}{
+			"id":                utils.PathSearch("id", relation, nil),
+			"relation_type":     utils.PathSearch("relation_type", relation, nil),
+			"source_table_id":   utils.PathSearch("source_table_id", relation, nil),
+			"source_table_name": utils.PathSearch("source_table_name", relation, nil),
+			"target_table_id":   utils.PathSearch("target_table_id", relation, nil),
+			"target_table_name": utils.PathSearch("target_table_name", relation, nil),
+			"created_at":        utils.PathSearch("create_time", relation, nil),
+			"updated_at":        utils.PathSearch("update_time", relation, nil),
+			"created_by":        utils.PathSearch("create_by", relation, nil),
+			"updated_by":        utils.PathSearch("update_by", relation, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceArchitectureTableModelRelationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	relations, err := listArchitectureTableModelRelations(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("relations", flattenArchitectureTableModelRelations(relations)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source to query the list of table model relations.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
Since relationship resources cannot be created, it is necessary to import model resources from external sources that already have relationship resources established.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataArchitectureTableModelRelations_basic -timeout 360m -parallel 10
=== RUN   TestAccDataArchitectureTableModelRelations_basic
=== PAUSE TestAccDataArchitectureTableModelRelations_basic
=== CONT  TestAccDataArchitectureTableModelRelations_basic
--- PASS: TestAccDataArchitectureTableModelRelations_basic (13.41s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  13.713s coverage: 3.9% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.