### PR TITLE
feat(dataarts/security): add new data source to query data categories

### DIFF
--- a/docs/data-sources/dataarts_security_data_categories.md
+++ b/docs/data-sources/dataarts_security_data_categories.md
@@ -1,0 +1,112 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_data_categories"
+description: |-
+  Use this data source to query DataArts Security data category list within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_data_categories
+
+Use this data source to query DataArts Security data category list within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_security_data_categories" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the data categories are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the data categories belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `categories` - The list of data categories.  
+  The [categories](#dataarts_security_data_categories_attr) structure is documented below.
+
+<a name="dataarts_security_data_categories_attr"></a>
+The `categories` block supports:
+
+* `category_id` - The ID of the data category.
+
+* `category_name` - The name of the data category.
+
+* `description` - The description of the data category.
+
+* `category_level` - The level of the data category in the tree.
+
+* `root_id` - The ID of the root node of the category tree.
+
+* `parent_id` - The ID of the parent category.
+
+* `category_path` - The path of the category in the tree.
+
+* `instance_id` - The instance ID to which the data category belongs.
+
+* `synchronize` - Whether the data category is synchronized with assets.
+
+* `children` - The children information of the data category, in JSON format.
+
+* `rules` - The list of data classification rules associated with the category.  
+  The [rules](#dataarts_security_data_categories_rules) structure is documented below.
+
+* `create_by` - The creator of the data category.
+
+* `create_time` - The creation time of the data category, in RFC3339 format.
+
+* `update_by` - The updater of the data category.
+
+* `update_time` - The latest update time of the data category, in RFC3339 format.
+
+<a name="dataarts_security_data_categories_rules"></a>
+The `rules` block supports:
+
+* `id` - The ID of the rule.
+
+* `name` - The name of the rule.
+
+* `type` - The type of the rule.
+
+* `secrecy_level` - The secrecy level name.
+
+* `secrecy_level_num` - The secrecy level number.
+
+* `enable` - Whether the rule is enabled.
+
+* `method` - The method of the rule.
+
+* `content_expression` - The content expression of the rule.
+
+* `column_expression` - The column expression of the rule.
+
+* `comment_expression` - The comment expression of the rule.
+
+* `combine_expression` - The combine expression of the rule.
+
+* `description` - The description of the rule.
+
+* `builtin_rule_id` - The builtin rule ID.
+
+* `match_type` - The match type of the rule.
+
+* `created_by` - The creator of the rule.
+
+* `created_at` - The creation time of the rule, in RFC3339 format.
+
+* `updated_by` - The updater of the rule.
+
+* `updated_at` - The latest update time of the rule, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1101,6 +1101,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_factory_resources": dataarts.DataSourceFactoryResources(),
 			"huaweicloud_dataarts_factory_scripts":   dataarts.DataSourceFactoryScripts(),
 			// DataArts Security
+			"huaweicloud_dataarts_security_data_categories":              dataarts.DataSourceSecurityDataCategories(),
 			"huaweicloud_dataarts_security_data_recognition_rules":       dataarts.DataSourceSecurityDataRecognitionRules(),
 			"huaweicloud_dataarts_security_dynamic_masking_policies":     dataarts.DataSourceSecurityDynamicMaskingPolicies(),
 			"huaweicloud_dataarts_security_permission_sets":              dataarts.DataSourceSecurityPermissionSets(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_data_categories_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_data_categories_test.go
@@ -1,0 +1,106 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSecurityDataCategories_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_security_data_categories.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsSecurityDataCategoryIds(t, 1)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSecurityDataCategories_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "categories.#", regexp.MustCompile(`^[1-9]([0-9]*)?`)),
+					resource.TestCheckResourceAttrSet(all, "categories.0.category_id"),
+					resource.TestCheckResourceAttrSet(all, "categories.0.category_name"),
+					resource.TestCheckResourceAttrSet(all, "categories.0.category_level"),
+					resource.TestCheckResourceAttrSet(all, "categories.0.root_id"),
+					resource.TestCheckResourceAttrSet(all, "categories.0.parent_id"),
+					resource.TestCheckResourceAttrSet(all, "categories.0.category_path"),
+					resource.TestCheckResourceAttrSet(all, "categories.0.instance_id"),
+					resource.TestCheckResourceAttrSet(all, "categories.0.create_by"),
+					resource.TestMatchResourceAttr(all, "categories.0.create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckOutput("is_rules_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSecurityDataCategories_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_security_data_secrecy_level" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+}
+
+locals {
+  category_id = try(split(",", "%[3]s")[0], null)
+}
+
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
+  workspace_id       = "%[1]s"
+  rule_type          = "CUSTOM"
+  name               = "%[2]s"
+  secrecy_level_id   = huaweicloud_dataarts_security_data_secrecy_level.test.id
+  category_id        = local.category_id
+  method             = "REGULAR"
+  content_expression = "^male$|^female&"
+  column_expression  = "phoneNumber|email"
+  comment_expression = ".*comment*."
+  description        = "Created by terraform script"
+  enable             = true
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_SECURITY_DATA_CATEGORY_IDS)
+}
+
+func testAccDataSecurityDataCategories_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_dataarts_security_data_categories" "test" {
+  workspace_id = "%[2]s"
+
+  depends_on = [huaweicloud_dataarts_security_data_recognition_rule.test]
+}
+
+locals {
+  associated_rule = try(element([for v in data.huaweicloud_dataarts_security_data_categories.test.categories : v.rules
+  if v.category_id == local.category_id][0], 0), null)
+}
+
+output "is_rules_set_and_valid" {
+  value = try(local.associated_rule.id == huaweicloud_dataarts_security_data_recognition_rule.test.id &&
+    local.associated_rule.name == huaweicloud_dataarts_security_data_recognition_rule.test.name &&
+    local.associated_rule.enable == huaweicloud_dataarts_security_data_recognition_rule.test.enable &&
+    local.associated_rule.method == huaweicloud_dataarts_security_data_recognition_rule.test.method &&
+    local.associated_rule.content_expression == huaweicloud_dataarts_security_data_recognition_rule.test.content_expression &&
+    local.associated_rule.column_expression == huaweicloud_dataarts_security_data_recognition_rule.test.column_expression &&
+    local.associated_rule.comment_expression == huaweicloud_dataarts_security_data_recognition_rule.test.comment_expression &&
+  local.associated_rule.description == huaweicloud_dataarts_security_data_recognition_rule.test.description, false)
+}
+`, testAccDataSecurityDataCategories_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_data_categories.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_data_categories.go
@@ -1,0 +1,338 @@
+package dataarts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/security/data-category
+func DataSourceSecurityDataCategories() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityDataCategoriesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the data categories are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the data categories belong.`,
+			},
+
+			// Attributes.
+			"categories": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of data categories.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"category_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the data category.`,
+						},
+						"category_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the data category.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the data category.`,
+						},
+						"category_level": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The level of the data category in the tree.`,
+						},
+						"root_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the root node of the category tree.`,
+						},
+						"parent_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the parent category.`,
+						},
+						"category_path": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The path of the category in the tree.`,
+						},
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The instance ID to which the data category belongs.`,
+						},
+						"synchronize": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the data category is synchronized with assets.`,
+						},
+						"children": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The children information of the data category, in JSON format.`,
+						},
+						"rules": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of data classification rules associated with the category.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the rule.`,
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the rule.`,
+									},
+									"type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The type of the rule.`,
+									},
+									"secrecy_level": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The secrecy level name.`,
+									},
+									"secrecy_level_num": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The secrecy level number.`,
+									},
+									"enable": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: `Whether the rule is enabled.`,
+									},
+									"method": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The method of the rule.`,
+									},
+									"content_expression": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The content expression of the rule.`,
+									},
+									"column_expression": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The column expression of the rule.`,
+									},
+									"comment_expression": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The comment expression of the rule.`,
+									},
+									"combine_expression": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The combine expression of the rule.`,
+									},
+									"description": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The description of the rule.`,
+									},
+									"builtin_rule_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The builtin rule ID.`,
+									},
+									"match_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The match type of the rule.`,
+									},
+									"created_by": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The creator of the rule.`,
+									},
+									"created_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The creation time of the rule, in RFC3339 format.`,
+									},
+									"updated_by": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The updater of the rule.`,
+									},
+									"updated_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The latest update time of the rule, in RFC3339 format.`,
+									},
+								},
+							},
+						},
+						"create_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator of the data category.`,
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the data category, in RFC3339 format.`,
+						},
+						"update_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The updater of the data category.`,
+						},
+						"update_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the data category, in RFC3339 format.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listSecurityDataCategories(client *golangsdk.ServiceClient, workspaceId string) ([]interface{}, error) {
+	httpUrl := "v1/{project_id}/security/data-category"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("category_groups", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func dataSourceSecurityDataCategoriesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	categories, err := listSecurityDataCategories(client, workspaceId)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Security data categories: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("categories", flattenSecurityDataCategories(categories)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSecurityDataCategories(categories []interface{}) []interface{} {
+	if len(categories) < 1 {
+		return []interface{}{}
+	}
+
+	result := make([]interface{}, 0, len(categories))
+	for _, v := range categories {
+		result = append(result, map[string]interface{}{
+			"category_id":    utils.PathSearch("category_id", v, nil),
+			"category_name":  utils.PathSearch("category_name", v, nil),
+			"description":    utils.PathSearch("description", v, nil),
+			"category_level": int(utils.PathSearch("category_level", v, float64(0)).(float64)),
+			"root_id":        utils.PathSearch("root_id", v, nil),
+			"parent_id":      utils.PathSearch("parent_id", v, nil),
+			"category_path":  utils.PathSearch("category_path", v, nil),
+			"instance_id":    utils.PathSearch("instance_id", v, nil),
+			"synchronize":    utils.PathSearch("synchronize", v, nil),
+			"children":       utils.JsonToString(utils.PathSearch("children", v, nil)),
+			"rules": flattenSecurityDataCategoryRules(utils.PathSearch("rule_list",
+				v, make([]interface{}, 0)).([]interface{})),
+			"create_by": utils.PathSearch("create_by", v, nil),
+			"create_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time",
+				v, float64(0)).(float64))/1000, false),
+			"update_by": utils.PathSearch("update_by", v, nil),
+			"update_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time",
+				v, float64(0)).(float64))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func flattenSecurityDataCategoryRules(rules []interface{}) []interface{} {
+	if len(rules) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(rules))
+	for _, rule := range rules {
+		result = append(result, map[string]interface{}{
+			"id":                 utils.PathSearch("uuid", rule, nil),
+			"name":               utils.PathSearch("name", rule, nil),
+			"type":               utils.PathSearch("rule_type", rule, nil),
+			"secrecy_level":      utils.PathSearch("secrecy_level", rule, nil),
+			"secrecy_level_num":  utils.PathSearch("secrecy_level_num", rule, nil),
+			"enable":             utils.PathSearch("enable", rule, nil),
+			"method":             utils.PathSearch("method", rule, nil),
+			"content_expression": utils.PathSearch("content_expression", rule, nil),
+			"column_expression":  utils.PathSearch("column_expression", rule, nil),
+			"comment_expression": utils.PathSearch("commit_expression", rule, nil),
+			"combine_expression": utils.PathSearch("combine_expression", rule, nil),
+			"description":        utils.PathSearch("description", rule, nil),
+			"builtin_rule_id":    utils.PathSearch("builtin_rule_id", rule, nil),
+			"match_type":         utils.PathSearch("match_type", rule, nil),
+			"created_by":         utils.PathSearch("created_by", rule, nil),
+			"created_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("created_at",
+				rule, float64(0)).(float64))/1000, false),
+			"updated_by": utils.PathSearch("updated_by", rule, nil),
+			"updated_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("updated_at",
+				rule, float64(0)).(float64))/1000, false),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_dataarts_security_data_categories`) to query DataArts Security data catergory list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
It has been confirmed with the developers that the API corresponding to the data source is a full query, and the limit and offset parameters are not effective.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataSecurityDataCategories_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataSecurityDataCategories_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSecurityDataCategories_basic
=== PAUSE TestAccDataSecurityDataCategories_basic
=== CONT  TestAccDataSecurityDataCategories_basic
--- PASS: TestAccDataSecurityDataCategories_basic (17.56s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  17.693s coverage: 5.3% of statements in ./huaweicloud/services/dataarts
```
<img width="1303" height="46" alt="image" src="https://github.com/user-attachments/assets/19d8eaaf-7e80-49e1-b69a-19693e59fd52" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
