### PR TITLE
feat(modelarts): supports new attributes for image element

### DIFF
--- a/docs/data-sources/modelarts_notebook_images.md
+++ b/docs/data-sources/modelarts_notebook_images.md
@@ -2,7 +2,8 @@
 subcategory: "AI Development Platform (ModelArts)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_modelarts_notebook_images"
-description: ""
+description: |-
+  Use this data source to get a list of ModelArts notebook images.
 ---
 
 # huaweicloud_modelarts_notebook_images
@@ -11,51 +12,95 @@ Use this data source to get a list of ModelArts notebook images.
 
 ## Example Usage
 
+### Query all notebook images without any filter
+
+```hcl
+data "huaweicloud_modelarts_notebook_images" "test" {}
+```
+
+### Query the notebook images using type filter
+
 ```hcl
 data "huaweicloud_modelarts_notebook_images" "test" {
   type = "BUILD_IN"
-}
-
-output "image_id" {
-  value = data.huaweicloud_modelarts_notebook_images.test.images[0].id
 }
 ```
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available images in the current region.
- All images that meet the filter criteria will be exported as attributes.
+The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to obtain images. If omitted, the provider-level region
- will be used.
+* `region` - (Optional, String) Specifies the region where the images are located.  
+  If omitted, the provider-level region will be used.
 
-* `name` - (Optional, String) Specifies the name of image.
+* `name` - (Optional, String) Specifies the name of the image to be queried.
 
-* `organization` - (Optional, String) Specifies the name of the organization (namespace) which image belongs to.
+* `type` - (Optional, String) Specifies the type of the image to be queried.  
+  The valid values are as follows:
+  + **BUILD_IN**: The system built-in image.
+  + **DEDICATED**: User-saved images.
 
-* `type` - (Optional, String) Specifies the type of image. The options are:
-  + `BUILD_IN`: The system built-in image.
-  + `DEDICATED`: User-saved images.
+  Defaults to **BUILD_IN**.
 
- The default value is `BUILD_IN`.
+* `namespace` - (Optional, String) Specifies the name of the namespace to which images belong.
 
-* `cpu_arch` - (Optional, String) Specifies the CPU architecture of image. The value can be **x86_64** and **aarch64**.
+* `workspace_id` - (Optional, String) Specifies the workspace ID to which images belong.
 
-* `workspace_id` - (Optional, String) Specifies the workspace ID which image belongs to.
+* `cpu_arch` - (Optional, String) Specifies the CPU architecture of the image to be queried.
+  The valid values are as follows:
+  + **x86_64**
+  + **aarch64**
 
 ## Attribute Reference
 
 The following attributes are exported:
 
-* `id` - Indicates a data source ID.
+* `id` - The data source ID.
 
