### PR TITLE
feat(GeminiDB): add new resource to manage node session kill

### DIFF
--- a/docs/resources/geminidb_node_session_kill.md
+++ b/docs/resources/geminidb_node_session_kill.md
@@ -1,0 +1,54 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_node_session_kill"
+description: |-
+  Manages a resource to kill node session within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_node_session_kill
+
+Manages a resource to kill node session within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource. Deleting this resource will not clear the corresponding request record,
+  but will only remove the resource information from the tf state file.
+  <br/>2. This resource only supports GeminiDB Redis instance.
+
+## Example Usage
+
+```hcl
+variable "node_id" {}
+variable "session_id_list" {
+  type = list(string)
+}
+
+resource "huaweicloud_geminidb_node_session_kill" "test" {
+  node_id     = var.node_id
+  is _all     = false
+  session_ids = var.session_id_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `node_id` - (Required, String, NonUpdatable) Specifies the node ID.
+
+* `is_all` - (Required, Bool, NonUpdatable) Specifies whether all sessions are closed.
+  The valid values are as follows:
+  + **true**: All sessions are closed.
+  + **false**: Not all sessions are closed.
+
+* `session_ids` - (Optional, List, NonUpdatable) Specifies the ID of the session to be closed.
+  When the parameter `is_all` is set to **false**, this parameter is required.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3673,6 +3673,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_instance":           geminidb.ResourceGeminiDbInstance(),
 			"huaweicloud_geminidb_memory_mapping":     geminidb.ResourceMemoryMapping(),
 			"huaweicloud_geminidb_memory_rule":        geminidb.ResourceMemoryRule(),
+			"huaweicloud_geminidb_node_session_kill":  geminidb.ResourceNodeSessionKill(),
 			"huaweicloud_geminidb_parameter_template": geminidb.ResourceGeminiDBParameterTemplate(),
 			"huaweicloud_geminidb_recycling_policy":   geminidb.ResourceGeminiDBRecyclingPolicy(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -775,6 +775,7 @@ var (
 
 	HW_GEMINIDB_MAPPING_ID = os.Getenv("HW_GEMINIDB_MAPPING_ID")
 	HW_GEMINIDB_NODE_ID    = os.Getenv("HW_GEMINIDB_NODE_ID")
+	HW_GEMINIDB_SESSION_ID = os.Getenv("HW_GEMINIDB_SESSION_ID")
 
 	HW_LTS_AGENCY_STREAM_NAME = os.Getenv("HW_LTS_AGENCY_STREAM_NAME")
 	HW_LTS_AGENCY_STREAM_ID   = os.Getenv("HW_LTS_AGENCY_STREAM_ID")
@@ -4400,6 +4401,13 @@ func TestAccPreCheckGeminiDBMappingId(t *testing.T) {
 func TestAccPreCheckGeminiDBNodeId(t *testing.T) {
 	if HW_GEMINIDB_NODE_ID == "" {
 		t.Skip("HW_GEMINIDB_NODE_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckGeminiDBSessionId(t *testing.T) {
+	if HW_GEMINIDB_SESSION_ID == "" {
+		t.Skip("HW_GEMINIDB_SESSION_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_node_session_kill_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_node_session_kill_test.go
@@ -1,0 +1,37 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccNodeSessionKill_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGeminiDBNodeId(t)
+			acceptance.TestAccPreCheckGeminiDBSessionId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testNodeSessionKill_basic(),
+			},
+		},
+	})
+}
+
+func testNodeSessionKill_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_geminidb_node_session_kill" "test" {
+  node_id     = "%[1]s"
+  is_all      = false
+  session_ids = ["%[2]s"]
+}
+`, acceptance.HW_GEMINIDB_NODE_ID, acceptance.HW_GEMINIDB_SESSION_ID)
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_node_session_kill.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_node_session_kill.go
@@ -1,0 +1,128 @@
+package geminidb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nodeSessionKillNonUpdatableParams = []string{
+	"node_id",
+	"is_all",
+	"session_ids",
+}
+
+// @API GaussDBforNoSQL DELETE /v3/{project_id}/redis/nodes/{node_id}/sessions
+func ResourceNodeSessionKill() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNodeSessionKillCreate,
+		ReadContext:   resourceNodeSessionKillRead,
+		UpdateContext: resourceNodeSessionKillUpdate,
+		DeleteContext: resourceNodeSessionKillDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nodeSessionKillNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"is_all": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"session_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildNodeSessionKillBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"is_all":      d.Get("is_all"),
+		"session_ids": utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("session_ids").([]interface{}))),
+	}
+
+	return bodyParams
+}
+
+func resourceNodeSessionKillCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/redis/nodes/{node_id}/sessions"
+		nodeId  = d.Get("node_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{node_id}", nodeId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildNodeSessionKillBodyParams(d)),
+	}
+
+	_, err = client.Request("DELETE", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error killing instance node session: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return nil
+}
+
+func resourceNodeSessionKillRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceNodeSessionKillUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceNodeSessionKillDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GeminiDB instance node session kill resource is not supported. The resource is only removed from the " +
+		"state, the resource remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to manage node session kill.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new resource to manage node session kill.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccNodeSessionKill_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccNodeSessionKill_basic -timeout 360m -parallel 4
=== RUN   TestAccNodeSessionKill_basic
=== PAUSE TestAccNodeSessionKill_basic
=== CONT  TestAccNodeSessionKill_basic
--- PASS: TestAccNodeSessionKill_basic (22.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  22.534s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/d5ce944c-db90-4cac-8713-90ef7a45b590" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
