### PR TITLE
feat(eip): new datasource to query segment tags

### DIFF
--- a/docs/data-sources/global_eip_segment_tags.md
+++ b/docs/data-sources/global_eip_segment_tags.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Elastic IP (EIP)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_global_eip_segment_tags"
+description: |-
+  Use this data source to get a list of global EIP segment tags.
+---
+
+# huaweicloud_global_eip_segment_tags
+
+Use this data source to get a list of global EIP segment tags.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_global_eip_segment_tags" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - Indicates the list of tags.
+
+  The [tags](#tags_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - Indicates the tag key.
+
+* `values` - Indicates the list of tag values.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2470,6 +2470,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_global_eip_bindings":                  eip.DataSourceGlobalEipBindings(),
 			"huaweicloud_global_eip_segments":                  eip.DataSourceGlobalEipSegments(),
 			"huaweicloud_global_eip_segment_support_masks":     eip.DataSourceGlobalEipSegmentSupportMasks(),
+			"huaweicloud_global_eip_segment_tags":              eip.DataSourceGlobalEipSegmentTags(),
 			"huaweicloud_global_eip_internet_bandwidth_limits": eip.DataSourceGlobalEipInternetBandwidthLimits(),
 			"huaweicloud_global_eip_support_regions":           eip.DataSourceGlobalEipSupportRegions(),
 			"huaweicloud_global_eip_tenant_support_regions":    eip.DataSourceGlobalEipTenantSupportRegions(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_segment_tags_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_segment_tags_test.go
@@ -1,0 +1,35 @@
+package eip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGlobalEipSegmentTags_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_global_eip_segment_tags.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGlobalEipSegmentTags_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "tags.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceGlobalEipSegmentTags_basic = `
+data "huaweicloud_global_eip_segment_tags" "test" {}
+`

--- a/huaweicloud/services/eip/data_source_huaweicloud_global_eip_segment_tags.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_global_eip_segment_tags.go
@@ -1,0 +1,105 @@
+package eip
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v3/global-eip-segment/tags
+func DataSourceGlobalEipSegmentTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGlobalEipSegmentTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"values": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGlobalEipSegmentTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "geip"
+		httpUrl = "v3/global-eip-segment/tags"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving global EIP segment tags: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate UUID: %s", err)
+	}
+	d.SetId(generateId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("tags", flattenGlobalEipSegmentTags(
+			utils.PathSearch("tags", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGlobalEipSegmentTags(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"key":    utils.PathSearch("key", v, nil),
+			"values": utils.PathSearch("values", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query segment tags

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o eip -f TestAccDataSourceGlobalEipSegmentTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eip" -v -coverprofile="./huaweicloud/services/acceptance/eip/eip_coverage.cov" -coverpkg="./huaweicloud/services/eip" -run TestAccDataSourceGlobalEipSegmentTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceGlobalEipSegmentTags_basic
=== PAUSE TestAccDataSourceGlobalEipSegmentTags_basic
=== CONT  TestAccDataSourceGlobalEipSegmentTags_basic
--- PASS: TestAccDataSourceGlobalEipSegmentTags_basic (14.65s)
PASS
coverage: 2.3% of statements in ./huaweicloud/services/eip
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       14.755s coverage: 2.3% of statements in ./huaweicloud/services/eip
```
<img width="1360" height="87" alt="image" src="https://github.com/user-attachments/assets/f7e30d34-7d7a-49a2-9383-f1b05477eb37" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
