### PR TITLE
feat(GeminiDB): add new data source to get list of instance sessions

### DIFF
--- a/docs/data-sources/geminidb_instance_sessions.md
+++ b/docs/data-sources/geminidb_instance_sessions.md
@@ -1,0 +1,76 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_instance_sessions"
+description: |-
+  Use this data source to get the list of instance sessions.
+---
+
+# huaweicloud_geminidb_instance_sessions
+
+Use this data source to get the list of instance sessions.
+
+-> This data source only supports GeminiDB Redis instances.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_geminidb_instance_sessions" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the instance ID.
+
+* `node_id` - (Optional, String) Specifies the node ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `node_sessions` - The list of instance sessions.
+  The [node_sessions](#instacne_sessions_struct) structure is documented below.
+
+<a name="instacne_sessions_struct"></a>
+The `node_sessions` block supports:
+
+* `node_id` - The node ID.
+
+* `sessions` - The list of node sessions.
+  The [sessions](#sessions_struct) structure is documented below.
+
+<a name="sessions_struct"></a>
+The `sessions` block supports:
+
+* `id` - The session ID.
+
+* `name` - The connection name.
+
+* `cmd` - The last executed command.
+
+* `age` - The connection duration, in seconds.
+
+* `idle` - The idle duration, in seconds.
+
+* `db` - The ID of the database that is being used by the client.
+
+* `addr` - The IP address and port of the client.
+
+* `fd` - The file descriptor for sockets.
+
+* `sub` - The number of subscribed channels.
+
+* `psub` - The number of subscribed modes.
+
+* `multi` - The number of commands executed in a transaction.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1447,6 +1447,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_database_versions":   geminidb.DataSourceDatabaseVersions(),
 			"huaweicloud_geminidb_dedicated_resources": geminidb.DataSourceDedicatedResources(),
 			"huaweicloud_geminidb_flavors":             geminidb.DataSourceGeminiDBFlavors(),
+			"huaweicloud_geminidb_instance_sessions":   geminidb.DataSourceInstanceSessions(),
 			"huaweicloud_geminidb_memory_mappings":     geminidb.DataSourceMemoryMappings(),
 			"huaweicloud_geminidb_memory_rules":        geminidb.DataSourceMemoryRules(),
 			"huaweicloud_geminidb_quotas":              geminidb.DataSourceQuotas(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -773,6 +773,7 @@ var (
 	HW_ELB_GATEWAY_TYPE = os.Getenv("HW_ELB_GATEWAY_TYPE")
 
 	HW_GEMINIDB_MAPPING_ID = os.Getenv("HW_GEMINIDB_MAPPING_ID")
+	HW_GEMINIDB_NODE_ID    = os.Getenv("HW_GEMINIDB_NODE_ID")
 
 	HW_LTS_AGENCY_STREAM_NAME = os.Getenv("HW_LTS_AGENCY_STREAM_NAME")
 	HW_LTS_AGENCY_STREAM_ID   = os.Getenv("HW_LTS_AGENCY_STREAM_ID")
@@ -4384,6 +4385,13 @@ func TestAccPreCheckElbGatewayType(t *testing.T) {
 func TestAccPreCheckGeminiDBMappingId(t *testing.T) {
 	if HW_GEMINIDB_MAPPING_ID == "" {
 		t.Skip("HW_GEMINIDB_MAPPING_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckGeminiDBNodeId(t *testing.T) {
+	if HW_GEMINIDB_NODE_ID == "" {
+		t.Skip("HW_GEMINIDB_NODE_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_instance_sessions_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_instance_sessions_test.go
@@ -1,0 +1,71 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceInstanceSessions_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_geminidb_instance_sessions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGeminiDBNodeId(t)
+			acceptance.TestAccCheckGeminidbInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceInstanceSessions_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "node_sessions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "node_sessions.0.node_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "node_sessions.0.sessions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "node_sessions.0.sessions.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "node_sessions.0.sessions.0.cmd"),
+					resource.TestCheckResourceAttrSet(dataSource, "node_sessions.0.sessions.0.age"),
+					resource.TestCheckResourceAttrSet(dataSource, "node_sessions.0.sessions.0.idle"),
+					resource.TestCheckResourceAttrSet(dataSource, "node_sessions.0.sessions.0.db"),
+					resource.TestCheckResourceAttrSet(dataSource, "node_sessions.0.sessions.0.addr"),
+					resource.TestCheckResourceAttrSet(dataSource, "node_sessions.0.sessions.0.fd"),
+					resource.TestCheckResourceAttrSet(dataSource, "node_sessions.0.sessions.0.multi"),
+
+					resource.TestCheckOutput("node_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceInstanceSessions_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_geminidb_instance_sessions" "test" {
+  instance_id = "%[1]s"
+  node_id     = "%[2]s"
+}
+
+locals {
+  node_id = data.huaweicloud_geminidb_instance_sessions.test.node_sessions[0].node_id
+}
+
+data "huaweicloud_geminidb_instance_sessions" "node_id_filter" {
+  instance_id = "%[1]s"
+  node_id     = local.node_id
+}
+
+output "node_id_filter_useful" {
+  value = length(data.huaweicloud_geminidb_instance_sessions.node_id_filter.node_sessions.0.sessions) > 0 && alltrue(
+    [for v in data.huaweicloud_geminidb_instance_sessions.node_id_filter.node_sessions[*].node_id : v == local.node_id]
+  )
+}
+`, acceptance.HW_GEMINIDB_INSATNCE_ID, acceptance.HW_GEMINIDB_NODE_ID)
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_instance_sessions.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_instance_sessions.go
@@ -1,0 +1,208 @@
+package geminidb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforNoSQL GET /v3/{project_id}/instances/{instance_id}/sessions
+func DataSourceInstanceSessions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceSessionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"node_sessions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"node_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sessions": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"cmd": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"age": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"idle": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"db": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"addr": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"fd": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"sub": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"psub": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"multi": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildInstanceSessionsQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("node_id"); ok {
+		queryParams = fmt.Sprintf("%s&node_id=%v", queryParams, v)
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func dataSourceInstanceSessionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/sessions"
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath += buildInstanceSessionsQueryParams(d)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the instance sessions: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("node_sessions", flattenInstanceSessions(
+			utils.PathSearch("node_sessions", getRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInstanceSessions(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"node_id": utils.PathSearch("node_id", v, nil),
+			"sessions": flattenINodeSessions(
+				utils.PathSearch("sessions", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func flattenINodeSessions(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"id":    utils.PathSearch("id", v, nil),
+			"name":  utils.PathSearch("name", v, nil),
+			"cmd":   utils.PathSearch("cmd", v, nil),
+			"age":   utils.PathSearch("age", v, nil),
+			"idle":  utils.PathSearch("idle", v, nil),
+			"db":    utils.PathSearch("db", v, nil),
+			"addr":  utils.PathSearch("addr", v, nil),
+			"fd":    utils.PathSearch("fd", v, nil),
+			"sub":   utils.PathSearch("sub", v, nil),
+			"psub":  utils.PathSearch("psub", v, nil),
+			"multi": utils.PathSearch("multi", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of instance sessions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to get list of instance sessions.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccDataSourceInstanceSessions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccDataSourceInstanceSessions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceInstanceSessions_basic
=== PAUSE TestAccDataSourceInstanceSessions_basic
=== CONT  TestAccDataSourceInstanceSessions_basic
--- PASS: TestAccDataSourceInstanceSessions_basic (22.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  22.626s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/2fc18f79-451d-4c44-b474-e0d4989a95af" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
