### PR TITLE
refactor: feat(modelarts): network resource supports associate SFS turbos

### DIFF
--- a/docs/resources/modelarts_network.md
+++ b/docs/resources/modelarts_network.md
@@ -8,16 +8,22 @@ description: ""
 # huaweicloud_modelarts_network
 
 Manages a Modelarts network resource within HuaweiCloud.  
-A maximum of 15 networks can be created.
 
 ## Example Usage
 
 ```hcl
-variable "cidr" {}
+variable "network_name" {}
+variable "peering_vpc_id" {}
+variable "peering_subnet_id" {}
 
 resource "huaweicloud_modelarts_network" "test" {
-  name = "demo"
-  cidr = var.cidr
+  name = var.network_name
+  cidr = "10.168.0.0/16"
+
+  peer_connections {
+    vpc_id    = var.peering_vpc_id
+    subnet_id = var.peering_subnet_id
+  }
 }
 ```
 
@@ -25,45 +31,39 @@ resource "huaweicloud_modelarts_network" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+* `region` - (Optional, String, ForceNew) Specifies the region where the network is located.  
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `name` - (Required, String, ForceNew) The name of network.  
-  The name can contain `4` to `32` characters, only lowercase letters, digits and hyphens (-) are allowed.
+* `name` - (Required, String, NonUpdatable) Specifies the name of the network.  
+  The valid value is limited from `4` to `32`, only lowercase letters, digits and hyphens (-) are allowed.
   The name must start with a lowercase letter and end with a lowercase letter or digit.
 
-  Changing this parameter will create a new resource.
+* `cidr` - (Required, String, NonUpdatable) Specifies the CIDR of the network.  
+  It's recommand to configure CIDR block as following ranges:
+  + **10.0.0.0/8-24**
+  + **172.16.0.0/12-24**
+  + **192.168.0.0/16-24**
 
-* `cidr` - (Required, String, ForceNew) Network CIDR.
-  Valid CIDR blocks are 10.0.0.0/8-24, 172.16.0.0/12-24, and 192.168.0.0/16-24.  
+* `workspace_id` - (Optional, String, NonUpdatable) Specifies the ID of the workspace to which the network belongs.  
+  Defaults to **0** (default workspace).  
 
