### PR TITLE
feat(RDS): rds instance support delete backup seletion

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -324,6 +324,11 @@ The following arguments are supported:
   + **EBACKUP**: CBR snapshot backup
   + **PHYSICALBACKUP**: physical backup(OBS)
 
+* `delete_backup_selection` - (Optional, String) Specifies whether to retain automated backups when deleting an instance.
+  Value options:
+  + **true**: Retain automated backups.
+  + **false**: Delete automated backups.
+
 The `db` block supports:
 
 * `type` - (Required, String, ForceNew) Specifies the DB engine. Available value are **MySQL**, **PostgreSQL**,
@@ -510,16 +515,16 @@ This resource provides the following timeouts configuration options:
 RDS instance can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_rds_instance.instance_1 <id>
+$ terraform import huaweicloud_rds_instance.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `db`, `restore`,`param_group_id`,
 `power_action`, `read_write_permissions`, `rotate_day`, `secret_id`, `secret_name`, `secret_version`,
 `dss_pool_id`, `lower_case_table_names`, `slow_log_show_original_status`, `charging_mode`, `period_unit`, `period`,
-`auto_renew`, `auto_pay`, `is_flexus`, `default_backup_method`. It is generally recommended running `terraform plan`
-after importing a RDS instance. You can then decide if changes should be applied to the instance, or the resource
-definition should be updated to align with the instance. Also, you can ignore changes as below.
+`auto_renew`, `auto_pay`, `is_flexus`, `default_backup_method`, `delete_backup_selection`. It is generally recommended
+running `terraform plan` after importing a RDS instance. You can then decide if changes should be applied to the
+instance, or the resource definition should be updated to align with the instance. Also, you can ignore changes as below.
 
 ```hcl
 resource "huaweicloud_rds_instance" "instance_1" {
@@ -529,7 +534,8 @@ resource "huaweicloud_rds_instance" "instance_1" {
     ignore_changes = [
       "db", "restore", "param_group_id", "power_action", "read_write_permissions", "rotate_day",
       "secret_id", "secret_name", "secret_version", "dss_pool_id", "lower_case_table_names", "slow_log_show_original_status",
-      "charging_mode", "period_unit", "period", "auto_renew", "auto_pay", "is_flexus", "default_backup_method"
+      "charging_mode", "period_unit", "period", "auto_renew", "auto_pay", "is_flexus", "default_backup_method",
+      "delete_backup_selection"
     ]
   }
 }

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1985,6 +1985,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ram_resource_instances_filter":             ram.DataSourceResourceInstancesFilter(),
 			"huaweicloud_ram_resource_instances_count":              ram.DataSourceResourceInstancesCount(),
 
+			"huaweicloud_rds_flavors":                            rds.DataSourceRdsFlavors(),
 			"huaweicloud_rds_available_flavors":                  rds.DataSourceRdsAvailableFlavors(),
 			"huaweicloud_rds_available_upgrade_small_versions":   rds.DataSourceAvailableUpgradeSmallVersions(),
 			"huaweicloud_rds_engine_versions":                    rds.DataSourceRdsEngineVersionsV3(),

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -1141,13 +1141,14 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
-  depends_on        = [huaweicloud_networking_secgroup_rule.ingress]
-  name              = "%[2]s"
-  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
-  tde_enabled       = true
+  depends_on              = [huaweicloud_networking_secgroup_rule.ingress]
+  name                    = "%[2]s"
+  flavor                  = data.huaweicloud_rds_flavors.test.flavors[0].name
+  security_group_id       = data.huaweicloud_networking_secgroup.test.id
+  subnet_id               = data.huaweicloud_vpc_subnet.test.id
+  vpc_id                  = data.huaweicloud_vpc.test.id
+  tde_enabled             = true
+  delete_backup_selection = false
 
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0],
@@ -1188,12 +1189,14 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
-  depends_on        = [huaweicloud_networking_secgroup_rule.ingress]
-  name              = "%[2]s"
-  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
+  depends_on              = [huaweicloud_networking_secgroup_rule.ingress]
+  name                    = "%[2]s"
+  flavor                  = data.huaweicloud_rds_flavors.test.flavors[0].name
+  security_group_id       = data.huaweicloud_networking_secgroup.test.id
+  subnet_id               = data.huaweicloud_vpc_subnet.test.id
+  vpc_id                  = data.huaweicloud_vpc.test.id
+  collation               = "Chinese_PRC_CI_AI"
+  delete_backup_selection = true
 
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0],
@@ -1207,7 +1210,7 @@ resource "huaweicloud_rds_instance" "test" {
   }
 
   volume {
-    type = "ULTRAHIGH"
+    type = "CLOUDSSD"
     size = 40
   }
 }

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
@@ -397,6 +397,11 @@ func ResourceRdsInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"delete_backup_selection": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+			},
 			"tags": common.TagsSchema(),
 			"time_zone": {
 				Type:     schema.TypeString,
@@ -733,6 +738,12 @@ func resourceRdsInstanceCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	if _, ok := d.GetOk("default_backup_method"); ok {
 		if err = updateDefaultBackupMethod(ctx, d, client); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if _, ok := d.GetOk("delete_backup_selection"); ok {
+		if err = updateDeleteBackupSelection(ctx, d, client); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -1459,6 +1470,10 @@ func resourceRdsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if err = updateDefaultBackupMethod(ctx, d, client); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err = updateDeleteBackupSelection(ctx, d, client); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -2466,6 +2481,32 @@ func updateDefaultBackupMethod(ctx context.Context, d *schema.ResourceData, clie
 func buildDefaultBackupMethodBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"default_backup_method": d.Get("default_backup_method"),
+	}
+	return bodyParams
+}
+
+func updateDeleteBackupSelection(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	if !d.HasChange("delete_backup_selection") {
+		return nil
+	}
+
+	_, err := updateRdsInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:          "v3/{project_id}/instances/{instance_id}/backups/delete-selection",
+		httpMethod:       "POST",
+		pathParams:       map[string]string{"instance_id": d.Id()},
+		updateBodyParams: buildDeleteBackupSelectionBodyParams(d),
+	})
+	if err != nil {
+		return fmt.Errorf("error updating instance(%s) delete backup selection: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func buildDeleteBackupSelectionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	deleteBackupSelection, _ := strconv.ParseBool(d.Get("delete_backup_selection").(string))
+	bodyParams := map[string]interface{}{
+		"selection": deleteBackupSelection,
 	}
 	return bodyParams
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance support delete backup seletion
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance support delete backup seletion
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_basic
--- PASS: TestAccRdsInstance_basic (1214.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1214.739s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_sqlserver'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_sqlserver -timeout 360m -parallel 4
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_sqlserver
--- PASS: TestAccRdsInstance_sqlserver (2665.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2665.573s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
