### PR TITLE
feat(CCE): data source to list pod-identity associations of a cluster

### DIFF
--- a/docs/data-sources/cce_cluster_pod_identity_associations.md
+++ b/docs/data-sources/cce_cluster_pod_identity_associations.md
@@ -1,0 +1,58 @@
+---
+subcategory: "CCE"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cce_pod_identity_associations"
+description: |-
+  Use this data source to get the pod identity associations of a specified CCE cluster within HuaweiCloud.
+---
+
+# huaweicloud_cce_pod_identity_associations
+
+Use this data source to get the pod identity associations of a specified CCE cluster within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_cce_pod_identity_associations" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the pod identity associations.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the cluster ID to query.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `associations` - The list of pod identity associations.
+  The [associations](#cce_pod_identity_associations_attr) structure is documented below.
+
+<a name="cce_pod_identity_associations_attr"></a>
+The `associations` block supports:
+
+* `uid` - The UID of the pod identity association.
+
+* `cluster_id` - The ID of the cluster that the pod identity association belongs to.
+
+* `namespace` - The namespace of the service account associated with a pod identity association.
+
+* `service_account` - The name of the service account associated with a pod identity association.
+
+* `agency_name` - The name of the agency associated with a pod identity association.
+
+* `created_at` - The time when a pod identity association was created.
+
+* `updated_at` - The time when a pod identity association was last updated.
+
+* `tags` - The key/value pairs to associate with the pod identity association.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -739,6 +739,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cce_chart_values":                       cce.DataSourceCCEShowChartValues(),
 			"huaweicloud_cce_cluster_upgrade_info":               cce.DataSourceCceClusterUpgradeInfo(),
 			"huaweicloud_cce_cluster_pod_identity_assume_agency": cce.DataSourceCCEClusterPodIdentityAssumeAgency(),
+			"huaweicloud_cce_cluster_pod_identity_associations":  cce.DataSourceCCEClusterPodIdentityAssociations(),
 
 			"huaweicloud_cce_autopilot_addon_templates":      cceautopilot.DataSourceCceAutopilotAddonTemplates(),
 			"huaweicloud_cce_autopilot_clusters":             cceautopilot.DataSourceCceAutopilotClusters(),

--- a/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_cluster_pod_identity_associations_test.go
+++ b/huaweicloud/services/acceptance/cce/data_source_huaweicloud_cce_cluster_pod_identity_associations_test.go
@@ -1,0 +1,47 @@
+package cce
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCCEClusterPodIdentityAssociations_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cce_cluster_pod_identity_associations.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCceClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCCEClusterPodIdentityAssociations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "associations.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "associations.0.uid"),
+					resource.TestCheckResourceAttr(dataSource, "associations.0.cluster_id", acceptance.HW_CCE_CLUSTER_ID),
+					resource.TestCheckResourceAttrSet(dataSource, "associations.0.namespace"),
+					resource.TestCheckResourceAttrSet(dataSource, "associations.0.service_account"),
+					resource.TestCheckResourceAttrSet(dataSource, "associations.0.agency_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "associations.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "associations.0.updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCCEClusterPodIdentityAssociations_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cce_cluster_pod_identity_associations" "test" {
+  cluster_id = "%s"
+}
+`, acceptance.HW_CCE_CLUSTER_ID)
+}

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_cluster_pod_identity_associations.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_cluster_pod_identity_associations.go
@@ -1,0 +1,142 @@
+package cce
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CCE GET /api/v3/projects/{project_id}/clusters/{cluster_id}/pod-identity-associations
+func DataSourceCCEClusterPodIdentityAssociations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCCEClusterPodIdentityAssociationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the cluster ID.",
+			},
+			"associations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     podIdentityAssociationSchema(),
+			},
+		},
+	}
+}
+
+func podIdentityAssociationSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"uid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_account": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"agency_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": common.TagsComputedSchema(),
+		},
+	}
+}
+
+func dataSourceCCEClusterPodIdentityAssociationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("cce", region)
+	if err != nil {
+		return diag.Errorf("error creating CCE client: %s", err)
+	}
+
+	httpUrl := "api/v3/projects/{project_id}/clusters/{cluster_id}/pod-identity-associations"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", d.Get("cluster_id").(string))
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error getting CCE cluster pod identity associations: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.Errorf("error retrieving CCE cluster pod identity associations: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("associations", flattenPodIdentityAssociationsBody(getRespBody)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPodIdentityAssociationsBody(resp interface{}) []interface{} {
+	curArray := resp.([]interface{})
+	res := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		res = append(res, map[string]interface{}{
+			"uid":             utils.PathSearch("uid", v, nil),
+			"cluster_id":      utils.PathSearch("clusterId", v, nil),
+			"namespace":       utils.PathSearch("namespace", v, nil),
+			"service_account": utils.PathSearch("serviceAccount", v, nil),
+			"agency_name":     utils.PathSearch("agencyName", v, nil),
+			"created_at":      utils.PathSearch("createdAt", v, nil),
+			"updated_at":      utils.PathSearch("updatedAt", v, nil),
+			"tags":            utils.FlattenTagsToMap(utils.PathSearch("tags", v, nil)),
+		})
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
data source to list pod-identity associations of a cluster
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
data source to list pod-identity associations of a cluster
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run=TestAccDataSourceCCEClusterPodIdentityAssociations_basic'
...
=== RUN   TestAccDataSourceCCEClusterPodIdentityAssociations_basic
=== PAUSE TestAccDataSourceCCEClusterPodIdentityAssociations_basic
=== CONT  TestAccDataSourceCCEClusterPodIdentityAssociations_basic
--- PASS: TestAccDataSourceCCEClusterPodIdentityAssociations_basic (11.74s)
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud      12.012s
```

<img width="951" height="197" alt="image" src="https://github.com/user-attachments/assets/0161fa7b-75c3-491a-89d6-484750dc7694" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