-  Changing this parameter will create a new resource.
+* `peer_connections` - (Optional, List) Specifies the list of networks that can be connected in peering mode.  
+The [peer_connections](#modelarts_network_peer_connections) structure is documented below.
 
-* `workspace_id` - (Optional, String, ForceNew) Workspace ID, which defaults to 0.  
-
-  Changing this parameter will create a new resource.
-
-* `peer_connections` - (Optional, List) List of networks that can be connected in peer mode.
-The [peer_connections](#ModelartsNetwork_PeerConnection) structure is documented below.
-
-<a name="ModelartsNetwork_PeerConnection"></a>
+<a name="modelarts_network_peer_connections"></a>
 The `peer_connections` block supports:
 
-* `vpc_id` - (Required, String) Interconnect VPC ID.  
+* `vpc_id` - (Required, String) Specifies the ID of the VPC to which the peering connection belongs.
 
-* `subnet_id` - (Required, String) Interconnect subnet ID.  
+* `subnet_id` - (Required, String) Specifies the ID of the subnet to which the peering connection belongs.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The resource ID.
+* `id` - The resource ID, the format is **{name}-{project_id}**.
 
-* `status` - The status of network.  
-  Value options are as follows:
-    + **Creating**: The network is being created.
-    + **Active**: The network is available.
-    + **Abnormal**: The network is in an error state.
+* `status` - The status of the network.
 
 ## Timeouts
 
@@ -75,8 +75,8 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-The modelarts network can be imported using the `id`, e.g.
+The network can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_modelarts_network.test 0ce123456a00f2591fabc00385ff1234
+$ terraform import huaweicloud_modelarts_network.test <id>
 ```

--- a/docs/resources/modelarts_network.md
+++ b/docs/resources/modelarts_network.md
@@ -2,7 +2,8 @@
 subcategory: "AI Development Platform (ModelArts)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_modelarts_network"
-description: ""
+description: |-
+  Manages a Modelarts network resource within HuaweiCloud.  
 ---
 
 # huaweicloud_modelarts_network
@@ -39,7 +40,7 @@ The following arguments are supported:
   The name must start with a lowercase letter and end with a lowercase letter or digit.
 
 * `cidr` - (Required, String, NonUpdatable) Specifies the CIDR of the network.  
-  It's recommand to configure CIDR block as following ranges:
+  It's recommanded to configure CIDR block as following ranges:
   + **10.0.0.0/8-24**
   + **172.16.0.0/12-24**
   + **192.168.0.0/16-24**
@@ -47,8 +48,12 @@ The following arguments are supported:
 * `workspace_id` - (Optional, String, NonUpdatable) Specifies the ID of the workspace to which the network belongs.  
   Defaults to **0** (default workspace).  
 
-* `peer_connections` - (Optional, List) Specifies the list of networks that can be connected in peering mode.  
-The [peer_connections](#modelarts_network_peer_connections) structure is documented below.
+* `peer_connections` - (Optional, List) Specifies the list of peering connections that can be connected to the
+  network.  
+  The [peer_connections](#modelarts_network_peer_connections) structure is documented below.
+
+* `sfs_turbos` - (Optional, List) Specifies the list of SFS Turbos that can be connected to the network.  
+  The [sfs_turbos](#modelarts_network_sfs_turbos) structure is documented below.
 
 <a name="modelarts_network_peer_connections"></a>
 The `peer_connections` block supports:
@@ -57,6 +62,13 @@ The `peer_connections` block supports:
 
 * `subnet_id` - (Required, String) Specifies the ID of the subnet to which the peering connection belongs.
 
+<a name="modelarts_network_sfs_turbos"></a>
+The `sfs_turbos` block supports:
+
+* `id` - (Required, String) Specifies the ID of the SFS Turbo to be associated.
+
+* `name` - (Required, String) Specifies the name of the SFS Turbo to be associated.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -64,6 +76,8 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The resource ID, the format is **{name}-{project_id}**.
 
 * `status` - The status of the network.
+
+* `subnet_id` - The ID of the subnet which the network is associated.
 
 ## Timeouts
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3913,7 +3913,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_devserver":                       modelarts.ResourceDevServer(),
 			"huaweicloud_modelarts_devserver_action":                modelarts.ResourceDevServerAction(),
 			"huaweicloud_modelarts_model":                           modelarts.ResourceModelartsModel(),
-			"huaweicloud_modelarts_network":                         modelarts.ResourceModelartsNetwork(),
+			"huaweicloud_modelarts_network":                         modelarts.ResourceNetwork(),
 			"huaweicloud_modelarts_notebook":                        modelarts.ResourceNotebook(),
 			"huaweicloud_modelarts_notebook_mount_storage":          modelarts.ResourceNotebookMountStorage(),
 			"huaweicloud_modelarts_resource_pool":                   modelarts.ResourceModelartsResourcePool(),

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_network_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_network_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
 )
 
@@ -38,36 +37,76 @@ func TestAccNetwork_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
+				// Create a network and with two SFS Turbo connections.
 				Config: testAccNetwork_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "cidr", "10.168.0.0/16"),
-					resource.TestCheckResourceAttr(rName, "status", "Active"),
+					resource.TestCheckResourceAttr(rName, "workspace_id", "0"),
 					resource.TestCheckResourceAttr(rName, "peer_connections.#", "0"),
+					resource.TestCheckResourceAttr(rName, "sfs_turbos.#", "2"),
+					resource.TestCheckResourceAttrPair(rName, "sfs_turbos.0.name",
+						"huaweicloud_sfs_turbo.test.0", "name"),
+					resource.TestCheckResourceAttrPair(rName, "sfs_turbos.0.id",
+						"huaweicloud_sfs_turbo.test.0", "id"),
+					resource.TestCheckResourceAttrPair(rName, "sfs_turbos.1.name",
+						"huaweicloud_sfs_turbo.test.1", "name"),
+					resource.TestCheckResourceAttrPair(rName, "sfs_turbos.1.id",
+						"huaweicloud_sfs_turbo.test.1", "id"),
+					resource.TestCheckResourceAttr(rName, "status", "Active"),
+					resource.TestCheckResourceAttrSet(rName, "subnet_id"),
 				),
 			},
 			{
-				Config: testAccNetwork_basic_step2(name), // add a connection
+				// Associate two peering connections and change the first associated SFS Turbo connection to another.
+				Config: testAccNetwork_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "cidr", "10.168.0.0/16"),
-					resource.TestCheckResourceAttr(rName, "status", "Active"),
+					resource.TestCheckResourceAttr(rName, "workspace_id", "0"),
+					resource.TestCheckResourceAttr(rName, "peer_connections.#", "2"),
 					resource.TestCheckResourceAttrPair(rName, "peer_connections.0.vpc_id",
-						"huaweicloud_vpc.test", "id"),
+						"huaweicloud_vpc.test.0", "id"),
 					resource.TestCheckResourceAttrPair(rName, "peer_connections.0.subnet_id",
-						"huaweicloud_vpc_subnet.test", "id"),
+						"huaweicloud_vpc_subnet.test.0", "id"),
+					resource.TestCheckResourceAttrPair(rName, "peer_connections.1.vpc_id",
+						"huaweicloud_vpc.test.1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "peer_connections.1.subnet_id",
+						"huaweicloud_vpc_subnet.test.1", "id"),
+					resource.TestCheckResourceAttr(rName, "sfs_turbos.#", "2"),
+					resource.TestCheckResourceAttrPair(rName, "sfs_turbos.0.name",
+						"huaweicloud_sfs_turbo.test.2", "name"),
+					resource.TestCheckResourceAttrPair(rName, "sfs_turbos.0.id",
+						"huaweicloud_sfs_turbo.test.2", "id"),
+					resource.TestCheckResourceAttrPair(rName, "sfs_turbos.1.name",
+						"huaweicloud_sfs_turbo.test.1", "name"),
+					resource.TestCheckResourceAttrPair(rName, "sfs_turbos.1.id",
+						"huaweicloud_sfs_turbo.test.1", "id"),
+					resource.TestCheckResourceAttr(rName, "status", "Active"),
+					resource.TestCheckResourceAttrSet(rName, "subnet_id"),
 				),
 			},
 			{
-				Config: testAccNetwork_basic_step3(name), // remove a connection
+				// Remove all SFS Turbo connections and change the first associated peering connection to another.
+				Config: testAccNetwork_basic_step3(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "cidr", "10.168.0.0/16"),
+					resource.TestCheckResourceAttr(rName, "workspace_id", "0"),
+					resource.TestCheckResourceAttr(rName, "peer_connections.#", "2"),
+					resource.TestCheckResourceAttrPair(rName, "peer_connections.0.vpc_id",
+						"huaweicloud_vpc.test.2", "id"),
+					resource.TestCheckResourceAttrPair(rName, "peer_connections.0.subnet_id",
+						"huaweicloud_vpc_subnet.test.2", "id"),
+					resource.TestCheckResourceAttrPair(rName, "peer_connections.1.vpc_id",
+						"huaweicloud_vpc.test.1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "peer_connections.1.subnet_id",
+						"huaweicloud_vpc_subnet.test.1", "id"),
+					resource.TestCheckResourceAttr(rName, "sfs_turbos.#", "0"),
 					resource.TestCheckResourceAttr(rName, "status", "Active"),
-					resource.TestCheckResourceAttr(rName, "peer_connections.#", "0"),
 				),
 			},
 			{
@@ -79,21 +118,125 @@ func TestAccNetwork_basic(t *testing.T) {
 	})
 }
 
+func testAccNetwork_basic_base(name string) string {
+	return fmt.Sprintf(`
+variable "enterprise_project_id" {
+  default = "%[1]s"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_vpc" "test" {
+  count = 3
+
+  name                  = format("%[2]s-%%d", count.index)
+  cidr                  = cidrsubnet("192.168.0.0/16", 2, count.index) # 192.168.0.0/18, 192.168.128.0/18, 192.168.192.0/18
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  count = 3
+
+  name       = format("%[2]s-%%d", count.index)
+  vpc_id     = huaweicloud_vpc.test[count.index].id
+  cidr       = cidrsubnet(huaweicloud_vpc.test[count.index].cidr, 6, 0)              # 192.168.0.0/24, 192.168.128.0/24, 192.168.192.0/24
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test[count.index].cidr, 6, 0), 1) # 192.168.0.1, 192.168.128.1, 192.168.192.1
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name                 = "%[2]s"
+  delete_default_rules = true
+}
+
+# Make sure open the full ingress access for 111, 2048, 2049, 2051, 2052 and 20048 ports and about TCP and UDP protocols.
+resource "huaweicloud_networking_secgroup_rule" "tcp_ingress_access" {
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  ports             = "111,2048,2049,2051,2052,20048"
+}
+
+resource "huaweicloud_networking_secgroup_rule" "udp_ingress_access" {
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  ports             = "111,2048,2049,2051,2052,20048"
+}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  depends_on = [
+    huaweicloud_networking_secgroup_rule.tcp_ingress_access,
+    huaweicloud_networking_secgroup_rule.udp_ingress_access,
+  ]
+
+  count = 3
+
+  name                  = format("%[2]s-%%d", count.index)
+  size                  = 1228
+  share_proto           = "NFS"
+  share_type            = "HPC"
+  hpc_bandwidth         = "40M"
+  vpc_id                = huaweicloud_vpc.test[count.index].id
+  subnet_id             = huaweicloud_vpc_subnet.test[count.index].id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+}
+
 func testAccNetwork_basic_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_modelarts_network" "test" {
-  # Network deletion will delete the peer connection, so the subnet can be deleted after the network is deleted.
-  depends_on = [huaweicloud_vpc_subnet.test]
-
   name = "%[2]s"
   cidr = "10.168.0.0/16" # The recommended connecting CIDR about SFS Turbo.
+
+  dynamic "sfs_turbos" {
+    for_each = slice(huaweicloud_sfs_turbo.test, 0, 2)
+
+    content {
+      name = sfs_turbos.value.name
+      id   = sfs_turbos.value.id
+    }
+  }
 }
