### PR TITLE
feat(eip): support `global_eip_segment` resource

### DIFF
--- a/docs/resources/global_eip_segment.md
+++ b/docs/resources/global_eip_segment.md
@@ -1,0 +1,123 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_global_eip_segment"
+description: |-
+  Manages a global EIP segment resource within HuaweiCloud.
+---
+
+# huaweicloud_global_eip_segment
+
+Manages a global EIP segment resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "geip_pool_name" {}
+variable "access_site" {}
+
+resource "huaweicloud_global_eip_segment" "test" {
+  geip_pool_name = var.geip_pool_name
+  access_site    = var.access_site
+  mask           = 29
+
+  tags {
+    key   = "foo"
+    value = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the resource is located.  
+  If omitted, the provider-level region will be used. Change this parameter will create a new resource.
+
+* `geip_pool_name` - (Required, String, NonUpdatable) Specifies the global EIP pool name.  
+  The value can be queried use the `huaweicloud_global_eip_pools` data source.
+
+* `access_site` - (Required, String, NonUpdatable) Specifies the access site name.  
+  The value can be queried use the `huaweicloud_global_eip_pools` data source.
+
+* `mask` - (Required, Int, NonUpdatable) Specifies the mask length of the segment.  
+  The value can be queried use the `huaweicloud_global_eip_segment_support_masks` data source
+
+* `name` - (Optional, String) Specifies the name of the global EIP segment.
+
+* `description` - (Optional, String) Specifies the description of the global EIP segment.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID to which the global
+  EIP segment belongs. If omitted, the default enterprise project is used.
+
+* `tags` - (Optional, List) Specifies the tags of the global EIP segment.
+
+  The [tags](#tags_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - (Required, String) Specifies the tag key.
+
+* `value` - (Optional, String) Specifies the tag value.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also as the segment ID.
+
+* `domain_id` - The domain ID.
+
+* `isp` - The ISP line.
+
+* `ip_version` - The IP version.
+
+* `cidr` - The IPv4 CIDR block.
+
+* `cidr_v6` - The IPv6 CIDR block.
+
+* `freezen` - Whether the segment is frozen.
+
+* `status` - The status of the segment.
+
+* `created_at` - The creation time of the segment.
+
+* `updated_at` - The update time of the segment.
+
+* `is_pre_paid` - Whether the segment is prepaid.
+
+* `is_charged` - Whether the segment is charged.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+
+## Import
+
+The global EIP segment can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_global_eip_segment.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `mask`. It is generally recommended
+running `terraform plan` after importing the resource. You can then decide if changes should be applied to the resource,
+or the resource definition should be updated to align with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_global_eip_segment" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      mask,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4341,6 +4341,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_global_eip":                              eip.ResourceGlobalEIP(),
 			"huaweicloud_global_eip_associate":                    eip.ResourceGlobalEIPAssociate(),
 			"huaweicloud_global_eip_internet_bandwidth_associate": eip.ResourceInternetBandwidthAssociate(),
+			"huaweicloud_global_eip_segment":                      eip.ResourceGlobalEipSegment(),
 			"huaweicloud_global_eip_segment_bandwidth_associate":  eip.ResourceSegmentBandwidthAssociate(),
 
 			"huaweicloud_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_eip_segment_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_eip_segment_test.go
@@ -1,0 +1,186 @@
+package eip
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getGlobalEipSegmentResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("geip", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GEIP client: %s", err)
+	}
+
+	getHttpUrl := "v3/{domain_id}/global-eip-segments/{global_eip_segment_id}"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{domain_id}", cfg.DomainID)
+	getPath = strings.ReplaceAll(getPath, "{global_eip_segment_id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func TestAccGlobalEipSegment_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_global_eip_segment.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getGlobalEipSegmentResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testGlobalEipSegment_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(rName, "geip_pool_name",
+						"${data.huaweicloud_global_eip_pools.all.geip_pools.0.name}"),
+					acceptance.TestCheckResourceAttrWithVariable(rName, "access_site",
+						"${data.huaweicloud_global_eip_pools.all.geip_pools.0.access_site}"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "description test"),
+					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
+					resource.TestCheckResourceAttr(rName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(rName, "tags.0.key", "key1"),
+					resource.TestCheckResourceAttr(rName, "tags.0.value", "value1"),
+					resource.TestCheckResourceAttr(rName, "tags.1.key", "key2"),
+					resource.TestCheckResourceAttr(rName, "tags.1.value", "value2"),
+					resource.TestCheckResourceAttrSet(rName, "domain_id"),
+					resource.TestCheckResourceAttrSet(rName, "isp"),
+					resource.TestCheckResourceAttrSet(rName, "ip_version"),
+					resource.TestCheckResourceAttrSet(rName, "cidr"),
+					resource.TestCheckResourceAttrSet(rName, "freezen"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "is_pre_paid"),
+					resource.TestCheckResourceAttrSet(rName, "is_charged"),
+				),
+			},
+			{
+				Config: testGlobalEipSegment_update(name + "_update"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(rName, "description", "description test"),
+					resource.TestCheckResourceAttr(rName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(rName, "tags.0.key", "key_updated"),
+					resource.TestCheckResourceAttr(rName, "tags.0.value", "value_updated"),
+				),
+			},
+			{
+				Config: testGlobalEipSegment_update2(""),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", ""),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "tags.#", "0"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"mask"},
+			},
+		},
+	})
+}
+
+func testGlobalEipSegment_base() string {
+	return `
+# Currently, only this global eip pool can create a global IP segment
+data "huaweicloud_global_eip_pools" "all" {
+  access_site = "cn-south-guangzhou"
+  name        = "bgp_segment_default"
+}
+`
+}
+
+func testGlobalEipSegment_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_global_eip_segment" "test" {
+  geip_pool_name        = data.huaweicloud_global_eip_pools.all.geip_pools[0].name
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  mask                  = 29
+  name                  = "%[2]s"
+  description           = "description test"
+  enterprise_project_id = "%[3]s"
+
+  tags {
+    key   = "key1"
+    value = "value1"
+  }
+  tags {
+    key   = "key2"
+    value = "value2"
+  }
+}
+`, testGlobalEipSegment_base(), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testGlobalEipSegment_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_global_eip_segment" "test" {
+  geip_pool_name        = data.huaweicloud_global_eip_pools.all.geip_pools[0].name
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  mask                  = 29
+  name                  = "%[2]s"
+  description           = "description test"
+  enterprise_project_id = "%[3]s"
+
+  tags {
+    key   = "key_updated"
+    value = "value_updated"
+  }
+}
+`, testGlobalEipSegment_base(), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testGlobalEipSegment_update2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_global_eip_segment" "test" {
+  geip_pool_name        = data.huaweicloud_global_eip_pools.all.geip_pools[0].name
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  mask                  = 29
+  name                  = "%[2]s"
+  description           = ""
+  enterprise_project_id = "%[3]s"
+}
+`, testGlobalEipSegment_base(), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/eip/resource_huaweicloud_global_eip_segment.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_global_eip_segment.go
@@ -1,0 +1,507 @@
+package eip
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// 1. When creating this resource, the function of binding to the global public network bandwidth was removed, and it
+// can only support the creation of global elastic public IP segment.
+// 2. If users need to bind to the global public network bandwidth, it is recommended to use the
+// `huaweicloud_global_eip_segment_bandwidth_associate` resource
+
+// @API EIP POST /v3/{domain_id}/global-eip-segments
+// @API EIP PUT /v3/{domain_id}/global-eip-segments/{global_eip_segment_id}
+// @API EIP GET /v3/{domain_id}/global-eip-segments/{global_eip_segment_id}
+// @API EIP DELETE /v3/{domain_id}/global-eip-segments/{global_eip_segment_id}
+// @API EIP GET /v3/{domain_id}/geip/jobs/{job_id}
+// @API EIP POST /v3/global-eip-segment/{resource_id}/tags/create
+// @API EIP POST /v3/global-eip-segment/{resource_id}/tags/delete
+
+var globalEipSegmentNonUpdatableParams = []string{
+	"geip_pool_name",
+	"access_site",
+	"mask",
+	"enterprise_project_id",
+}
+
+func ResourceGlobalEipSegment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGlobalEipSegmentCreate,
+		ReadContext:   resourceGlobalEipSegmentRead,
+		UpdateContext: resourceGlobalEipSegmentUpdate,
+		DeleteContext: resourceGlobalEipSegmentDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: customdiff.All(
+			config.FlexibleForceNew(globalEipSegmentNonUpdatableParams),
+		),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"geip_pool_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"access_site": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mask": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			// The `name` can be left blank, so no `Computed` is added.
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// The `description` can be left blank, so no `Computed` is added.
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// The `tags` can be left blank, so no `Computed` is added.
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"isp": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip_version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cidr": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cidr_v6": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"freezen": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_pre_paid": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"is_charged": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCreateGlobalEipSegmentTagsBodyParams(tagList []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(tagList))
+	for _, item := range tagList {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		tag := map[string]interface{}{
+			"key":   m["key"],
+			"value": m["value"],
+		}
+
+		rst = append(rst, tag)
+	}
+
+	return rst
+}
+
+func buildCreateGlobalEipSegmentBodyParams(d *schema.ResourceData, epsID string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"geip_pool_name":        d.Get("geip_pool_name"),
+		"access_site":           d.Get("access_site"),
+		"mask":                  d.Get("mask"),
+		"name":                  utils.ValueIgnoreEmpty(d.Get("name")),
+		"description":           utils.ValueIgnoreEmpty(d.Get("description")),
+		"enterprise_project_id": utils.ValueIgnoreEmpty(epsID),
+	}
+	if tagList := d.Get("tags").([]interface{}); len(tagList) > 0 {
+		bodyParams["tags"] = buildCreateGlobalEipSegmentTagsBodyParams(tagList)
+	}
+
+	return map[string]interface{}{
+		"global_eip_segment": utils.RemoveNil(bodyParams),
+	}
+}
+
+func resourceGlobalEipSegmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "geip"
+		httpUrl = "v3/{domain_id}/global-eip-segments"
+		epsID   = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{domain_id}", cfg.DomainID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateGlobalEipSegmentBodyParams(d, epsID),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating global EIP segment: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("global_eip_segment.id", respBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating global EIP segment: ID is not found in API response")
+	}
+
+	d.SetId(id)
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error creating global EIP segment: job_id is not found in API response")
+	}
+
+	if err = waitGlobalEipSegmentCreateJobSuccess(ctx, client, d.Timeout(schema.TimeoutCreate), cfg.DomainID, jobId); err != nil {
+		return diag.Errorf("error waiting for global EIP segment create job (%s) to succeed: %s", jobId, err)
+	}
+
+	return resourceGlobalEipSegmentRead(ctx, d, meta)
+}
+
+func waitGlobalEipSegmentCreateJobSuccess(ctx context.Context, client *golangsdk.ServiceClient,
+	timeout time.Duration, domainId, jobId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			jobDetail, err := getGlobalEipSegmentJobDetail(client, domainId, jobId)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch("job.status", jobDetail, "").(string)
+			if status == "" {
+				return jobDetail, "ERROR", errors.New("status is not found in job detail response")
+			}
+
+			if status == "FINISH_SUCC" {
+				return jobDetail, "COMPLETED", nil
+			}
+
+			// Due to the unclear API description, and for program security reasons, all other states are categorized as
+			// types requiring PENDING.
+			return jobDetail, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func getGlobalEipSegmentJobDetail(client *golangsdk.ServiceClient, domainId, jobId string) (interface{}, error) {
+	requestPath := client.Endpoint + "v3/{domain_id}/geip/jobs/{job_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", domainId)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving global EIP segment job detail: %s", err)
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceGlobalEipSegmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "geip"
+		httpUrl = "v3/{domain_id}/global-eip-segments/{global_eip_segment_id}"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{domain_id}", cfg.DomainID)
+	getPath = strings.ReplaceAll(getPath, "{global_eip_segment_id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		// When the resource does not exist, the get API returns a `404` error code.
+		return common.CheckDeletedDiag(d, err, "error retrieving global EIP segment")
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	seg := utils.PathSearch("global_eip_segment", respBody, nil)
+	if seg == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("geip_pool_name", utils.PathSearch("geip_pool_name", seg, nil)),
+		d.Set("access_site", utils.PathSearch("access_site", seg, nil)),
+		d.Set("name", utils.PathSearch("name", seg, nil)),
+		d.Set("description", utils.PathSearch("description", seg, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", seg, nil)),
+		d.Set("tags", flattenGlobalEipSegmentTagsList(
+			utils.PathSearch("tags", seg, make([]interface{}, 0)).([]interface{}))),
+		d.Set("domain_id", utils.PathSearch("domain_id", seg, nil)),
+		d.Set("isp", utils.PathSearch("isp", seg, nil)),
+		d.Set("ip_version", utils.PathSearch("ip_version", seg, nil)),
+		d.Set("cidr", utils.PathSearch("cidr", seg, nil)),
+		d.Set("cidr_v6", utils.PathSearch("cidr_v6", seg, nil)),
+		d.Set("freezen", utils.PathSearch("freezen", seg, false)),
+		d.Set("status", utils.PathSearch("status", seg, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", seg, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", seg, nil)),
+		d.Set("is_pre_paid", utils.PathSearch("is_pre_paid", seg, false)),
+		d.Set("is_charged", utils.PathSearch("is_charged", seg, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGlobalEipSegmentTagsList(tagsResp []interface{}) []interface{} {
+	if len(tagsResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(tagsResp))
+	for _, tag := range tagsResp {
+		rst = append(rst, map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, ""),
+			"value": utils.PathSearch("value", tag, ""),
+		})
+	}
+
+	return rst
+}
+
+func updateGlobalEipSegmentTags(client *golangsdk.ServiceClient, d *schema.ResourceData, id string) error {
+	oRaw, nRaw := d.GetChange("tags")
+	oList := oRaw.([]interface{})
+	nList := nRaw.([]interface{})
+
+	manageTagsHttpUrl := "v3/global-eip-segment/{resource_id}/tags/{action}"
+	manageTagsPath := client.Endpoint + manageTagsHttpUrl
+	manageTagsPath = strings.ReplaceAll(manageTagsPath, "{resource_id}", id)
+	manageTagsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200, 201, 204,
+		},
+	}
+
+	if len(oList) > 0 {
+		manageTagsOpt.JSONBody = map[string]interface{}{
+			"tags": buildCreateGlobalEipSegmentTagsBodyParams(oList),
+		}
+
+		deleteTagsPath := strings.ReplaceAll(manageTagsPath, "{action}", "delete")
+		_, err := client.Request("POST", deleteTagsPath, &manageTagsOpt)
+		if err != nil {
+			return fmt.Errorf("error deleting old tags: %s", err)
+		}
+	}
+
+	if len(nList) > 0 {
+		manageTagsOpt.JSONBody = map[string]interface{}{
+			"tags": buildCreateGlobalEipSegmentTagsBodyParams(nList),
+		}
+		createTagsPath := strings.ReplaceAll(manageTagsPath, "{action}", "create")
+		_, err := client.Request("POST", createTagsPath, &manageTagsOpt)
+		if err != nil {
+			return fmt.Errorf("error creating new tags: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func buildUpdateGlobalEipSegmentBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"global_eip_segment": map[string]interface{}{
+			"name":        d.Get("name"),
+			"description": d.Get("description"),
+		},
+	}
+}
+
+func resourceGlobalEipSegmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "geip"
+		httpUrl = "v3/{domain_id}/global-eip-segments/{global_eip_segment_id}"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	if d.HasChanges("name", "description") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{domain_id}", cfg.DomainID)
+		updatePath = strings.ReplaceAll(updatePath, "{global_eip_segment_id}", d.Id())
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         buildUpdateGlobalEipSegmentBodyParams(d),
+		}
+
+		resp, err := client.Request("PUT", updatePath, &updateOpt)
+		if err != nil {
+			return diag.Errorf("error updating global EIP segment: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		jobID := utils.PathSearch("job_id", respBody, "").(string)
+		if jobID != "" {
+			if err = waitGlobalEipSegmentCreateJobSuccess(ctx, client, d.Timeout(schema.TimeoutUpdate), cfg.DomainID, jobID); err != nil {
+				return diag.Errorf("error waiting for global EIP segment update job (%s) to succeed: %s", jobID, err)
+			}
+		}
+	}
+
+	if d.HasChange("tags") {
+		if tagErr := updateGlobalEipSegmentTags(client, d, d.Id()); tagErr != nil {
+			return diag.Errorf("error updating tags of global EIP segment (%s): %s", d.Id(), tagErr)
+		}
+	}
+
+	return resourceGlobalEipSegmentRead(ctx, d, meta)
+}
+
+func resourceGlobalEipSegmentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "geip"
+		httpUrl = "v3/{domain_id}/global-eip-segments/{global_eip_segment_id}"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{domain_id}", cfg.DomainID)
+	deletePath = strings.ReplaceAll(deletePath, "{global_eip_segment_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200, 201, 204,
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting global EIP segment: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `global_eip_segment` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `global_eip_segment` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o eip -f TestAccGlobalEipSegment_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccGlobalEipSegment_basic -timeout 360m -parallel 10
=== RUN   TestAccGlobalEipSegment_basic
=== PAUSE TestAccGlobalEipSegment_basic
=== CONT  TestAccGlobalEipSegment_basic
--- PASS: TestAccGlobalEipSegment_basic (51.39s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip  coverage: 7.0% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       51.501s coverage: 7.0% of statements in ./huaweicloud/services/eip
```
<img width="854" height="36" alt="image" src="https://github.com/user-attachments/assets/5055f17f-1ac9-473b-8926-0d80cdff47b1" />



* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
<img width="1272" height="893" alt="image" src="https://github.com/user-attachments/assets/71ba2499-8eb8-48b5-b2b8-769e6dad1e9e" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
