### PR TITLE
feat(geminidb): add data source to get list of memory acceleration rules

### DIFF
--- a/docs/data-sources/geminidb_memory_rules.md
+++ b/docs/data-sources/geminidb_memory_rules.md
@@ -1,0 +1,95 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_memory_rules"
+description: |-
+  Use this data source to get the list of memory acceleration rules under the specified memory acceleration mapping.
+---
+
+# huaweicloud_geminidb_memory_rules
+
+Use this data source to get the list of memory acceleration rules under the specified memory acceleration mapping.
+
+## Example Usage
+
+### Query all rules under the specified mapping
+
+```hcl
+variable "mapping_id" {}
+
+data "huaweicloud_geminidb_memory_rules" "test" {
+  dbcache_mapping_id = var.mapping_id
+}
+```
+
+### Query rule by rule ID
+
+```hcl
+variable "mapping_id" {}
+variable "rule_id" {}
+
+data "huaweicloud_geminidb_memory_rules" "test" {
+  dbcache_mapping_id = var.mapping_id
+  rule_id            = var.rule_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `dbcache_mapping_id` - (Required, String) Specifies the memory acceleration mapping ID.
+
+* `rule_id` - (Optional, String) Specifies the memory acceleration rule ID.
+
+* `rule_name` - (Optional, String) Specifies the memory acceleration rule name.
+  If the name starts with `*`, fuzzy search results are returned. Otherwise, an exact result is returned.
+
+* `source_db_schema` - (Optional, String) Specifies the source database name.
+  If the name starts with `*`, fuzzy search results are returned. Otherwise, an exact result is returned.
+
+* `source_db_table` - (Optional, String) Specifies the source database table name.
+  If the name starts with `*`, fuzzy search results are returned. Otherwise, an exact result is returned.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `rules` - The list of memory acceleration rules.
+  The [rules](#rules_struct) structure is documented below.
+
+<a name="rules_struct"></a>
+The `rules` block supports:
+
+* `id` - The memory acceleration rule ID.
+
+* `name` - The memory acceleration rule name.
+
+* `status` - The memory acceleration rule status.
+  + **normal**
+  + **createfail**
+
+* `source_db_schema` - The source database name.
+
+* `source_db_table` - The source database table name.
+
+* `storage_type` - The storage type of the destination database.
+
+* `target_database` - The dstination database.
+
+* `key_columns` - The columns used by mapped keys.
+
+* `value_columns` - The columns used by mapped values.
+
+* `ttl` - The lifetime of a key. (unit: ms)
+
+* `key_separator` - The key separator of a mapping.
+
+* `value_separator` - The value separator of a mapping.
+
+* `key_prefix` - The key prefix.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1429,6 +1429,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_backups":           geminidb.DataSourceGeminiDBBackups(),
 			"huaweicloud_geminidb_database_versions": geminidb.DataSourceDatabaseVersions(),
 			"huaweicloud_geminidb_flavors":           geminidb.DataSourceGeminiDBFlavors(),
+			"huaweicloud_geminidb_memory_rules":      geminidb.DataSourceMemoryRules(),
 			"huaweicloud_geminidb_quotas":            geminidb.DataSourceQuotas(),
 
 			"huaweicloud_gaussdb_storage_types":             gaussdb.DataSourceGaussDbStorageTypes(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -769,6 +769,8 @@ var (
 
 	HW_ELB_GATEWAY_TYPE = os.Getenv("HW_ELB_GATEWAY_TYPE")
 
+	HW_GEMINIDB_MAPPING_ID = os.Getenv("HW_GEMINIDB_MAPPING_ID")
+
 	HW_LTS_AGENCY_STREAM_NAME = os.Getenv("HW_LTS_AGENCY_STREAM_NAME")
 	HW_LTS_AGENCY_STREAM_ID   = os.Getenv("HW_LTS_AGENCY_STREAM_ID")
 	HW_LTS_AGENCY_GROUP_NAME  = os.Getenv("HW_LTS_AGENCY_GROUP_NAME")
@@ -4357,6 +4359,13 @@ func TestAccPreCheckDcsBackupId(t *testing.T) {
 func TestAccPreCheckElbGatewayType(t *testing.T) {
 	if HW_ELB_GATEWAY_TYPE == "" {
 		t.Skip("HW_ELB_GATEWAY_TYPE must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckGeminiDBMappingId(t *testing.T) {
+	if HW_GEMINIDB_MAPPING_ID == "" {
+		t.Skip("HW_GEMINIDB_MAPPING_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_memory_rules_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_memory_rules_test.go
@@ -1,0 +1,110 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceMemoryRules_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_geminidb_memory_rules.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGeminiDBMappingId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMemoryRules_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.source_db_schema"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.source_db_table"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.storage_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.target_database"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.key_columns.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.value_columns.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.ttl"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.key_separator"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.key_prefix"),
+
+					resource.TestCheckOutput("rule_id_filter_useful", "true"),
+					resource.TestCheckOutput("rule_name_filter_useful", "true"),
+					resource.TestCheckOutput("source_db_schema_filter_useful", "true"),
+					resource.TestCheckOutput("source_db_table_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMemoryRules_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_geminidb_memory_rules" "test" {
+  dbcache_mapping_id = "%[1]s"
+}
+
+locals {
+  rule_id          = data.huaweicloud_geminidb_memory_rules.test.rules[0].id
+  rule_name        = data.huaweicloud_geminidb_memory_rules.test.rules[0].name
+  source_db_schema = data.huaweicloud_geminidb_memory_rules.test.rules[0].source_db_schema
+  source_db_table  = data.huaweicloud_geminidb_memory_rules.test.rules[0].source_db_table
+}
+
+data "huaweicloud_geminidb_memory_rules" "rule_id_filter" {
+  dbcache_mapping_id = "%[1]s"
+  rule_id            = local.rule_id
+}
+
+output "rule_id_filter_useful" {
+  value = length(data.huaweicloud_geminidb_memory_rules.rule_id_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_geminidb_memory_rules.rule_id_filter.rules[*].id : v == local.rule_id]
+  )
+}
+
+data "huaweicloud_geminidb_memory_rules" "rule_name_filter" {	
+  dbcache_mapping_id = "%[1]s"
+  rule_name          = local.rule_name
+}
+
+output "rule_name_filter_useful" {
+  value = length(data.huaweicloud_geminidb_memory_rules.rule_name_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_geminidb_memory_rules.rule_name_filter.rules[*].name : v == local.rule_name]
+  )
+}
+
+data "huaweicloud_geminidb_memory_rules" "source_db_schema_filter" {
+  dbcache_mapping_id = "%[1]s"
+  source_db_schema   = local.source_db_schema
+}
+
+output "source_db_schema_filter_useful" {
+  value = length(data.huaweicloud_geminidb_memory_rules.source_db_schema_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_geminidb_memory_rules.source_db_schema_filter.rules[*].source_db_schema : v == local.source_db_schema]
+  )
+}
+
+data "huaweicloud_geminidb_memory_rules" "source_db_table_filter" {
+  dbcache_mapping_id = "%[1]s"
+  source_db_table    = local.source_db_table
+}
+
+output "source_db_table_filter_useful" {
+  value = length(data.huaweicloud_geminidb_memory_rules.source_db_table_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_geminidb_memory_rules.source_db_table_filter.rules[*].source_db_table : v == local.source_db_table]
+  )
+}
+`, acceptance.HW_GEMINIDB_MAPPING_ID)
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_memory_rules.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_memory_rules.go
@@ -1,0 +1,218 @@
+package geminidb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforNoSQL GET /v3/{project_id}/dbcache/rules
+func DataSourceMemoryRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMemoryRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"dbcache_mapping_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rule_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rule_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"source_db_schema": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"source_db_table": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_db_schema": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_db_table": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"target_database": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"key_columns": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"value_columns": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"ttl": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"key_separator": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value_separator": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"key_prefix": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildMemoryRulesQueryParams(d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("?dbcache_mapping_id=%v&limit=200", d.Get("dbcache_mapping_id"))
+
+	if v, ok := d.GetOk("rule_id"); ok {
+		queryParams = fmt.Sprintf("%s&rule_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("rule_name"); ok {
+		queryParams = fmt.Sprintf("%s&rule_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("source_db_schema"); ok {
+		queryParams = fmt.Sprintf("%s&source_db_schema=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("source_db_table"); ok {
+		queryParams = fmt.Sprintf("%s&source_db_table=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceMemoryRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/dbcache/rules"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildMemoryRulesQueryParams(d)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", getPath, offset)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving the memory acceleration rules: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		memoryRules := utils.PathSearch("rules", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(memoryRules) == 0 {
+			break
+		}
+
+		result = append(result, memoryRules...)
+		offset += len(memoryRules)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("rules", flattenMemoryRules(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenMemoryRules(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"id":               utils.PathSearch("id", v, nil),
+			"name":             utils.PathSearch("name", v, nil),
+			"status":           utils.PathSearch("status", v, nil),
+			"source_db_schema": utils.PathSearch("source_db_schema", v, nil),
+			"source_db_table":  utils.PathSearch("source_db_table", v, nil),
+			"storage_type":     utils.PathSearch("storage_type", v, nil),
+			"target_database":  utils.PathSearch("target_database", v, nil),
+			"key_columns":      utils.PathSearch("key_columns", v, nil),
+			"value_columns":    utils.PathSearch("value_columns", v, nil),
+			"ttl":              utils.PathSearch("ttl", v, nil),
+			"key_separator":    utils.PathSearch("key_separator", v, nil),
+			"value_separator":  utils.PathSearch("value_separator", v, nil),
+			"key_prefix":       utils.PathSearch("key_prefix", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to get list of memory acceleration rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to get list of memory acceleration rules.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccDataSourceMemoryRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccDataSourceMemoryRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceMemoryRules_basic
=== PAUSE TestAccDataSourceMemoryRules_basic
=== CONT  TestAccDataSourceMemoryRules_basic
--- PASS: TestAccDataSourceMemoryRules_basic (22.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  23.039s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/c7b7ce7e-0f74-4b39-9596-6f6bf3a3ee82" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