-`, common.TestVpc(name), name)
+`, testAccNetwork_basic_base(name), name)
 }
 
 func testAccNetwork_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelarts_network" "test" {
+  name = "%[2]s"
+  cidr = "10.168.0.0/16" # The recommended connecting CIDR about SFS Turbo.
+
+  dynamic "peer_connections" {
+    for_each = slice(huaweicloud_vpc_subnet.test, 0, 2)
+
+    content {
+      vpc_id    = peer_connections.value.vpc_id
+      subnet_id = peer_connections.value.id
+    }
+  }
+
+  dynamic "sfs_turbos" {
+    for_each = [element(huaweicloud_sfs_turbo.test, 2), element(huaweicloud_sfs_turbo.test, 1)] # Reverse traversal.
+
+    content {
+      name = sfs_turbos.value.name
+      id   = sfs_turbos.value.id
+    }
+  }
+}
+`, testAccNetwork_basic_base(name), name)
+}
+
+func testAccNetwork_basic_step3(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -103,14 +246,14 @@ resource "huaweicloud_modelarts_network" "test" {
   name = "%[2]s"
   cidr = "10.168.0.0/16"
 
-  peer_connections {
-    vpc_id    = huaweicloud_vpc.test.id
-    subnet_id = huaweicloud_vpc_subnet.test.id
+  dynamic "peer_connections" {
+    for_each = [element(huaweicloud_vpc_subnet.test, 2), element(huaweicloud_vpc_subnet.test, 1)] # Reverse traversal.
+
+    content {
+      vpc_id    = peer_connections.value.vpc_id
+      subnet_id = peer_connections.value.id
+    }
   }
 }
-`, common.TestVpc(name), name)
-}
-
-func testAccNetwork_basic_step3(name string) string {
-	return testAccNetwork_basic_step1(name)
+`, testAccNetwork_basic_base(name), name)
 }

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_network_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_network_test.go
@@ -2,67 +2,34 @@ package modelarts
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
 )
 
-func getModelartsNetworkResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	region := acceptance.HW_REGION_NAME
-	// getModelartsNetwork: Query the Modelarts network.
-	var (
-		getModelartsNetworkHttpUrl = "v1/{project_id}/networks/{id}"
-		getModelartsNetworkProduct = "modelarts"
-	)
-	getModelartsNetworkClient, err := cfg.NewServiceClient(getModelartsNetworkProduct, region)
+func getNetworkResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("modelarts", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	getModelartsNetworkPath := getModelartsNetworkClient.Endpoint + getModelartsNetworkHttpUrl
-	getModelartsNetworkPath = strings.ReplaceAll(getModelartsNetworkPath, "{project_id}", getModelartsNetworkClient.ProjectID)
-	getModelartsNetworkPath = strings.ReplaceAll(getModelartsNetworkPath, "{id}", state.Primary.ID)
-
-	getModelartsNetworkOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
-	}
-
-	getModelartsNetworkResp, err := getModelartsNetworkClient.Request("GET", getModelartsNetworkPath, &getModelartsNetworkOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving Modelarts network: %s", err)
-	}
-
-	getModelartsNetworkRespBody, err := utils.FlattenResponse(getModelartsNetworkResp)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving Modelarts network: %s", err)
-	}
-
-	return getModelartsNetworkRespBody, nil
+	return modelarts.GetNetworkById(client, state.Primary.ID)
 }
 
-func TestAccModelartsNetwork_basic(t *testing.T) {
-	var obj interface{}
+func TestAccNetwork_basic(t *testing.T) {
+	var (
+		obj interface{}
 
-	name := acceptance.RandomAccResourceNameWithDash()
-	rName := "huaweicloud_modelarts_network.test"
+		rName = "huaweicloud_modelarts_network.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getNetworkResourceFunc)
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getModelartsNetworkResourceFunc,
+		name = acceptance.RandomAccResourceNameWithDash()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -71,21 +38,21 @@ func TestAccModelartsNetwork_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testModelartsNetwork_basic(name),
+				Config: testAccNetwork_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "cidr", "192.168.20.0/24"),
+					resource.TestCheckResourceAttr(rName, "cidr", "10.168.0.0/16"),
 					resource.TestCheckResourceAttr(rName, "status", "Active"),
 					resource.TestCheckResourceAttr(rName, "peer_connections.#", "0"),
 				),
 			},
 			{
-				Config: testModelartsNetwork_basic_update(name), // add a connection
+				Config: testAccNetwork_basic_step2(name), // add a connection
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "cidr", "192.168.20.0/24"),
+					resource.TestCheckResourceAttr(rName, "cidr", "10.168.0.0/16"),
 					resource.TestCheckResourceAttr(rName, "status", "Active"),
 					resource.TestCheckResourceAttrPair(rName, "peer_connections.0.vpc_id",
 						"huaweicloud_vpc.test", "id"),
@@ -94,11 +61,11 @@ func TestAccModelartsNetwork_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testModelartsNetwork_basic(name), // remove a connection
+				Config: testAccNetwork_basic_step3(name), // remove a connection
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "cidr", "192.168.20.0/24"),
+					resource.TestCheckResourceAttr(rName, "cidr", "10.168.0.0/16"),
 					resource.TestCheckResourceAttr(rName, "status", "Active"),
 					resource.TestCheckResourceAttr(rName, "peer_connections.#", "0"),
 				),
@@ -112,33 +79,38 @@ func TestAccModelartsNetwork_basic(t *testing.T) {
 	})
 }
 
-func testModelartsNetwork_basic(name string) string {
+func testAccNetwork_basic_step1(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_modelarts_network" "test" {
-  name = "%s"
-  cidr = "192.168.20.0/24"
+  # Network deletion will delete the peer connection, so the subnet can be deleted after the network is deleted.
+  depends_on = [huaweicloud_vpc_subnet.test]
 
-  depends_on = [huaweicloud_vpc.test, huaweicloud_vpc_subnet.test]
+  name = "%[2]s"
+  cidr = "10.168.0.0/16" # The recommended connecting CIDR about SFS Turbo.
 }
 `, common.TestVpc(name), name)
 }
 
