### PR TITLE
feat(eip): support `global_eip_tenant_support_regions` data source

### DIFF
--- a/docs/data-sources/global_eip_tenant_support_regions.md
+++ b/docs/data-sources/global_eip_tenant_support_regions.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_global_eip_tenant_support_regions"
+description: |-
+  Use this data source to get the list of regions that can be bound for global EIP at the given access site.
+---
+
+# huaweicloud_global_eip_tenant_support_regions
+
+Use this data source to get the list of regions that can be bound for global EIP at the given access site.
+
+## Example Usage
+
+```hcl
+variable "access_site" {}
+
+data "huaweicloud_global_eip_tenant_support_regions" "test" {
+  access_site = var.access_site
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `access_site` - (Required, String) Specifies the access site.  
+  The value can be obtained using the `huaweicloud_global_eip_access_sites` data source.
+
+* `fields` - (Optional, List) Specifies the fields to return.  
+  Supported values include **id**, **instance_type**, **region_id**, **public_border_group**, **access_site**,
+  **status**, **created_at**, and **updated_at**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `support_regions` - The list of global EIP support region objects for the site.
+
+  The [support_regions](#support_regions_struct) structure is documented below.
+
+<a name="support_regions_struct"></a>
+The `support_regions` block supports:
+
+* `id` - The ID of the region binding record.
+
+* `instance_type` - The supported instance type.  
+  The valid values are as follows:
+  + **DC-CONNECT-GATEWAY**
+  + **IPV6-DC-CONNECT-GATEWAY**
+  + **ECS**
+  + **IPV6-ECS**
+  + **PORT**
+  + **IPV6-PORT**
+  + **VIP**
+  + **IPV6-VIP**
+  + **ELB**
+  + **IPV6-ELB**
+  + **NATGW**
+
+* `public_border_group` - Indicates whether the resource is in the central site or at an edge site.
+  The value is **center** or an edge site name.
+
+* `region_id` - The region ID.
+
+* `access_site` - The access site.
+
+* `status` - The site status.  
+  The valid values are as follows:
+  + **ACTIVE**: Already online.
+  + **INACTIVE**: Offline.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The update time.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2460,6 +2460,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_global_eip_segment_support_masks":     eip.DataSourceGlobalEipSegmentSupportMasks(),
 			"huaweicloud_global_eip_internet_bandwidth_limits": eip.DataSourceGlobalEipInternetBandwidthLimits(),
 			"huaweicloud_global_eip_support_regions":           eip.DataSourceGlobalEipSupportRegions(),
+			"huaweicloud_global_eip_tenant_support_regions":    eip.DataSourceGlobalEipTenantSupportRegions(),
 			"huaweicloud_global_eip_access_sites":              eip.DataSourceGlobalEIPAccessSites(),
 			"huaweicloud_global_internet_bandwidths":           eip.DataSourceGlobalInternetBandwidths(),
 			"huaweicloud_global_internet_bandwidth_tags":       eip.DataSourceGlobalInternetBandwidthTags(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_tenant_support_regions_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_tenant_support_regions_test.go
@@ -1,0 +1,67 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGlobalEipTenantSupportRegions_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_global_eip_tenant_support_regions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceGlobalEipTenantSupportRegions_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.instance_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.region_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.public_border_group"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.access_site"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "support_regions.0.updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceGlobalEipTenantSupportRegions_base() string {
+	return `
+data "huaweicloud_global_eip_access_sites" "all" {}
+`
+}
+
+func testDataSourceGlobalEipTenantSupportRegions_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_global_eip_tenant_support_regions" "test" {
+  access_site = data.huaweicloud_global_eip_access_sites.all.access_sites[0].name
+
+  fields = [
+    "id",
+    "instance_type",
+    "region_id",
+    "public_border_group",
+    "access_site",
+    "status",
+    "created_at",
+    "updated_at",
+  ]
+}
+`, testDataSourceGlobalEipTenantSupportRegions_base())
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_global_eip_tenant_support_regions.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_global_eip_tenant_support_regions.go
@@ -1,0 +1,166 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v3/{domain_id}/global-eips/support-instances/{access_site}
+func DataSourceGlobalEipTenantSupportRegions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGlobalEipTenantSupportRegionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"access_site": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"fields": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"support_regions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_border_group": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"access_site": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildGlobalEipTenantSupportRegionsQueryParams(d *schema.ResourceData) string {
+	req := ""
+
+	if fields := d.Get("fields").([]interface{}); len(fields) > 0 {
+		for _, v := range fields {
+			req += fmt.Sprintf("&fields=%v", v)
+		}
+	}
+
+	if req != "" {
+		req = "?" + req[1:]
+	}
+
+	return req
+}
+
+func dataSourceGlobalEipTenantSupportRegionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "geip"
+		httpUrl = "v3/{domain_id}/global-eips/support-instances/{access_site}"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{domain_id}", cfg.DomainID)
+	requestPath = strings.ReplaceAll(requestPath, "{access_site}", d.Get("access_site").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestPathWithQuery := requestPath + buildGlobalEipTenantSupportRegionsQueryParams(d)
+	resp, err := client.Request("GET", requestPathWithQuery, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving global EIP tenant support regions: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("support_regions", flattenGlobalEipTenantSupportRegions(
+			utils.PathSearch("support_regions", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGlobalEipTenantSupportRegions(regions []interface{}) []interface{} {
+	if len(regions) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(regions))
+	for _, r := range regions {
+		rst = append(rst, map[string]interface{}{
+			"id":                  utils.PathSearch("id", r, nil),
+			"instance_type":       utils.PathSearch("instance_type", r, nil),
+			"public_border_group": utils.PathSearch("public_border_group", r, nil),
+			"region_id":           utils.PathSearch("region_id", r, nil),
+			"access_site":         utils.PathSearch("access_site", r, nil),
+			"status":              utils.PathSearch("status", r, nil),
+			"created_at":          utils.PathSearch("created_at", r, nil),
+			"updated_at":          utils.PathSearch("updated_at", r, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `global_eip_tenant_support_regions` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `global_eip_tenant_support_regions` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o eip -f TestAccDataSourceGlobalEipTenantSupportRegions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccDataSourceGlobalEipTenantSupportRegions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceGlobalEipTenantSupportRegions_basic
=== PAUSE TestAccDataSourceGlobalEipTenantSupportRegions_basic
=== CONT  TestAccDataSourceGlobalEipTenantSupportRegions_basic
--- PASS: TestAccDataSourceGlobalEipTenantSupportRegions_basic (19.26s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip  coverage: 3.8% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       19.428s coverage: 3.8% of statements in ./huaweicloud/services/eip
```
<img width="981" height="43" alt="image" src="https://github.com/user-attachments/assets/35ba4db2-4e4a-4ebc-b3ea-3ecf1f2a43fd" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