-* `images` - Indicates a list of all images found. Structure is documented below.
+* `images` - The list of images that match the filter parameters.  
+  The [images](#modelarts_notebook_images_attr) structure is documented below.
 
-The `images` block contains:
+<a name="modelarts_notebook_images_attr"></a>
+The `images` block supports:
 
 * `id` - The ID of the image.
+
 * `name` - The name of the image.
-* `swr_path` - The path the image in HuaweiCloud SWR service (SoftWare Repository for Container).
+
+* `namespace` - The name of the namespace to which the image belongs.
+
+* `workspace_id` - The workspace ID to which the image belongs.
+
+* `resource_categories` - The supported flavors of the image.
+  + **CPU**
+  + **GPU**
+  + **ASCEND**
+
+* `dev_services` - The supported services of the image.  
+  + **NOTEBOOK**
+  + **SSH**
+
+* `service_type` - The supported service type of the image.
+  + **COMMON**
+  + **INFERENCE**
+  + **TRAIN**
+  + **DEV**
+  + **UNKNOWN**
+
+* `show_name` - The name of the image to be displayed.
+
+* `swr_path` - The storage path of the image.
+
 * `type` - The type of the image.
-* `cpu_arch` - The CPU architecture of the image. The value can be **x86_64** and **aarch64**.
+  + **BUILD_IN**
+  + **DEDICATED**
+
 * `description` - The description of the image.
+
+* `cpu_arch` - The CPU architecture of the image.
+  + **x86_64**
+  + **aarch64**
+
+* `status` - The status of the image.
+  + **ERROR**
+  + **ACTIVE**

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_notebook_images_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_notebook_images_test.go
@@ -1,7 +1,7 @@
 package modelarts
 
 import (
-	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -10,47 +10,129 @@ import (
 )
 
 func TestAccNotebookImages_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_modelarts_notebook_images.test"
+	var (
+		all = "data.huaweicloud_modelarts_notebook_images.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+		byName   = "data.huaweicloud_modelarts_notebook_images.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byType   = "data.huaweicloud_modelarts_notebook_images.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byWorkspaceId   = "data.huaweicloud_modelarts_notebook_images.filter_by_workspace_id"
+		dcByWorkspaceId = acceptance.InitDataSourceCheck(byWorkspaceId)
+
+		byCpuArch   = "data.huaweicloud_modelarts_notebook_images.filter_by_cpu_arch"
+		dcByCpuArch = acceptance.InitDataSourceCheck(byCpuArch)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceImages_basic("BUILD_IN", "x86_64"),
+				Config: testAccDataSourceImages_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "images.0.type", "BUILD_IN"),
-					resource.TestCheckResourceAttr(dataSourceName, "images.0.cpu_arch", "x86_64"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.id"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.name"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.swr_path"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.description"),
-				),
-			},
-			{
-				Config: testAccDataSourceImages_basic("BUILD_IN", "aarch64"),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "images.0.type", "BUILD_IN"),
-					resource.TestCheckResourceAttr(dataSourceName, "images.0.cpu_arch", "aarch64"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.id"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.name"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.swr_path"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.description"),
+					resource.TestMatchResourceAttr(all, "images.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(all, "images.0.type", "BUILD_IN"),
+					resource.TestCheckResourceAttr(all, "images.0.cpu_arch", "x86_64"),
+					resource.TestCheckResourceAttrSet(all, "images.0.id"),
+					resource.TestCheckResourceAttrSet(all, "images.0.name"),
+					resource.TestCheckResourceAttrSet(all, "images.0.swr_path"),
+					resource.TestCheckResourceAttrSet(all, "images.0.description"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					dcByWorkspaceId.CheckResourceExists(),
+					resource.TestCheckOutput("is_workspace_id_filter_useful", "true"),
+					dcByCpuArch.CheckResourceExists(),
+					resource.TestCheckOutput("is_cpu_arch_filter_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceImages_basic(imageType, cpuArch string) string {
-	return fmt.Sprintf(`
-data "huaweicloud_modelarts_notebook_images" "test" {
-  type     = "%s"
-  cpu_arch = "%s"
+const testAccDataSourceImages_basic string = `
+# Query all notebook images without any filter.
+data "huaweicloud_modelarts_notebook_images" "all" {}
+
+# Filter by parameter 'name'.
+locals {
+  image_name = data.huaweicloud_modelarts_notebook_images.all.images[0].name
 }
-`, imageType, cpuArch)
+
+data "huaweicloud_modelarts_notebook_images" "filter_by_name" {
+  name = local.image_name
 }
+
+locals {
+  filter_by_name_result = [
+    for v in data.huaweicloud_modelarts_notebook_images.filter_by_name.images[*].name : v == local.image_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.filter_by_name_result) > 0 && alltrue(local.filter_by_name_result)
+}
+
+# Filter by parameter 'type'.
+locals {
+  image_type = data.huaweicloud_modelarts_notebook_images.all.images[0].type
+}
+
+data "huaweicloud_modelarts_notebook_images" "filter_by_type" {
+  type = local.image_type
+}
+
+locals {
+  filter_by_type_result = [
+    for v in data.huaweicloud_modelarts_notebook_images.filter_by_type.images[*].type : v == local.image_type
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.filter_by_type_result) > 0 && alltrue(local.filter_by_type_result)
+}
+
+# Filter by parameter 'workspace_id'.
+locals {
+  image_workspace_id = data.huaweicloud_modelarts_notebook_images.all.images[0].workspace_id
+}
+
+data "huaweicloud_modelarts_notebook_images" "filter_by_workspace_id" {
+  workspace_id = local.image_workspace_id
+}
+
+locals {
+  filter_by_workspace_id_result = [
+    for v in data.huaweicloud_modelarts_notebook_images.filter_by_workspace_id.images[*].workspace_id : v == local.image_workspace_id
+  ]
+}
+
+output "is_workspace_id_filter_useful" {
+  value = length(local.filter_by_workspace_id_result) > 0 && alltrue(local.filter_by_workspace_id_result)
+}
+
+# Filter by parameter 'cpu_arch'.
+locals {
+  image_cpu_arch = data.huaweicloud_modelarts_notebook_images.all.images[0].cpu_arch
+}
+
+data "huaweicloud_modelarts_notebook_images" "filter_by_cpu_arch" {
+  cpu_arch = local.image_cpu_arch
+}
+
+locals {
+  filter_by_cpu_arch_result = [
+    for v in data.huaweicloud_modelarts_notebook_images.filter_by_cpu_arch.images[*].cpu_arch : v == local.image_cpu_arch
+  ]
+}
+
+output "is_cpu_arch_filter_useful" {
+  value = length(local.filter_by_cpu_arch_result) > 0 && alltrue(local.filter_by_cpu_arch_result)
+}
+`

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_notebook_images.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_notebook_images.go
@@ -2,16 +2,18 @@ package modelarts
 
 import (
 	"context"
-	"log"
+	"fmt"
+	"strconv"
+	"strings"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/chnsz/golangsdk/openstack/modelarts/v1/notebook"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -22,61 +24,125 @@ func DataSourceNotebookImages() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the images are located.`,
 			},
+
+			// Optional parameters.
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the image to be queried.`,
 			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "BUILD_IN",
+				Description: `The type of the image to be queried.`,
+			},
+			"namespace": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the namespace to which images belong.`,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The workspace ID to which images belong.`,
+			},
+			"cpu_arch": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The CPU architecture of the image to be queried.`,
+			},
+
+			// Deprecated parameters.
 			"organization": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Description: utils.SchemaDesc(
+					`The name of the organization (namespace) to which images belong`,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					},
+				),
 			},
-			"type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "BUILD_IN",
-				ValidateFunc: validation.StringInSlice([]string{"BUILD_IN", "DEDICATED"}, false),
-			},
-			"cpu_arch": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"x86_64", "aarch64"}, false),
-			},
-			"workspace_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+
+			// Attributes.
 			"images": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of images that match the filter parameters.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the image.`,
 						},
 						"name": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the image.`,