-func testModelartsNetwork_basic_update(name string) string {
+func testAccNetwork_basic_step2(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_modelarts_network" "test" {
-  name = "%s"
-  cidr = "192.168.20.0/24"
+  depends_on = [huaweicloud_vpc_subnet.test]
+
+  name = "%[2]s"
+  cidr = "10.168.0.0/16"
 
   peer_connections {
     vpc_id    = huaweicloud_vpc.test.id
     subnet_id = huaweicloud_vpc_subnet.test.id
   }
-
-  depends_on = [huaweicloud_vpc.test, huaweicloud_vpc_subnet.test]
 }
 `, common.TestVpc(name), name)
+}
+
+func testAccNetwork_basic_step3(name string) string {
+	return testAccNetwork_basic_step1(name)
 }

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_network.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_network.go
@@ -81,7 +81,13 @@ func ResourceNetwork() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Elem:        networkPeeringConnectionSchema(),
-				Description: `The list of networks that can be connected in peering mode.`,
+				Description: `The list of peering connections that can be connected to the network.`,
+			},
+			"sfs_turbos": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        networkSfsTurboSchema(),
+				Description: `The list of SFS Turbos that can be connected to the network.`,
 			},
 
 			// Attributes.
@@ -89,6 +95,11 @@ func ResourceNetwork() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `The status of the network.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the subnet which the network is associated.`,
 			},
 
 			// Internal parameters.
@@ -123,6 +134,23 @@ func networkPeeringConnectionSchema() *schema.Resource {
 	}
 }
 
+func networkSfsTurboSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the SFS Turbo to be associated.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the SFS Turbo to be associated.`,
+			},
+		},
+	}
+}
+
 func buildNetworkPeerConnections(peeringConncetions []interface{}) []map[string]interface{} {
 	if len(peeringConncetions) < 1 {
 		return nil
@@ -133,6 +161,23 @@ func buildNetworkPeerConnections(peeringConncetions []interface{}) []map[string]
 		result = append(result, map[string]interface{}{
 			"peerVpcId":    utils.ValueIgnoreEmpty(utils.PathSearch("vpc_id", peeringConnection, "")),
 			"peerSubnetId": utils.ValueIgnoreEmpty(utils.PathSearch("subnet_id", peeringConnection, "")),
+		})
+	}
+
+	return result
+}
+
+func buildNetworkSfsTurboConnections(subnetId string, sfsTurboConnections []interface{}) []map[string]interface{} {
+	if len(sfsTurboConnections) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(sfsTurboConnections))
+	for _, sfsTurboConnection := range sfsTurboConnections {
+		result = append(result, map[string]interface{}{
+			"name":     utils.ValueIgnoreEmpty(utils.PathSearch("name", sfsTurboConnection, "")),
+			"sfsId":    utils.ValueIgnoreEmpty(utils.PathSearch("id", sfsTurboConnection, "")),
+			"subnetId": subnetId,
 		})
 	}
 
@@ -151,9 +196,6 @@ func buildCreateNetworkBodyParams(d *schema.ResourceData) map[string]interface{}
 		},
 		"spec": map[string]interface{}{
 			"cidr": d.Get("cidr"),
-			"connection": map[string]interface{}{
-				"peerConnectionList": buildNetworkPeerConnections(d.Get("peer_connections").([]interface{})),
-			},
 		},
 	}
 }
@@ -260,7 +302,18 @@ func resourceNetworkCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error waiting for the network (%s) creation to complete: %s", d.Id(), err)
 	}
 
-	return resourceNetworkRead(ctx, d, meta)
+	respBody, err = GetNetworkById(client, d.Id())
+	if err != nil {
+		return diag.Errorf("error retrieving network (%s): %s", d.Id(), err)
+	}
+	// To ensure that subsequent SFS Turbo mounting can proceed normally, the subnet_id must be set in advance.
+	subnetId := utils.PathSearch("status.subnets[0].networkId", respBody, "").(string)
+	if subnetId == "" {
+		return diag.Errorf("unable to find the subnet ID from the API response")
+	}
+	d.Set("subnet_id", subnetId)
+
+	return resourceNetworkUpdate(ctx, d, meta)
 }
 
 func flattenNetworkPeerConnections(peeringConnections []interface{}) []map[string]interface{} {
@@ -273,6 +326,21 @@ func flattenNetworkPeerConnections(peeringConnections []interface{}) []map[strin
 		result = append(result, map[string]interface{}{
 			"vpc_id":    utils.PathSearch("peerVpcId", peeringConnection, ""),
 			"subnet_id": utils.PathSearch("peerSubnetId", peeringConnection, ""),
+		})
+	}
+	return result
+}
+
+func flattenNetworkSfsTurboConnections(sfsTurboConnections []interface{}) []map[string]interface{} {
+	if len(sfsTurboConnections) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(sfsTurboConnections))
+	for _, sfsTurboConnection := range sfsTurboConnections {
+		result = append(result, map[string]interface{}{
+			"id":   utils.PathSearch("sfsId", sfsTurboConnection, ""),
+			"name": utils.PathSearch("name", sfsTurboConnection, ""),
 		})
 	}
 	return result
