### PR TITLE
feat(drs): new datasource to query quotas

### DIFF
--- a/docs/data-sources/drs_quotas.md
+++ b/docs/data-sources/drs_quotas.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_quotas"
+description: |-
+  Use this data source to get the quotas information of DRS within HuaweiCloud.
+---
+
+# huaweicloud_drs_quotas
+
+Use this data source to get the quotas information of DRS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_drs_quotas" "test" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `quotas` - The quotas information.
+
+  The [quotas](#quotas_struct) structure is documented below.
+
+<a name="quotas_struct"></a>
+The `quotas` block supports:
+
+* `resource` - The resource quotas information.
+
+  The [resource](#resource_struct) structure is documented below.
+
+<a name="resource_struct"></a>
+The `resource` block supports:
+
+* `type` - The quota type.
+  The valid values are as follows:
+  + **instances**: The number of instances.
+  + **cpu**: The CPU quota.
+  + **cores**: The CPU cores quota.
+  + **server_groups**: The server groups quota.
+  + **mem**: The memory quota.
+  + **ram**: The RAM quota.
+
+* `min` - The minimum value of the quota.
+
+* `max` - The maximum value of the quota.
+
+* `quota` - The actual value of the user quota.
+
+* `used` - The used value of the quota.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1329,6 +1329,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_job_object_support": drs.DataSourceDrsJobObjectSupport(),
 			"huaweicloud_drs_node_types":         drs.DataSourceNodeTypes(),
 			"huaweicloud_drs_object_mappings":    drs.DataSourceDrsObjectMappings(),
+			"huaweicloud_drs_quotas":             drs.DataSourceDrsQuotas(),
 			"huaweicloud_drs_subscriptions":      drs.DataSourceDrsSubscriptions(),
 			"huaweicloud_drs_tags":               drs.DataSourceDrsTags(),
 			"huaweicloud_drs_timelines":          drs.DataSourceDrsTimelines(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_quotas_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_quotas_test.go
@@ -1,0 +1,40 @@
+package drs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsQuotas_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_quotas.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDrsQuotas_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.resource.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.resource.0.min"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.resource.0.max"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.resource.0.quota"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "quotas.0.resource.0.used"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceDrsQuotas_basic = `
+data "huaweicloud_drs_quotas" "test" {}
+`

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_quotas.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_quotas.go
@@ -1,0 +1,142 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v3/{project_id}/quotas
+func DataSourceDrsQuotas() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceQuotasRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"quotas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"min": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"max": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"quota": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"used": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceQuotasRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v3/{project_id}/quotas"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DRS quotas: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("quotas", flattenQuotas(utils.PathSearch("quotas", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenQuotas(respBody interface{}) []interface{} {
+	if respBody == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"resource": flattenResource(utils.PathSearch("resource", respBody, nil)),
+		},
+	}
+}
+
+func flattenResource(respBody interface{}) []interface{} {
+	if respBody == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"type":  utils.PathSearch("type", respBody, nil),
+			"min":   utils.PathSearch("min", respBody, nil),
+			"max":   utils.PathSearch("max", respBody, nil),
+			"quota": utils.PathSearch("quota", respBody, nil),
+			"used":  utils.PathSearch("used", respBody, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query quotas

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o drs -f TestAccDataSourceDrsQuotas_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsQuotas_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsQuotas_basic
=== PAUSE TestAccDataSourceDrsQuotas_basic
=== CONT  TestAccDataSourceDrsQuotas_basic
--- PASS: TestAccDataSourceDrsQuotas_basic (13.30s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       13.387s coverage: 3.7% of statements in ./huaweicloud/services/drs
```
<img width="1350" height="92" alt="image" src="https://github.com/user-attachments/assets/c2970923-dd1f-41e8-aef2-b0aabbb01966" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
