### PR TITLE
feat(GeminiDB): add new data source to get list of dedicated resources

### DIFF
--- a/docs/data-sources/geminidb_dedicated_resources.md
+++ b/docs/data-sources/geminidb_dedicated_resources.md
@@ -1,0 +1,62 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_dedicated_resources"
+description: |-
+  Use this data source to get the list of dedicated resource.
+---
+
+# huaweicloud_geminidb_dedicated_resources
+
+Use this data source to get the list of dedicated resource.
+
+-> This data source only supports GeminiDB Cassandra instances.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_geminidb_dedicated_resources" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resources` - The list of dedicated resources.
+  The [resources](#dedicated_resources_struct) structure is documented below.
+
+<a name="dedicated_resources_struct"></a>
+The `resources` block supports:
+
+* `id` - The dedicated resource ID.
+
+* `resource_name` - The dedicated resource name.
+
+* `engine_name` - The API name.
+
+* `availability_zone` - The AZ information.
+
+* `architecture` - The type of the compute host in the dedicated resource.
+
+* `capacity` - The capacity of the dedicated resource.
+  The [capacity](#capacity_struct) structure is documented below.
+
+* `status` - The status of a dedicated resource.
+
+<a name="capacity_struct"></a>
+The `capacity` block supports:
+
+* `vcpus` - The CPU cores.
+
+* `ram` - The memory size, in GB.
+
+* `volume` - The storage size, in GB.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1437,6 +1437,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_accounts":            geminidb.DataSourceGeminiDbAccounts(),
 			"huaweicloud_geminidb_backups":             geminidb.DataSourceGeminiDBBackups(),
 			"huaweicloud_geminidb_database_versions":   geminidb.DataSourceDatabaseVersions(),
+			"huaweicloud_geminidb_dedicated_resources": geminidb.DataSourceDedicatedResources(),
 			"huaweicloud_geminidb_flavors":             geminidb.DataSourceGeminiDBFlavors(),
 			"huaweicloud_geminidb_memory_rules":        geminidb.DataSourceMemoryRules(),
 			"huaweicloud_geminidb_quotas":              geminidb.DataSourceQuotas(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_dedicated_resources_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_dedicated_resources_test.go
@@ -1,0 +1,44 @@
+package geminidb
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDedicatedResources_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_geminidb_dedicated_resources.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDedicatedResources_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.engine_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.availability_zone"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.architecture"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.capacity.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.capacity.0.vcpus"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.capacity.0.ram"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.capacity.0.volume"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.status"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceDedicatedResources_basic = `data "huaweicloud_geminidb_dedicated_resources" "test" {}`

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_dedicated_resources.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_dedicated_resources.go
@@ -1,0 +1,177 @@
+package geminidb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforNoSQL GET /v3/{project_id}/dedicated-resources
+func DataSourceDedicatedResources() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDedicatedResourcesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"engine_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"architecture": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"capacity": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"vcpus": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"ram": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"volume": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDedicatedResourcesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/dedicated-resources?limit=100"
+		// The `offset` value is `0` in API document, Actually, the `offset` value is `1`.
+		offset = 1
+		result = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", getPath, offset)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving the dedicated resources: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dedicatedResources := utils.PathSearch("resources", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(dedicatedResources) == 0 {
+			break
+		}
+
+		result = append(result, dedicatedResources...)
+		offset += len(dedicatedResources)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("resources", flattenDedicatedResources(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDedicatedResources(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"id":                utils.PathSearch("id", v, nil),
+			"resource_name":     utils.PathSearch("resource_name", v, nil),
+			"engine_name":       utils.PathSearch("engine_name", v, nil),
+			"availability_zone": utils.PathSearch("availability_zone", v, nil),
+			"architecture":      utils.PathSearch("architecture", v, nil),
+			"capacity":          flattenDedicatedResourceCapacity(utils.PathSearch("capacity", v, nil)),
+			"status":            utils.PathSearch("status", v, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenDedicatedResourceCapacity(resp interface{}) []map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"vcpus":  utils.PathSearch("vcpus", resp, nil),
+		"ram":    utils.PathSearch("ram", resp, nil),
+		"volume": utils.PathSearch("volume", resp, nil),
+	}
+
+	return []map[string]interface{}{result}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of dedicated resources.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to get list of dedicated resources.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccDataSourceDedicatedResources_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccDataSourceDedicatedResources_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDedicatedResources_basic
=== PAUSE TestAccDataSourceDedicatedResources_basic
=== CONT  TestAccDataSourceDedicatedResources_basic
--- PASS: TestAccDataSourceDedicatedResources_basic (19.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  19.922s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/42074447-92c3-4f71-a075-6cb85cdf7253" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
