### PR TITLE
feat(drs): new datasource to query processes

### DIFF
--- a/docs/data-sources/drs_batch_progresses.md
+++ b/docs/data-sources/drs_batch_progresses.md
@@ -1,0 +1,95 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_batch_progresses"
+description: |-
+  Use this data source to get the progresses list for specified DRS jobs within HuaweiCloud.
+---
+
+# huaweicloud_drs_batch_progresses
+
+Use this data source to get the progresses list for specified DRS jobs within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "job_ids" { 
+  type = list(string) 
+}
+
+data "huaweicloud_drs_batch_progresses" "test" { 
+  job_ids = var.job_ids 
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_ids` - (Required, List) Specifies the list of DRS job IDs to query.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `results` - The progresses list.
+
+  The [results](#results_struct) structure is documented below.
+
+<a name="results_struct"></a>
+The `results` block supports:
+
+* `job_id` - The ID of the DRS job.
+
+* `progress` - The migration percentage.
+
+* `incre_trans_delay` - The incremental migration delay in seconds.
+
+* `incre_trans_delay_millis` - The incremental migration delay in milliseconds.
+
+* `task_mode` - The task mode.
+  The valid values are as follows:
+  + **FULL_TRANS**: Full migration.
+  + **INCR_TRANS**: Incremental migration.
+  + **FULL_INCR_TRANS**: Full + incremental migration.
+
+* `transfer_status` - The task status.
+  The valid values are as follows:
+  + **CREATING**: Creating.
+  + **CREATE_FAILED**: Creation failed.
+  + **CONFIGURATION**: Configuring.
+  + **WAITING_FOR_START**: Waiting to start.
+  + **RELEASE_RESOURCE_COMPLETE**: Completed.
+  + **DELETED**: Deleted.
+  + **INCRE_TRANSFER_STARTED**: Incremental migration in progress.
+  + **INCRE_TRANSFER_FAILED**: Incremental migration failed.
+  + **FULL_TRANSFER_STARTED**: Full migration in progress.
+  + **FULL_TRANSFER_COMPLETE**: Full migration completed.
+  + **PAUSING**: Pausing.
+  + **FULL_TRANSFER_FAILED**: Full migration failed.
+
+* `process_time` - The migration time, timestamp.
+
+* `remaining_time` - The estimated remaining time.
+
+* `progress_map` - The data, structure, and index migration progress information.
+
+  The [progress_map](#progress_map_struct) structure is documented below.
+
+* `error_code` - The error code.
+
+* `error_msg` - The error message.
+
+<a name="progress_map_struct"></a>
+The `progress_map` block supports:
+
+* `key` - The key of the progress map.
+
+* `completed` - The completion progress.
+
+* `remaining_time` - The estimated remaining time.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1318,6 +1318,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_drs_availability_zones": drs.DataSourceAvailabilityZones(),
 			"huaweicloud_drs_batch_get_params":   drs.DataSourceDrsBatchGetParams(),
+			"huaweicloud_drs_batch_progresses":   drs.DataSourceDrsBatchProgresses(),
 			"huaweicloud_drs_job_configurations": drs.DataSourceDrsJobConfigurations(),
 			"huaweicloud_drs_job_links":          drs.DataSourceJobLinks(),
 			"huaweicloud_drs_job_monitor_data":   drs.DataSourceDrsJobMonitorData(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_batch_progresses_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_batch_progresses_test.go
@@ -1,0 +1,46 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsBatchProgresses_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_batch_progresses.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobIds(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDrsBatchProgresses_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.job_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.progress"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.task_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.transfer_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.remaining_time"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDrsBatchProgresses_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_batch_progresses" "test" {
+  job_ids = split(",", "%s")
+}
+`, acceptance.HW_DRS_JOB_IDS)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_batch_progresses.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_batch_progresses.go
@@ -1,0 +1,200 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS POST /v3/{project_id}/jobs/batch-progress
+func DataSourceDrsBatchProgresses() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsBatchProgressesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"job_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"progress": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"incre_trans_delay": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"incre_trans_delay_millis": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"task_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"transfer_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"process_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"remaining_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"progress_map": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"completed": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"remaining_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"error_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_msg": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildBatchProgressesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"jobs": utils.ExpandToStringList(d.Get("job_ids").([]interface{})),
+	}
+}
+
+func dataSourceDrsBatchProgressesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v3/{project_id}/jobs/batch-progress"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildBatchProgressesBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DRS batch progresses: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("results", flattenBatchProgressesResults(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenBatchProgressesResults(respBody interface{}) []interface{} {
+	resultsRaw := utils.PathSearch("results", respBody, make([]interface{}, 0)).([]interface{})
+	if len(resultsRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resultsRaw))
+	for _, item := range resultsRaw {
+		progressMap := utils.PathSearch("progress_map", item, make(map[string]interface{})).(map[string]interface{})
+		result = append(result, map[string]interface{}{
+			"job_id":                   utils.PathSearch("job_id", item, nil),
+			"progress":                 utils.PathSearch("progress", item, nil),
+			"incre_trans_delay":        utils.PathSearch("incre_trans_delay", item, nil),
+			"incre_trans_delay_millis": utils.PathSearch("incre_trans_delay_millis", item, nil),
+			"task_mode":                utils.PathSearch("task_mode", item, nil),
+			"transfer_status":          utils.PathSearch("transfer_status", item, nil),
+			"process_time":             utils.PathSearch("process_time", item, nil),
+			"remaining_time":           utils.PathSearch("remaining_time", item, nil),
+			"progress_map":             flattenProgressMap(progressMap),
+			"error_code":               utils.PathSearch("error_code", item, nil),
+			"error_msg":                utils.PathSearch("error_msg", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenProgressMap(progressMapRaw map[string]interface{}) []interface{} {
+	result := make([]interface{}, 0, len(progressMapRaw))
+	for key, value := range progressMapRaw {
+		item, ok := value.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		result = append(result, map[string]interface{}{
+			"key":            key,
+			"completed":      utils.PathSearch("completed", item, nil),
+			"remaining_time": utils.PathSearch("remaining_time", item, nil),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

New datasource to query processes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o drs -f TestAccDataSourceDrsBatchProgresses_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsBatchProgresses_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsBatchProgresses_basic
=== PAUSE TestAccDataSourceDrsBatchProgresses_basic
=== CONT  TestAccDataSourceDrsBatchProgresses_basic
--- PASS: TestAccDataSourceDrsBatchProgresses_basic (17.53s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       17.612s coverage: 4.5% of statements in ./huaweicloud/services/drs
```
<img width="1290" height="84" alt="image" src="https://github.com/user-attachments/assets/5fc0b672-8e7d-47ed-8799-045d4d3e9471" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
