### PR TITLE
refactor: feat(modelarts): refactor the notebook and supports tags management

### DIFF
--- a/docs/resources/modelarts_notebook.md
+++ b/docs/resources/modelarts_notebook.md
@@ -65,100 +65,114 @@ resource "huaweicloud_modelarts_notebook" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the resource. If omitted, the
-  provider-level region will be used. Changing this parameter will create a new resource.
+* `region` - (Optional, String, ForceNew) Specifies the region where the notebook is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `name` - (Required, String) Specifies the name of the notebook. The name consists of 1 to 64 characters,
- starting with a letter. Only letters, digits and underscores (_) are allowed.
+* `name` - (Required, String) Specifies the name of the notebook.  
+  The valid length is limited from `1` to `64`, only letters, digits and underscores (_) are allowed.
+  The name must starting with a letter.
 
-* `flavor_id` - (Required, String) Specifies the flavor ID. The options are as follows:
-  - **modelarts.vm.cpu.2u**: General-purpose Intel CPU specifications, suitable for data exploration and algorithm
-   discovery.
-  - **modelarts.vm.cpu.8u**: General computing-plus Intel CPU specifications, suitable for compute-intensive
-   applications.
-  - **modelarts.bm.gpu.v100NV32**: One NVIDIA V100 GPU with 32GB of memory, suitable for deep learning algorithm
-   training and debugging.
-  - **modelarts.bm.d910.xlarge.1**: One Ascend 910 NPU with 32GB of memory, suitable for deep learning code running
-   and debugging.
-  - **modelarts.bm.d910.xlarge.2**: Two Ascend 910 NPU with 32GB of memory, suitable for deep learning code running
-   and debugging.
-  - **modelarts.bm.d910.xlarge.8**: Eight Ascend 910 NPU with 32GB of memory, suitable for deep learning code running
-   and debugging.
+* `flavor_id` - (Required, String) Specifies the flavor ID of the notebook.
 
-* `image_id` - (Required, String) Specifies the image ID of notebook.
+* `image_id` - (Required, String) Specifies the image ID of the notebook.
 