+						},
+						"namespace": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the namespace to which the image belongs.`,
+						},
+						"workspace_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The workspace ID to which the image belongs.`,
+						},
+						"resource_categories": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The resource categories of the image.`,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"dev_services": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The dev services of the image.`,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"service_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The service type of the image.`,
+						},
+						"show_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the image to be displayed.`,
 						},
 						"swr_path": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The storage path of the image.`,
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"cpu_arch": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the image.`,
 						},
 						"description": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Description: `The description of the image.`,
+							Computed:    true,
+						},
+						"cpu_arch": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The CPU architecture of the image.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the image.`,
 						},
 					},
 				},
@@ -85,71 +151,126 @@ func DataSourceNotebookImages() *schema.Resource {
 	}
 }
 
-func dataSourceNotebookImagesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ModelArtsV1Client(region)
-	if err != nil {
-		return diag.Errorf("error creating ModelArts v1 client, err=%s", err)
+func buildListNotebookImagesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
 	}
 
-	listOpts := notebook.ListImageOpts{
-		Name:        d.Get("name").(string),
-		Namespace:   d.Get("organization").(string),
-		Type:        d.Get("type").(string),
-		WorkspaceId: d.Get("workspace_id").(string),
-		Offset:      0,
+	if v, ok := d.GetOk("organization"); ok {
+		res = fmt.Sprintf("%s&namespace=%v", res, v)
 	}
 
-	page, err := notebook.ListImages(client, listOpts)
-	if err != nil {
-		return diag.Errorf("unable to retrieve ModelArts notebook images: %s ", err)
+	if v, ok := d.GetOk("type"); ok {
+		res = fmt.Sprintf("%s&type=%v", res, v)
 	}
 
-	p, err := page.AllPages()
-	if err != nil {
-		return diag.Errorf("error querying ModelArts notebook images: %s", err)
-	}
-	images, err := notebook.ExtractImages(p)
-	if err != nil {
-		return diag.Errorf("error querying ModelArts notebook images: %s", err)
+	if v, ok := d.GetOk("workspace_id"); ok {
+		res = fmt.Sprintf("%s&workspace_id=%v", res, v)
 	}
 
-	if len(images) == 0 {
-		return diag.Errorf("no data found. Please change your search criteria and try again")
+	return res
+}
+
+func listNotebookImages(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/images?limit={limit}"
+		limit   = 200
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildListNotebookImagesQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
 
-	filter := map[string]interface{}{
-		"Arch": d.Get("cpu_arch"),
-	}
-
-	filterImages, err := utils.FilterSliceWithField(images, filter)
-	if err != nil {
-		return diag.Errorf("filter ModelArts notebook images failed: %s", err)
-	}
-	log.Printf("[DEBUG] filter %d ModelArts notebook images from %d through options %v", len(filterImages), len(images), filter)
-
-	var rst []map[string]interface{}
-	var ids []string
-	for _, v := range filterImages {
-		img := v.(notebook.ImageDetail)
-		item := map[string]interface{}{
-			"id":          img.Id,
-			"name":        img.Name,
-			"type":        img.Type,
-			"swr_path":    img.SwrPath,
-			"description": img.Description,
-			"cpu_arch":    img.Arch,
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
 		}
-		rst = append(rst, item)
-		ids = append(ids, img.Id)
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		images := utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, images...)
+		if len(images) < limit {
+			break
+		}
+		offset += len(images)
 	}
 
-	err = d.Set("images", rst)
+	return result, nil
+}
+
+func manualFilterNotebookImages(images []interface{}, architecture string) []interface{} {
+	if architecture != "" {
+		return utils.PathSearch(fmt.Sprintf("[?arch=='%s']", architecture), images, make([]interface{}, 0)).([]interface{})
+	}
+	return images
+}
+
+func flattenNotebookImages(images []interface{}) []interface{} {
+	if len(images) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(images))
+	for _, image := range images {
+		result = append(result, map[string]interface{}{
+			"id":                  utils.PathSearch("id", image, nil),
+			"name":                utils.PathSearch("name", image, nil),
+			"namespace":           utils.PathSearch("namespace", image, nil),
+			"workspace_id":        utils.PathSearch("workspace_id", image, nil),
+			"resource_categories": utils.PathSearch("resource_categories", image, nil),
+			"dev_services":        utils.PathSearch("dev_services", image, nil),
+			"service_type":        utils.PathSearch("service_type", image, nil),
+			"show_name":           utils.PathSearch("show_name", image, nil),
+			"swr_path":            utils.PathSearch("swr_path", image, nil),
+			"type":                utils.PathSearch("type", image, nil),
+			"description":         utils.PathSearch("description", image, nil),
+			"cpu_arch":            utils.PathSearch("arch", image, nil),
+			"status":              utils.PathSearch("status", image, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceNotebookImagesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("modelarts", region)
 	if err != nil {
-		return diag.Errorf("set images err:%s", err)
+		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	d.SetId(hashcode.Strings(ids))
-	return nil
+	images, err := listNotebookImages(client, d)
+	if err != nil {
+		return diag.Errorf("error listing ModelArts notebook images: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("images", flattenNotebookImages(manualFilterNotebookImages(images, d.Get("cpu_arch").(string)))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Currently, we cannot make sure which image is used in the CPU flavor or GPU flavor.
- Supplement some attributes.
- Deprecated the organization parameter and supports the new parameter `namespace` to instead.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1039" height="113" alt="image" src="https://github.com/user-attachments/assets/e3c1a538-7ccb-42e3-9b13-42bb6b976dbf" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new attributes for image element about data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccNotebookImages_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccNotebookImages_basic -timeout 360m -parallel 10
=== RUN   TestAccNotebookImages_basic
=== PAUSE TestAccNotebookImages_basic
=== CONT  TestAccNotebookImages_basic
--- PASS: TestAccNotebookImages_basic (21.72s)
PASS
coverage: 5.4% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 21.811s coverage: 5.4% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
