### PR TITLE
feat(drs): add drs drivers datasource

### DIFF
--- a/docs/data-sources/drs_drivers.md
+++ b/docs/data-sources/drs_drivers.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_drivers"
+description: |-
+  Use this data source to get the list of driver files for DRS within HuaweiCloud.
+---
+
+# huaweicloud_drs_drivers
+
+Use this data source to get the list of driver files for DRS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "driver_type" {}
+
+data "huaweicloud_drs_drivers" "test" {
+  driver_type = var.driver_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `driver_type` - (Required, String) Specifies the type of the driver file to be queried.
+  The valid values are as follows:
+  + **db2**: DB2 for LUW.
+  + **informix**: Informix.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `items` - The list of driver file details.
+
+  The [items](#items) structure is documented below.
+
+<a name="items"></a>
+The `items` block supports:
+
+* `driver_name` - The name of the driver file.
+
+* `last_modified` - The last modification time of the driver file.
+
+* `size` - The size of the driver file, in bytes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1310,6 +1310,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_node_types":         drs.DataSourceNodeTypes(),
 			"huaweicloud_drs_subscriptions":      drs.DataSourceDrsSubscriptions(),
 			"huaweicloud_drs_job_configurations": drs.DataSourceDrsJobConfigurations(),
+			"huaweicloud_drs_drivers":            drs.DataSourceDrsDrivers(),
 
 			// EventGrid
 			"huaweicloud_eg_connections":           eg.DataSourceConnections(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_drivers_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_drivers_test.go
@@ -1,0 +1,36 @@
+package drs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsDrivers_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_drs_drivers.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDrsDrivers_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "items.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceDrsDrivers_basic = `
+data "huaweicloud_drs_drivers" "test" {
+  driver_type = "db2"
+}
+`

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_drivers.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_drivers.go
@@ -1,0 +1,144 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v5/{project_id}/drivers
+func DataSourceDrsDrivers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsDriversRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"driver_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"driver_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"last_modified": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildDriversQueryParams(d *schema.ResourceData, offset int) string {
+	queryParams := fmt.Sprintf("driver_type=%s", d.Get("driver_type").(string))
+
+	if offset > 0 {
+		queryParams += fmt.Sprintf("&offset=%d", offset)
+	}
+
+	return queryParams
+}
+
+func dataSourceDrsDriversRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v5/{project_id}/drivers"
+		result  = make([]interface{}, 0)
+		offset  = 0
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		queryParams := buildDriversQueryParams(d, offset)
+		currentListPath := fmt.Sprintf("%s?%s", listPath, queryParams)
+
+		listResp, err := client.Request("GET", currentListPath, &reqOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DRS drivers data: %s", err)
+		}
+		listRespBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		drivers := utils.PathSearch("items", listRespBody, make([]interface{}, 0)).([]interface{})
+
+		if len(drivers) == 0 {
+			break
+		}
+
+		result = append(result, drivers...)
+
+		offset += len(drivers)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("items", flattenDrivers(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDrivers(driversResp []interface{}) []interface{} {
+	if len(driversResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(driversResp))
+	for _, v := range driversResp {
+		rst = append(rst, map[string]interface{}{
+			"driver_name":   utils.PathSearch("driver_name", v, nil),
+			"last_modified": utils.PathSearch("last_modified", v, nil),
+			"size":          utils.PathSearch("size", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a new data source huaweicloud_drs_drivers for HuaweiCloud Data Replication Service (DRS), which allows users to query the list of driver files supported by DRS. This is essential for database migration scenarios where users need to verify available driver versions and details before creating migration jobs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add data source huaweicloud_drs_drivers to support querying DRS driver files
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/drs' TESTARGS='-run=TestAccDataSourceDrsDrivers_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run=TestAccDataSourceDrsDrivers_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDrsDrivers_basic
=== PAUSE TestAccDataSourceDrsDrivers_basic
=== CONT  TestAccDataSourceDrsDrivers_basic
--- PASS: TestAccDataSourceDrsDrivers_basic (26.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       26.640s
```
<img width="438" height="21" alt="Snipaste_2026-05-13_10-33-59" src="https://github.com/user-attachments/assets/e3322f02-5bc5-4692-8b95-ef716064d002" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