-* `volume` - (Required, List) Specifies the volume information. Structure is documented below.
+* `volume` - (Required, List) Specifies the volume configuration of the notebook.  
+  The [volume](#modelarts_notebook_volume) structure is documented below.
 
-* `description` - (Optional, String) Specifies the description of notebook. It contains a maximum of `512` characters and
- cannot contain special characters `&<>"'/`.
+* `description` - (Optional, String) Specifies the description of the notebook.  
+  It contains a maximum of `512` characters and cannot contain special characters `&<>"'/`.
 
-* `key_pair` - (Optional, String, ForceNew) Specifies the key pair name for remote SSH access.
- Changing this parameter will create a new resource.
+* `key_pair` - (Optional, String, NonUpdatable) Specifies the key pair name for remote SSH access.  
+  Required if the parameter `allowed_access_ips` is set.
 
-* `allowed_access_ips` - (Optional, List) Specifies public IP addresses that are allowed for remote SSH access.
- If the parameter is not specified, all IP addresses will be allowed for remote SSH access.
+* `allowed_access_ips` - (Optional, List) Specifies the public IP addresses that are allowed for remote SSH access.  
+  If the parameter is not specified, all IP addresses will be allowed for remote SSH access.
 
-* `pool_id` - (Optional, String, ForceNew) Specifies the ID of Dedicated resource pool which the notebook used.
- Changing this parameter will create a new resource.
+* `pool_id` - (Optional, String, NonUpdatable) Specifies the ID of the dedicated resource pool which the notebook used.
 
-* `workspace_id` - (Optional, String, ForceNew) Specifies the workspace ID which the notebook belongs to.
- The default value is `0`. Changing this parameter will create a new resource.
+* `workspace_id` - (Optional, String, NonUpdatable) Specifies the workspace ID to which the notebook belongs.  
+  The default value is **0** (default workspace).
 
+<a name="modelarts_notebook_volume"></a>
 The `volume` block supports:
 
-* `type` - (Required, String, ForceNew) Specifies the volume type. The options are as follows:
-  - *EFS*: use Scalable File Service, default 50GB is **free**.
-  - *EVS*: use Elastic Volume Service, default size is 5 GB.
-  
- Changing this parameter will create a new resource.
+* `type` - (Required, String, NonUpdatable) Specifies the storage type.  
+  The valid values are as follows:
+  + **EFS**
+  + **EVS**
 
-* `size` - (Optional, Int) Specifies the volume size. Its value range is from `5` GB to `4,096` GB.
+* `ownership` - (Optional, String, NonUpdatable) Specifies the storage ownership.  
+  The valid values are as follows:
+  + **MANAGED**: The shared storage disk of the ModelArts service.
+  + **DEDICATED**: The dedicated storage disk, only supported when the value of parameter `volume.type` is **EFS**.
 
-* `ownership` - (Optional, String, ForceNew) Specifies the volume ownership. The options are as follows:
-  - *MANAGED*: shared storage disk of the ModelArts service.
-  - *DEDICATED*: dedicated storage disk, only supported when the category is `EFS`.
+  Defaults to **MANAGED**.
 
- Changing this parameter will create a new resource.
+* `size` - (Optional, Int) Specifies the storage size, in GB.  
+  The valid value range is from `5` to `4,096`.  
+  Required if the value of parameter `volume.type` is **EVS** and the value of parameter `volume.ownership` is
+  **MANAGED**.
 
-* `uri` - (Optional, String, ForceNew) Specifies the URL of dedicated storage disk, which is mandatory when the `type`
- is `EFS` and the `ownership` is `DEDICATED`. Example: `192.168.0.1:/user-9sfdsdgdfgh5ea4d56871e75d6966aa274/mount/`.
- Changing this parameter will create a new resource.
+* `uri` - (Optional, String, NonUpdatable) Specifies the storage URL of the dedicated disk.  
+  E.g. **9048456e-4e9a-11f1-ba0c-fa16520f410a.c67b108f-4e99-11f1-81fd-fa1652d6f62f.sfsturbo.internal:/**.  
+  Required if the value of parameter `volume.type` is **EFS** and the value of parameter `volume.ownership` is
+  **DEDICATED**.
 
-* `id` - (Optional, String, ForceNew) Specifies the ID of dedicated storage disk, which is mandatory when the `type`
- is `EFS` and the `ownership` is `DEDICATED`.
- Changing this parameter will create a new resource.
+* `id` - (Optional, String, NonUpdatable) Specifies the storage ID of the dedicated disk.  
+  Required if the value of parameter `volume.type` is **EFS** and the value of parameter `volume.ownership` is
+  **DEDICATED**.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The resource ID in UUID format.
-* `auto_stop_enabled` - Whether enabled the notebook instance to automatically stop.
-* `status` - Notebook status. Valid values include: `INIT`, `CREATING`, `STARTING`, `STOPPING`, `DELETING`, `RUNNING`,
- `STOPPED`, `SNAPSHOTTING`, `CREATE_FAILED`, `START_FAILED`, `DELETE_FAILED`, `ERROR`, `DELETED`, `FROZEN`.
-* `image_name` - The image name.
-* `image_swr_path` - The image path in swr.
-* `image_type` - The image type. Valid values include: `BUILD_IN`, `DEDICATED`.
-* `created_at` - The notebook creation time.
-* `updated_at` - The notebook update time.
-* `pool_name` - The name of Dedicated resource pool which the notebook used.
-* `url` - The web url of the notebook.
-* `ssh_uri` - The uri for remote SSH access.
-* `volume/mount_path` - The local mount path of volume.
-* `mount_storages` - An array of storages which mount to the notebook. Structure is documented below.
+* `id` - The resource ID, in UUID format.
 
-The `mount_storages` block contains:
+* `auto_stop_enabled` - Whether the notebook auto stop is enabled.
 
-* `id` - The mount ID.
-* `type` - The type of storage which be mounted.
-* `path` - The path of storage which be mounted.
-* `mount_path` - The local mount path.
-* `status` - The status of mount.
+* `status` - The status of the notebook.
+  + **RUNNING**
+  + **STOPPED**
+  + **FROZEN**
+
+* `image_type` - The type of the image which the notebook used.
+  + **BUILD_IN**
+  + **DEDICATED**
+
+* `image_name` - The name of the image which the notebook used.
+
+* `image_swr_path` - The SWR repository path of the image which the notebook used.
+
+* `created_at` - The creation time of the notebook, in UTC format.
+
+* `updated_at` - The latest update time of the notebook, in UTC format.
+
+* `pool_name` - The name of the dedicated resource pool which the notebook used.
+
+* `url` - The web URL of the notebook.
+
+* `ssh_uri` - The URL for remote SSH access of the notebook.
+
+* `mount_storages` - The storages which are mounted to the notebook.  
+  The [mount_storages](#modelarts_notebook_mount_storages_attr) structure is documented below.
+
+<a name="modelarts_notebook_mount_storages_attr"></a>
+The `mount_storages` block supports:
+
+* `id` - The ID of the storage which is mounted to the notebook.
+
+* `type` - The type of the storage which is mounted to the notebook.
+
+* `mount_path` - The local mount path of the storage which is mounted to the notebook.
+
+* `path` - The source path of the storage which is mounted to the notebook.
+
+* `status` - The status of the storage which is mounted to the notebook.
 
 ## Import
 
-The notebook can be imported by `id`.
+The notebook can be imported by `id`, e.g.
 
 ```bash
-terraform import huaweicloud_modelarts_notebook.test b11b407c-e604-4e8d-8bc4-92398320b847
+$ terraform import huaweicloud_modelarts_notebook.test <id>
 ```

--- a/docs/resources/modelarts_notebook.md
+++ b/docs/resources/modelarts_notebook.md
@@ -34,6 +34,11 @@ resource "huaweicloud_modelarts_notebook" "test" {
     type = "EVS"
     size = 5
   }
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
 }
 ```
 
@@ -92,6 +97,8 @@ The following arguments are supported:
 
 * `workspace_id` - (Optional, String, NonUpdatable) Specifies the workspace ID to which the notebook belongs.  
   The default value is **0** (default workspace).
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the notebook.
 
 <a name="modelarts_notebook_volume"></a>
 The `volume` block supports:

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_test.go
@@ -67,6 +67,9 @@ func TestAccNotebook_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(managed, "created_at"),
 					resource.TestCheckResourceAttrSet(managed, "updated_at"),
 					resource.TestCheckResourceAttrSet(managed, "url"),
+					resource.TestCheckResourceAttr(managed, "tags.%", "2"),
+					resource.TestCheckResourceAttr(managed, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(managed, "tags.key", "value"),
 					// Dedicated notebook
 					rcDedicated.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dedicated, "name", name+"-dedicated"),
@@ -89,6 +92,7 @@ func TestAccNotebook_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dedicated, "updated_at"),
 					resource.TestCheckResourceAttrSet(dedicated, "url"),
 					resource.TestCheckResourceAttrSet(dedicated, "ssh_uri"),
+					resource.TestCheckResourceAttr(dedicated, "tags.%", "0"),
 				),
 			},
 			{
@@ -112,6 +116,9 @@ func TestAccNotebook_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(managed, "created_at"),
 					resource.TestCheckResourceAttrSet(managed, "updated_at"),
 					resource.TestCheckResourceAttrSet(managed, "url"),
+					resource.TestCheckResourceAttr(managed, "tags.%", "2"),
+					resource.TestCheckResourceAttr(managed, "tags.foo", "baar"),
+					resource.TestCheckResourceAttr(managed, "tags.owner", "terraform"),
 					// Dedicated notebook
 					rcDedicated.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dedicated, "name", updateName+"-dedicated"),
@@ -134,6 +141,9 @@ func TestAccNotebook_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dedicated, "updated_at"),
 					resource.TestCheckResourceAttrSet(dedicated, "url"),
 					resource.TestCheckResourceAttrSet(dedicated, "ssh_uri"),
+					resource.TestCheckResourceAttr(dedicated, "tags.%", "2"),
+					resource.TestCheckResourceAttr(dedicated, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dedicated, "tags.owner", "terraform"),
 				),
 			},
 			{
@@ -305,6 +315,11 @@ resource "huaweicloud_modelarts_notebook" "managed" {
     ownership = "MANAGED"
     size      = 10
   }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }
 
 resource "huaweicloud_modelarts_notebook" "dedicated" {
@@ -340,6 +355,11 @@ resource "huaweicloud_modelarts_notebook" "managed" {
     ownership = "MANAGED"
     size      = 20
   }
+
+  tags = {
+    foo   = "baar"
+    owner = "terraform"
+  }
 }
 
 resource "huaweicloud_modelarts_notebook" "dedicated" {
@@ -356,6 +376,11 @@ resource "huaweicloud_modelarts_notebook" "dedicated" {
     ownership = "DEDICATED"
     uri       = format("%%s:/", huaweicloud_modelarts_network.test.sfs_turbos[0].uri)
     id        = huaweicloud_sfs_turbo.test.id
+  }
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
   }
 }
 `, baseConfig, name)

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_test.go
@@ -7,75 +7,142 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/modelarts/v1/notebook"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
 )
 
 func getNotebookResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.ModelArtsV1Client(acceptance.HW_REGION_NAME)
+	client, err := cfg.NewServiceClient("modelarts", acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating ModelArts v1 client, err=%s", err)
+		return nil, fmt.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	return notebook.Get(client, state.Primary.ID)
+	return modelarts.GetNotebookById(client, state.Primary.ID)
 }
 
-func TestAccResourceNotebook_basic(t *testing.T) {
-	var instance notebook.CreateOpts
-	resourceName := "huaweicloud_modelarts_notebook.test"
-	name := acceptance.RandomAccResourceName()
-	updateName := acceptance.RandomAccResourceName()
+func TestAccNotebook_basic(t *testing.T) {
+	var (
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&instance,
-		getNotebookResourceFunc,
+		managed     = "huaweicloud_modelarts_notebook.managed"
+		rcManaged   = acceptance.InitResourceCheck(managed, &obj, getNotebookResourceFunc)
+		dedicated   = "huaweicloud_modelarts_notebook.dedicated"
+		rcDedicated = acceptance.InitResourceCheck(dedicated, &obj, getNotebookResourceFunc)
+
+		name       = acceptance.RandomAccResourceNameWithDash()
+		updateName = acceptance.RandomAccResourceNameWithDash()
+
+		baseConfig = testAccNotebook_basic_base(name)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRunnerPublicIPs(t, 2)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcManaged.CheckResourceDestroy(),
+			rcDedicated.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotebook_basic(name),
+				Config: testAccNotebook_basic_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "flavor_id", "modelarts.vm.cpu.2u"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "EFS"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.ownership", "MANAGED"),
-					resource.TestCheckResourceAttr(resourceName, "auto_stop_enabled", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_swr_path"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_type"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "url"),
+					// Managed notebook
+					rcManaged.CheckResourceExists(),
+					resource.TestCheckResourceAttr(managed, "name", name+"-managed"),
+					resource.TestCheckResourceAttrSet(managed, "flavor_id"),
+					resource.TestCheckResourceAttrSet(managed, "image_id"),
+					resource.TestCheckResourceAttr(managed, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(managed, "allowed_access_ips.#", "0"),
+					resource.TestCheckResourceAttr(managed, "volume.0.type", "EVS"),
+					resource.TestCheckResourceAttr(managed, "volume.0.ownership", "MANAGED"),
+					resource.TestCheckResourceAttr(managed, "volume.0.size", "10"),
+					resource.TestCheckResourceAttr(managed, "auto_stop_enabled", "false"),
+					resource.TestCheckResourceAttr(managed, "image_type", "BUILD_IN"),
+					resource.TestCheckResourceAttrSet(managed, "image_name"),
+					resource.TestCheckResourceAttrSet(managed, "image_swr_path"),
+					resource.TestCheckResourceAttrSet(managed, "created_at"),
+					resource.TestCheckResourceAttrSet(managed, "updated_at"),
+					resource.TestCheckResourceAttrSet(managed, "url"),
+					// Dedicated notebook
+					rcDedicated.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dedicated, "name", name+"-dedicated"),
+					resource.TestCheckResourceAttrSet(dedicated, "flavor_id"),
+					resource.TestCheckResourceAttrSet(dedicated, "image_id"),
+					resource.TestCheckResourceAttr(dedicated, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttrPair(dedicated, "key_pair", "huaweicloud_kps_keypair.test", "name"),
+					resource.TestCheckResourceAttrPair(dedicated, "pool_id", "huaweicloud_modelarts_resource_pool.test", "id"),
+					resource.TestCheckResourceAttr(managed, "allowed_access_ips.#", "0"),
+					resource.TestCheckResourceAttr(dedicated, "volume.0.type", "EFS"),
+					resource.TestCheckResourceAttr(dedicated, "volume.0.ownership", "DEDICATED"),
+					resource.TestCheckResourceAttrSet(dedicated, "volume.0.uri"),
+					resource.TestCheckResourceAttrPair(dedicated, "volume.0.id", "huaweicloud_sfs_turbo.test", "id"),
+					resource.TestCheckResourceAttr(dedicated, "auto_stop_enabled", "false"),
+					resource.TestCheckResourceAttrSet(dedicated, "pool_name"),
+					resource.TestCheckResourceAttr(dedicated, "image_type", "BUILD_IN"),
+					resource.TestCheckResourceAttrSet(dedicated, "image_name"),
+					resource.TestCheckResourceAttrSet(dedicated, "image_swr_path"),
+					resource.TestCheckResourceAttrSet(dedicated, "created_at"),
+					resource.TestCheckResourceAttrSet(dedicated, "updated_at"),
+					resource.TestCheckResourceAttrSet(dedicated, "url"),
+					resource.TestCheckResourceAttrSet(dedicated, "ssh_uri"),
 				),
 			},
 			{
-				Config: testAccNotebook_basic(updateName),
+				Config: testAccNotebook_basic_step2(baseConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", updateName),
-					resource.TestCheckResourceAttr(resourceName, "flavor_id", "modelarts.vm.cpu.2u"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "EFS"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.ownership", "MANAGED"),
-					resource.TestCheckResourceAttr(resourceName, "auto_stop_enabled", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_swr_path"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_type"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "url"),
+					// Managed notebook
+					rcManaged.CheckResourceExists(),
+					resource.TestCheckResourceAttr(managed, "name", updateName+"-managed"),
+					resource.TestCheckResourceAttrSet(managed, "flavor_id"),
+					resource.TestCheckResourceAttrSet(managed, "image_id"),
+					resource.TestCheckResourceAttr(managed, "description", "Updated by terraform script"),
+					resource.TestCheckResourceAttr(managed, "key_pair", ""),
+					resource.TestCheckResourceAttr(managed, "allowed_access_ips.#", "0"),
+					resource.TestCheckResourceAttr(managed, "volume.0.type", "EVS"),
+					resource.TestCheckResourceAttr(managed, "volume.0.ownership", "MANAGED"),
+					resource.TestCheckResourceAttr(managed, "volume.0.size", "20"),
+					resource.TestCheckResourceAttr(managed, "auto_stop_enabled", "false"),
+					resource.TestCheckResourceAttr(managed, "image_type", "BUILD_IN"),
+					resource.TestCheckResourceAttrSet(managed, "image_name"),
+					resource.TestCheckResourceAttrSet(managed, "image_swr_path"),
+					resource.TestCheckResourceAttrSet(managed, "created_at"),
+					resource.TestCheckResourceAttrSet(managed, "updated_at"),
+					resource.TestCheckResourceAttrSet(managed, "url"),
+					// Dedicated notebook
+					rcDedicated.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dedicated, "name", updateName+"-dedicated"),
+					resource.TestCheckResourceAttrSet(dedicated, "flavor_id"),
+					resource.TestCheckResourceAttrSet(dedicated, "image_id"),
+					resource.TestCheckResourceAttr(dedicated, "description", ""),
+					resource.TestCheckResourceAttrPair(dedicated, "key_pair", "huaweicloud_kps_keypair.test", "name"),
+					resource.TestCheckResourceAttr(dedicated, "allowed_access_ips.#", "2"),
+					resource.TestCheckResourceAttr(dedicated, "volume.0.type", "EFS"),
+					resource.TestCheckResourceAttr(dedicated, "volume.0.ownership", "DEDICATED"),
+					resource.TestCheckResourceAttrSet(dedicated, "volume.0.uri"),
+					resource.TestCheckResourceAttrPair(dedicated, "volume.0.id", "huaweicloud_sfs_turbo.test", "id"),
+					resource.TestCheckResourceAttr(dedicated, "auto_stop_enabled", "false"),
+					resource.TestCheckResourceAttrPair(dedicated, "pool_id", "huaweicloud_modelarts_resource_pool.test", "id"),
+					resource.TestCheckResourceAttrSet(dedicated, "pool_name"),
+					resource.TestCheckResourceAttr(dedicated, "image_type", "BUILD_IN"),
+					resource.TestCheckResourceAttrSet(dedicated, "image_name"),
+					resource.TestCheckResourceAttrSet(dedicated, "image_swr_path"),
+					resource.TestCheckResourceAttrSet(dedicated, "created_at"),
+					resource.TestCheckResourceAttrSet(dedicated, "updated_at"),
+					resource.TestCheckResourceAttrSet(dedicated, "url"),
+					resource.TestCheckResourceAttrSet(dedicated, "ssh_uri"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      managed,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      dedicated,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -83,203 +150,213 @@ func TestAccResourceNotebook_basic(t *testing.T) {
 	})
 }
 
-func testAccNotebook_basic(rName string) string {
+func testAccNotebook_basic_base(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_modelarts_notebook" "test" {
-  name      = "%s"
-  flavor_id = "modelarts.vm.cpu.2u"
-  image_id  = "e1a07296-22a8-4f05-8bc8-e936c8e54090"
-  volume {
-    type = "EFS"
-  }
-}
-`, rName)
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
 }
 
-func TestAccResourceNotebook_dedicated(t *testing.T) {
-	var instance notebook.CreateOpts
-	resourceName := "huaweicloud_modelarts_notebook.test"
-	name := acceptance.RandomAccResourceNameWithDash()
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&instance,
-		getNotebookResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccNotebook_dedicated(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "flavor_id", "modelarts.vm.cpu.2u"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "EFS"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.ownership", "DEDICATED"),
-					resource.TestCheckResourceAttrPair(resourceName, "volume.0.uri", "huaweicloud_sfs_turbo.test", "export_location"),
-					resource.TestCheckResourceAttrPair(resourceName, "volume.0.id", "huaweicloud_sfs_turbo.test", "id"),
-					resource.TestCheckResourceAttr(resourceName, "auto_stop_enabled", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_swr_path"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_type"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "url"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
+variable "runner_public_ips" {
+  type    = string
+  default = "%[2]s"
 }
 
-func testAccNotebook_dedicated(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
+locals {
+  runner_public_ips = split(",", var.runner_public_ips)
+}
 
 data "huaweicloud_availability_zones" "test" {}
 
-resource "huaweicloud_sfs_turbo" "test" {
-  name              = "%[2]s"
-  size              = 1228
-  share_proto       = "NFS"
-  share_type        = "HPC"
-  hpc_bandwidth     = "40M"
-  vpc_id            = huaweicloud_vpc.test.id
-  subnet_id         = huaweicloud_vpc_subnet.test.id
+resource "huaweicloud_vpc" "test" {
+  name                  = "%[3]s"
+  cidr                  = "192.168.0.0/16"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[3]s"
+  vpc_id     = huaweicloud_vpc.test.id
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0)              # 192.168.0.0/24
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0), 1) # 192.168.0.1
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name                 = "%[3]s"
+  delete_default_rules = true
+}
+
+# Make sure open the full ingress access for 111, 2048, 2049, 2051, 2052 and 20048 ports and about TCP and UDP protocols.
+resource "huaweicloud_networking_secgroup_rule" "tcp_ingress_access" {
   security_group_id = huaweicloud_networking_secgroup.test.id
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  ports             = "111,2048,2049,2051,2052,20048"
+}
+
+resource "huaweicloud_networking_secgroup_rule" "udp_ingress_access" {
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  ports             = "111,2048,2049,2051,2052,20048"
+}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  depends_on = [
+    huaweicloud_networking_secgroup_rule.tcp_ingress_access,
+    huaweicloud_networking_secgroup_rule.udp_ingress_access,
+  ]
+
+  name                  = "%[3]s"
+  size                  = 1228
+  share_proto           = "NFS"
+  share_type            = "HPC"
+  hpc_bandwidth         = "40M"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
 
 resource "huaweicloud_modelarts_network" "test" {
-  name = "%[2]s"
-  cidr = "172.16.0.0/12"
+  name = "%[3]s"
+  cidr = "10.168.0.0/16" # The recommended connecting CIDR about SFS Turbo.
 
-  peer_connections {
-    vpc_id    = huaweicloud_vpc.test.id 
-    subnet_id = huaweicloud_vpc_subnet.test.id
+  sfs_turbos {
+    name = huaweicloud_sfs_turbo.test.name
+    id   = huaweicloud_sfs_turbo.test.id
   }
 }
 
+data "huaweicloud_modelarts_resource_flavors" "test" {
+  type = "Dedicate"
+}
+
+locals {
+  available_resource_flavors_with_onsale_and_less_memory = [
+    for o in data.huaweicloud_modelarts_resource_flavors.test.flavors: o if
+      lookup(o.az_status, data.huaweicloud_availability_zones.test.names[0], "soldout") == "normal" &&
+      length(regexall("modelarts.vm.cpu", o.id)) > 0 && o.cpu <= 16
+  ]
+}
+
 resource "huaweicloud_modelarts_resource_pool" "test" {
-  name        = "%[2]s"
+  name        = "%[3]s"
   scope       = ["Notebook", "Train", "Infer"]
   network_id  = huaweicloud_modelarts_network.test.id
 
   resources {
-    flavor_id = "modelarts.vm.cpu.8ud"
+    flavor_id = try(local.available_resource_flavors_with_onsale_and_less_memory[0].id, null)
     count     = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      resources,
+    ]
   }
 }
 
-resource "huaweicloud_modelarts_notebook" "test" {
-  name      = "%[2]s"
-  flavor_id = "modelarts.vm.cpu.2u"
-  image_id  = "e1a07296-22a8-4f05-8bc8-e936c8e54090"
-  pool_id   = huaweicloud_modelarts_resource_pool.test.id
+data "huaweicloud_modelarts_notebook_flavors" "test" {
+  type     = "MANAGED"
+  category = "CPU"
+}
+
+locals {
+  available_notebook_flavors_with_onsale = [
+    for o in data.huaweicloud_modelarts_notebook_flavors.test.flavors: o if
+      !o.sold_out && !strcontains(o.id, "free")
+  ]
+}
+
+data "huaweicloud_modelarts_notebook_images" "test" {
+  type     = "BUILD_IN"
+  cpu_arch = try(data.huaweicloud_modelarts_notebook_flavors.test.flavors[0].arch, "x86_64")
+}
+
+locals {
+  available_notebook_images_with_onsale = [
+    for o in data.huaweicloud_modelarts_notebook_images.test.images: o if
+      contains(o.resource_categories, "CPU") && o.status == "ACTIVE" && contains(o.dev_services, "NOTEBOOK")
+  ]
+}
+
+resource "huaweicloud_kps_keypair" "test" {
+  name = "%[3]s"
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, acceptance.HW_RUNNER_PUBLIC_IPS, name)
+}
+
+func testAccNotebook_basic_step1(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelarts_notebook" "managed" {
+  name        = "%[2]s-managed"
+  flavor_id   = try(local.available_notebook_flavors_with_onsale[0].id, null)
+  image_id    = try(data.huaweicloud_modelarts_notebook_images.test.images[0].id, null)
+  description = "Created by terraform script"
+
+  volume {
+    type      = "EVS"
+    ownership = "MANAGED"
+    size      = 10
+  }
+}
+
+resource "huaweicloud_modelarts_notebook" "dedicated" {
+  name        = "%[2]s-dedicated"
+  flavor_id   = try(local.available_notebook_flavors_with_onsale[0].id, null)
+  image_id    = try(local.available_notebook_images_with_onsale[0].id, null)
+  description = "Created by terraform script"
+  key_pair    = huaweicloud_kps_keypair.test.name
+  pool_id     = huaweicloud_modelarts_resource_pool.test.id
 
   volume {
     type      = "EFS"
     ownership = "DEDICATED"
-    uri       = huaweicloud_sfs_turbo.test.export_location
+    uri       = format("%%s:/", huaweicloud_modelarts_network.test.sfs_turbos[0].uri)
     id        = huaweicloud_sfs_turbo.test.id
   }
 }
-`, common.TestBaseNetwork(rName), rName)
+`, baseConfig, name)
 }
 
-func TestAccResourceNotebook_all(t *testing.T) {
-	var instance notebook.CreateOpts
-	resourceName := "huaweicloud_modelarts_notebook.test"
-	name := acceptance.RandomAccResourceName()
-	updateName := acceptance.RandomAccResourceName()
-	ip := "10.1.1.2"
-	updateIp := "10.1.1.3"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&instance,
-		getNotebookResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccNotebook_All(name, ip),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "flavor_id", "modelarts.vm.cpu.2u"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "EFS"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.ownership", "MANAGED"),
-					resource.TestCheckResourceAttr(resourceName, "auto_stop_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "description", name),
-					resource.TestCheckResourceAttr(resourceName, "allowed_access_ips.0", ip),
-					resource.TestCheckResourceAttrSet(resourceName, "image_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_swr_path"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_type"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "url"),
-				),
-			},
-			{
-				Config: testAccNotebook_All(updateName, updateIp),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", updateName),
-					resource.TestCheckResourceAttr(resourceName, "flavor_id", "modelarts.vm.cpu.2u"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "EFS"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.ownership", "MANAGED"),
-					resource.TestCheckResourceAttr(resourceName, "auto_stop_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "description", updateName),
-					resource.TestCheckResourceAttr(resourceName, "allowed_access_ips.0", updateIp),
-					resource.TestCheckResourceAttrSet(resourceName, "image_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_swr_path"),
-					resource.TestCheckResourceAttrSet(resourceName, "image_type"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "url"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func testAccNotebook_All(rName string, ip string) string {
+func testAccNotebook_basic_step2(baseConfig, name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_kps_keypair" "test" {
-  name       = "%s"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
-}
+%[1]s
 
-resource "huaweicloud_modelarts_notebook" "test" {
-  name        = "%s"
-  flavor_id   = "modelarts.vm.cpu.2u"
-  image_id    = "e1a07296-22a8-4f05-8bc8-e936c8e54090"
-  description = "%s"
-
-  allowed_access_ips = ["%s"]
-  key_pair           = huaweicloud_kps_keypair.test.name
+resource "huaweicloud_modelarts_notebook" "managed" {
+  name        = "%[2]s-managed"
+  flavor_id   = try(local.available_notebook_flavors_with_onsale[1].id, null)
+  image_id    = try(local.available_notebook_images_with_onsale[1].id, null)
+  description = "Updated by terraform script"
 
   volume {
-    type = "EFS"
+    type      = "EVS"
+    ownership = "MANAGED"
+    size      = 20
   }
 }
-`, rName, rName, rName, ip)
+
+resource "huaweicloud_modelarts_notebook" "dedicated" {
+  name               = "%[2]s-dedicated"
+  # The exclusive upgradeable flavors are not included in the basic list.
+  flavor_id          = try(local.available_notebook_flavors_with_onsale[0].id, null)
+  image_id           = try(local.available_notebook_images_with_onsale[1].id, null)
+  key_pair           = huaweicloud_kps_keypair.test.name
+  allowed_access_ips = try(slice(local.runner_public_ips, 0, 2), null)
+  pool_id            = huaweicloud_modelarts_resource_pool.test.id
+
+  volume {
+    type      = "EFS"
+    ownership = "DEDICATED"
+    uri       = format("%%s:/", huaweicloud_modelarts_network.test.sfs_turbos[0].uri)
+    id        = huaweicloud_sfs_turbo.test.id
+  }
+}
+`, baseConfig, name)
 }

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_resource_pool_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_resource_pool_test.go
@@ -2,55 +2,24 @@ package modelarts
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
 )
 
 func getModelartsResourcePoolResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	region := acceptance.HW_REGION_NAME
-	var (
-		getModelartsResourcePoolHttpUrl = "v2/{project_id}/pools/{id}"
-		getModelartsResourcePoolProduct = "modelarts"
-	)
-	getModelartsResourcePoolClient, err := cfg.NewServiceClient(getModelartsResourcePoolProduct, region)
+	client, err := cfg.NewServiceClient("modelarts", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	getModelartsResourcePoolPath := getModelartsResourcePoolClient.Endpoint + getModelartsResourcePoolHttpUrl
-	getModelartsResourcePoolPath = strings.ReplaceAll(getModelartsResourcePoolPath, "{project_id}", getModelartsResourcePoolClient.ProjectID)
-	getModelartsResourcePoolPath = strings.ReplaceAll(getModelartsResourcePoolPath, "{id}", state.Primary.ID)
-
-	getModelartsResourcePoolOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
-	}
-
-	getModelartsResourcePoolResp, err := getModelartsResourcePoolClient.Request("GET", getModelartsResourcePoolPath,
-		&getModelartsResourcePoolOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving Modelarts resource pool: %s", err)
-	}
-
-	getModelartsResourcePoolRespBody, err := utils.FlattenResponse(getModelartsResourcePoolResp)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving Modelarts resource pool: %s", err)
-	}
-
-	return getModelartsResourcePoolRespBody, nil
+	return modelarts.GetResourcePoolById(client, state.Primary.ID)
 }
 
 func TestAccModelartsResourcePool_basic(t *testing.T) {

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_notebook.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_notebook.go
@@ -37,12 +37,14 @@ var (
 	}
 )
 
-// @API ModelArts POST /v1/{project_id}/notebooks/{id}/start
-// @API ModelArts POST /v1/{project_id}/notebooks/{id}/stop
 // @API ModelArts POST /v1/{project_id}/notebooks
 // @API ModelArts GET /v1/{project_id}/notebooks/{id}
 // @API ModelArts GET /v1/{project_id}/notebooks/{instance_id}/storage
+// @API ModelArts POST /v1/{project_id}/notebooks/{resource_id}/tags/create
+// @API ModelArts DELETE /v1/{project_id}/notebooks/{resource_id}/tags/delete
 // @API ModelArts PUT /v1/{project_id}/notebooks/{id}
+// @API ModelArts POST /v1/{project_id}/notebooks/{id}/stop
+// @API ModelArts POST /v1/{project_id}/notebooks/{id}/start
 // @API ModelArts DELETE /v1/{project_id}/notebooks/{id}
 func ResourceNotebook() *schema.Resource {
 	return &schema.Resource{
@@ -161,6 +163,7 @@ func ResourceNotebook() *schema.Resource {
 				Computed:    true,
 				Description: `The workspace ID to which the notebook belongs.`,
 			},
+			"tags": common.TagsSchema(`The tags of the notebook.`),
 
 			// Attributes.
 			"auto_stop_enabled": {
@@ -374,6 +377,108 @@ func waitForNotebookStatusCompleted(ctx context.Context, client *golangsdk.Servi
 	return nil
 }
 
+func buildNotebookTagsBodyParams(tags map[string]interface{}) map[string]interface{} {
+	if len(tags) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(tags))
+	for k, v := range tags {
+		result = append(result, map[string]interface{}{
+			"key":   k,
+			"value": v,
+		})
+	}
+
+	return map[string]interface{}{
+		"tags": result,
+	}
+}
+
+func deleteNotebookTags(client *golangsdk.ServiceClient, workspaceId, notebookId string, tags map[string]interface{}) error {
+	httpUrl := "v1/{project_id}/notebooks/{resource_id}/tags/delete"
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{resource_id}", notebookId)
+	if workspaceId != "" {
+		deletePath += fmt.Sprintf("?workspace_id=%s", workspaceId)
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildNotebookTagsBodyParams(tags),
+		OkCodes:  []int{204},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &opt)
+	return err
+}
+
+func createNotebookTags(client *golangsdk.ServiceClient, workspaceId, notebookId string, tags map[string]interface{}) error {
+	httpUrl := "v1/{project_id}/notebooks/{resource_id}/tags/create"
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{resource_id}", notebookId)
+	if workspaceId != "" {
+		createPath += fmt.Sprintf("?workspace_id=%s", workspaceId)
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildNotebookTagsBodyParams(tags),
+		OkCodes:  []int{204},
+	}
+
+	_, err := client.Request("POST", createPath, &opt)
+	return err
+}
+
+func updateNotebookTags(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		workspaceId    = d.Get("workspace_id").(string)
+		notebookId     = d.Id()
+		oldRaw, newRaw = d.GetChange("tags")
+		oldTags        = oldRaw.(map[string]interface{})
+		newTags        = newRaw.(map[string]interface{})
+		removeTags     = make(map[string]interface{})
+		addTags        = make(map[string]interface{})
+	)
+
+	for k, oldVal := range oldTags {
+		if newVal, ok := newTags[k]; !ok || newVal != oldVal {
+			removeTags[k] = oldVal
+		}
+	}
+	if len(removeTags) > 0 {
+		err := deleteNotebookTags(client, workspaceId, notebookId, removeTags)
+		if err != nil {
+			return err
+		}
+	}
+
+	for k, newVal := range newTags {
+		if oldVal, ok := oldTags[k]; !ok || oldVal != newVal {
+			addTags[k] = newVal
+		}
+	}
+	if len(addTags) > 0 {
+		err := createNotebookTags(client, workspaceId, notebookId, addTags)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func resourceNotebookCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg    = meta.(*config.Config)
@@ -399,6 +504,13 @@ func resourceNotebookCreate(ctx context.Context, d *schema.ResourceData, meta in
 	err = waitForNotebookStatusCompleted(ctx, client, resourceId, []string{"RUNNING"}, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	if d.HasChange("tags") {
+		err = updateNotebookTags(client, d)
+		if err != nil {
+			return diag.Errorf("error creating ModelArts notebook tags: %s", err)
+		}
 	}
 
 	return resourceNotebookRead(ctx, d, meta)
@@ -513,6 +625,7 @@ func resourceNotebookRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("allowed_access_ips", utils.PathSearch("endpoints[?service=='SSH']|[0].allowed_access_ips", respBody, nil)),
 		d.Set("pool_id", utils.PathSearch("pool.id", respBody, nil)),
 		d.Set("workspace_id", utils.PathSearch("workspace_id", respBody, nil)),
+		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("tags", respBody, nil))),
 		// Attributes.
 		d.Set("auto_stop_enabled", utils.PathSearch("lease.enable", respBody, false)),
 		d.Set("status", utils.PathSearch("status", respBody, nil)),
@@ -696,6 +809,13 @@ func resourceNotebookUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		err = startNotebook(ctx, client, notebookId, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return diag.Errorf("error start ModelArts notebook (%s): %s", notebookId, err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		err = updateNotebookTags(client, d)
+		if err != nil {
+			return diag.Errorf("error updating ModelArts notebook tags: %s", err)
 		}
 	}
 

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_notebook.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_notebook.go
@@ -2,59 +2,85 @@ package modelarts
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/modelarts/v1/notebook"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var (
+	notebookNonUpdatableParams = []string{
+		"key_pair",
+		"pool_id",
+		"workspace_id",
+		"volume.*.type",
+		"volume.*.ownership",
+		"volume.*.uri",
+		"volume.*.id",
+	}
+	notebookNotFoundErrCodes = []string{
+		"ModelArts.6309",
+		"ModelArts.6357",
+		"ModelArts.6404",
+	}
+)
+
 // @API ModelArts POST /v1/{project_id}/notebooks/{id}/start
 // @API ModelArts POST /v1/{project_id}/notebooks/{id}/stop
-// @API ModelArts GET /v1/{project_id}/notebooks/{id}/storage
-// @API ModelArts DELETE /v1/{project_id}/notebooks/{id}
-// @API ModelArts GET /v1/{project_id}/notebooks/{id}
-// @API ModelArts PUT /v1/{project_id}/notebooks/{id}
 // @API ModelArts POST /v1/{project_id}/notebooks
+// @API ModelArts GET /v1/{project_id}/notebooks/{id}
+// @API ModelArts GET /v1/{project_id}/notebooks/{instance_id}/storage
+// @API ModelArts PUT /v1/{project_id}/notebooks/{id}
+// @API ModelArts DELETE /v1/{project_id}/notebooks/{id}
 func ResourceNotebook() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceNotebookCreate,
 		ReadContext:   resourceNotebookRead,
 		UpdateContext: resourceNotebookUpdate,
 		DeleteContext: resourceNotebookDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
+		CustomizeDiff: config.FlexibleForceNew(notebookNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the notebook is located.`,
 			},
+
+			// Required parameters.
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the notebook.`,
 			},
 			"flavor_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The flavor ID of the notebook.`,
 			},
 			"image_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The image ID of the notebook.`,
 			},
 			"volume": {
 				Type:     schema.TypeList,
@@ -63,108 +89,129 @@ func ResourceNotebook() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice([]string{"EFS", "EVS"}, false),
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The storage type.`,
 						},
 						"ownership": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							Default:      "MANAGED",
-							ValidateFunc: validation.StringInSlice([]string{"MANAGED", "DEDICATED"}, false),
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "MANAGED",
+							Description: `The storage ownership.`,
 						},
 						"size": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `The storage size, in GB.`,
 						},
 						"uri": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"id": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"mount_path": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Computed:    true,
-							Description: "schema: Computed",
+							Description: `The storage URL of the dedicated disk.`,
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The storage ID of the dedicated disk.`,
+						},
+						"mount_path": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							Description: utils.SchemaDesc(
+								`The local mount path of the storage.`,
+								utils.SchemaDescInput{
+									Internal: true,
+								},
+							),
 						},
 					},
 				},
+				Description: `The volume configuration of the notebook.`,
 			},
+
+			// Optional parameters.
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the notebook.`,
 			},
 			"key_pair": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				RequiredWith: []string{"allowed_access_ips"},
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The key pair name for remote SSH access.`,
 			},
 			"allowed_access_ips": {
 				Type:         schema.TypeList,
 				Optional:     true,
 				Elem:         &schema.Schema{Type: schema.TypeString},
 				RequiredWith: []string{"key_pair"},
+				Description:  `The public IP addresses that are allowed for remote SSH access.`,
 			},
 			"pool_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the dedicated resource pool which the notebook used.`,
 			},
 			"workspace_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The workspace ID to which the notebook belongs.`,
 			},
+
+			// Attributes.
 			"auto_stop_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the notebook auto stop is enabled.`,
 			},
 			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"image_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"image_swr_path": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the notebook.`,
 			},
 			"image_type": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the image which the notebook used.`,
+			},
+			"image_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the image which the notebook used.`,
+			},
+			"image_swr_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The SWR repository path of the image which the notebook used.`,
 			},
 			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the notebook, in UTC format.`,
 			},
 			"updated_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the notebook, in UTC format.`,
 			},
 			"pool_name": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the dedicated resource pool which the notebook used.`,
 			},
 			"url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The web URL of the notebook.`,
 			},
 			"ssh_uri": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URL for remote SSH access of the notebook.`,
 			},
 			"mount_storages": {
 				Type:     schema.TypeList,
@@ -172,66 +219,184 @@ func ResourceNotebook() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the storage which is mounted to the notebook.`,
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the storage which is mounted to the notebook.`,
 						},
 						"mount_path": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The local mount path of the storage which is mounted to the notebook.`,
 						},
 						"path": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The source path of the storage which is mounted to the notebook.`,
 						},
 						"status": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the storage which is mounted to the notebook.`,
 						},
 					},
 				},
+				Description: `The storages which are mounted to the notebook.`,
 			},
 		},
 	}
 }
 
+func buildNotebookVolume(volumes []interface{}) map[string]interface{} {
+	if len(volumes) < 1 {
+		return nil
+	}
+
+	category := utils.PathSearch("type", volumes[0], "").(string)
+	ownership := utils.PathSearch("ownership", volumes[0], "").(string)
+	result := map[string]interface{}{
+		"category":  category,
+		"ownership": ownership,
+		"capacity":  utils.ValueIgnoreEmpty(utils.PathSearch("size", volumes[0], 0).(int)),
+	}
+	if category == "EFS" && ownership == "DEDICATED" {
+		result["uri"] = utils.PathSearch("uri", volumes[0], nil)
+		result["id"] = utils.PathSearch("id", volumes[0], nil)
+	}
+
+	return result
+}
+
+func buildCreateNotebookBodyParams(d *schema.ResourceData) map[string]interface{} {
+	result := map[string]interface{}{
+		// Fixed values.
+		"feature":  "NOTEBOOK",
+		"duration": -1,
+		// Required parameters.
+		"name":     d.Get("name"),
+		"flavor":   d.Get("flavor_id"),
+		"image_id": d.Get("image_id"),
+		"volume":   buildNotebookVolume(d.Get("volume").([]interface{})),
+		// Optional parameters.
+		"description":  utils.ValueIgnoreEmpty(d.Get("description")),
+		"pool_id":      utils.ValueIgnoreEmpty(d.Get("pool_id")),
+		"workspace_id": utils.ValueIgnoreEmpty(d.Get("workspace_id")),
+	}
+
+	if v, ok := d.GetOk("key_pair"); ok {
+		result["endpoints"] = []map[string]interface{}{
+			{
+				"service":            "SSH",
+				"key_pair_names":     []string{v.(string)},
+				"allowed_access_ips": d.Get("allowed_access_ips"),
+			},
+		}
+	}
+
+	return result
+}
+
+func createNotebook(client *golangsdk.ServiceClient, requestBody map[string]interface{}) (interface{}, error) {
+	httpUrl := "v1/{project_id}/notebooks"
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(requestBody),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func refreshNotebookStatus(client *golangsdk.ServiceClient, notebookId string, targetStatus []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetNotebookById(client, notebookId)
+		if err != nil {
+			parsedErr := common.ConvertExpected400ErrInto404Err(err, "error_code", notebookNotFoundErrCodes...)
+			if parsedErr != nil {
+				if _, ok := parsedErr.(golangsdk.ErrDefault404); ok && len(targetStatus) < 1 {
+					return "Resource Not Found", "COMPLETED", nil
+				}
+				return respBody, "ERROR", parsedErr
+			}
+		}
+
+		unexpectedStatus := []string{
+			"CREATE_FAILED",
+			"START_FAILED",
+			"DELETE_FAILED",
+			"ERROR",
+		}
+		if utils.StrSliceContains(unexpectedStatus, utils.PathSearch("status", respBody, "").(string)) {
+			return respBody, "ERROR", fmt.Errorf("unexpected status (%s)", utils.PathSearch("status", respBody, "").(string))
+		}
+
+		if utils.StrSliceContains(targetStatus, utils.PathSearch("status", respBody, "").(string)) {
+			evsVolumePendingStatuses := []string{"INITIALIZING", "RESIZING", "DELETING"}
+			evsVolumeStatus := utils.PathSearch("[volume][?category=='EVS'].status|[0]", respBody, "").(string)
+			if evsVolumeStatus != "" && utils.StrSliceContains(evsVolumePendingStatuses, evsVolumeStatus) {
+				return respBody, "PENDING", nil
+			}
+			return respBody, "COMPLETED", nil
+		}
+		return respBody, "PENDING", nil
+	}
+}
+
+func waitForNotebookStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, notebookId string, targetStatus []string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshNotebookStatus(client, notebookId, targetStatus),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for ModelArts notebook (%s) status to be completed: %s", notebookId, err)
+	}
+	return nil
+}
+
 func resourceNotebookCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ModelArtsV1Client(region)
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
 	if err != nil {
-		return diag.Errorf("error creating ModelArts v1 client, err=%s", err)
+		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	volume, err := buildVolumeParamter(d)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	leaseHour := -1
-	opts := notebook.CreateOpts{
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
-		Feature:     "NOTEBOOK",
-		Flavor:      d.Get("flavor_id").(string),
-		ImageId:     d.Get("image_id").(string),
-		Duration:    &leaseHour,
-		PoolId:      d.Get("pool_id").(string),
-		WorkspaceId: d.Get("workspace_id").(string),
-		Volume:      *volume,
-		Endpoints:   buildEndpointsParamter(d),
-	}
-
-	rs, err := notebook.Create(client, opts)
+	respBody, err := createNotebook(client, buildCreateNotebookBodyParams(d))
 	if err != nil {
 		return diag.Errorf("error creating ModelArts notebook: %s", err)
 	}
 
-	d.SetId(rs.Id)
+	resourceId := utils.PathSearch("id", respBody, "").(string)
+	if resourceId == "" {
+		return diag.Errorf("unable to find the ModelArts notebook ID from the API response")
+	}
+	d.SetId(resourceId)
 
-	err = waitingNotebookForRunning(ctx, client, rs.Id, d.Timeout(schema.TimeoutCreate))
+	err = waitForNotebookStatusCompleted(ctx, client, resourceId, []string{"RUNNING"}, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -239,297 +404,342 @@ func resourceNotebookCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return resourceNotebookRead(ctx, d, meta)
 }
 
+func GetNotebookById(client *golangsdk.ServiceClient, notebookId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/notebooks/{id}"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", notebookId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func flattenNotebookVolume(volume map[string]interface{}) []interface{} {
+	if len(volume) < 1 {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"type":       utils.PathSearch("category", volume, nil),
+			"ownership":  utils.PathSearch("ownership", volume, nil),
+			"size":       utils.PathSearch("capacity", volume, nil),
+			"uri":        utils.PathSearch("uri", volume, nil),
+			"id":         utils.PathSearch("id", volume, nil),
+			"mount_path": utils.PathSearch("mount_path", volume, nil),
+		},
+	}
+}
+
+func listNotebookMountedStorages(client *golangsdk.ServiceClient, notebookId string) ([]interface{}, error) {
+	httpUrl := "v1/{project_id}/notebooks/{instance_id}/storage"
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", notebookId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	return utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenNotebookMountStorages(mounts []interface{}) []interface{} {
+	if len(mounts) < 1 {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"id":         utils.PathSearch("id", mounts[0], nil),
+			"type":       utils.PathSearch("category", mounts[0], nil),
+			"mount_path": utils.PathSearch("mount_path", mounts[0], nil),
+			"path":       utils.PathSearch("uri", mounts[0], nil),
+			"status":     utils.PathSearch("status", mounts[0], nil),
+		},
+	}
+}
+
 func resourceNotebookRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ModelArtsV1Client(region)
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		notebookId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
 	if err != nil {
-		return diag.Errorf("error creating ModelArts v1 client, err=%s", err)
+		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	detail, err := notebook.Get(client, d.Id())
+	respBody, err := GetNotebookById(client, notebookId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, parseModlArtsErrorToError404(err), "error retrieving ModelArts notebook")
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", notebookNotFoundErrCodes...),
+			"error retrieving ModelArts notebook")
 	}
 
-	keyPair, uri, ips := parseEndpoints(detail.Endpoints)
 	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("name", detail.Name),
-		d.Set("flavor_id", detail.Flavor),
-		d.Set("image_id", detail.Image.Id),
-		d.Set("description", detail.Description),
-		d.Set("pool_id", detail.Pool.Id),
-		d.Set("workspace_id", detail.WorkspaceId),
-		d.Set("status", detail.Status),
-		d.Set("image_name", detail.Image.Name),
-		d.Set("image_type", detail.Image.Type),
-		d.Set("image_swr_path", detail.Image.SwrPath),
-		d.Set("created_at", time.Unix(int64(detail.CreateAt)/1000, 0).UTC().Format("2006-01-02 15:04:05 MST")),
-		d.Set("updated_at", time.Unix(int64(detail.UpdateAt)/1000, 0).UTC().Format("2006-01-02 15:04:05 MST")),
-		d.Set("auto_stop_enabled", detail.Lease.Enable),
-		d.Set("pool_name", detail.Pool.Name),
-		d.Set("url", detail.Url),
-		d.Set("key_pair", keyPair),
-		d.Set("allowed_access_ips", ips),
-		d.Set("ssh_uri", uri),
-		setVolumeToState(d, detail.Volume),
-		setMountStoragesToState(d, client),
+		// Required parameters.
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("flavor_id", utils.PathSearch("flavor", respBody, nil)),
+		d.Set("image_id", utils.PathSearch("image.id", respBody, nil)),
+		d.Set("volume", flattenNotebookVolume(utils.PathSearch("volume", respBody, make(map[string]interface{})).(map[string]interface{}))),
+		// Optional parameters.
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("key_pair", utils.PathSearch("endpoints[?service=='SSH']|[0].key_pair_names|[0]", respBody, nil)),
+		d.Set("allowed_access_ips", utils.PathSearch("endpoints[?service=='SSH']|[0].allowed_access_ips", respBody, nil)),
+		d.Set("pool_id", utils.PathSearch("pool.id", respBody, nil)),
+		d.Set("workspace_id", utils.PathSearch("workspace_id", respBody, nil)),
+		// Attributes.
+		d.Set("auto_stop_enabled", utils.PathSearch("lease.enable", respBody, false)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("image_type", utils.PathSearch("image.type", respBody, nil)),
+		d.Set("image_name", utils.PathSearch("image.name", respBody, nil)),
+		d.Set("image_swr_path", utils.PathSearch("image.swr_path", respBody, nil)),
+		d.Set("created_at", time.Unix(int64(utils.PathSearch("create_at",
+			respBody, float64(0)).(float64))/1000, 0).UTC().Format("2006-01-02 15:04:05 MST")),
+		d.Set("updated_at", time.Unix(int64(utils.PathSearch("update_at",
+			respBody, float64(0)).(float64))/1000, 0).UTC().Format("2006-01-02 15:04:05 MST")),
+		d.Set("pool_name", utils.PathSearch("pool.name", respBody, nil)),
+		d.Set("url", utils.PathSearch("url", respBody, nil)),
+		d.Set("ssh_uri", utils.PathSearch("endpoints[?service=='SSH']|[0].uri", respBody, nil)),
 	)
+
+	mountedStorages, err := listNotebookMountedStorages(client, d.Id())
+	if err != nil {
+		log.Printf("[ERROR] Failed to query the mounted storages of ModelArts notebook (%s): %s", notebookId, err)
+	} else {
+		mErr = multierror.Append(mErr, d.Set("mount_storages", flattenNotebookMountStorages(mountedStorages)))
+	}
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceNotebookUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ModelArtsV1Client(region)
+func buildUpdateNotebookByRunningStateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	result := map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": d.Get("description"),
+	}
+
+	if d.HasChange("volume.0.size") {
+		result["storage_new_size"] = d.Get("volume.0.size")
+	}
+
+	return result
+}
+
+func updateNotebook(client *golangsdk.ServiceClient, notebookId string, requestBody map[string]interface{}) error {
+	httpUrl := "v1/{project_id}/notebooks/{id}"
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{id}", notebookId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(requestBody),
+	}
+
+	_, err := client.Request("PUT", updatePath, &opt)
+	return err
+}
+
+func stopNotebook(ctx context.Context, client *golangsdk.ServiceClient, notebookId string, timeout time.Duration) error {
+	httpUrl := "v1/{project_id}/notebooks/{id}/stop"
+
+	stopPath := client.Endpoint + httpUrl
+	stopPath = strings.ReplaceAll(stopPath, "{project_id}", client.ProjectID)
+	stopPath = strings.ReplaceAll(stopPath, "{id}", notebookId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("POST", stopPath, &opt)
 	if err != nil {
-		return diag.Errorf("error creating ModelArts v1 client, err=%s", err)
+		return err
+	}
+	return waitForNotebookStatusCompleted(ctx, client, notebookId, []string{"STOPPED"}, timeout)
+}
+
+func buildUpdateNotebookByStoppedStateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	result := map[string]interface{}{
+		"flavor":   d.Get("flavor_id"),
+		"image_id": d.Get("image_id"),
 	}
 
-	if d.HasChanges("name", "description", "endpoints") {
-		desc := d.Get("description").(string)
-		opts := notebook.UpdateOpts{
-			Name:        d.Get("name").(string),
-			Description: &desc,
-			Endpoints:   buildEndpointsParamter(d),
-		}
-
-		_, err := notebook.Update(client, d.Id(), opts)
-		if err != nil {
-			return diag.Errorf("error update ModelArts notebook: %s", err)
+	if v, ok := d.GetOk("key_pair"); ok {
+		result["endpoints"] = []map[string]interface{}{
+			{
+				"service":            "SSH",
+				"key_pair_names":     []string{v.(string)},
+				"allowed_access_ips": d.Get("allowed_access_ips"),
+			},
 		}
 	}
 
-	if d.HasChanges("flavor_id", "image_id", "volume.0.size") {
-		// stop
-		status := d.Get("status").(string)
-		if status != notebook.StatusStopped {
-			_, err := notebook.Stop(client, d.Id())
+	return result
+}
+
+func buildStartNotebookBodyParams(duration int, actionType string) string {
+	res := "?"
+	if duration != 0 {
+		res += fmt.Sprintf("duration=%d", duration)
+	}
+	if actionType != "" {
+		res += fmt.Sprintf("type=%s", actionType)
+	}
+	return res
+}
+
+func startNotebook(ctx context.Context, client *golangsdk.ServiceClient, notebookId string, timeout time.Duration) error {
+	httpUrl := "v1/{project_id}/notebooks/{id}/start"
+
+	startPath := client.Endpoint + httpUrl
+	startPath = strings.ReplaceAll(startPath, "{project_id}", client.ProjectID)
+	startPath = strings.ReplaceAll(startPath, "{id}", notebookId)
+	startPath += buildStartNotebookBodyParams(-1, "")
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("POST", startPath, &opt)
+	if err != nil {
+		return err
+	}
+	return waitForNotebookStatusCompleted(ctx, client, notebookId, []string{"RUNNING"}, timeout)
+}
+
+func resourceNotebookUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		notebookId = d.Id()
+	)
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	if d.HasChanges("name", "description", "volume.0.size") {
+		notebook, err := GetNotebookById(client, notebookId)
+		if err != nil {
+			return diag.Errorf("error get ModelArts notebook (%s): %s", notebookId, err)
+		}
+		if utils.PathSearch("status", notebook, "").(string) == "STOPPED" {
+			log.Printf("[DEBUG] Try to start notebook (%s) because the status is STOPPED now", notebookId)
+			err = startNotebook(ctx, client, notebookId, d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
-				return diag.FromErr(err)
-			}
-
-			err = waitingNotebookForStopped(ctx, client, d.Id(), d.Timeout(schema.TimeoutUpdate))
-			if err != nil {
-				return diag.FromErr(err)
+				return diag.Errorf("error start ModelArts notebook (%s): %s", notebookId, err)
 			}
 		}
 
-		// change
-		storageSize := d.Get("volume.0.size").(int)
-		opts := notebook.UpdateOpts{
-			Flavor:         d.Get("flavor_id").(string),
-			ImageId:        d.Get("image_id").(string),
-			StorageNewSize: &storageSize,
+		err = updateNotebook(client, notebookId, buildUpdateNotebookByRunningStateBodyParams(d))
+		if err != nil {
+			return diag.Errorf("error update ModelArts notebook (%s): %s", notebookId, err)
+		}
+		err = waitForNotebookStatusCompleted(ctx, client, notebookId, []string{"RUNNING"}, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return diag.Errorf("error waiting for ModelArts notebook (%s) status to be running: %s", notebookId, err)
+		}
+	}
+
+	if d.HasChanges("flavor_id", "image_id", "allowed_access_ips") {
+		// Stop notebook before updating the flavor, image and endpoints
+		err := stopNotebook(ctx, client, notebookId, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			if !errors.As(common.ConvertExpected400ErrInto404Err(err, "error_code", "ModelArts.6357"), &golangsdk.ErrDefault404{}) {
+				return diag.Errorf("error stop ModelArts notebook (%s): %s", notebookId, err)
+			}
+			log.Printf("[DEBUG] The notebook (%s) is already stopped, so skip the stop operation", notebookId)
 		}
 
-		_, err := notebook.Update(client, d.Id(), opts)
+		err = updateNotebook(client, notebookId, buildUpdateNotebookByStoppedStateBodyParams(d))
 		if err != nil {
-			return diag.Errorf("error update ModelArts notebook: %s", err)
+			return diag.Errorf("error update ModelArts notebook (%s): %s", notebookId, err)
 		}
 
-		// start the instance
-		_, err = notebook.Start(client, d.Id(), -1)
+		// Start notebook after updating the flavor, image and endpoints
+		err = startNotebook(ctx, client, notebookId, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return diag.FromErr(err)
-		}
-
-		err = waitingNotebookForRunning(ctx, client, d.Id(), d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return diag.FromErr(err)
+			return diag.Errorf("error start ModelArts notebook (%s): %s", notebookId, err)
 		}
 	}
 
 	return resourceNotebookRead(ctx, d, meta)
 }
 
+func deleteNotebook(ctx context.Context, client *golangsdk.ServiceClient, notebookId string, timeout time.Duration) error {
+	httpUrl := "v1/{project_id}/notebooks/{id}"
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{id}", notebookId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &opt)
+	if err != nil {
+		return err
+	}
+	return waitForNotebookStatusCompleted(ctx, client, notebookId, nil, timeout)
+}
+
 func resourceNotebookDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ModelArtsV1Client(region)
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		notebookId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
 	if err != nil {
-		return diag.Errorf("error creating ModelArts v1 client, err=%s", err)
+		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	_, err = notebook.Delete(client, d.Id())
+	err = deleteNotebook(ctx, client, notebookId, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.Errorf("delete ModelArts notebook failed. %q:%s", d.Id(), err)
-	}
-
-	err = waitingNotebookForDeleted(ctx, client, d.Id(), d.Timeout(schema.TimeoutDelete))
-	if err != nil {
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", notebookNotFoundErrCodes...),
+			fmt.Sprintf("error delete ModelArts notebook (%s)", notebookId))
 	}
 
 	return nil
-}
-
-func buildVolumeParamter(d *schema.ResourceData) (*notebook.VolumeReq, error) {
-	rst := notebook.VolumeReq{
-		Category:  d.Get("volume.0.type").(string),
-		Ownership: d.Get("volume.0.ownership").(string),
-	}
-
-	if rst.Category == "EFS" && rst.Ownership == "DEDICATED" {
-		v, ok := d.GetOk("volume.0.uri")
-		if !ok {
-			return nil, fmt.Errorf("the parameter 'uri' is mandatory if the storage type is EFS and ownership is DEDICATED")
-		}
-		rst.Uri = v.(string)
-		v, ok = d.GetOk("volume.0.id")
-		if !ok {
-			return nil, fmt.Errorf("the parameter 'id' is mandatory if the storage type is EFS and ownership is DEDICATED")
-		}
-		rst.ID = v.(string)
-	}
-
-	if v, ok := d.GetOk("volume.0.size"); ok {
-		capacity := v.(int)
-		rst.Capacity = &capacity
-	}
-
-	return &rst, nil
-}
-
-func buildEndpointsParamter(d *schema.ResourceData) []notebook.EndpointsReq {
-	if v, ok := d.GetOk("key_pair"); ok {
-		endpoint := notebook.EndpointsReq{
-			Service:          "SSH",
-			AllowedAccessIps: utils.ExpandToStringList(d.Get("allowed_access_ips").([]interface{})),
-			KeyPairNames:     []string{v.(string)},
-		}
-		return []notebook.EndpointsReq{endpoint}
-	}
-	return nil
-}
-
-func setVolumeToState(d *schema.ResourceData, volume notebook.VolumeRes) error {
-	result := make(map[string]interface{})
-	result["type"] = volume.Category
-	result["ownership"] = volume.Ownership
-	result["size"] = volume.Capacity
-	result["uri"] = volume.URI
-	result["id"] = volume.ID
-	result["mount_path"] = volume.MountPath
-	return d.Set("volume", []map[string]interface{}{result})
-}
-
-func parseEndpoints(configs []notebook.Endpoints) (keyPair, uri string, ips []string) {
-	for _, v := range configs {
-		if v.Service == "SSH" {
-			return v.KeyPairNames[0], v.Uri, v.AllowedAccessIps
-		}
-	}
-	return
-}
-
-func setMountStoragesToState(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
-	resp, err := notebook.ListMounts(client, d.Id())
-	if err != nil {
-		log.Printf("[ERROR] Failed to query the mount storage of ModelArts notebook instance=%s", d.Id())
-		return nil
-	}
-	rst := make([]map[string]interface{}, len(resp.Data))
-	for i, v := range resp.Data {
-		storage := make(map[string]interface{})
-		storage["id"] = v.Id
-		storage["type"] = v.Category
-		storage["mount_path"] = v.MountPath
-		storage["path"] = v.Uri
-		storage["status"] = v.Status
-		rst[i] = storage
-	}
-	return d.Set("mount_storages", rst)
-}
-
-func waitingNotebookForRunning(ctx context.Context, client *golangsdk.ServiceClient, id string, timeout time.Duration) error {
-	createStateConf := &resource.StateChangeConf{
-		Pending: []string{notebook.StatusInit, notebook.StatusCreating, notebook.StatusStarting, notebook.StatusSnapshotting},
-		Target:  []string{notebook.StatusRunning},
-		Refresh: func() (interface{}, string, error) {
-			resp, err := notebook.Get(client, id)
-			if err != nil {
-				return nil, "failed", err
-			}
-			if resp.Status == notebook.StatusCreateFailed || resp.Status == notebook.StatusError {
-				return nil, "failed", fmt.Errorf("error_code: %s, error_msg: %s", resp.Status, resp.FailReason)
-			}
-			return resp, resp.Status, err
-		},
-		Timeout:      timeout,
-		PollInterval: 10 * timeout,
-		Delay:        10 * time.Second,
-	}
-	_, err := createStateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return fmt.Errorf("error waiting for ModelArts notebook (%s) to be created: %s", id, err)
-	}
-	return nil
-}
-
-func waitingNotebookForStopped(ctx context.Context, client *golangsdk.ServiceClient, id string, timeout time.Duration) error {
-	createStateConf := &resource.StateChangeConf{
-		Pending: []string{notebook.StatusRunning, notebook.StatusStopping},
-		Target:  []string{notebook.StatusStopped},
-		Refresh: func() (interface{}, string, error) {
-			resp, err := notebook.Get(client, id)
-			if err != nil {
-				return nil, "failed", err
-			}
-			if resp.Status == notebook.StatusError {
-				return nil, "failed", fmt.Errorf("error_code: %s, error_msg: %s", resp.Status, resp.FailReason)
-			}
-			return resp, resp.Status, err
-		},
-		Timeout:      timeout,
-		PollInterval: 10 * timeout,
-		Delay:        10 * time.Second,
-	}
-	_, err := createStateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return fmt.Errorf("error waiting for ModelArts notebook (%s) to be stopped: %s", id, err)
-	}
-	return nil
-}
-
-func waitingNotebookForDeleted(ctx context.Context, client *golangsdk.ServiceClient, id string, timeout time.Duration) error {
-	createStateConf := &resource.StateChangeConf{
-		Pending: []string{notebook.StatusRunning, notebook.StatusDeleting},
-		Target:  []string{notebook.StatusDeleted},
-		Refresh: func() (interface{}, string, error) {
-			resp, err := notebook.Get(client, id)
-			if err != nil {
-				err = parseModlArtsErrorToError404(err)
-				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return resp, notebook.StatusDeleted, nil
-				}
-				return nil, "failed", err
-			}
-			if resp.Status == notebook.StatusError || resp.Status == notebook.StatusDeleteFailed {
-				return nil, "failed", fmt.Errorf("error_code: %s, error_msg: %s", resp.Status, resp.FailReason)
-			}
-			return resp, resp.Status, err
-		},
-		Timeout:      timeout,
-		PollInterval: 10 * timeout,
-		Delay:        10 * time.Second,
-	}
-	_, err := createStateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return fmt.Errorf("error waiting for ModelArts notebook (%s) to be deleted: %s", id, err)
-	}
-	return nil
-}
-
-func parseModlArtsErrorToError404(respErr error) error {
-	var apiError notebook.ModelartsError
-	if errCode, ok := respErr.(golangsdk.ErrDefault400); ok {
-		pErr := json.Unmarshal(errCode.Body, &apiError)
-		if pErr == nil && (apiError.ErrorCode == "ModelArts.6309" || apiError.ErrorCode == "ModelArts.6404") {
-			return golangsdk.ErrDefault404(errCode)
-		}
-	}
-	return respErr
 }

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_notebook_mount_storage.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_notebook_mount_storage.go
@@ -85,7 +85,7 @@ func resourceNotebookMountStorageCreate(ctx context.Context, d *schema.ResourceD
 	// check the notebook instance
 	notebookDetail, err := notebook.Get(client, notebookId)
 	if err != nil {
-		err = parseModlArtsErrorToError404(err)
+		err = common.ConvertExpected400ErrInto404Err(err, "error_code", notebookNotFoundErrCodes...)
 		if _, ok := err.(golangsdk.ErrDefault404); ok {
 			return diag.Errorf("the nodebook id=%s is not exist", notebookId)
 		}
@@ -134,7 +134,8 @@ func resourceNotebookMountStorageRead(_ context.Context, d *schema.ResourceData,
 
 	detail, err := notebook.GetMount(client, notebookId, mountId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, parseModlArtsErrorToError404(err), "ModelArts notebook's mount storage")
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", notebookNotFoundErrCodes...),
+			"error retrieving ModelArts notebook's mount storage")
 	}
 
 	mErr := multierror.Append(
@@ -210,7 +211,7 @@ func waitingNotebookMountForDeleted(ctx context.Context, client *golangsdk.Servi
 		Refresh: func() (interface{}, string, error) {
 			resp, err := notebook.GetMount(client, notebookId, mountId)
 			if err != nil {
-				err = parseModlArtsErrorToError404(err)
+				err = common.ConvertExpected400ErrInto404Err(err, "error_code", notebookNotFoundErrCodes...)
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
 					return resp, "UNMOUNTED", nil
 				}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
@@ -787,6 +787,41 @@ func getServerIdsByNodeNames(actionNodeNames []interface{}, actionNodes []interf
 	return serverIds
 }
 
+func waitForResourcePoolScopeStatusesCompleted(ctx context.Context, client *golangsdk.ServiceClient, resourcePoolId string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshResourcePoolScopeStatuses(client, resourcePoolId),
+		Timeout:      timeout,
+		Delay:        45 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func refreshResourcePoolScopeStatuses(client *golangsdk.ServiceClient, resourcePoolId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		scopes, err := GetResourcePoolById(client, resourcePoolId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		var (
+			scopesStatuses = utils.PathSearch("status.scope", scopes, make([]interface{}, 0)).([]interface{})
+			targetStatus   = []string{"Enabled", "Disabled"}
+		)
+
+		for _, scopeStatus := range scopesStatuses {
+			if !utils.StrSliceContains(targetStatus, utils.PathSearch("state", scopeStatus, "").(string)) {
+				return "SCOPE_STATUS_PENDING", "PENDING", nil
+			}
+		}
+		return "SCOPE_STATUS_COMPLETED", "COMPLETED", nil
+	}
+}
+
 func resourceModelartsResourcePoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
@@ -853,6 +888,12 @@ func resourceModelartsResourcePoolCreate(ctx context.Context, d *schema.Resource
 
 	if err := d.Set("server_ids", getServerIdsByNodeNames(actionNodeNames, actionNodes.([]interface{}))); err != nil {
 		log.Printf("[ERROR] error setting the server IDs for creating resource pool (%s): %s", resourcePoolId, err)
+	}
+
+	// Subsequent resource deployment can only proceed normally when all job types are enabled.
+	err = waitForResourcePoolScopeStatusesCompleted(ctx, client, resourcePoolId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		log.Printf("[ERROR] error waiting for the scope statuses of resource pool (%s) creation to complete: %s", resourcePoolId, err)
 	}
 
 	return resourceModelartsResourcePoolRead(ctx, d, meta)
@@ -1169,18 +1210,23 @@ func buildResourcePoolResourcesCreatingStep(creatingSteps []interface{}) map[str
 }
 
 func resourceModelartsResourcePoolRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		resourcePoolId = d.Id()
+	)
 
-	var mErr *multierror.Error
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
 
-	getModelartsResourcePoolRespBody, err := queryResourcePool(cfg, region, d)
+	getModelartsResourcePoolRespBody, err := GetResourcePoolById(client, resourcePoolId)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "error retrieving Modelarts resource pool")
 	}
 
-	mErr = multierror.Append(
-		mErr,
+	mErr := multierror.Append(nil,
 		d.Set("region", region),
 		d.Set("name", utils.PathSearch(`metadata.labels."os.modelarts/name"`,
 			getModelartsResourcePoolRespBody, nil)),
@@ -1222,26 +1268,16 @@ func resourceModelartsResourcePoolRead(_ context.Context, d *schema.ResourceData
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func queryResourcePool(cfg *config.Config, region string, d *schema.ResourceData) (interface{}, error) {
+func GetResourcePoolById(client *golangsdk.ServiceClient, resourcePoolId string) (interface{}, error) {
 	var (
-		getModelartsResourcePoolHttpUrl = "v2/{project_id}/pools/{id}"
-		getModelartsResourcePoolProduct = "modelarts"
+		httpUrl = "v2/{project_id}/pools/{id}"
 	)
-	getModelartsResourcePoolClient, err := cfg.NewServiceClient(getModelartsResourcePoolProduct, region)
-	if err != nil {
-		return nil, golangsdk.ErrDefault404{
-			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("error creating ModelArts client: %s", err)),
-			},
-		}
-	}
 
-	getModelartsResourcePoolPath := getModelartsResourcePoolClient.Endpoint + getModelartsResourcePoolHttpUrl
-	getModelartsResourcePoolPath = strings.ReplaceAll(getModelartsResourcePoolPath, "{project_id}",
-		getModelartsResourcePoolClient.ProjectID)
-	getModelartsResourcePoolPath = strings.ReplaceAll(getModelartsResourcePoolPath, "{id}", d.Id())
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", resourcePoolId)
 
-	getModelartsResourcePoolOpt := golangsdk.RequestOpts{
+	getOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		OkCodes: []int{
 			200,
@@ -1249,18 +1285,12 @@ func queryResourcePool(cfg *config.Config, region string, d *schema.ResourceData
 		MoreHeaders: map[string]string{"Content-Type": "application/json"},
 	}
 
-	getModelartsResourcePoolResp, err := getModelartsResourcePoolClient.Request("GET", getModelartsResourcePoolPath,
-		&getModelartsResourcePoolOpt)
-
+	requestResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
 		return nil, err
 	}
 
-	getModelartsResourcePoolRespBody, err := utils.FlattenResponse(getModelartsResourcePoolResp)
-	if err != nil {
-		return nil, err
-	}
-	return getModelartsResourcePoolRespBody, nil
+	return utils.FlattenResponse(requestResp)
 }
 
 func flattenResourcePoolResourcesRootVolume(rootVolume interface{}) []map[string]interface{} {
@@ -2163,7 +2193,7 @@ func resourceModelartsResourcePoolDelete(ctx context.Context, d *schema.Resource
 	}
 
 	// When there is no node in the resource pool, the resource pool will be automatically deleted.
-	_, err = queryResourcePool(cfg, region, d)
+	_, err = GetResourcePoolById(client, resourcePoolName)
 	if _, ok := err.(golangsdk.ErrDefault404); ok {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting resource pool (%s)", resourcePoolName))
 	}
@@ -2183,7 +2213,7 @@ func resourceModelartsResourcePoolDelete(ctx context.Context, d *schema.Resource
 		}
 	}
 
-	err = deleteResourcePoolWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))
+	err = deleteResourcePoolWaitingForStateCompleted(ctx, client, resourcePoolName, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return diag.Errorf("error waiting for the Modelarts resource pool (%s) deletion to complete: %s", d.Id(), err)
 	}
@@ -2242,14 +2272,12 @@ func unsubscribePrePaidBillingNodes(ctx context.Context, client, bssClient *gola
 	return nil
 }
 
-func deleteResourcePoolWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+func deleteResourcePoolWaitingForStateCompleted(ctx context.Context, client *golangsdk.ServiceClient, resourcePoolId string, t time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			cfg := meta.(*config.Config)
-			region := cfg.GetRegion(d)
-			res, err := queryResourcePool(cfg, region, d)
+			res, err := GetResourcePoolById(client, resourcePoolId)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
 					res = map[string]string{"code": "COMPLETED"}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Using new code format (auto-generate style) to refactor the notebook resource.
- Adjust the incorrect update method: volume must be updated in running status, allowed_access_ips must be update in stopped status.
- trying start notebook before last update option is failed
- supports tags management

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1051" height="126" alt="image" src="https://github.com/user-attachments/assets/e3424b83-8144-4f19-9fb5-8a37135ec77a" />

Stop a notebook while it is already stopped.
<img width="1640" height="430" alt="image" src="https://github.com/user-attachments/assets/0e08c959-e3b9-429a-9b0a-2ea4a6da42dd" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. sub-resources can be created after corresponding scope statuses completed
2. using new code format to rewrite resource codes
3. notebook supports tags management
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccNotebook_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccNotebook_basic -timeout 360m -parallel 10
=== RUN   TestAccNotebook_basic
=== PAUSE TestAccNotebook_basic
=== CONT  TestAccNotebook_basic
--- PASS: TestAccNotebook_basic (2360.78s)
PASS
coverage: 21.7% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 2360.867s       coverage: 21.7% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1729" height="983" alt="image" src="https://github.com/user-attachments/assets/1bcdb921-0738-420c-a103-f229e8781a8f" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1729" height="983" alt="image" src="https://github.com/user-attachments/assets/1bcdb921-0738-420c-a103-f229e8781a8f" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
