### PR TITLE
feat(dataarts/architecture): add new data source to query aggregation logic tables

### DIFF
--- a/docs/data-sources/dataarts_architecture_aggregation_logic_tables.md
+++ b/docs/data-sources/dataarts_architecture_aggregation_logic_tables.md
@@ -1,0 +1,311 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_architecture_aggregation_logic_tables"
+description: |-
+  Use this data source to query DataArts Architecture aggregation logic tables within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_architecture_aggregation_logic_tables
+
+Use this data source to query DataArts Architecture aggregation logic tables within HuaweiCloud.
+
+## Example Usage
+
+### Query all aggregation logic tables under a specified workspace
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+### Filter aggregation logic table by name
+
+```hcl
+variable "workspace_id" {}
+variable "aggregation_logic_table_name" {}
+
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "test" {
+  workspace_id = var.workspace_id
+  name         = var.aggregation_logic_table_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the aggregation logic tables are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the aggregation logic tables belong.
+
+* `name` - (Optional, String) Specifies the Chinese name or English name of the aggregation logic table
+  to be fuzzy queried.
+
+* `name_ch` - (Optional, String) Specifies the Chinese name of the aggregation logic table to be exactly queried.
+
+* `name_en` - (Optional, String) Specifies the English name of the aggregation logic table to be exactly queried.
+
+* `create_by` - (Optional, String) Specifies the creator of the aggregation logic table to be queried.
+
+* `approver` - (Optional, String) Specifies the approver of the aggregation logic table to be queried.
+
+* `owner` - (Optional, String) Specifies the owner of the aggregation logic table to be queried.
+
+* `status` - (Optional, String) Specifies the publishing status of the aggregation logic table to be queried.  
+  The valid values are as follows:
+  + **DRAFT**
+  + **PUBLISH_DEVELOPING**
+  + **PUBLISHED**
+  + **OFFLINE_DEVELOPING**
+  + **OFFLINE**
+  + **REJECT**
+
+* `sync_status` - (Optional, String) Specifies the synchronization status of the aggregation logic table
+  to be queried.  
+  The valid values are as follows:
+  + **RUNNING**
+  + **NO_NEED**
+  + **SUMMARY_SUCCESS**
+  + **SUMMARY_FAILED**
+
+* `sync_key` - (Optional, List) Specifies the list of synchronization task types of the aggregation logic table.  
+  The valid values are as follows:
+  + **BUSINESS_ASSET**
+  + **DATA_QUALITY**
+  + **TECHNICAL_ASSET**
+  + **META_DATA_LINK**
+  + **PHYSICAL_TABLE**: Create table in production environment.
+  + **DEV_PHYSICAL_TABLE**: Create table in development environment.
+  + **DLF_TASK**
+  + **MATERIALIZATION**
+  + **PUBLISH_TO_DLM**
+  + **SUMMARY_STATUS**
+
+* `biz_catalog_id` - (Optional, String) Specifies the business catalog ID to which the aggregation logic table belongs.
+
+* `begin_time` - (Optional, String) Specifies the start time of the modification time for the aggregation
+  logic table, in RFC3339 format.  
+  Must be `UTC` time, and must be used together with `end_time`.
+
+* `end_time` - (Optional, String) Specifies the end time of the modification time for the aggregation
+  logic table, in RFC3339 format.  
+  Must be `UTC` time, and must be used together with `begin_time`.
+
+* `auto_generate` - (Optional, Bool) Specifies whether the aggregation logic table is auto-generated.  
+  Defaults to **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tables` - The list of aggregation logic tables that match the filter parameters.  
+  The [tables](#architecture_aggregation_logic_tables) structure is documented below.
+
+<a name="architecture_aggregation_logic_tables"></a>
+The `tables` block supports:
+
+* `id` - The ID of the aggregation logic table.
+
+* `tb_name` - The physical table name in English of the aggregation logic table.
+
+* `tb_logic_name` - The display name in Chinese of the aggregation logic table.
+
+* `dw_id` - The ID of the data connection.
+
+* `dw_name` - The name of the data connection.
+
+* `dw_type` - The type of the data connection.
+
+* `db_name` - The name of the database.
+
+* `owner` - The asset owner of the aggregation logic table.
+
+* `description` - The description of the aggregation logic table.
+
+* `alias` - The alias of the aggregation logic table.
+
+* `queue_name` - The queue name of the DLI data connection.
+
+* `schema` - The schema name of the aggregation logic table.
+
+* `table_attributes` - The list of attributes of the aggregation logic table.  
+  The [table_attributes](#architecture_aggregation_logic_tables_attributes) structure is documented below.
+
+* `table_type` - The type of the aggregation logic table.
+
+* `distribute` - The distribution mode of the database.
+
+* `distribute_column` - The column used for hash distribution.
+
+* `compression` - The compression level of the DWS table.
+
+* `pre_combine_field` - The column used for table combine or versioning.
+
+* `obs_location` - The OBS storage path of the external table.
+
+* `configs` - The additional configuration of the aggregation logic table, in JSON format.
+
+* `dimension_group` - The ID of the statistical dimension of the derived indicator.
+
+* `group_name` - The name of the dimension group of the derivative metric.
+
+* `group_code` - The dimension group code of the derivative metric.
+
+* `sql` - The SQL statement of the aggregation logic table.
+
+* `partition_conf` - The partition expression of the aggregation logic table.
+
+* `dirty_out_switch` - Whether to enable dirty data output switch.
+
+* `dirty_out_database` - The output database of the dirty data.
+
+* `dirty_out_prefix` - The prefix of the dirty data table.
+
+* `dirty_out_suffix` - The suffix of the dirty data table.
+
+* `secret_type` - The type of the data secrecy level.
+
+* `self_defined_fields` - The list of user-defined extended fields for the aggregation logic table.  
+  The [self_defined_fields](#architecture_aggregation_logic_tables_self_defined_fields) structure is documented below.
+
+* `tb_id` - The internal table ID of the aggregation logic table.
+
+* `status` - The publishing status of the aggregation logic table.
+
+* `model_id` - The ID of the model to which the aggregation logic table belongs.
+
+* `create_by` - The creator of the aggregation logic table.
+
+* `create_time` - The creation time of the aggregation logic table, in RFC3339 format.
+
+* `update_time` - The latest update time of the aggregation logic table, in RFC3339 format.
+
+* `env_type` - The publishing environment type of the aggregation logic table.
+
+* `physical_table` - The status of the table creation in the production environment.
+
+* `dev_physical_table` - The status of the table creation in the development environment.
+
+* `technical_asset` - The synchronization status of the technical asset.
+
+* `business_asset` - The synchronization status of the business asset.
+
+* `meta_data_link` - The status of the asset association.
+
+* `tb_guid` - The technical catalog asset GUID after the aggregation logic table is published.
+
+* `tb_logic_guid` - The business catalog asset GUID after the aggregation logic table is published.
+
+* `data_quality` - The status of the data quality job creation.
+
+* `quality_id` - The ID of the data quality.
+
+* `dlf_task` - The status of the DLF task.
+
+* `dlf_task_id` - The ID of the DLF task.
+
+* `publish_to_dlm` - The status of the DLM API generation.
+
+* `api_id` - The ID of the API after publishing.
+
+* `summary_status` - The synchronization status of the summary.
+
+* `reversed` - Whether the aggregation logic table is reversed.
+
+* `table_version` - The version of the aggregation logic table.  
+  If the value is `2`, it means that the aggregation logic table is automatically aggregated.
+
+* `dev_version` - The development environment version of the aggregation logic table.
+
+* `prod_version` - The production environment version of the aggregation logic table.
+
+* `dev_version_name` - The development environment version name of the aggregation logic table.
+
+* `prod_version_name` - The production environment version name of the aggregation logic table.
+
+* `approval_info` - The approval information of the aggregation logic table.  
+  The [approval_info](#architecture_aggregation_logic_tables_approval_info) structure is documented below.
+
+<a name="architecture_aggregation_logic_tables_attributes"></a>
+The `table_attributes` block supports:
+
+* `id` - The ID of the attribute.
+
+* `name_ch` - The Chinese name of the attribute.
+
+* `name_en` - The English name of the attribute.
+
+* `data_type` - The data type of the attribute.
+
+* `attribute_type` - The configuration type of the attribute.
+
+* `is_primary_key` - Whether the attribute is the primary key.
+
+* `is_partition_key` - Whether the attribute is used as a partition key.
+
+* `not_null` - Whether the attribute is not null.
+
+* `description` - The description of the attribute.
+
+* `data_type_extend` - The data type extend field of attribute.
+
+* `domain_type` - The domain type of the attribute.
+
+* `ref_id` - The ID of the object referenced by the attribute.
+
+* `ref_name_ch` - The Chinese name of the object associated with the attribute.
+
+* `ref_name_en` - The English name of the object associated with the attribute.
+
+* `stand_row_id` - The ID of the data standard associated with the attribute.
+
+* `stand_row_name` - The name of the data standard associated with the attribute.
+
+* `ordinal` - The sequence number of the attribute.
+
+* `alias` - The alias of the attribute.
+
+* `secrecy_levels` - The list of secrecy levels associated with the attribute.  
+  The [secrecy_levels](#architecture_aggregation_logic_tables_secrecy_levels) structure is documented below.
+
+<a name="architecture_aggregation_logic_tables_self_defined_fields"></a>
+The `self_defined_fields` block supports:
+
+* `fd_name_ch` - The Chinese display name of the custom extended field.
+
+* `fd_name_en` - The English name of the custom extended field.
+
+* `not_null` - Whether the custom extended field requires a value.
+
+* `fd_value` - The value of the custom extended field.
+
+<a name="architecture_aggregation_logic_tables_approval_info"></a>
+The `approval_info` block supports:
+
+* `id` - The ID of the approval for the aggregation logic table.
+
+* `approver` - The approver of the aggregation logic table.
+
+* `approval_status` - The approval status of the aggregation logic table.
+
+* `msg` - The approval message for the aggregation logic table.
+
+* `approval_time` - The approval time for the aggregation logic table, in RFC3339 format.
+
+<a name="architecture_aggregation_logic_tables_secrecy_levels"></a>
+The `secrecy_levels` block supports:
+
+* `id` - The ID of the secrecy level.
+
+* `uuid` - The UUID of the secrecy level.
+
+* `name` - The name of the secrecy level.
+
+* `slevel` - The secrecy level number.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1076,6 +1076,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_studio_workspace_users":      dataarts.DataSourceStudioWorkspaceUsers(),
 			"huaweicloud_dataarts_studio_workspace_user_roles": dataarts.DataSourceStudioWorkspaceUserRoles(),
 			// DataArts Architecture
+			"huaweicloud_dataarts_architecture_aggregation_logic_tables":         dataarts.DataSourceArchitectureAggregationLogicTables(),
 			"huaweicloud_dataarts_architecture_approvals":                        dataarts.DataSourceArchitectureApprovals(),
 			"huaweicloud_dataarts_architecture_data_standard_template_customs":   dataarts.DataSourceArchitectureDataStandardTemplateCustoms(),
 			"huaweicloud_dataarts_architecture_data_standard_template_optionals": dataarts.DataSourceArchitectureDataStandardTemplateOptionals(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_aggregation_logic_tables_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_aggregation_logic_tables_test.go
@@ -1,0 +1,627 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataArchitectureAggregationLogicTables_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_architecture_aggregation_logic_tables.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byNameCh   = "data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_name_ch"
+		dcByNameCh = acceptance.InitDataSourceCheck(byNameCh)
+
+		byNameEn   = "data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_name_en"
+		dcByNameEn = acceptance.InitDataSourceCheck(byNameEn)
+
+		byCreateBy   = "data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_create_by"
+		dcByCreateBy = acceptance.InitDataSourceCheck(byCreateBy)
+
+		byApprover   = "data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_approver"
+		dcByApprover = acceptance.InitDataSourceCheck(byApprover)
+
+		byOwner   = "data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_owner"
+		dcByOwner = acceptance.InitDataSourceCheck(byOwner)
+
+		byStatus   = "data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		bySyncStatus   = "data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_sync_status"
+		dcBySyncStatus = acceptance.InitDataSourceCheck(bySyncStatus)
+
+		byBeginTime   = "data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_begin_time"
+		dcByBeginTime = acceptance.InitDataSourceCheck(byBeginTime)
+
+		byBizCatalogId   = "data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_biz_catalog_id"
+		dcByBizCatalogId = acceptance.InitDataSourceCheck(byBizCatalogId)
+
+		byAutoGenerate   = "data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_auto_generate"
+		dcByAutoGenerate = acceptance.InitDataSourceCheck(byAutoGenerate)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsConnectionID(t)
+			acceptance.TestAccPreCheckDataArtsArchitectureReviewer(t)
+			acceptance.TestAccPreCheckDataArtsRelatedDliQueueName(t)
+			acceptance.TestAccPreCheckDataArtsArchitectureSecrecyLevelIds(t, 1)
+		},
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.9.1",
+			},
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataArchitectureAggregationLogicTables_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "tables.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'name' parameter fuzzy search.
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					// Filter by 'name_ch' parameter exact match.
+					dcByNameCh.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_ch_filter_useful", "true"),
+					resource.TestCheckResourceAttrPair(byNameCh, "tables.0.id",
+						"huaweicloud_dataarts_architecture_aggregation_logic_table.test", "id"),
+					resource.TestCheckResourceAttrPair(byNameCh, "tables.0.tb_name",
+						"huaweicloud_dataarts_architecture_aggregation_logic_table.test", "tb_name"),
+					resource.TestCheckResourceAttrPair(byNameCh, "tables.0.tb_logic_name",
+						"huaweicloud_dataarts_architecture_aggregation_logic_table.test", "tb_logic_name"),
+					resource.TestCheckResourceAttr(byNameCh, "tables.0.dw_id", acceptance.HW_DATAARTS_CONNECTION_ID),
+					resource.TestCheckResourceAttr(byNameCh, "tables.0.dw_type", "DLI"),
+					resource.TestCheckResourceAttr(byNameCh, "tables.0.owner", acceptance.HW_DATAARTS_ARCHITECTURE_USER_NAME),
+					resource.TestCheckResourceAttr(byNameCh, "tables.0.description", "Created by terraform script"),
+					resource.TestCheckResourceAttrPair(byNameCh, "tables.0.alias",
+						"huaweicloud_dataarts_architecture_aggregation_logic_table.test", "alias"),
+					resource.TestCheckResourceAttr(byNameCh, "tables.0.queue_name", acceptance.HW_DATAARTS_DLI_QUEUE_NAME),
+					resource.TestCheckResourceAttr(byNameCh, "tables.0.table_attributes.#", "1"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.id"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.name_ch"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.name_en"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.data_type"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.attribute_type"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.is_primary_key"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.is_partition_key"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.not_null"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.description"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.domain_type"),
+					resource.TestCheckResourceAttrPair(byNameCh, "tables.0.table_attributes.0.ref_id",
+						"huaweicloud_dataarts_architecture_business_metric.test", "id"),
+					resource.TestCheckResourceAttrPair(byNameCh, "tables.0.table_attributes.0.stand_row_id",
+						"huaweicloud_dataarts_architecture_data_standard.test", "id"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.alias"),
+					resource.TestCheckResourceAttr(byNameCh, "tables.0.table_attributes.0.secrecy_levels.#", "1"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.secrecy_levels.0.id"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.secrecy_levels.0.uuid"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.secrecy_levels.0.name"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.secrecy_levels.0.slevel"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.table_attributes.0.ordinal"),
+					resource.TestCheckResourceAttr(byNameCh, "tables.0.table_type", "EXTERNAL"),
+					resource.TestCheckResourceAttrPair(byNameCh, "tables.0.obs_location",
+						"huaweicloud_dli_table.test", "bucket_location"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.configs"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.dimension_group"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.sql"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.partition_conf"),
+					resource.TestCheckResourceAttr(byNameCh, "tables.0.dirty_out_switch", "true"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.dirty_out_database"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.dirty_out_prefix"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.dirty_out_suffix"),
+					resource.TestCheckResourceAttr(byNameCh, "tables.0.self_defined_fields.#", "1"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.self_defined_fields.0.fd_name_ch"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.self_defined_fields.0.fd_name_en"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.self_defined_fields.0.not_null"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.self_defined_fields.0.fd_value"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.tb_logic_guid"),
+					resource.TestCheckResourceAttr(byNameCh, "tables.0.status", "PUBLISHED"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.model_id"),
+					resource.TestCheckResourceAttr(byNameCh, "tables.0.create_by", acceptance.HW_DATAARTS_ARCHITECTURE_USER_NAME),
+					resource.TestMatchResourceAttr(byNameCh, "tables.0.create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byNameCh, "tables.0.update_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.env_type"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.physical_table"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.technical_asset"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.meta_data_link"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.data_quality"),
+					resource.TestCheckResourceAttrSet(byNameCh, "tables.0.summary_status"),
+					// Filter by 'name_en' parameter exact match.
+					dcByNameEn.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_en_filter_useful", "true"),
+					// Filter by 'create_by' parameter exact match.
+					dcByCreateBy.CheckResourceExists(),
+					resource.TestCheckOutput("is_create_by_filter_useful", "true"),
+					// Filter by 'approver' parameter.
+					dcByApprover.CheckResourceExists(),
+					resource.TestCheckOutput("is_approver_filter_useful", "true"),
+					// Filter by 'owner' parameter.
+					dcByOwner.CheckResourceExists(),
+					resource.TestCheckOutput("is_owner_filter_useful", "true"),
+					// Filter by 'status' parameter.
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					// Filter by 'sync_status' and 'sync_key' parameter.
+					dcBySyncStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_sync_status_filter_useful", "true"),
+					// Filter by 'begin_time' and 'end_time' parameter.
+					dcByBeginTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_begin_time_filter_useful", "true"),
+					// Filter by 'biz_catalog_id' parameter.
+					dcByBizCatalogId.CheckResourceExists(),
+					resource.TestCheckOutput("is_biz_catalog_id_filter_useful", "true"),
+					// Filter by 'auto_generate' parameter.
+					dcByAutoGenerate.CheckResourceExists(),
+					resource.TestCheckOutput("is_auto_generate_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataArchitectureAggregationLogicTables_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_database" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket = replace("%[1]s", "_", "-")
+  acl    = "private"
+}
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "user/data/user.csv"
+  content      = "Jason,Tokyo"
+  content_type = "text/plain"
+}
+
+resource "huaweicloud_dli_table" "test" {
+  database_name   = huaweicloud_dli_database.test.name
+  name            = "%[1]s"
+  data_location   = "OBS"
+  data_format     = "csv"
+  bucket_location = "obs://${huaweicloud_obs_bucket_object.test.bucket}/user/data"
+
+  columns {
+    name = "name"
+    type = "string"
+  }
+  columns {
+    name         = "address"
+    type         = "string"
+    is_partition = true
+  }
+}
+
+resource "huaweicloud_dataarts_architecture_data_standard_template" "test" {
+  workspace_id = "%[2]s"
+
+  custom_fields {
+    fd_name    = "%[1]s"
+    required   = false
+    searchable = false
+  }
+}
+
+resource "huaweicloud_dataarts_architecture_directory" "test" {
+  workspace_id = "%[2]s"
+  name         = "%[1]s"
+  type         = "STANDARD_ELEMENT"
+
+  depends_on = [huaweicloud_dataarts_architecture_data_standard_template.test]
+}
+
+resource "huaweicloud_dataarts_architecture_data_standard" "test" {
+  workspace_id = "%[2]s"
+  directory_id = huaweicloud_dataarts_architecture_directory.test.id
+
+  values {
+    fd_name  = "nameCh"
+    fd_value = "%[1]s"
+  }
+  values {
+    fd_name  = "nameEn"
+    fd_value = "%[1]s"
+  }
+}
+
+resource "huaweicloud_dataarts_architecture_subject" "test" {
+  workspace_id = "%[2]s"
+  name         = "%[1]s"
+  code         = "%[1]s"
+  owner        = "%[3]s"
+  level        = 1
+}
+
+resource "huaweicloud_dataarts_architecture_process" "test" {
+  workspace_id = "%[2]s"
+  name         = "%[1]s"
+  owner        = "%[3]s"
+}
+
+resource "huaweicloud_dataarts_architecture_business_metric" "test" {
+  name             = "%[1]s"
+  workspace_id     = "%[2]s"
+  biz_catalog_id   = huaweicloud_dataarts_architecture_process.test.id
+  owner            = "%[3]s"
+  owner_department = "test-department"
+  time_filters     = "双周"
+  interval_type    = "HOUR"
+  destination      = "test destination"
+  definition       = "test definition"
+  expression       = "a+b+c"
+}
+
+locals {
+  biz_infos = [
+    {
+      biz_id   = huaweicloud_dataarts_architecture_data_standard.test.id
+      biz_type = "STANDARD_ELEMENT"
+    },
+    {
+      biz_id   = huaweicloud_dataarts_architecture_business_metric.test.id
+      biz_type = "BIZ_METRIC"
+    },
+    {
+      biz_id   = huaweicloud_dataarts_architecture_subject.test.id
+      biz_type = "SUBJECT"
+    },
+  ]
+}
+
+resource "huaweicloud_dataarts_architecture_batch_publishment" "test" {
+  workspace_id       = "%[2]s"
+  approver_user_id   = "%[4]s"
+  approver_user_name = "%[3]s"
+  fast_approval      = true
+
+  dynamic "biz_infos" {
+    for_each = local.biz_infos
+
+    content {
+      biz_id   = biz_infos.value.biz_id
+      biz_type = biz_infos.value.biz_type
+    }
+  }
+}
+
+resource "huaweicloud_dataarts_architecture_aggregation_logic_table" "test" {
+  workspace_id  = "%[2]s"
+  tb_name       = "dws_%[1]s"
+  tb_logic_name = "%[1]s"
+  l3_id         = huaweicloud_dataarts_architecture_subject.test.id
+  dw_id         = "%[5]s"
+  dw_type       = "DLI"
+  db_name       = huaweicloud_dli_database.test.name
+  owner         = "%[3]s"
+  alias         = "%[1]s_alias"
+  queue_name    = "%[6]s"
+  table_type    = "EXTERNAL"
+  obs_location  = huaweicloud_dli_table.test.bucket_location
+
+  table_attributes {
+    name_ch        = "key3_ch"
+    name_en        = "key3_en"
+    alias          = "key_alias"
+    data_type      = "STRING"
+    attribute_type = "BIZ_METRIC"
+    ref_id         = huaweicloud_dataarts_architecture_business_metric.test.id
+    is_primary_key = true
+    not_null       = true
+    description    = "Created attribute by terraform script"
+    stand_row_id   = huaweicloud_dataarts_architecture_data_standard.test.id
+
+    secrecy_levels {
+      id = try(split(",", "%[7]s")[0], null)
+    }
+  }
+
+  configs = jsonencode({
+    custom = "value"
+  })
+
+  description        = "Created by terraform script"
+  sql                = "select * from ${huaweicloud_dli_table.test.name}"
+  partition_conf     = "name is not null"
+  dirty_out_switch   = true
+  dirty_out_database = huaweicloud_dli_database.test.name
+  dirty_out_prefix   = "tf"
+  dirty_out_suffix   = "test"
+  secret_type        = "PUBLIC"
+
+  self_defined_fields {
+    fd_name_ch = "key_ch1"
+    fd_name_en = "key_en1"
+    not_null   = true
+    fd_value   = "value"
+  }
+
+  depends_on = [huaweicloud_dataarts_architecture_batch_publishment.test]
+}
+
+resource "huaweicloud_dataarts_architecture_batch_publishment" "aggregation_logic_table" {
+  workspace_id       = "%[2]s"
+  approver_user_id   = "%[4]s"
+  approver_user_name = "%[3]s"
+  fast_approval      = true
+
+  biz_infos {
+    biz_id   = huaweicloud_dataarts_architecture_aggregation_logic_table.test.id
+    biz_type = "AGGREGATION_LOGIC_TABLE"
+  }
+}
+
+resource "time_sleep" "wait_after_aggregation_logic_table_publishment" {
+  depends_on      = [huaweicloud_dataarts_architecture_batch_publishment.aggregation_logic_table]
+  create_duration = "60s"
+}
+`,
+		name,
+		acceptance.HW_DATAARTS_WORKSPACE_ID,
+		acceptance.HW_DATAARTS_ARCHITECTURE_USER_NAME,
+		acceptance.HW_DATAARTS_ARCHITECTURE_USER_ID,
+		acceptance.HW_DATAARTS_CONNECTION_ID,
+		acceptance.HW_DATAARTS_DLI_QUEUE_NAME,
+		acceptance.HW_DATAARTS_ARCHITECTURE_SECRECY_LEVEL_IDS,
+	)
+}
+
+func testAccDataArchitectureAggregationLogicTables_basic(name string) string {
+	currentTime := time.Now().UTC()
+	beginTime := currentTime.Add(-2 * time.Minute).Format("2006-01-02T15:04:05.000Z")
+	endTime := currentTime.Add(3 * time.Minute).Format("2006-01-02T15:04:05.000Z")
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "test" {
+  workspace_id = "%[2]s"
+
+  depends_on = [huaweicloud_dataarts_architecture_aggregation_logic_table.test]
+}
+
+# Filter by 'name' parameter fuzzy search.
+locals {
+  name_ch = huaweicloud_dataarts_architecture_aggregation_logic_table.test.tb_logic_name
+  name    = substr(local.name_ch, 1, 4)
+}
+
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "filter_by_name" {
+  workspace_id = "%[2]s"
+  name         = local.name
+
+  depends_on = [huaweicloud_dataarts_architecture_batch_publishment.aggregation_logic_table]
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_name.tables[*].tb_logic_name : strcontains(v, local.name)
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by 'name_ch' parameter exact match.
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "filter_by_name_ch" {
+  workspace_id = "%[2]s"
+  name_ch      = local.name_ch
+
+  depends_on = [time_sleep.wait_after_aggregation_logic_table_publishment]
+}
+
+locals {
+  name_ch_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_name_ch.tables[*].tb_logic_name : v == local.name_ch
+  ]
+}
+
+output "is_name_ch_filter_useful" {
+  value = length(local.name_ch_filter_result) > 0 && alltrue(local.name_ch_filter_result)
+}
+
+# Filter by 'name_en' parameter exact match.
+locals {
+  name_en = huaweicloud_dataarts_architecture_aggregation_logic_table.test.tb_name
+}
+
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "filter_by_name_en" {
+  workspace_id = "%[2]s"
+  name_en      = local.name_en
+
+  depends_on = [huaweicloud_dataarts_architecture_aggregation_logic_table.test]
+}
+
+locals {
+  name_en_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_name_en.tables[*].tb_name : v == local.name_en
+  ]
+}
+
+output "is_name_en_filter_useful" {
+  value = length(local.name_en_filter_result) > 0 && alltrue(local.name_en_filter_result)
+}
+
+# Filter by 'create_by' parameter exact match.
+locals {
+  create_by = huaweicloud_dataarts_architecture_aggregation_logic_table.test.created_by
+}
+
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "filter_by_create_by" {
+  workspace_id = "%[2]s"
+  create_by    = local.create_by
+
+  depends_on = [huaweicloud_dataarts_architecture_aggregation_logic_table.test]
+}
+
+locals {
+  create_by_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_create_by.tables[*].create_by : v == local.create_by
+  ]
+}
+
+output "is_create_by_filter_useful" {
+  value = length(local.create_by_filter_result) > 0 && alltrue(local.create_by_filter_result)
+}
+
+# Filter by 'approver' parameter.
+locals {
+  approver = "%[3]s"
+}
+
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "filter_by_approver" {
+  workspace_id = "%[2]s"
+  approver     = local.approver
+
+  depends_on = [huaweicloud_dataarts_architecture_batch_publishment.aggregation_logic_table]
+}
+
+locals {
+  approver_filter_result = [
+    for v in try(flatten(data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_approver.tables[*].approval_info[*])[*], []) :
+    v.approver == local.approver
+  ]
+}
+
+output "is_approver_filter_useful" {
+  value = length(local.approver_filter_result) > 0 && alltrue(local.approver_filter_result)
+}
+
+# Filter by 'owner' parameter.
+locals {
+  owner = huaweicloud_dataarts_architecture_aggregation_logic_table.test.owner
+}
+
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "filter_by_owner" {
+  workspace_id = "%[2]s"
+  owner        = local.owner
+
+  depends_on = [huaweicloud_dataarts_architecture_aggregation_logic_table.test]
+}
+
+locals {
+  owner_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_owner.tables[*].owner : v == local.owner
+  ]
+}
+
+output "is_owner_filter_useful" {
+  value = length(local.owner_filter_result) > 0 && alltrue(local.owner_filter_result)
+}
+
+# Filter by 'status' parameter.
+locals {
+  status = "PUBLISHED"
+}
+
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "filter_by_status" {
+  workspace_id = "%[2]s"
+  status       = local.status
+
+  depends_on = [time_sleep.wait_after_aggregation_logic_table_publishment]
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_status.tables[*].status : v == local.status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+# Filter by 'sync_status' and 'sync_key' parameter.
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "filter_by_sync_status" {
+  workspace_id = "%[2]s"
+  sync_status  = "SUMMARY_SUCCESS"
+  sync_key     = ["BUSINESS_ASSET"]
+
+  depends_on = [time_sleep.wait_after_aggregation_logic_table_publishment]
+}
+
+locals {
+  sync_status_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_sync_status.tables[*].business_asset :
+    v == "CREATE_SUCCESS"
+  ]
+}
+
+output "is_sync_status_filter_useful" {
+  value = length(local.sync_status_filter_result) > 0 && alltrue(local.sync_status_filter_result)
+}
+
+# Filter by 'begin_time' and 'end_time' parameter.
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "filter_by_begin_time" {
+  workspace_id = "%[2]s"
+  begin_time   = "%[4]s"
+  end_time     = "%[5]s"
+
+  depends_on = [time_sleep.wait_after_aggregation_logic_table_publishment]
+}
+
+locals {
+  begin_time_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_begin_time.tables[*].update_time :
+    timecmp("%[4]s", formatdate("YYYY-MM-DD'T'HH:mm:ss'Z'", timeadd(v, "-8h"))) <= 0 &&
+    timecmp(formatdate("YYYY-MM-DD'T'HH:mm:ss'Z'", timeadd(v, "-8h")), "%[5]s") <= 0
+  ]
+}
+
+output "is_begin_time_filter_useful" {
+  value = length(local.begin_time_filter_result) > 0 && alltrue(local.begin_time_filter_result)
+}
+
+# Filter by 'biz_catalog_id' parameter.
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "filter_by_biz_catalog_id" {
+  workspace_id   = "%[2]s"
+  biz_catalog_id = huaweicloud_dataarts_architecture_aggregation_logic_table.test.l3_id
+
+  depends_on = [time_sleep.wait_after_aggregation_logic_table_publishment]
+}
+
+output "is_biz_catalog_id_filter_useful" {
+  value = length(data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_biz_catalog_id.tables) > 0
+}
+
+# Filter by 'auto_generate' parameter.
+data "huaweicloud_dataarts_architecture_aggregation_logic_tables" "filter_by_auto_generate" {
+  workspace_id  = "%[2]s"
+  auto_generate = false
+
+  depends_on = [time_sleep.wait_after_aggregation_logic_table_publishment]
+}
+
+output "is_auto_generate_filter_useful" {
+  value = length(data.huaweicloud_dataarts_architecture_aggregation_logic_tables.filter_by_auto_generate.tables) > 0
+}
+`, testAccDataArchitectureAggregationLogicTables_base(name),
+		acceptance.HW_DATAARTS_WORKSPACE_ID,
+		acceptance.HW_DATAARTS_ARCHITECTURE_USER_NAME,
+		beginTime,
+		endTime,
+	)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_aggregation_logic_tables.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_aggregation_logic_tables.go
@@ -1,0 +1,898 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/design/aggregation-logic-tables
+func DataSourceArchitectureAggregationLogicTables() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceArchitectureAggregationLogicTablesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the aggregation logic tables are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the aggregation logic tables belong.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The Chinese name or English name of the aggregation logic table to be fuzzy queried.`,
+			},
+			"name_ch": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The Chinese name of the aggregation logic table to be exactly queried.`,
+			},
+			"name_en": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The English name of the aggregation logic table to be exactly queried.`,
+			},
+			"create_by": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The creator of the aggregation logic table to be queried.`,
+			},
+			"approver": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The approver of the aggregation logic table to be queried.`,
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The owner of the aggregation logic table to be queried.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The publishing status of the aggregation logic table to be queried.`,
+			},
+			"sync_status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The synchronization status of the aggregation logic table to be queried.`,
+			},
+			"sync_key": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of synchronization task types of the aggregation logic table.`,
+			},
+			"biz_catalog_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The business catalog ID to which the aggregation logic table belongs.`,
+			},
+			"begin_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The start time of the modification time for the aggregation logic table, in RFC3339 format.`,
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The end time of the modification time for the aggregation logic table, in RFC3339 format.`,
+			},
+			"auto_generate": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether the aggregation logic table is auto-generated.`,
+			},
+
+			// Attributes.
+			"tables": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the aggregation logic table.`,
+						},
+						"tb_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The physical table name in English of the aggregation logic table.`,
+						},
+						"tb_logic_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The display name in Chinese of the aggregation logic table.`,
+						},
+						"dw_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the data connection.`,
+						},
+						"dw_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the data connection.`,
+						},
+						"dw_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the data connection.`,
+						},
+						"db_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the database.`,
+						},
+						"owner": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The asset owner of the aggregation logic table.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the aggregation logic table.`,
+						},
+						"alias": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The alias of the aggregation logic table.`,
+						},
+						"queue_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The queue name of the DLI data connection.`,
+						},
+						"schema": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The schema name of the aggregation logic table.`,
+						},
+						"table_attributes": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        architectureAggregationLogicTablesAttributeSchema(),
+							Description: `The list of attributes of the aggregation logic table.`,
+						},
+						"table_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the aggregation logic table.`,
+						},
+						"distribute": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The distribution mode of the database.`,
+						},
+						"distribute_column": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The column used for hash distribution.`,
+						},
+						"compression": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The compression level of the DWS table.`,
+						},
+						"pre_combine_field": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The column used for table combine or versioning.`,
+						},
+						"obs_location": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The OBS storage path of the external table.`,
+						},
+						"configs": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The additional configuration of the aggregation logic table, in JSON format.`,
+						},
+						"dimension_group": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the statistical dimension of the derived indicator.`,
+						},
+						"group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the dimension group of the derivative metric.`,
+						},
+						"group_code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The dimension group code of the derivative metric.`,
+						},
+						"sql": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The SQL statement of the aggregation logic table.`,
+						},
+						"partition_conf": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The partition expression of the aggregation logic table.`,
+						},
+						"dirty_out_switch": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether to enable dirty data output switch.`,
+						},
+						"dirty_out_database": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The output database of the dirty data.`,
+						},
+						"dirty_out_prefix": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The prefix of the dirty data table.`,
+						},
+						"dirty_out_suffix": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The suffix of the dirty data table.`,
+						},
+						"secret_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the data secrecy level.`,
+						},
+						"self_defined_fields": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        architectureAggregationLogicTablesSelfDefinedFieldSchema(),
+							Description: `The list of user-defined extended fields for the aggregation logic table.`,
+						},
+						"tb_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The internal table ID of the aggregation logic table.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The publishing status of the aggregation logic table.`,
+						},
+						"model_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the model to which the aggregation logic table belongs.`,
+						},
+						"create_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator of the aggregation logic table.`,
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the aggregation logic table, in RFC3339 format.`,
+						},
+						"update_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the aggregation logic table, in RFC3339 format.`,
+						},
+						"env_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The publishing environment type of the aggregation logic table.`,
+						},
+						"physical_table": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the table creation in the production environment.`,
+						},
+						"dev_physical_table": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the table creation in the development environment.`,
+						},
+						"technical_asset": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The synchronization status of the technical asset.`,
+						},
+						"business_asset": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The synchronization status of the business asset.`,
+						},
+						"meta_data_link": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the asset association.`,
+						},
+						"tb_guid": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The technical catalog asset GUID after the aggregation logic table is published.`,
+						},
+						"tb_logic_guid": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The business catalog asset GUID after the aggregation logic table is published.`,
+						},
+						"data_quality": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the data quality job creation.`,
+						},
+						"quality_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the data quality.`,
+						},
+						"dlf_task": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the DLF task.`,
+						},
+						"dlf_task_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the DLF task.`,
+						},
+						"publish_to_dlm": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the DLM API generation.`,
+						},
+						"api_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the API after publishing.`,
+						},
+						"summary_status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The synchronization status of the summary.`,
+						},
+						"reversed": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the aggregation logic table is reversed.`,
+						},
+						"table_version": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The version of the aggregation logic table.`,
+						},
+						"dev_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The development environment version of the aggregation logic table.`,
+						},
+						"prod_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The production environment version of the aggregation logic table.`,
+						},
+						"dev_version_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The development environment version name of the aggregation logic table.`,
+						},
+						"prod_version_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The production environment version name of the aggregation logic table.`,
+						},
+						"approval_info": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        architectureAggregationLogicTablesApprovalInfoSchema(),
+							Description: `The approval information of the aggregation logic table.`,
+						},
+					},
+				},
+				Description: `The list of aggregation logic tables that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func architectureAggregationLogicTablesAttributeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the attribute.`,
+			},
+			"name_ch": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The Chinese name of the attribute.`,
+			},
+			"name_en": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The English name of the attribute.`,
+			},
+			"data_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data type of the attribute.`,
+			},
+			"attribute_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The configuration type of the attribute.`,
+			},
+			"is_primary_key": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the attribute is the primary key.`,
+			},
+			"is_partition_key": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the attribute is used as a partition key.`,
+			},
+			"not_null": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the attribute is not null.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the attribute.`,
+			},
+			"data_type_extend": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data type extend field of attribute.`,
+			},
+			"domain_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The domain type of the attribute.`,
+			},
+			"ref_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the object referenced by the attribute.`,
+			},
+			"ref_name_ch": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The Chinese name of the object associated with the attribute.`,
+			},
+			"ref_name_en": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The English name of the object associated with the attribute.`,
+			},
+			"stand_row_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the data standard associated with the attribute.`,
+			},
+			"stand_row_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the data standard associated with the attribute.`,
+			},
+			"ordinal": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The sequence number of the attribute.`,
+			},
+			"alias": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The alias of the attribute.`,
+			},
+			"secrecy_levels": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        architectureAggregationLogicTablesAttributeSecrecyLevelSchema(),
+				Description: `The list of secrecy levels associated with the attribute.`,
+			},
+		},
+	}
+}
+
+func architectureAggregationLogicTablesAttributeSecrecyLevelSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the secrecy level.`,
+			},
+			"uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The UUID of the secrecy level.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the secrecy level.`,
+			},
+			"slevel": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The secrecy level number.`,
+			},
+		},
+	}
+}
+
+func architectureAggregationLogicTablesSelfDefinedFieldSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"fd_name_ch": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The Chinese display name of the custom extended field.`,
+			},
+			"fd_name_en": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The English name of the custom extended field.`,
+			},
+			"not_null": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the custom extended field requires a value.`,
+			},
+			"fd_value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the custom extended field.`,
+			},
+		},
+	}
+}
+
+func architectureAggregationLogicTablesApprovalInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the approval for the aggregation logic table.`,
+			},
+			"approver": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The approver of the aggregation logic table.`,
+			},
+			"approval_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The approval status of the aggregation logic table.`,
+			},
+			"msg": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The approval message for the aggregation logic table.`,
+			},
+			"approval_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The approval time for the aggregation logic table, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func buildArchitectureAggregationLogicTablesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("name_ch"); ok {
+		res = fmt.Sprintf("%s&name_ch=%v", res, v)
+	}
+	if v, ok := d.GetOk("name_en"); ok {
+		res = fmt.Sprintf("%s&name_en=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("create_by"); ok {
+		res = fmt.Sprintf("%s&create_by=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("approver"); ok {
+		res = fmt.Sprintf("%s&approver=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("owner"); ok {
+		res = fmt.Sprintf("%s&owner=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("sync_status"); ok {
+		res = fmt.Sprintf("%s&sync_status=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("sync_key"); ok {
+		for _, item := range v.([]interface{}) {
+			res = fmt.Sprintf("%s&sync_key=%v", res, item)
+		}
+	}
+
+	if v, ok := d.GetOk("biz_catalog_id"); ok {
+		res = fmt.Sprintf("%s&biz_catalog_id=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("begin_time"); ok {
+		res = fmt.Sprintf("%s&begin_time=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("end_time"); ok {
+		res = fmt.Sprintf("%s&end_time=%v", res, v)
+	}
+
+	if d.Get("auto_generate").(bool) {
+		res = fmt.Sprintf("%s&auto_generate=true", res)
+	}
+
+	return res
+}
+
+func listArchitectureAggregationLogicTables(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/design/aggregation-logic-tables?limit={limit}"
+		offset  = 0
+		// Defaults to `50`. The maximum value is `100`.
+		limit  = 100
+		result = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildArchitectureAggregationLogicTablesQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildArchitectureMoreHeaders(d.Get("workspace_id").(string)),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		tables := utils.PathSearch("data.value.records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, tables...)
+
+		if len(tables) < limit {
+			break
+		}
+
+		offset += len(tables)
+	}
+
+	return result, nil
+}
+
+func dataSourceArchitectureAggregationLogicTablesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	tables, err := listArchitectureAggregationLogicTables(client, d)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Architecture aggregation logic tables: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("tables", flattenArchitectureAggregationLogicTables(tables)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenArchitectureAggregationLogicTables(tables []interface{}) []interface{} {
+	if len(tables) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(tables))
+	for _, table := range tables {
+		result = append(result, map[string]interface{}{
+			"id":            utils.PathSearch("id", table, nil),
+			"tb_name":       utils.PathSearch("tb_name", table, nil),
+			"tb_logic_name": utils.PathSearch("tb_logic_name", table, nil),
+			"dw_id":         utils.PathSearch("dw_id", table, nil),
+			"dw_name":       utils.PathSearch("dw_name", table, nil),
+			"dw_type":       utils.PathSearch("dw_type", table, nil),
+			"db_name":       utils.PathSearch("db_name", table, nil),
+			"owner":         utils.PathSearch("owner", table, nil),
+			"description":   utils.PathSearch("description", table, nil),
+			"alias":         utils.PathSearch("alias", table, nil),
+			"queue_name":    utils.PathSearch("queue_name", table, nil),
+			"schema":        utils.PathSearch("schema", table, nil),
+			"table_attributes": flattenArchitectureAggregationLogicTablesAttributes(
+				utils.PathSearch("table_attributes", table, make([]interface{}, 0)).([]interface{})),
+			"table_type":         utils.PathSearch("table_type", table, nil),
+			"distribute":         utils.PathSearch("distribute", table, nil),
+			"distribute_column":  utils.PathSearch("distribute_column", table, nil),
+			"compression":        utils.PathSearch("compression", table, nil),
+			"pre_combine_field":  utils.PathSearch("pre_combine_field", table, nil),
+			"obs_location":       utils.PathSearch("obs_location", table, nil),
+			"configs":            utils.PathSearch("configs", table, nil),
+			"dimension_group":    utils.PathSearch("dimension_group", table, nil),
+			"group_name":         utils.PathSearch("group_name", table, nil),
+			"group_code":         utils.PathSearch("group_code", table, nil),
+			"sql":                utils.PathSearch("sql", table, nil),
+			"partition_conf":     utils.PathSearch("partition_conf", table, nil),
+			"dirty_out_switch":   utils.PathSearch("dirty_out_switch", table, false),
+			"dirty_out_database": utils.PathSearch("dirty_out_database", table, nil),
+			"dirty_out_prefix":   utils.PathSearch("dirty_out_prefix", table, nil),
+			"dirty_out_suffix":   utils.PathSearch("dirty_out_suffix", table, nil),
+			"secret_type":        utils.PathSearch("secret_type", table, nil),
+			"self_defined_fields": flattenArchitectureAggregationLogicTablesSelfDefinedFields(
+				utils.PathSearch("self_defined_fields", table, make([]interface{}, 0)).([]interface{})),
+			"tb_id":              utils.PathSearch("tb_id", table, nil),
+			"status":             utils.PathSearch("status", table, nil),
+			"model_id":           utils.PathSearch("model_id", table, nil),
+			"create_by":          utils.PathSearch("create_by", table, nil),
+			"create_time":        utils.PathSearch("create_time", table, nil),
+			"update_time":        utils.PathSearch("update_time", table, nil),
+			"env_type":           utils.PathSearch("env_type", table, nil),
+			"physical_table":     utils.PathSearch("physical_table", table, nil),
+			"dev_physical_table": utils.PathSearch("dev_physical_table", table, nil),
+			"technical_asset":    utils.PathSearch("technical_asset", table, nil),
+			"business_asset":     utils.PathSearch("business_asset", table, nil),
+			"meta_data_link":     utils.PathSearch("meta_data_link", table, nil),
+			"tb_guid":            utils.PathSearch("tb_guid", table, nil),
+			"tb_logic_guid":      utils.PathSearch("tb_logic_guid", table, nil),
+			"data_quality":       utils.PathSearch("data_quality", table, nil),
+			"quality_id":         utils.PathSearch("quality_id", table, nil),
+			"dlf_task":           utils.PathSearch("dlf_task", table, nil),
+			"dlf_task_id":        utils.PathSearch("dlf_task_id", table, nil),
+			"publish_to_dlm":     utils.PathSearch("publish_to_dlm", table, nil),
+			"api_id":             utils.PathSearch("api_id", table, nil),
+			"summary_status":     utils.PathSearch("summary_status", table, nil),
+			"reversed":           utils.PathSearch("reversed", table, false),
+			"table_version":      utils.PathSearch("table_version", table, 0),
+			"dev_version":        utils.PathSearch("dev_version", table, nil),
+			"prod_version":       utils.PathSearch("prod_version", table, nil),
+			"dev_version_name":   utils.PathSearch("dev_version_name", table, nil),
+			"prod_version_name":  utils.PathSearch("prod_version_name", table, nil),
+			"approval_info": flattenArchitectureAggregationLogicTablesApprovalInfo(utils.PathSearch("approval_info",
+				table, nil)),
+		})
+	}
+
+	return result
+}
+
+func flattenArchitectureAggregationLogicTablesAttributes(attributes []interface{}) []interface{} {
+	if len(attributes) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(attributes))
+	for _, attr := range attributes {
+		result = append(result, map[string]interface{}{
+			"id":               utils.PathSearch("id", attr, nil),
+			"name_ch":          utils.PathSearch("name_ch", attr, nil),
+			"name_en":          utils.PathSearch("name_en", attr, nil),
+			"data_type":        utils.PathSearch("data_type", attr, nil),
+			"attribute_type":   utils.PathSearch("attribute_type", attr, nil),
+			"is_primary_key":   utils.PathSearch("is_primary_key", attr, nil),
+			"is_partition_key": utils.PathSearch("is_partition_key", attr, nil),
+			"not_null":         utils.PathSearch("not_null", attr, nil),
+			"description":      utils.PathSearch("description", attr, nil),
+			"data_type_extend": utils.PathSearch("data_type_extend", attr, nil),
+			"domain_type":      utils.PathSearch("domain_type", attr, nil),
+			"ref_id":           utils.PathSearch("ref_id", attr, nil),
+			"ref_name_ch":      utils.PathSearch("ref_name_ch", attr, nil),
+			"ref_name_en":      utils.PathSearch("ref_name_en", attr, nil),
+			"stand_row_id":     utils.PathSearch("stand_row_id", attr, nil),
+			"stand_row_name":   utils.PathSearch("stand_row_name", attr, nil),
+			"ordinal":          utils.PathSearch("ordinal", attr, 0),
+			"alias":            utils.PathSearch("alias", attr, nil),
+			"secrecy_levels": flattenArchitectureAggregationLogicTablesAttributeSecrecyLevels(
+				utils.PathSearch("secrecy_levels", attr, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result
+}
+
+func flattenArchitectureAggregationLogicTablesAttributeSecrecyLevels(levels []interface{}) []interface{} {
+	if len(levels) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(levels))
+	for _, level := range levels {
+		result = append(result, map[string]interface{}{
+			"id":     utils.PathSearch("secrecyLevel_id", level, nil),
+			"uuid":   utils.PathSearch("uuid", level, nil),
+			"name":   utils.PathSearch("secrecyLevel_name", level, nil),
+			"slevel": utils.PathSearch("slevel", level, nil),
+		})
+	}
+	return result
+}
+
+func flattenArchitectureAggregationLogicTablesSelfDefinedFields(fields []interface{}) []interface{} {
+	if len(fields) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(fields))
+	for _, field := range fields {
+		result = append(result, map[string]interface{}{
+			"fd_name_ch": utils.PathSearch("fd_name_ch", field, nil),
+			"fd_name_en": utils.PathSearch("fd_name_en", field, nil),
+			"not_null":   utils.PathSearch("not_null", field, nil),
+			"fd_value":   utils.PathSearch("fd_value", field, nil),
+		})
+	}
+	return result
+}
+
+func flattenArchitectureAggregationLogicTablesApprovalInfo(approval interface{}) []interface{} {
+	if approval == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"id":              utils.PathSearch("id", approval, nil),
+			"approver":        utils.PathSearch("approver", approval, nil),
+			"approval_status": utils.PathSearch("approval_status", approval, nil),
+			"msg":             utils.PathSearch("msg", approval, nil),
+			"approval_time":   utils.PathSearch("approval_time", approval, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_dataarts_architecture_aggregation_logic_tables`) to query aggregation logic table list. 

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataArchitectureAggregationLogicTables_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataArchitectureAggregationLogicTables_basic -timeout 360m -parallel 10
=== RUN   TestAccDataArchitectureAggregationLogicTables_basic
=== PAUSE TestAccDataArchitectureAggregationLogicTables_basic
=== CONT  TestAccDataArchitectureAggregationLogicTables_basic
--- PASS: TestAccDataArchitectureAggregationLogicTables_basic (156.81s)
PASS
coverage: 13.9% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  156.940s        coverage: 13.9% of statements in ./huaweicloud/services/dataarts

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
