### PR TITLE
feat(drs): add drs name validation resource

### DIFF
--- a/docs/data-sources/drs-name-validation.md
+++ b/docs/data-sources/drs-name-validation.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_name_validation"
+description: |-
+  Manages a DRS job name validation resource.
+---
+
+# huaweicloud_drs_name_validation
+
+Manages a DRS job name validation resource.
+
+-> 1. This resource is a one-time action resource used to verify the availability of a DRS job name. Deleting this resource
+  will not perform any operations on the cloud, but will only remove the resource information from the tf state file.
+  <br/>2. This resource is used to verify whether the job name meets the format requirements and is available
+  before creating a DRS job.
+
+## Example Usage
+
+```hcl
+variable "name" {}
+variable "type" {}
+
+resource "huaweicloud_drs_name_validation" "test" {
+  name = var.name
+  type = var.type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, NonUpdatable) Specifies the DRS job name to be validated.
+  The name must meet the following rules: 4 to 50 characters, starts with a letter, can contain letters, digits,
+  hyphens (-) and underscores (_), and cannot contain other special characters.
+
+* `type` - (Required, String, NonUpdatable) Specifies the type of the DRS job.
+  The valid values are as follows:
+  + **TRANS**
+  + **SUBSCRIPTION**
+  + **OFFLINE**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `is_valid` - Whether the job name is valid.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3494,6 +3494,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_drs_job":                            drs.ResourceDrsJob(),
 			"huaweicloud_drs_job_primary_standby_switch":     drs.ResourceDRSPrimaryStandbySwitch(),
+			"huaweicloud_drs_name_validation":                drs.ResourceDrsNameValidation(),
 			"huaweicloud_drs_download_batch_create_template": drs.ResourceDownloadBatchCreateTemplate(),
 			"huaweicloud_drs_stop_job":                       drs.ResourceStopJob(),
 

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_name_validation_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_name_validation_test.go
@@ -1,0 +1,45 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDrsNameValidation_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_drs_name_validation.test"
+		rName        = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDrsNameValidation_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "trans"),
+					resource.TestCheckResourceAttrSet(resourceName, "is_valid"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDrsNameValidation_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_drs_name_validation" "test" {
+  name = "%s"
+  type = "trans"
+}
+`, rName)
+}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_name_validation.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_name_validation.go
@@ -1,0 +1,132 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nameValidationNonUpdatableParams = []string{"name", "type"}
+
+// @API DRS POST /v5/{project_id}/jobs/name-validation
+func ResourceDrsNameValidation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDrsNameValidationCreate,
+		ReadContext:   resourceDrsNameValidationRead,
+		UpdateContext: resourceDrsNameValidationUpdate,
+		DeleteContext: resourceDrsNameValidationDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nameValidationNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"is_valid": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildNameValidationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name": d.Get("name"),
+		"type": d.Get("type"),
+	}
+	return utils.RemoveNil(bodyParams)
+}
+
+func resourceDrsNameValidationCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/jobs/name-validation"
+	)
+
+	client, err := cfg.NewServiceClient("drs", region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildNameValidationBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error validating DRS name: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("is_valid", utils.PathSearch("is_valid", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDrsNameValidationRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDrsNameValidationUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceDrsNameValidationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to validate a DRS job name. Deleting this resource will not
+perform any operations on the cloud, but will only remove the resource information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a new action resource huaweicloud_drs_job_name_validation for HuaweiCloud Data Replication Service (DRS). This resource is used to verify the validity and availability of a job name before creating a DRS job, which helps users avoid job creation failures caused by invalid or duplicate names. It is implemented as an action resource in accordance with the team's PMO specifications and best practices.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add action resource huaweicloud_drs_name_validation for DRS job name verification
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/drs' TESTARGS='-run=TestAccDrsNameValidation_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run=TestAccDrsNameValidation_basic -timeout 360m -parallel 4
=== RUN   TestAccDrsNameValidation_basic
=== PAUSE TestAccDrsNameValidation_basic
=== CONT  TestAccDrsNameValidation_basic
--- PASS: TestAccDrsNameValidation_basic (27.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       27.252s
```
<img width="453" height="16" alt="Snipaste_2026-05-14_15-31-54" src="https://github.com/user-attachments/assets/08e1087e-2e9a-4c63-b592-f9f5f74b9d92" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