@@ -297,12 +365,18 @@ func resourceNetworkRead(_ context.Context, d *schema.ResourceData, meta interfa
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
+		// Required parameters.
 		d.Set("name", utils.PathSearch(`metadata.labels."os.modelarts/name"`, respBody, nil)),
-		d.Set("workspace_id", utils.PathSearch(`metadata.labels."os.modelarts/workspace.id"`, respBody, nil)),
 		d.Set("cidr", utils.PathSearch("spec.cidr", respBody, nil)),
+		// Optional parameters.
+		d.Set("workspace_id", utils.PathSearch(`metadata.labels."os.modelarts/workspace.id"`, respBody, nil)),
 		d.Set("peer_connections", flattenNetworkPeerConnections(utils.PathSearch("spec.connection.peerConnectionList",
 			respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("sfs_turbos", flattenNetworkSfsTurboConnections(utils.PathSearch("spec.connection.sfsTurboConnectionList",
+			respBody, make([]interface{}, 0)).([]interface{}))),
+		// Attributes.
 		d.Set("status", utils.PathSearch("status.phase", respBody, nil)),
+		d.Set("subnet_id", utils.PathSearch("status.subnets[0].networkId", respBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -312,31 +386,49 @@ func buildUpdateNetworkBodyParams(d *schema.ResourceData) map[string]interface{}
 	return map[string]interface{}{
 		"spec": map[string]interface{}{
 			"connection": map[string]interface{}{
-				"peerConnectionList": buildNetworkPeerConnections(d.Get("peer_connections").([]interface{})),
+				"peerConnectionList":     buildNetworkPeerConnections(d.Get("peer_connections").([]interface{})),
+				"sfsTurboConnectionList": buildNetworkSfsTurboConnections(d.Get("subnet_id").(string), d.Get("sfs_turbos").([]interface{})),
 			},
 		},
 	}
 }
 
-func parseNetworkAssociatedPeerConnections(connections []interface{}) []string {
+func parseNetworkAssociatedPeerConnections(connections []interface{}) []interface{} {
 	if len(connections) < 1 {
 		return nil
 	}
 
-	result := make([]string, 0, len(connections))
+	result := make([]interface{}, 0, len(connections))
 	for _, connection := range connections {
-		result = append(result, fmt.Sprintf("%s:%s", utils.PathSearch("peerVpcId|vpc_id", connection, ""), utils.PathSearch("peerSubnetId|subnet_id", connection, "")))
+		result = append(result, fmt.Sprintf("%s:%s", utils.PathSearch("peerVpcId|vpc_id", connection, ""),
+			utils.PathSearch("peerSubnetId|subnet_id", connection, "")))
 	}
 
 	return result
 }
 
-func checkAllPeerConnectionsExist(remoteConnections, localConnections []string) bool {
+func checkAllPeeringConnectionsExist(remoteConnections, localConnections []interface{}) bool {
 	if len(localConnections) < 1 || len(remoteConnections) < 1 {
 		return true
 	}
 
-	return utils.IsSliceContainsAnyAnotherSliceElement(remoteConnections, localConnections, true, true)
+	return utils.SliceContainsAnother(remoteConnections, localConnections)
+}
+
+func checkAllSfsTurboConnectionsExistAndActive(remoteConnections, localSfsTurboIds []interface{}) bool {
+	if len(localSfsTurboIds) < len(remoteConnections) {
+		// The removal of SFS Turbos is in progress.
+		// The operation is considered complete when corresponding SFS Turbo status records are cleared.
+		return false
+	}
+
+	for _, localSfsTurboId := range localSfsTurboIds {
+		if remoteConnection := utils.PathSearch(fmt.Sprintf("[?sfsId == '%s']|[0]", localSfsTurboId),
+			remoteConnections, nil); remoteConnection == nil || utils.PathSearch("status", remoteConnection, "").(string) != "Active" {
+			return false
+		}
+	}
+	return true
 }
 
 func refreshNetworkConnectionsFunc(client *golangsdk.ServiceClient, d *schema.ResourceData) resource.StateRefreshFunc {
@@ -353,9 +445,16 @@ func refreshNetworkConnectionsFunc(client *golangsdk.ServiceClient, d *schema.Re
 
 		remoteConnections := parseNetworkAssociatedPeerConnections(utils.PathSearch("spec.connection.peerConnectionList",
 			respBody, make([]interface{}, 0)).([]interface{}))
-		if !checkAllPeerConnectionsExist(remoteConnections, localConnections) {
+		if !checkAllPeeringConnectionsExist(remoteConnections, localConnections) {
 			log.Printf("some peer connections are not found, remote: %v, local: %v", remoteConnections, localConnections)
 			return "Missing Some Peer Connections", "PENDING", nil
+		}
+
+		remoteSfsTurboConnections := utils.PathSearch("status.connectionStatus.sfsTurboStatus", respBody, make([]interface{}, 0)).([]interface{})
+		localSfsTurboIds := utils.PathSearch("[*].id", d.Get("sfs_turbos").([]interface{}), make([]interface{}, 0)).([]interface{})
+		if !checkAllSfsTurboConnectionsExistAndActive(remoteSfsTurboConnections, localSfsTurboIds) {
+			log.Printf("some SFS Turbo connections are not found, remote: %v, local: %v", remoteSfsTurboConnections, localSfsTurboIds)
+			return "Missing Some SFS Turbo Connections", "PENDING", nil
 		}
 
 		return respBody, "COMPLETED", nil
@@ -408,7 +507,7 @@ func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	if d.HasChange("peer_connections") {
+	if d.HasChanges("peer_connections", "sfs_turbos") {
 		if err = updateNetworkConnections(ctx, client, d); err != nil {
 			return diag.Errorf("error updating network connections: %s", err)
 		}
@@ -430,11 +529,11 @@ func waitForNetworkDeleteCompleted(ctx context.Context, client *golangsdk.Servic
 	return err
 }
 
-func deleteNetwork(ctx context.Context, client *golangsdk.ServiceClient, networkID string) error {
+func deleteNetwork(client *golangsdk.ServiceClient, networkId string) error {
 	httpURL := "v1/{project_id}/networks/{id}"
 	deletePath := client.Endpoint + httpURL
 	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
-	deletePath = strings.ReplaceAll(deletePath, "{id}", networkID)
+	deletePath = strings.ReplaceAll(deletePath, "{id}", networkId)
 
 	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -457,7 +556,7 @@ func resourceNetworkDelete(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	err = deleteNetwork(ctx, client, networkId)
+	err = deleteNetwork(client, networkId)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting network (%s)", networkId))
 	}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_network.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_network.go
@@ -1,13 +1,9 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product ModelArts
-// ---------------------------------------------------------------
-
 package modelarts
 
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -15,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -23,135 +20,127 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var networkNonUpdatableParams = []string{
+	"name",
+	"cidr",
+	"workspace_id",
+}
+
+// @API ModelArts POST /v1/{project_id}/networks
 // @API ModelArts GET /v1/{project_id}/networks/{id}
 // @API ModelArts PATCH /v1/{project_id}/networks/{id}
 // @API ModelArts DELETE /v1/{project_id}/networks/{id}
-// @API ModelArts POST /v1/{project_id}/networks
-func ResourceModelartsNetwork() *schema.Resource {
+func ResourceNetwork() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceModelartsNetworkCreate,
-		UpdateContext: resourceModelartsNetworkUpdate,
-		ReadContext:   resourceModelartsNetworkRead,
-		DeleteContext: resourceModelartsNetworkDelete,
+		CreateContext: resourceNetworkCreate,
+		ReadContext:   resourceNetworkRead,
+		UpdateContext: resourceNetworkUpdate,
+		DeleteContext: resourceNetworkDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
 			Update: schema.DefaultTimeout(20 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(networkNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the network is located.`,
 			},
+
+			// Required parameters.
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: `The name of network.`,
+				Description: `The name of the network.`,
 			},
 			"cidr": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: `Network CIDR.`,
+				Description: `The CIDR of the network.`,
 			},
+
+			// Optional parameters.
 			"workspace_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				ForceNew:    true,
-				Description: `Workspace ID, which defaults to 0.`,
+				Description: `The ID of the workspace to which the network belongs.`,
 			},
 			"peer_connections": {
 				Type:        schema.TypeList,
-				Elem:        modelartsNetworkPeerConnectionSchema(),
 				Optional:    true,
-				Description: `List of networks that can be connected in peer mode.`,
+				Elem:        networkPeeringConnectionSchema(),
+				Description: `The list of networks that can be connected in peering mode.`,
 			},
+
+			// Attributes.
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `The status of network.`,
+				Description: `The status of the network.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
 }
 
-func modelartsNetworkPeerConnectionSchema() *schema.Resource {
-	sc := schema.Resource{
+func networkPeeringConnectionSchema() *schema.Resource {
+	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"vpc_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `ID of the peer VPC.`,
+				Description: `The ID of the VPC to which the peering connection belongs.`,
 			},
 			"subnet_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `ID of the peer subnet.`,
+				Description: `The ID of the subnet to which the peering connection belongs.`,
 			},
 		},
 	}
-	return &sc
 }
 
-func resourceModelartsNetworkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// createNetwork: create a Modelarts network.
-	var (
-		createNetworkHttpUrl = "v1/{project_id}/networks"
-		createNetworkProduct = "modelarts"
-	)
-	createNetworkClient, err := cfg.NewServiceClient(createNetworkProduct, region)
-	if err != nil {
-		return diag.Errorf("error creating ModelArts client: %s", err)
+func buildNetworkPeerConnections(peeringConncetions []interface{}) []map[string]interface{} {
+	if len(peeringConncetions) < 1 {
+		return nil
 	}
 
-	createNetworkPath := createNetworkClient.Endpoint + createNetworkHttpUrl
-	createNetworkPath = strings.ReplaceAll(createNetworkPath, "{project_id}", createNetworkClient.ProjectID)
-
-	createNetworkOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	result := make([]map[string]interface{}, 0, len(peeringConncetions))
+	for _, peeringConnection := range peeringConncetions {
+		result = append(result, map[string]interface{}{
+			"peerVpcId":    utils.ValueIgnoreEmpty(utils.PathSearch("vpc_id", peeringConnection, "")),
+			"peerSubnetId": utils.ValueIgnoreEmpty(utils.PathSearch("subnet_id", peeringConnection, "")),
+		})
 	}
 
-	createNetworkOpt.JSONBody = utils.RemoveNil(buildCreateNetworkBodyParams(d))
-	createNetworkResp, err := createNetworkClient.Request("POST", createNetworkPath, &createNetworkOpt)
-	if err != nil {
-		return diag.Errorf("error creating Modelarts network: %s", err)
-	}
-
-	createNetworkRespBody, err := utils.FlattenResponse(createNetworkResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	id := utils.PathSearch("metadata.name", createNetworkRespBody, nil)
-	if id == nil {
-		return diag.Errorf("error creating Modelarts network: ID is not found in API response")
-	}
-	d.SetId(id.(string))
-
-	err = createNetworkWaitingForStateCompleted(ctx, createNetworkClient, id.(string), d.Timeout(schema.TimeoutCreate))
-	if err != nil {
-		return diag.Errorf("error waiting for the Modelarts network (%s) creation to complete: %s", d.Id(), err)
-	}
-	return resourceModelartsNetworkRead(ctx, d, meta)
+	return result
 }
 
 func buildCreateNetworkBodyParams(d *schema.ResourceData) map[string]interface{} {
-	bodyParams := map[string]interface{}{
+	return map[string]interface{}{
 		"apiVersion": "v1",
 		"kind":       "Network",
 		"metadata": map[string]interface{}{
@@ -163,308 +152,318 @@ func buildCreateNetworkBodyParams(d *schema.ResourceData) map[string]interface{}
 		"spec": map[string]interface{}{
 			"cidr": d.Get("cidr"),
 			"connection": map[string]interface{}{
-				"peerConnectionList": buildNetworkRequestBodyPeerConnection(d.Get("peer_connections")),
+				"peerConnectionList": buildNetworkPeerConnections(d.Get("peer_connections").([]interface{})),
 			},
 		},
 	}
-	return bodyParams
 }
 
-func buildNetworkRequestBodyPeerConnection(rawParams interface{}) []map[string]interface{} {
-	if rawArray, ok := rawParams.([]interface{}); ok {
-		if len(rawArray) == 0 {
-			return []map[string]interface{}{}
-		}
+func createNetwork(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	httpURL := "v1/{project_id}/networks"
 
-		rst := make([]map[string]interface{}, len(rawArray))
-		for i, v := range rawArray {
-			raw := v.(map[string]interface{})
-			rst[i] = map[string]interface{}{
-				"peerVpcId":    utils.ValueIgnoreEmpty(raw["vpc_id"]),
-				"peerSubnetId": utils.ValueIgnoreEmpty(raw["subnet_id"]),
-			}
-		}
-		return rst
-	}
-	return []map[string]interface{}{}
-}
+	createPath := client.Endpoint + httpURL
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
 
-func createNetworkWaitingForStateCompleted(ctx context.Context, client *golangsdk.ServiceClient, networkId string, t time.Duration) error {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING"},
-		Target:  []string{"COMPLETED"},
-		Refresh: func() (interface{}, string, error) {
-			getModelartsNetworkRespBody, err := getModelartsNetwork(client, networkId)
-			if err != nil {
-				return nil, "ERROR", err
-			}
-
-			statusRaw := utils.PathSearch(`status.phase`, getModelartsNetworkRespBody, "")
-
-			status := fmt.Sprintf("%v", statusRaw)
-
-			targetStatus := []string{
-				"Active",
-			}
-			if utils.StrSliceContains(targetStatus, status) {
-				return getModelartsNetworkRespBody, "COMPLETED", nil
-			}
-
-			pendingStatus := []string{
-				"Creating", "",
-			}
-			if utils.StrSliceContains(pendingStatus, status) {
-				return getModelartsNetworkRespBody, "PENDING", nil
-			}
-
-			return getModelartsNetworkRespBody, status, nil
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
 		},
-		Timeout:      t,
-		Delay:        10 * time.Second,
-		PollInterval: 10 * time.Second,
+		JSONBody: utils.RemoveNil(buildCreateNetworkBodyParams(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(createResp)
+}
+
+func GetNetworkById(client *golangsdk.ServiceClient, networkId string) (interface{}, error) {
+	httpURL := "v1/{project_id}/networks/{id}"
+
+	getPath := client.Endpoint + httpURL
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", networkId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func refreshNetworkStatusFunc(client *golangsdk.ServiceClient, networkId string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetNetworkById(client, networkId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
+				return "RESOURCE_NOT_FOUND", "COMPLETED", nil
+			}
+			return respBody, "ERROR", err
+		}
+
+		status := utils.PathSearch("status.phase", respBody, "").(string)
+		if utils.StrSliceContains(targets, status) {
+			return respBody, "COMPLETED", nil
+		}
+
+		return respBody, "PENDING", nil
+	}
+}
+
+func waitForNetworkCreateCompleted(ctx context.Context, client *golangsdk.ServiceClient, networkId string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshNetworkStatusFunc(client, networkId, []string{"Active"}),
+		Timeout:      timeout,
+		Delay:        20 * time.Second,
+		PollInterval: 20 * time.Second,
 	}
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
 }
 
-func resourceModelartsNetworkRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+func resourceNetworkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
 
 	client, err := cfg.NewServiceClient("modelarts", region)
 	if err != nil {
 		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
-	// getModelartsNetwork: Query the Modelarts network.
-	getModelartsNetworkRespBody, err := getModelartsNetwork(client, d.Id())
+
+	respBody, err := createNetwork(client, d)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving Modelarts network")
+		return diag.Errorf("error creating network: %s", err)
 	}
 
-	mErr := multierror.Append(nil,
-		d.Set("region", region),
-		d.Set("name", utils.PathSearch(`metadata.labels."os.modelarts/name"`, getModelartsNetworkRespBody, nil)),
-		d.Set("workspace_id", utils.PathSearch(`metadata.labels."os.modelarts/workspace.id"`, getModelartsNetworkRespBody, nil)),
-		d.Set("cidr", utils.PathSearch("spec.cidr", getModelartsNetworkRespBody, nil)),
-		d.Set("peer_connections", flattenGetNetworkResponseBodyPeerConnection(getModelartsNetworkRespBody)),
-		d.Set("status", utils.PathSearch("status.phase", getModelartsNetworkRespBody, nil)),
-	)
+	resourceId := utils.PathSearch("metadata.name", respBody, "").(string)
+	if resourceId == "" {
+		return diag.Errorf("unable to find the network ID from the API response")
+	}
+	d.SetId(resourceId)
 
-	return diag.FromErr(mErr.ErrorOrNil())
+	if err = waitForNetworkCreateCompleted(ctx, client, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for the network (%s) creation to complete: %s", d.Id(), err)
+	}
+
+	return resourceNetworkRead(ctx, d, meta)
 }
 
-func getModelartsNetwork(client *golangsdk.ServiceClient, networkId string) (interface{}, error) {
-	var (
-		getModelartsNetworkHttpUrl = "v1/{project_id}/networks/{id}"
-	)
-
-	getModelartsNetworkPath := client.Endpoint + getModelartsNetworkHttpUrl
-	getModelartsNetworkPath = strings.ReplaceAll(getModelartsNetworkPath, "{project_id}", client.ProjectID)
-	getModelartsNetworkPath = strings.ReplaceAll(getModelartsNetworkPath, "{id}", networkId)
-
-	getModelartsNetworkOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
-	}
-
-	getModelartsNetworkResp, err := client.Request("GET", getModelartsNetworkPath, &getModelartsNetworkOpt)
-
-	if err != nil {
-		return nil, err
-	}
-
-	getModelartsNetworkRespBody, err := utils.FlattenResponse(getModelartsNetworkResp)
-	if err != nil {
-		return nil, err
-	}
-	return getModelartsNetworkRespBody, nil
-}
-
-func flattenGetNetworkResponseBodyPeerConnection(resp interface{}) []interface{} {
-	if resp == nil {
+func flattenNetworkPeerConnections(peeringConnections []interface{}) []map[string]interface{} {
+	if len(peeringConnections) < 1 {
 		return nil
 	}
-	curJson := utils.PathSearch("spec.connection.peerConnectionList", resp, make([]interface{}, 0))
-	curArray := curJson.([]interface{})
-	rst := make([]interface{}, 0, len(curArray))
-	for _, v := range curArray {
-		rst = append(rst, map[string]interface{}{
-			"vpc_id":    utils.PathSearch("peerVpcId", v, nil),
-			"subnet_id": utils.PathSearch("peerSubnetId", v, nil),
+
+	result := make([]map[string]interface{}, 0, len(peeringConnections))
+	for _, peeringConnection := range peeringConnections {
+		result = append(result, map[string]interface{}{
+			"vpc_id":    utils.PathSearch("peerVpcId", peeringConnection, ""),
+			"subnet_id": utils.PathSearch("peerSubnetId", peeringConnection, ""),
 		})
 	}
-	return rst
+	return result
 }
 
-func resourceModelartsNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg       = meta.(*config.Config)
 		region    = cfg.GetRegion(d)
 		networkId = d.Id()
 	)
+
 	client, err := cfg.NewServiceClient("modelarts", region)
 	if err != nil {
 		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	updateNetworkChanges := []string{
-		"peer_connections",
+	respBody, err := GetNetworkById(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving network (%s)", networkId))
 	}
 
-	if d.HasChanges(updateNetworkChanges...) {
-		// updateNetwork: update the ModelArts network.
-		updateNetworkHttpUrl := "v1/{project_id}/networks/{id}"
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch(`metadata.labels."os.modelarts/name"`, respBody, nil)),
+		d.Set("workspace_id", utils.PathSearch(`metadata.labels."os.modelarts/workspace.id"`, respBody, nil)),
+		d.Set("cidr", utils.PathSearch("spec.cidr", respBody, nil)),
+		d.Set("peer_connections", flattenNetworkPeerConnections(utils.PathSearch("spec.connection.peerConnectionList",
+			respBody, make([]interface{}, 0)).([]interface{}))),
+		d.Set("status", utils.PathSearch("status.phase", respBody, nil)),
+	)
 
-		updateNetworkPath := client.Endpoint + updateNetworkHttpUrl
-		updateNetworkPath = strings.ReplaceAll(updateNetworkPath, "{project_id}", client.ProjectID)
-		updateNetworkPath = strings.ReplaceAll(updateNetworkPath, "{id}", networkId)
-
-		updateNetworkOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
-			MoreHeaders: map[string]string{"Content-Type": "application/merge-patch+json"},
-		}
-
-		updateNetworkOpt.JSONBody = buildUpdateNetworkBodyParams(d)
-		_, err = client.Request("PATCH", updateNetworkPath, &updateNetworkOpt)
-		if err != nil {
-			return diag.Errorf("error updating Modelarts network: %s", err)
-		}
-		err = updateNetworkWaitingForStateCompleted(ctx, client, networkId, d.Get("peer_connections").([]interface{}),
-			d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return diag.Errorf("error waiting for the Modelarts network (%s) update to complete: %s", d.Id(), err)
-		}
-	}
-	return resourceModelartsNetworkRead(ctx, d, meta)
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func buildUpdateNetworkBodyParams(d *schema.ResourceData) map[string]interface{} {
-	bodyParams := map[string]interface{}{
+	return map[string]interface{}{
 		"spec": map[string]interface{}{
 			"connection": map[string]interface{}{
-				"peerConnectionList": buildNetworkRequestBodyPeerConnection(d.Get("peer_connections")),
+				"peerConnectionList": buildNetworkPeerConnections(d.Get("peer_connections").([]interface{})),
 			},
 		},
 	}
-	return bodyParams
 }
 
-func updateNetworkWaitingForStateCompleted(ctx context.Context, client *golangsdk.ServiceClient, networkId string, peerConnections []interface{},
-	t time.Duration) error {
+func parseNetworkAssociatedPeerConnections(connections []interface{}) []string {
+	if len(connections) < 1 {
+		return nil
+	}
+
+	result := make([]string, 0, len(connections))
+	for _, connection := range connections {
+		result = append(result, fmt.Sprintf("%s:%s", utils.PathSearch("peerVpcId|vpc_id", connection, ""), utils.PathSearch("peerSubnetId|subnet_id", connection, "")))
+	}
+
+	return result
+}
+
+func checkAllPeerConnectionsExist(remoteConnections, localConnections []string) bool {
+	if len(localConnections) < 1 || len(remoteConnections) < 1 {
+		return true
+	}
+
+	return utils.IsSliceContainsAnyAnotherSliceElement(remoteConnections, localConnections, true, true)
+}
+
+func refreshNetworkConnectionsFunc(client *golangsdk.ServiceClient, d *schema.ResourceData) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var (
+			networkId        = d.Id()
+			localConnections = parseNetworkAssociatedPeerConnections(d.Get("peer_connections").([]interface{}))
+		)
+
+		respBody, err := GetNetworkById(client, networkId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		remoteConnections := parseNetworkAssociatedPeerConnections(utils.PathSearch("spec.connection.peerConnectionList",
+			respBody, make([]interface{}, 0)).([]interface{}))
+		if !checkAllPeerConnectionsExist(remoteConnections, localConnections) {
+			log.Printf("some peer connections are not found, remote: %v, local: %v", remoteConnections, localConnections)
+			return "Missing Some Peer Connections", "PENDING", nil
+		}
+
+		return respBody, "COMPLETED", nil
+	}
+}
+
+func waitForNetworkConnectionsUpdateCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING"},
-		Target:  []string{"COMPLETED"},
-		Refresh: func() (interface{}, string, error) {
-			getModelartsNetworkRespBody, err := getModelartsNetwork(client, networkId)
-			if err != nil {
-				return nil, "ERROR", err
-			}
-
-			// if peer_connections is empty, then check status.connectionStatus.peerConnectionStatus is empty
-			if len(peerConnections) == 0 {
-				if utils.PathSearch(`length(status.connectionStatus.peerConnectionStatus)`, getModelartsNetworkRespBody, float64(0)).(float64) > 0 {
-					return getModelartsNetworkRespBody, "PENDING", nil
-				}
-
-				return getModelartsNetworkRespBody, "COMPLETED", nil
-			}
-
-			// if peer_connections is not empty, then check those connections are all
-			// in `status.connectionStatus.peerConnectionStatus` and the status is `Active`
-			for _, v := range peerConnections {
-				raw := v.(map[string]interface{})
-				peerVpcId := utils.ValueIgnoreEmpty(raw["vpc_id"])
-				peerSubnetId := utils.ValueIgnoreEmpty(raw["subnet_id"])
-
-				searchAbnormalJsonPath := fmt.Sprintf(`length(status.connectionStatus.peerConnectionStatus[?peerVpcId=='%s'
-                     && peerSubnetId=='%s' && phase=='Abnormal'])`, peerVpcId, peerSubnetId)
-				if utils.PathSearch(searchAbnormalJsonPath, getModelartsNetworkRespBody, float64(0)).(float64) > 0 {
-					return nil, "ERROR", fmt.Errorf("error updating peer_connections, vpc_id: %s, subnet_id: %s", peerVpcId, peerSubnetId)
-				}
-
-				searchActiveJsonPath := fmt.Sprintf(`length(status.connectionStatus.peerConnectionStatus[?peerVpcId=='%s'
-                     && peerSubnetId=='%s' && phase=='Active'])`, peerVpcId, peerSubnetId)
-				if utils.PathSearch(searchActiveJsonPath, getModelartsNetworkRespBody, float64(0)).(float64) == 0 {
-					return getModelartsNetworkRespBody, "PENDING", nil
-				}
-			}
-
-			return getModelartsNetworkRespBody, "COMPLETED", nil
-		},
-		Timeout:      t,
-		Delay:        30 * time.Second,
-		PollInterval: 30 * time.Second,
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshNetworkConnectionsFunc(client, d),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        20 * time.Second,
+		PollInterval: 20 * time.Second,
 	}
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
 }
 
-func resourceModelartsNetworkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// deleteNetwork: delete Modelarts network
+func updateNetworkConnections(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpURL := "v1/{project_id}/networks/{id}"
+	updatePath := client.Endpoint + httpURL
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/merge-patch+json",
+		},
+		JSONBody: buildUpdateNetworkBodyParams(d),
+	}
+
+	_, err := client.Request("PATCH", updatePath, &updateOpt)
+	if err != nil {
+		return err
+	}
+
+	return waitForNetworkConnectionsUpdateCompleted(ctx, client, d)
+}
+
+func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		deleteNetworkHttpUrl = "v1/{project_id}/networks/{id}"
-		deleteNetworkProduct = "modelarts"
-		cfg                  = meta.(*config.Config)
-		region               = cfg.GetRegion(d)
-		networkId            = d.Id()
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
 	)
 
-	deleteNetworkClient, err := cfg.NewServiceClient(deleteNetworkProduct, region)
+	client, err := cfg.NewServiceClient("modelarts", region)
 	if err != nil {
 		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	deleteNetworkPath := deleteNetworkClient.Endpoint + deleteNetworkHttpUrl
-	deleteNetworkPath = strings.ReplaceAll(deleteNetworkPath, "{project_id}", deleteNetworkClient.ProjectID)
-	deleteNetworkPath = strings.ReplaceAll(deleteNetworkPath, "{id}", networkId)
-
-	deleteNetworkOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	if d.HasChange("peer_connections") {
+		if err = updateNetworkConnections(ctx, client, d); err != nil {
+			return diag.Errorf("error updating network connections: %s", err)
+		}
 	}
-
-	_, err = deleteNetworkClient.Request("DELETE", deleteNetworkPath, &deleteNetworkOpt)
-	if err != nil {
-		return diag.Errorf("error deleting Modelarts network: %s", err)
-	}
-
-	err = deleteNetworkWaitingForStateCompleted(ctx, deleteNetworkClient, networkId, d.Timeout(schema.TimeoutDelete))
-	if err != nil {
-		return diag.Errorf("error waiting for the Modelarts network (%s) deletion to complete: %s", networkId, err)
-	}
-	return nil
+	return resourceNetworkRead(ctx, d, meta)
 }
 
-func deleteNetworkWaitingForStateCompleted(ctx context.Context, client *golangsdk.ServiceClient, networkId string, t time.Duration) error {
+func waitForNetworkDeleteCompleted(ctx context.Context, client *golangsdk.ServiceClient, networkId string,
+	timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING"},
-		Target:  []string{"COMPLETED"},
-		Refresh: func() (interface{}, string, error) {
-			_, err := getModelartsNetwork(client, networkId)
-			if err != nil {
-				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					var obj = map[string]string{"code": "COMPLETED"}
-					return obj, "COMPLETED", nil
-				}
-
-				return nil, "ERROR", err
-			}
-
-			return nil, "PENDING", nil
-		},
-		Timeout:      t,
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshNetworkStatusFunc(client, networkId, nil),
+		Timeout:      timeout,
 		Delay:        20 * time.Second,
-		PollInterval: 10 * time.Second,
+		PollInterval: 20 * time.Second,
 	}
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
+}
+
+func deleteNetwork(ctx context.Context, client *golangsdk.ServiceClient, networkID string) error {
+	httpURL := "v1/{project_id}/networks/{id}"
+	deletePath := client.Endpoint + httpURL
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{id}", networkID)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceNetworkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		networkId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	err = deleteNetwork(ctx, client, networkId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting network (%s)", networkId))
+	}
+
+	if err = waitForNetworkDeleteCompleted(ctx, client, networkId, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for the network (%s) deletion to complete: %s", networkId, err)
+	}
+	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports SFS Turbos management for the ModelArts network.
And adjust the peering connection associate logic.
Before that, we are using the new code format about auto-generate style to rewrite the resource codes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1083" height="301" alt="image" src="https://github.com/user-attachments/assets/b210c8fa-5d89-4d88-a0ea-36508df0ee31" />

Even if the SFS turbo list is reversed, the TypeList still fine because the API response will not ordering this list.
<img width="1790" height="1309" alt="image" src="https://github.com/user-attachments/assets/a065da47-8970-498a-9791-b4c4098558b9" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new feature about associate SFS Turbos for the ModelArts network resource.
2. supports corresponding documentation and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccNetwork_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccNetwork_basic -timeout 360m -parallel 10
=== RUN   TestAccNetwork_basic
=== PAUSE TestAccNetwork_basic
=== CONT  TestAccNetwork_basic
--- PASS: TestAccNetwork_basic (908.52s)
PASS
coverage: 7.8% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 908.643s        coverage: 7.8% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="910" height="326" alt="image" src="https://github.com/user-attachments/assets/1c9ed43d-0a02-4463-a5b6-80089298b18a" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1745" height="875" alt="image" src="https://github.com/user-attachments/assets/e29e2610-a9d7-4a80-b473-400ba2b7dad0" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
