### PR TITLE
chore: docs(dataarts/architecture): change 'model_id' from an attribute to a parameter and optimize documents

### DIFF
--- a/docs/data-sources/dataarts_architecture_models.md
+++ b/docs/data-sources/dataarts_architecture_models.md
@@ -88,6 +88,7 @@ The `models` block supports:
 * `type` - The workspace type.  
   + **THIRD_NF**
   + **DIMENSION**
+  + **DM**
 
 * `biz_catalog_ids` - The associated business catalog IDs.
 

--- a/docs/resources/dataarts_architecture_aggregation_logic_table.md
+++ b/docs/resources/dataarts_architecture_aggregation_logic_table.md
@@ -106,6 +106,9 @@ The following arguments are supported:
 
 * `description` - (Required, String) Specifies the description of the aggregation logic table.
 
+* `model_id` - (Optional, String) Specifies the ID of the model to which the aggregation logic table belongs.  
+  If omitted, the aggregation logic table will be created in the default model.
+
 * `alias` - (Optional, String) Specifies the alias of the aggregation logic table.
 
 * `queue_name` - (Optional, String) Specifies the queue name corresponding to the DLI data connection.  
@@ -284,8 +287,6 @@ In addition to all arguments above, the following attributes are exported:
 * `group_name` - The name of the dimension group of the derivative metric.
 
 * `group_code` - The dimension group code of the derivative metric.
-
-* `model_id` - The ID of the model to which the aggregation logic table belongs.
 
 * `created_by` - The account name of the user who created the aggregation logic table.
 

--- a/docs/resources/dataarts_architecture_model.md
+++ b/docs/resources/dataarts_architecture_model.md
@@ -47,7 +47,11 @@ The following arguments are supported:
 
 * `name` - (Required, String) Specifies the model name.
 
-* `type` - (Required, String) Specifies the model type. The valid values are **THIRD_NF** and **DIMENSION**.
+* `type` - (Required, String) Specifies the model type.  
+  The valid values are as follows:
+  + **THIRD_NF**
+  + **DIMENSION**
+  + **DM**
 
 * `description` - (Optional, String) Specifies the description of model.
 
@@ -62,7 +66,12 @@ The following arguments are supported:
   + **MYSQL**
   + **ORACLE**
 
-* `level` - (Optional, String) Specifies the data warehouse layer. Valid values are **SDI** and **DWI**.
+* `level` - (Optional, String) Specifies the data warehouse layer.  
+  The valid values are as follows:
+  + **SDI**
+  + **DWI**
+  + **DWR**
+  + **DM**
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_aggregation_logic_table_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_aggregation_logic_table_test.go
@@ -59,6 +59,7 @@ func TestAccArchitectureAggregationLogicTable_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "alias", fmt.Sprintf("%s_alias", name)),
 					resource.TestCheckResourceAttr(rName, "queue_name", acceptance.HW_DATAARTS_DLI_QUEUE_NAME),
 					resource.TestCheckResourceAttr(rName, "table_type", "MANAGED"),
+					resource.TestCheckResourceAttrSet(rName, "model_id"),
 					resource.TestCheckResourceAttr(rName, "description", "Created by terraform script"),
 					resource.TestCheckResourceAttr(rName, "sql", fmt.Sprintf("SELECT * FROM %s", name)),
 					resource.TestCheckResourceAttr(rName, "partition_conf", "name is not null"),
@@ -131,6 +132,7 @@ func TestAccArchitectureAggregationLogicTable_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "queue_name", acceptance.HW_DATAARTS_DLI_QUEUE_NAME),
 					resource.TestCheckResourceAttr(rName, "table_type", "EXTERNAL"),
 					resource.TestCheckResourceAttrPair(rName, "obs_location", "huaweicloud_dli_table.test", "bucket_location"),
+					resource.TestCheckResourceAttrPair(rName, "model_id", "huaweicloud_dataarts_architecture_model.test", "id"),
 					resource.TestCheckResourceAttr(rName, "description", "Updated by terraform script"),
 					resource.TestCheckResourceAttr(rName, "sql", fmt.Sprintf("SELECT name FROM %s", name)),
 					resource.TestCheckResourceAttr(rName, "partition_conf", "key1_en is not null"),
