### PR TITLE
feat(eip): support `global_eip_segments_by_tags` data source

### DIFF
--- a/docs/data-sources/global_eip_segments_by_tags.md
+++ b/docs/data-sources/global_eip_segments_by_tags.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_global_eip_segments_by_tags"
+description: |-
+  Use this data source to get the list of global EIP segments filtered by tags.
+---
+
+# huaweicloud_global_eip_segments_by_tags
+
+Use this data source to get the list of global EIP segments filtered by tags.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_global_eip_segments_by_tags" "test" {
+  tags {
+    key   = "key1"
+    value = "value1"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `tags` - (Required, List) Specifies the tag filter conditions. It can contain up to `20` tags.
+
+  The [tags](#query_tags) structure is documented below.
+
+<a name="query_tags"></a>
+The `tags` block supports:
+
+* `key` - (Required, String) Specifies the tag key.
+
+* `value` - (Optional, String) Specifies the tag value.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resources` - The list of resources.
+
+  The [resources](#resources_struct) structure is documented below.
+
+<a name="resources_struct"></a>
+The `resources` block supports:
+
+* `resource_id` - The resource ID.
+
+* `resource_detail` - The resource detail object.
+
+* `tags` - The tag list associated with the resource.
+
+  The [tags](#tags_struct) structure is documented below.
+
+* `resource_name` - The resource name.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `value` - The value of the tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2478,6 +2478,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_global_internet_bandwidth_tags":       eip.DataSourceGlobalInternetBandwidthTags(),
 			"huaweicloud_global_eips":                          eip.DataSourceGlobalEIPs(),
 			"huaweicloud_global_eips_by_tags":                  eip.DataSourceGlobalEipsByTags(),
+			"huaweicloud_global_eip_segments_by_tags":          eip.DataSourceGlobalEipSegmentsByTags(),
 			"huaweicloud_global_eip_tags":                      eip.DataSourceGlobalEipTags(),
 			"huaweicloud_global_internet_bandwidths_by_tags":   eip.DataSourceGlobalInternetBandwidthsByTags(),
 

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_segments_by_tags_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_segments_by_tags_test.go
@@ -1,0 +1,112 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGlobalEipSegmentsByTags_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_global_eip_segments_by_tags.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceGlobalEipSegmentsByTags_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.resource_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "resources.0.tags.#"),
+					resource.TestCheckResourceAttr(dataSource, "resources.0.tags.0.key", "key1"),
+					resource.TestCheckResourceAttr(dataSource, "resources.0.tags.0.value", "value1"),
+
+					resource.TestCheckOutput("tags_filter_is_useful", "true"),
+					resource.TestCheckOutput("multiple_tags_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceGlobalEipSegmentsByTags_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_global_eip_pools" "all" {
+  access_site = "cn-south-guangzhou"
+  name        = "bgp_segment_default"
+}
+
+resource "huaweicloud_global_eip_segment" "test" {
+  geip_pool_name        = data.huaweicloud_global_eip_pools.all.geip_pools[0].name
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  mask                  = 29
+  name                  = "%[1]s"
+  description           = "description test"
+  enterprise_project_id = "%[2]s"
+
+  tags {
+    key   = "key1"
+    value = "value1"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testDataSourceGlobalEipSegmentsByTags_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_global_eip_segments_by_tags" "test" {
+  depends_on = [huaweicloud_global_eip_segment.test]
+
+  tags {
+    key   = "key1"
+    value = "value1"
+  }
+}
+
+data "huaweicloud_global_eip_segments_by_tags" "filter_by_tags" {
+  depends_on = [huaweicloud_global_eip_segment.test]
+
+  tags {
+    key   = data.huaweicloud_global_eip_segments_by_tags.test.resources[0].tags[0].key
+    value = data.huaweicloud_global_eip_segments_by_tags.test.resources[0].tags[0].value
+  }
+}
+
+output "tags_filter_is_useful" {
+  value = length(data.huaweicloud_global_eip_segments_by_tags.filter_by_tags.resources) > 0
+}
+
+data "huaweicloud_global_eip_segments_by_tags" "multiple_tags_filter" {
+  depends_on = [huaweicloud_global_eip_segment.test]
+
+  tags {
+    key   = "key1"
+    value = "value1"
+  }
+
+  tags {
+    key   = "non-exist-key"
+    value = "non-exist-value"
+  }
+}
+
+output "multiple_tags_filter_is_useful" {
+  value = length(data.huaweicloud_global_eip_segments_by_tags.multiple_tags_filter.resources) == 0
+}
+`, testDataSourceGlobalEipSegmentsByTags_base(name))
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_global_eip_segments_by_tags.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_global_eip_segments_by_tags.go
@@ -1,0 +1,206 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP POST /v3/global-eip-segment/resource-instances/filter
+func DataSourceGlobalEipSegmentsByTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGlobalEipSegmentsByTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						// In the API documentation, it is of type `Object`,
+						// but here it has been changed to type `string`.
+						"resource_detail": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"resource_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildGlobalEipSegmentsByTagsRequestPath(requestPath string, offset int) string {
+	if offset == 0 {
+		return requestPath
+	}
+
+	return fmt.Sprintf("%s?offset=%d", requestPath, offset)
+}
+
+func buildGlobalEipSegmentsByTagsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	tags := d.Get("tags").([]interface{})
+	res := make([]map[string]interface{}, 0, len(tags))
+	for _, tagRaw := range tags {
+		tag, ok := tagRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		res = append(res, map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.ValueIgnoreEmpty(utils.PathSearch("value", tag, nil)),
+		})
+	}
+
+	return map[string]interface{}{
+		"tags": res,
+	}
+}
+
+func dataSourceGlobalEipSegmentsByTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "geip"
+		httpUrl = "v3/global-eip-segment/resource-instances/filter"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildGlobalEipSegmentsByTagsBodyParams(d)),
+	}
+
+	for {
+		currentRequestPath := buildGlobalEipSegmentsByTagsRequestPath(requestPath, offset)
+		resp, err := client.Request("POST", currentRequestPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving global EIP segments by tags: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		resourcesResp := utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{})
+		if len(resourcesResp) == 0 {
+			break
+		}
+
+		result = append(result, resourcesResp...)
+
+		offset += len(resourcesResp)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("resources", flattenGlobalEipSegmentsByTags(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGlobalEipSegmentsByTags(resourcesResp []interface{}) []interface{} {
+	if len(resourcesResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(resourcesResp))
+	for i, v := range resourcesResp {
+		rst[i] = map[string]interface{}{
+			"resource_id":     utils.PathSearch("resource_id", v, nil),
+			"resource_detail": utils.JsonToString(utils.PathSearch("resource_detail", v, nil)),
+			"tags": flattenGlobalEipSegmentsByTagsTagsResp(
+				utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})),
+			"resource_name": utils.PathSearch("resource_name", v, nil),
+		}
+	}
+
+	return rst
+}
+
+func flattenGlobalEipSegmentsByTagsTagsResp(tagsResp []interface{}) []interface{} {
+	if len(tagsResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(tagsResp))
+	for i, tag := range tagsResp {
+		rst[i] = map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.PathSearch("value", tag, nil),
+		}
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `global_eip_segments_by_tags` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `global_eip_segments_by_tags` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o eip -f TestAccDataSourceGlobalEipSegmentsByTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccDataSourceGlobalEipSegmentsByTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceGlobalEipSegmentsByTags_basic
=== PAUSE TestAccDataSourceGlobalEipSegmentsByTags_basic
=== CONT  TestAccDataSourceGlobalEipSegmentsByTags_basic
--- PASS: TestAccDataSourceGlobalEipSegmentsByTags_basic (23.46s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip  coverage: 6.8% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       23.594s coverage: 6.8% of statements in ./huaweicloud/services/eip
```
<img width="938" height="37" alt="image" src="https://github.com/user-attachments/assets/be6f6237-5e8b-4ea1-be5a-59a9e86e2b21" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
