### PR TITLE
feat(eip): new resource to associate segment and bandwidth

### DIFF
--- a/docs/resources/global_eip_segment_bandwidth_associate.md
+++ b/docs/resources/global_eip_segment_bandwidth_associate.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_global_eip_segment_bandwidth_associate"
+description: |-
+  Manages a global EIP segment bandwidth association resource within HuaweiCloud.
+---
+
+# huaweicloud_global_eip_segment_bandwidth_associate
+
+Manages a global EIP segment bandwidth association resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "global_eip_segment_id" {}
+variable "internet_bandwidth_id" {}
+
+resource "huaweicloud_global_eip_segment_bandwidth_associate" "test" {
+  global_eip_segment_id = var.global_eip_segment_id
+  internet_bandwidth_id = var.internet_bandwidth_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `global_eip_segment_id` - (Required, String, NonUpdatable) Specifies the global EIP segment ID.
+
+* `internet_bandwidth_id` - (Required, String, NonUpdatable) Specifies the internet bandwidth ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. Same with the global EIP segment ID.
+
+* `internet_bandwidth` - The internet bandwidth information.
+
+  The [internet_bandwidth](#internet_bandwidth_struct) structure is documented below.
+
+<a name="internet_bandwidth_struct"></a>
+The `internet_bandwidth` block supports:
+
+* `id` - The internet bandwidth ID.
+
+* `size` - The internet bandwidth size.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The global EIP segment bandwidth association resource can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_global_eip_segment_bandwidth_associate.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4336,6 +4336,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_global_eip":                              eip.ResourceGlobalEIP(),
 			"huaweicloud_global_eip_associate":                    eip.ResourceGlobalEIPAssociate(),
 			"huaweicloud_global_eip_internet_bandwidth_associate": eip.ResourceInternetBandwidthAssociate(),
+			"huaweicloud_global_eip_segment_bandwidth_associate":  eip.ResourceSegmentBandwidthAssociate(),
 
 			"huaweicloud_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),
 			"huaweicloud_vpc_peering_connection_accepter": vpc.ResourceVpcPeeringConnectionAccepterV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -443,6 +443,8 @@ var (
 	HW_DC_CONNECT_GATEWAY_ID              = os.Getenv("HW_DC_CONNECT_GATEWAY_ID")
 	HW_GLOBAL_EIP_ID                      = os.Getenv("HW_GLOBAL_EIP_ID")
 	HW_GLOBAL_INTERNET_BANDWIDTH_ID       = os.Getenv("HW_GLOBAL_INTERNET_BANDWIDTH_ID")
+	HW_GLOBAL_EIP_SEGMENT_ID              = os.Getenv("HW_GLOBAL_EIP_SEGMENT_ID")
+	HW_GLOBAL_EIP_BANDWIDTH_ID            = os.Getenv("HW_GLOBAL_EIP_BANDWIDTH_ID")
 
 	HW_DSC_INSTANCE_ID    = os.Getenv("HW_DSC_INSTANCE_ID")
 	HW_DSC_ALARM_TOPIC_ID = os.Getenv("HW_DSC_ALARM_TOPIC_ID")
@@ -2841,6 +2843,20 @@ func TestAccPreCheckGlobalEipId(t *testing.T) {
 func TestAccPreCheckGlobalInternetBandwidthId(t *testing.T) {
 	if HW_GLOBAL_INTERNET_BANDWIDTH_ID == "" {
 		t.Skip("HW_GLOBAL_INTERNET_BANDWIDTH_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckGlobalEipSegmentId(t *testing.T) {
+	if HW_GLOBAL_EIP_SEGMENT_ID == "" {
+		t.Skip("HW_GLOBAL_EIP_SEGMENT_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckGlobalEipBandwidthId(t *testing.T) {
+	if HW_GLOBAL_EIP_BANDWIDTH_ID == "" {
+		t.Skip("HW_GLOBAL_EIP_BANDWIDTH_ID must be set for this acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_eip_segment_bandwidth_associate_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_eip_segment_bandwidth_associate_test.go
@@ -1,0 +1,70 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
+)
+
+func getSegmentBandwidthAssociateFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("geip", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GEIP client: %s", err)
+	}
+
+	return eip.GetEipSegmentDetail(client, cfg.DomainID, state.Primary.ID)
+}
+
+func TestAccSegmentBandwidthAssociate_basic(t *testing.T) {
+	var obj interface{}
+
+	rName := "huaweicloud_global_eip_segment_bandwidth_associate.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getSegmentBandwidthAssociateFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGlobalEipSegmentId(t)
+			acceptance.TestAccPreCheckGlobalEipBandwidthId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSegmentBandwidthAssociate_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "global_eip_segment_id", acceptance.HW_GLOBAL_EIP_SEGMENT_ID),
+					resource.TestCheckResourceAttr(rName, "internet_bandwidth_id", acceptance.HW_GLOBAL_EIP_BANDWIDTH_ID),
+					resource.TestCheckResourceAttrSet(rName, "internet_bandwidth.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "internet_bandwidth.0.size"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSegmentBandwidthAssociate_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_global_eip_segment_bandwidth_associate" "test" {
+  global_eip_segment_id = "%[1]s"
+  internet_bandwidth_id = "%[2]s"
+}
+`, acceptance.HW_GLOBAL_EIP_SEGMENT_ID, acceptance.HW_GLOBAL_EIP_BANDWIDTH_ID)
+}

--- a/huaweicloud/services/eip/resource_huaweicloud_global_eip_segment_bandwidth_associate.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_global_eip_segment_bandwidth_associate.go
@@ -1,0 +1,313 @@
+package eip
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP POST /v3/{domain_id}/global-eip-segments/batch-attach-internet-bandwidths
+// @API EIP POST /v3/{domain_id}/global-eip-segments/batch-detach-internet-bandwidths
+// @API EIP GET /v3/{domain_id}/global-eip-segments/{global_eip_segment_id}
+// @API EIP GET /v3/{domain_id}/geip/jobs/{job_id}
+func ResourceSegmentBandwidthAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSegmentBandwidthAssociateCreate,
+		ReadContext:   resourceSegmentBandwidthAssociateRead,
+		UpdateContext: resourceSegmentBandwidthAssociateUpdate,
+		DeleteContext: resourceSegmentBandwidthAssociateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew([]string{
+			"global_eip_segment_id",
+			"internet_bandwidth_id",
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"global_eip_segment_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"internet_bandwidth_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"internet_bandwidth": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAttachSegmentBandwidthAssociateBodyParams(segmentId, bandwidthId string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"global_eip_segment_id": segmentId,
+		"internet_bandwidth_id": bandwidthId,
+	}
+
+	return map[string]interface{}{
+		"global_eip_segments": []map[string]interface{}{bodyParams},
+	}
+}
+
+func getEipJobDetail(client *golangsdk.ServiceClient, domainId, jobId string) (interface{}, error) {
+	requestPath := client.Endpoint + "v3/{domain_id}/geip/jobs/{job_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", domainId)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving EIP job detail: %s", err)
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func waitSegmentBandwidthAssociateJobSuccess(ctx context.Context, client *golangsdk.ServiceClient,
+	timeout time.Duration, domainId, jobId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			jobDetail, err := getEipJobDetail(client, domainId, jobId)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch("job.status", jobDetail, "").(string)
+			if status == "" {
+				return jobDetail, "ERROR", errors.New("status is not found in job detail response")
+			}
+
+			if status == "FINISH_SUCC" {
+				return jobDetail, "COMPLETED", nil
+			}
+
+			// Due to the unclear API description, and for program security reasons, all other states are categorized as
+			// types requiring PENDING.
+			return jobDetail, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceSegmentBandwidthAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		domainId    = cfg.DomainID
+		httpUrl     = "v3/{domain_id}/global-eip-segments/batch-attach-internet-bandwidths"
+		segmentId   = d.Get("global_eip_segment_id").(string)
+		bandwidthId = d.Get("internet_bandwidth_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", domainId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildAttachSegmentBandwidthAssociateBodyParams(segmentId, bandwidthId),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error attaching EIP bandwidth (%s) to segment (%s): %s", bandwidthId, segmentId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error attaching EIP bandwidth (%s) to segment (%s): Job ID is not found in API response",
+			bandwidthId, segmentId)
+	}
+
+	d.SetId(segmentId)
+
+	err = waitSegmentBandwidthAssociateJobSuccess(ctx, client, d.Timeout(schema.TimeoutCreate), domainId, jobId)
+	if err != nil {
+		return diag.Errorf("error waiting for EIP segment bandwidth association job (%s) to succeed: %s", jobId, err)
+	}
+
+	return resourceSegmentBandwidthAssociateRead(ctx, d, meta)
+}
+
+func GetEipSegmentDetail(client *golangsdk.ServiceClient, domainId, segmentId string) (interface{}, error) {
+	requestPath := client.Endpoint + "v3/{domain_id}/global-eip-segments/{global_eip_segment_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", domainId)
+	requestPath = strings.ReplaceAll(requestPath, "{global_eip_segment_id}", segmentId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	internetBandwidthRespBody := utils.PathSearch("global_eip_segment.internet_bandwidth", respBody, nil)
+	if internetBandwidthRespBody == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return respBody, nil
+}
+
+func resourceSegmentBandwidthAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		domainId  = cfg.DomainID
+		segmentId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	respBody, err := GetEipSegmentDetail(client, domainId, segmentId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving EIP segment detail")
+	}
+
+	mErr := multierror.Append(
+		d.Set("global_eip_segment_id", utils.PathSearch("global_eip_segment.id", respBody, nil)),
+		d.Set("internet_bandwidth_id", utils.PathSearch("global_eip_segment.internet_bandwidth.id", respBody, nil)),
+		d.Set("internet_bandwidth", flattenInternetBandwidth(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInternetBandwidth(respBody interface{}) []interface{} {
+	internetBandwidth := utils.PathSearch("global_eip_segment.internet_bandwidth", respBody, nil)
+	if internetBandwidth == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"id":   utils.PathSearch("id", internetBandwidth, nil),
+			"size": utils.PathSearch("size", internetBandwidth, nil),
+		},
+	}
+}
+
+func resourceSegmentBandwidthAssociateUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func buildDetachSegmentBandwidthAssociateBodyParams(segmentId string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"global_eip_segment_id": segmentId,
+	}
+
+	return map[string]interface{}{
+		"global_eip_segments": []map[string]interface{}{bodyParams},
+	}
+}
+
+func resourceSegmentBandwidthAssociateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		domainId  = cfg.DomainID
+		httpUrl   = "v3/{domain_id}/global-eip-segments/batch-detach-internet-bandwidths"
+		segmentId = d.Get("global_eip_segment_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", domainId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDetachSegmentBandwidthAssociateBodyParams(segmentId),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error detaching EIP segment (%s) bandwidth: %s", segmentId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error detaching EIP segment (%s) bandwidth: Job ID is not found in API response", segmentId)
+	}
+
+	if err := waitSegmentBandwidthAssociateJobSuccess(ctx, client, d.Timeout(schema.TimeoutDelete), domainId, jobId); err != nil {
+		return diag.Errorf("error waiting for EIP segment bandwidth disassociation job (%s) to succeed: %s", jobId, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New resource to associate segment and bandwidth.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o eip -f TestAccSegmentBandwidthAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccSegmentBandwidthAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccSegmentBandwidthAssociate_basic
=== PAUSE TestAccSegmentBandwidthAssociate_basic
=== CONT  TestAccSegmentBandwidthAssociate_basic
--- PASS: TestAccSegmentBandwidthAssociate_basic (38.66s)
PASS
coverage: 4.4% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       38.784s coverage: 4.4% of statements in ./huaweicloud/services/eip
```
<img width="1324" height="77" alt="image" src="https://github.com/user-attachments/assets/326d3c69-1cd6-48ce-b3dc-2622dfdb16de" />


* [X] Documentation updated.
* [X] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="829" height="175" alt="image" src="https://github.com/user-attachments/assets/ed55b6e4-4acd-4591-98a1-62bbc1a2386d" />
    
    <img width="948" height="194" alt="image" src="https://github.com/user-attachments/assets/a089c00b-7a65-4ffb-a450-bb59ef46d8d8" />


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
