### PR TITLE
feat(dataarts): add new data source to query the list of subjects

### DIFF
--- a/docs/data-sources/dataarts_architecture_subjects.md
+++ b/docs/data-sources/dataarts_architecture_subjects.md
@@ -1,0 +1,204 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_architecture_subjects"
+description: |-
+  Use this data source to get the list of subjects within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_architecture_subjects
+
+Use this data source to get the list of subjects within HuaweiCloud.
+
+## Example Usage
+
+### Query all subjects and without any filter
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_architecture_subjects" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+### Query the subjects and using status filter
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_architecture_subjects" "test" {
+  workspace_id = var.workspace_id
+  status       = "PUBLISHED"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the subjects are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the subjects belong.
+
+* `name` - (Optional, String) Specifies the name or code of the subject (fuzzy query).
+
+* `create_by` - (Optional, String) Specifies the creator of the subject.
+
+* `owner` - (Optional, String) Specifies the owner of the subject.
+
+* `status` - (Optional, String) Specifies the business status of the subject.  
+  The valid values are as follows:
+  + **DRAFT**: Draft.
+  + **PUBLISH_DEVELOPING**: Publishing.
+  + **PUBLISHED**: Published.
+  + **OFFLINE_DEVELOPING**: Going offline.
+  + **OFFLINE**: Offline.
+  + **REJECT**: Rejected.
+
+* `begin_time` - (Optional, String) Specifies the start time for filtering, in RFC3339 format.
+
+* `end_time` - (Optional, String) Specifies the end time for filtering, in RFC3339 format.
+
+* `parent_id` - (Optional, String) Specifies the parent directory ID of the subject.  
+  The root node does not have this ID. An empty value means all nodes,
+  and `-1` means nodes under the root node.
+
+* `level` - (Optional, Int) Specifies the level of the subject.
+
+* `with_relation` - (Optional, Bool) Specifies whether to include relation information.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, in UUID format.
+
+* `subjects` - The list of subjects that matched filter parameters.  
+  The [subjects](#dataarts_architecture_subject) structure is documented below.
+
+<a name="dataarts_architecture_subject"></a>
+The `subjects` block supports:
+
+* `id` - The ID of the subject.
+
+* `name` - The Chinese name of the subject.
+
+* `name_en` - The English name of the subject.
+
+* `description` - The description of the subject.
+
+* `qualified_name` - The qualified name of the subject.
+
+* `guid` - The GUID of the subject, automatically generated.
+
+* `code` - The code of the subject.
+
+* `alias` - The alias of the subject.
+
+* `status` - The business status of the subject.
+
+* `new_biz` - The business version management information, in JSON format.
+
+* `data_owner` - The data owner of the subject.
+
+* `data_owner_list` - The data owner list of the subject.
+
+* `data_department` - The data department of the subject.
+
+* `path` - The path of the subject.
+
+* `level` - The level of the subject.
+
+* `ordinal` - The ordinal of the subject.
+
+* `owner` - The owner of the subject.
+
+* `parent_id` - The parent directory ID of the subject.
+
+* `swap_order_id` - The swap order ID of the subject.
+
+* `qualified_id` - The qualified ID of the subject.
+
+* `from_public` - Whether the subject is from public layer.
+
+* `created_by` - The creator of the subject.
+
+* `updated_by` - The last editor of the subject.
+
+* `created_at` - The creation time of the subject, in RFC3339 format.
+
+* `updated_at` - The latest update time of the subject, in RFC3339 format.
+
+* `children_num` - The number of child processes.
+
+* `children` - The child directories, in JSON format.
+
+* `self_defined_field` - The self-defined field in JSON format.
+
+* `relations` - The list of relations.  
+  The [relations](#dataarts_architecture_subject_relation) structure is documented below.
+
+<a name="dataarts_architecture_subject_relation"></a>
+The `relations` block supports:
+
+* `id` - The ID of the relation.
+
+* `source_table_id` - The source table ID of the relation.
+
+* `target_table_id` - The target table ID of the relation.
+
+* `name` - The name of the relation.
+
+* `source_table_name` - The source table name of the relation.
+
+* `target_table_name` - The target table name of the relation.
+
+* `role` - The role of the relation.
+
+* `source_type` - The source type of the relation.
+  + **ONE**
+  + **ZERO_OR_ONE**
+  + **ZERO_OR_N**
+  + **ONE_OR_N**
+
+* `target_type` - The target type of the relation.
+  + **ONE**
+  + **ZERO_OR_ONE**
+  + **ZERO_OR_N**
+  + **ONE_OR_N**
+
+* `created_by` - The creator of the relation.
+
+* `updated_by` - The last editor of the relation.
+
+* `created_at` - The creation time of the relation, in RFC3339 format.
+
+* `updated_at` - The latest update time of the relation, in RFC3339 format.
+
+* `mappings` - The list of mappings.  
+  The [mappings](#dataarts_architecture_subject_relation_mapping) structure is documented below.
+
+<a name="dataarts_architecture_subject_relation_mapping"></a>
+The `mappings` block supports:
+
+* `id` - The ID of the mapping.
+
+* `relation_id` - The relation ID of the mapping.
+
+* `source_field_id` - The source field ID of the mapping.
+
+* `target_field_id` - The target field ID of the mapping.
+
+* `source_field_name` - The source field name of the mapping.
+
+* `target_field_name` - The target field name of the mapping.
+
+* `created_by` - The creator of the mapping.
+
+* `updated_by` - The last editor of the mapping.
+
+* `created_at` - The creation time of the mapping, in RFC3339 format.
+
+* `updated_at` - The latest update time of the mapping, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1082,6 +1082,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_models":                           dataarts.DataSourceArchitectureModels(),
 			"huaweicloud_dataarts_architecture_model_statistic":                  dataarts.DataSourceArchitectureModelStatistic(),
 			"huaweicloud_dataarts_architecture_processes":                        dataarts.DataSourceArchitectureProcesses(),
+			"huaweicloud_dataarts_architecture_subjects":                         dataarts.DataSourceArchitectureSubjects(),
 			"huaweicloud_dataarts_architecture_table_models":                     dataarts.DataSourceArchitectureTableModels(),
 			"huaweicloud_dataarts_architecture_table_model_relations":            dataarts.DataSourceArchitectureTableModelRelations(),
 			// DataArts DataService

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_subjects_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_subjects_test.go
@@ -1,0 +1,220 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceArchitectureSubjects_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_architecture_subjects.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_dataarts_architecture_subjects.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byStatus   = "data.huaweicloud_dataarts_architecture_subjects.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byCreateBy   = "data.huaweicloud_dataarts_architecture_subjects.filter_by_create_by"
+		dcByCreateBy = acceptance.InitDataSourceCheck(byCreateBy)
+
+		byLevel   = "data.huaweicloud_dataarts_architecture_subjects.filter_by_level"
+		dcByLevel = acceptance.InitDataSourceCheck(byLevel)
+
+		byWithRelation   = "data.huaweicloud_dataarts_architecture_subjects.filter_by_with_relation"
+		dcByWithRelation = acceptance.InitDataSourceCheck(byWithRelation)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceArchitectureSubjects_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "subjects.#", regexp.MustCompile(`^[1-9]([0-9]+)?$`)),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.id"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.name"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.name_en"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.description"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.qualified_name"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.code"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.status"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.data_owner_list"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.path"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.level"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.ordinal"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.owner"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.from_public"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.created_by"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.updated_by"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.created_at"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.updated_at"),
+					resource.TestCheckResourceAttrSet(all, "subjects.0.children_num"),
+					resource.TestMatchResourceAttr(all, "subjects.0.relations.#", regexp.MustCompile(`^[0-9]+$`)),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					dcByCreateBy.CheckResourceExists(),
+					resource.TestCheckOutput("is_create_by_filter_useful", "true"),
+					dcByLevel.CheckResourceExists(),
+					resource.TestCheckOutput("is_level_filter_useful", "true"),
+					dcByWithRelation.CheckResourceExists(),
+					resource.TestCheckOutput("is_with_relation_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceArchitectureSubjects_basic_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_subject" "test" {
+  count = 3
+
+  workspace_id = "%[1]s"
+  name         = format("%[2]s-%%d", count.index)
+  code         = format("%[2]s_code-%%d", count.index)
+  owner        = "terraform_test"
+  level        = 1
+  description  = "Created by terraform script"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccDataSourceArchitectureSubjects_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all subjects without any filter.
+data "huaweicloud_dataarts_architecture_subjects" "all" {
+  workspace_id = "%[2]s"
+
+  depends_on = [huaweicloud_dataarts_architecture_subject.test]
+}
+
+# Filter subjects by name.
+locals {
+  name = huaweicloud_dataarts_architecture_subject.test[0].name
+}
+
+data "huaweicloud_dataarts_architecture_subjects" "filter_by_name" {
+  workspace_id = "%[2]s"
+  name         = local.name
+
+  depends_on = [huaweicloud_dataarts_architecture_subject.test]
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_subjects.filter_by_name.subjects 
+	: v.name == local.name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter subjects by status.
+locals {
+  status = "DRAFT"
+}
+
+data "huaweicloud_dataarts_architecture_subjects" "filter_by_status" {
+  workspace_id = "%[2]s"
+  status       = local.status
+
+  depends_on = [huaweicloud_dataarts_architecture_subject.test]
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_subjects.filter_by_status.subjects
+    : v.status == local.status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+# Filter subjects by create_by.
+locals {
+  owner = data.huaweicloud_dataarts_architecture_subjects.all.subjects[0].owner
+}
+
+data "huaweicloud_dataarts_architecture_subjects" "filter_by_create_by" {
+  workspace_id = "%[2]s"
+  create_by    = local.owner
+
+  depends_on = [huaweicloud_dataarts_architecture_subject.test]
+}
+
+locals {
+  create_by_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_subjects.filter_by_create_by.subjects
+    : v.created_by == local.owner
+  ]
+}
+
+output "is_create_by_filter_useful" {
+  value = length(local.create_by_filter_result) > 0 && alltrue(local.create_by_filter_result)
+}
+
+# Filter subjects by level.
+data "huaweicloud_dataarts_architecture_subjects" "filter_by_level" {
+  workspace_id = "%[2]s"
+  level        = 1
+
+  depends_on = [huaweicloud_dataarts_architecture_subject.test]
+}
+
+locals {
+  level_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_subjects.filter_by_level.subjects
+    : v.level == 1
+  ]
+}
+
+output "is_level_filter_useful" {
+  value = length(local.level_filter_result) > 0 && alltrue(local.level_filter_result)
+}
+
+# Filter subjects by with_relation.
+locals {
+  with_relation = true
+}
+
+data "huaweicloud_dataarts_architecture_subjects" "filter_by_with_relation" {
+  workspace_id   = "%[2]s"
+  with_relation  = local.with_relation
+
+  depends_on = [huaweicloud_dataarts_architecture_subject.test]
+}
+
+locals {
+  with_relation_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_subjects.filter_by_with_relation.subjects
+    : length(v.relations) >= 0
+  ]
+}
+
+output "is_with_relation_filter_useful" {
+  value = length(local.with_relation_filter_result) > 0 && alltrue(local.with_relation_filter_result)
+}
+`, testAccDataSourceArchitectureSubjects_basic_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_subjects.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_subjects.go
@@ -1,0 +1,583 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v3/{project_id}/design/subjects
+func DataSourceArchitectureSubjects() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceArchitectureSubjectsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the subjects are located.",
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the workspace to which the subjects belong.",
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name or code of the subject (fuzzy query).",
+			},
+			"create_by": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The creator of the subject.",
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The owner of the subject.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The business status of the subject.",
+			},
+			"begin_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The start time for filtering, in RFC3339 format.",
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The end time for filtering, in RFC3339 format.",
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The parent directory ID of the subject.",
+			},
+			"level": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The level of the subject.",
+			},
+			"with_relation": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether to include relation information.",
+			},
+
+			// Attributes.
+			"subjects": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureSubject(),
+				Description: "The list of subjects that matched filter parameters.",
+			},
+		},
+	}
+}
+
+func dataArchitectureSubject() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the subject.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The Chinese name of the subject.",
+			},
+			"name_en": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The English name of the subject.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the subject.",
+			},
+			"qualified_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The qualified name of the subject.",
+			},
+			"guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The GUID of the subject, automatically generated.",
+			},
+			"code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The code of the subject.",
+			},
+			"alias": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The alias of the subject.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The business status of the subject.",
+			},
+			"new_biz": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The business version management information, in JSON format.",
+			},
+			"data_owner": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The data owner of the subject.",
+			},
+			"data_owner_list": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The data owner list of the subject.",
+			},
+			"data_department": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The data department of the subject.",
+			},
+			"path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The path of the subject.",
+			},
+			"level": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The level of the subject.",
+			},
+			"ordinal": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The ordinal of the subject.",
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The owner of the subject.",
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The parent directory ID of the subject.",
+			},
+			"swap_order_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The swap order ID of the subject.",
+			},
+			"qualified_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The qualified ID of the subject.",
+			},
+			"from_public": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the subject is from public layer.",
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creator of the subject.",
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The last editor of the subject.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the subject, in RFC3339 format.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the subject, in RFC3339 format.",
+			},
+			"children_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The number of child processes.",
+			},
+			"children": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The child directories, in JSON format.",
+			},
+			"self_defined_field": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The self-defined field in JSON format.",
+			},
+			"relations": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureSubjectRelation(),
+				Description: "The list of relations.",
+			},
+		},
+	}
+}
+
+func dataArchitectureSubjectRelation() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the relation.",
+			},
+			"source_table_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The source table ID of the relation.",
+			},
+			"target_table_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The target table ID of the relation.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the relation.",
+			},
+			"source_table_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The source table name of the relation.",
+			},
+			"target_table_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The target table name of the relation.",
+			},
+			"role": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The role of the relation.",
+			},
+			"source_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The source type of the relation.",
+			},
+			"target_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The target type of the relation.",
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creator of the relation.",
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The last editor of the relation.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the relation, in RFC3339 format.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the relation, in RFC3339 format.",
+			},
+			"mappings": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureSubjectMapping(),
+				Description: "The list of mappings.",
+			},
+		},
+	}
+}
+
+func dataArchitectureSubjectMapping() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the mapping.",
+			},
+			"relation_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The relation ID of the mapping.",
+			},
+			"source_field_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The source field ID of the mapping.",
+			},
+			"target_field_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The target field ID of the mapping.",
+			},
+			"source_field_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The source field name of the mapping.",
+			},
+			"target_field_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The target field name of the mapping.",
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creator of the mapping.",
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The last editor of the mapping.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the mapping, in RFC3339 format.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the mapping, in RFC3339 format.",
+			},
+		},
+	}
+}
+
+func buildArchitectureSubjectsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("create_by"); ok {
+		res = fmt.Sprintf("%s&create_by=%v", res, v)
+	}
+	if v, ok := d.GetOk("owner"); ok {
+		res = fmt.Sprintf("%s&owner=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("begin_time"); ok {
+		res = fmt.Sprintf("%s&begin_time=%v", res, v)
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		res = fmt.Sprintf("%s&end_time=%v", res, v)
+	}
+	if v, ok := d.GetOk("parent_id"); ok {
+		res = fmt.Sprintf("%s&parent_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("level"); ok {
+		res = fmt.Sprintf("%s&level=%v", res, v)
+	}
+	if v, ok := d.GetOk("with_relation"); ok {
+		res = fmt.Sprintf("%s&with_relation=%v", res, v)
+	}
+
+	return res
+}
+
+func listArchitectureSubjects(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/design/subjects?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildArchitectureSubjectsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildArchitectureMoreHeaders(d.Get("workspace_id").(string)),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		subjects := utils.PathSearch("data.value.records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, subjects...)
+
+		if len(subjects) < limit {
+			break
+		}
+		offset += len(subjects)
+	}
+
+	return result, nil
+}
+
+func flattenArchitectureSubjectMappings(mappings []interface{}) []map[string]interface{} {
+	if len(mappings) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(mappings))
+	for _, mapping := range mappings {
+		result = append(result, map[string]interface{}{
+			"id":                utils.PathSearch("id", mapping, nil),
+			"relation_id":       utils.PathSearch("relation_id", mapping, nil),
+			"source_field_id":   utils.PathSearch("source_field_id", mapping, nil),
+			"target_field_id":   utils.PathSearch("target_field_id", mapping, nil),
+			"source_field_name": utils.PathSearch("source_field_name", mapping, nil),
+			"target_field_name": utils.PathSearch("target_field_name", mapping, nil),
+			"created_by":        utils.PathSearch("create_by", mapping, nil),
+			"updated_by":        utils.PathSearch("update_by", mapping, nil),
+			"created_at":        utils.PathSearch("create_time", mapping, nil),
+			"updated_at":        utils.PathSearch("update_time", mapping, nil),
+		})
+	}
+	return result
+}
+
+func flattenArchitectureSubjectRelations(relations []interface{}) []map[string]interface{} {
+	if len(relations) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(relations))
+	for _, relation := range relations {
+		result = append(result, map[string]interface{}{
+			"id":                utils.PathSearch("id", relation, nil),
+			"source_table_id":   utils.PathSearch("source_table_id", relation, nil),
+			"target_table_id":   utils.PathSearch("target_table_id", relation, nil),
+			"name":              utils.PathSearch("name", relation, nil),
+			"source_table_name": utils.PathSearch("source_table_name", relation, nil),
+			"target_table_name": utils.PathSearch("target_table_name", relation, nil),
+			"role":              utils.PathSearch("role", relation, nil),
+			"source_type":       utils.PathSearch("source_type", relation, nil),
+			"target_type":       utils.PathSearch("target_type", relation, nil),
+			"created_by":        utils.PathSearch("create_by", relation, nil),
+			"updated_by":        utils.PathSearch("update_by", relation, nil),
+			"created_at":        utils.PathSearch("create_time", relation, nil),
+			"updated_at":        utils.PathSearch("update_time", relation, nil),
+			"mappings": flattenArchitectureSubjectMappings(
+				utils.PathSearch("mappings", relation, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result
+}
+
+func flattenArchitectureSubjects(subjects []interface{}) []map[string]interface{} {
+	if len(subjects) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(subjects))
+	for _, subject := range subjects {
+		result = append(result, map[string]interface{}{
+			"id":                 utils.PathSearch("id", subject, nil),
+			"name":               utils.PathSearch("name_ch", subject, nil),
+			"name_en":            utils.PathSearch("name_en", subject, nil),
+			"description":        utils.PathSearch("description", subject, nil),
+			"qualified_name":     utils.PathSearch("qualified_name", subject, nil),
+			"guid":               utils.PathSearch("guid", subject, nil),
+			"code":               utils.PathSearch("code", subject, nil),
+			"alias":              utils.PathSearch("alias", subject, nil),
+			"status":             utils.PathSearch("status", subject, nil),
+			"new_biz":            utils.JsonToString(utils.PathSearch("new_biz", subject, nil)),
+			"data_owner":         utils.PathSearch("data_owner", subject, nil),
+			"data_owner_list":    utils.PathSearch("data_owner_list", subject, nil),
+			"data_department":    utils.PathSearch("data_department", subject, nil),
+			"path":               utils.PathSearch("path", subject, nil),
+			"level":              utils.PathSearch("level", subject, nil),
+			"ordinal":            utils.PathSearch("ordinal", subject, nil),
+			"owner":              utils.PathSearch("owner", subject, nil),
+			"parent_id":          utils.PathSearch("parent_id", subject, nil),
+			"swap_order_id":      utils.PathSearch("swap_order_id", subject, nil),
+			"qualified_id":       utils.PathSearch("qualified_id", subject, nil),
+			"from_public":        utils.PathSearch("from_public", subject, nil),
+			"created_by":         utils.PathSearch("create_by", subject, nil),
+			"updated_by":         utils.PathSearch("update_by", subject, nil),
+			"created_at":         utils.PathSearch("create_time", subject, nil),
+			"updated_at":         utils.PathSearch("update_time", subject, nil),
+			"children_num":       utils.PathSearch("children_num", subject, nil),
+			"children":           utils.JsonToString(utils.PathSearch("children", subject, nil)),
+			"self_defined_field": utils.JsonToString(utils.PathSearch("self_defined_field", subject, nil)),
+			"relations": flattenArchitectureSubjectRelations(
+				utils.PathSearch("relations", subject, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result
+}
+
+func dataSourceArchitectureSubjectsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	subjects, err := listArchitectureSubjects(client, d)
+	if err != nil {
+		return diag.Errorf("error querying architecture subjects: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("subjects", flattenArchitectureSubjects(subjects)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data source to query the list of subjects.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.tf`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataSourceArchitectureSubjects_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceArchitectureSubjects_basic
=== PAUSE TestAccDataSourceArchitectureSubjects_basic
=== CONT  TestAccDataSourceArchitectureSubjects_basic
--- PASS: TestAccDataSourceArchitectureSubjects_basic (15.98s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  16.113s coverage: 5.1% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.