### PR TITLE
feat(drs): new datasource to query timelines

### DIFF
--- a/docs/data-sources/drs_timelines.md
+++ b/docs/data-sources/drs_timelines.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_timelines"
+description: |-
+  Use this data source to get the list of operation timelines for a specified DRS job within HuaweiCloud.
+---
+
+# huaweicloud_drs_timelines
+
+Use this data source to get the list of operation timelines for a specified DRS job within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+data "huaweicloud_drs_timelines" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the ID of the DRS job.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `timelines` - The list of DRS job operation timelines.
+
+  The [timelines](#timelines_struct) structure is documented below.
+
+<a name="timelines_struct"></a>
+The `timelines` block supports:
+
+* `name` - The name of the timeline.
+
+* `status` - The status of the timeline. Valid values are **success** and **failed**.
+
+* `operation_time` - The operation time of the timeline, for example, **2026-05-18T02:28:54Z**.
+
+* `user_name` - The user name of the timeline.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1328,6 +1328,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_object_mappings":    drs.DataSourceDrsObjectMappings(),
 			"huaweicloud_drs_subscriptions":      drs.DataSourceDrsSubscriptions(),
 			"huaweicloud_drs_tags":               drs.DataSourceDrsTags(),
+			"huaweicloud_drs_timelines":          drs.DataSourceDrsTimelines(),
 			"huaweicloud_drs_drivers":            drs.DataSourceDrsDrivers(),
 
 			// EventGrid

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_timelines_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_timelines_test.go
@@ -1,0 +1,44 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsTimelines_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_drs_timelines.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDrsTimelines_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "timelines.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "timelines.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "timelines.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "timelines.0.operation_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "timelines.0.user_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDrsTimelines_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_timelines" "test" {
+  job_id = "%s"
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_timelines.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_timelines.go
@@ -1,0 +1,151 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v5/{project_id}/jobs/{job_id}/timelines
+func DataSourceDrsTimelines() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsTimelinesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"timelines": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"operation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildTimelinesQueryParams(offset int) string {
+	defaultLimit := 1000
+	if offset == 0 {
+		return fmt.Sprintf("?limit=%d", defaultLimit)
+	}
+
+	return fmt.Sprintf("?limit=%d&offset=%d", defaultLimit, offset)
+}
+
+func dataSourceDrsTimelinesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v5/{project_id}/jobs/{job_id}/timelines"
+		result  = make([]interface{}, 0)
+		offset  = 0
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{job_id}", d.Get("job_id").(string))
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"X-Language":   "en-us",
+		},
+	}
+
+	for {
+		currentListPath := listPath + buildTimelinesQueryParams(offset)
+
+		listResp, err := client.Request("GET", currentListPath, &reqOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DRS timelines: %s", err)
+		}
+
+		listRespBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		timelines := utils.PathSearch("timelines", listRespBody, make([]interface{}, 0)).([]interface{})
+		if len(timelines) == 0 {
+			break
+		}
+
+		result = append(result, timelines...)
+		offset += len(timelines)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("timelines", flattenTimelines(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTimelines(timelinesResp []interface{}) []interface{} {
+	if len(timelinesResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(timelinesResp))
+	for _, v := range timelinesResp {
+		rst = append(rst, map[string]interface{}{
+			"name":           utils.PathSearch("name", v, nil),
+			"status":         utils.PathSearch("status", v, nil),
+			"operation_time": utils.PathSearch("operation_time", v, nil),
+			"user_name":      utils.PathSearch("user_name", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query timelines

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o drs -f TestAccDataSourceDrsTimelines_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsTimelines_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsTimelines_basic
=== PAUSE TestAccDataSourceDrsTimelines_basic
=== CONT  TestAccDataSourceDrsTimelines_basic
--- PASS: TestAccDataSourceDrsTimelines_basic (16.05s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       16.137s coverage: 4.7% of statements in ./huaweicloud/services/drs
```
<img width="1273" height="75" alt="image" src="https://github.com/user-attachments/assets/0b5479c1-a916-4e7d-93e0-d9365542a70a" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