@@ -336,6 +338,15 @@ resource "huaweicloud_dataarts_architecture_batch_publishment" "test" {
     }
   }
 }
+
+resource "huaweicloud_dataarts_architecture_model" "test" {
+  workspace_id = "%[2]s"
+  name         = "%[1]s"
+  type         = "DM"
+  physical     = true
+  dw_type      = "DLI"
+  level        = "DM"
+}
 `, name, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_ARCHITECTURE_USER_ID, acceptance.HW_DATAARTS_ARCHITECTURE_USER_NAME)
 }
 
@@ -444,6 +455,7 @@ resource "huaweicloud_dataarts_architecture_aggregation_logic_table" "test" {
   queue_name    = "%[5]s"
   table_type    = "EXTERNAL"
   obs_location  = huaweicloud_dli_table.test.bucket_location
+  model_id      = huaweicloud_dataarts_architecture_model.test.id
 
   table_attributes {
     name_ch          = "key2_ch"

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_aggregation_logic_table.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_aggregation_logic_table.go
@@ -248,6 +248,12 @@ func ResourceArchitectureAggregationLogicTable() *schema.Resource {
 				Computed:    true,
 				Description: `The type of the database table.`,
 			},
+			"model_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The ID of the model to which the aggregation logic table belongs.`,
+			},
 			"distribute": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -376,11 +382,6 @@ func ResourceArchitectureAggregationLogicTable() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `The dimension group code of the derivative metric.`,
-			},
-			"model_id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: `The ID of the model to which the aggregation logic table belongs.`,
 			},
 			"created_by": {
 				Type:        schema.TypeString,
@@ -538,6 +539,7 @@ func buildCreateArchitectureAggregationLogicTableBodyParams(d *schema.ResourceDa
 		"schema":              utils.ValueIgnoreEmpty(d.Get("schema")),
 		"table_attributes":    buildArchitectureAggregationLogicTableAttributes(d.Get("table_attributes").([]interface{})),
 		"table_type":          utils.ValueIgnoreEmpty(d.Get("table_type")),
+		"model_id":            utils.ValueIgnoreEmpty(d.Get("model_id")),
 		"distribute":          utils.ValueIgnoreEmpty(d.Get("distribute")),
 		"distribute_column":   utils.ValueIgnoreEmpty(d.Get("distribute_column")),
 		"compression":         utils.ValueIgnoreEmpty(d.Get("compression")),
@@ -925,6 +927,7 @@ func buildUpdateArchitectureAggregationLogicTableBodyParams(d *schema.ResourceDa
 		"schema":              utils.ValueIgnoreEmpty(d.Get("schema")),
 		"table_attributes":    buildArchitectureAggregationLogicTableAttributes(d.Get("table_attributes").([]interface{})),
 		"table_type":          utils.ValueIgnoreEmpty(d.Get("table_type")),
+		"model_id":            utils.ValueIgnoreEmpty(d.Get("model_id")),
 		"distribute":          utils.ValueIgnoreEmpty(d.Get("distribute")),
 		"distribute_column":   utils.ValueIgnoreEmpty(d.Get("distribute_column")),
 		"compression":         utils.ValueIgnoreEmpty(d.Get("compression")),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. For aggregation logic table  resource: The `model_id` field should be a parameter, If not specified, the aggregation logic table will be created under the system's default model.
2. For model resource and data source:  Supplement some field(`level `and `type`) enumeration values.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. change 'model_id' from an attribute to a parameter for aggregation logic table resource.
2. supplement some field enumeration values for model resource and data source documentations.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccArchitectureAggregationLogicTable_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccArchitectureAggregationLogicTable_basic -timeout 360m -parallel 10
=== RUN   TestAccArchitectureAggregationLogicTable_basic
=== PAUSE TestAccArchitectureAggregationLogicTable_basic
=== CONT  TestAccArchitectureAggregationLogicTable_basic
--- PASS: TestAccArchitectureAggregationLogicTable_basic (54.71s)
PASS
coverage: 13.7% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  54.813s coverage: 13.7% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
