### PR TITLE
feat(DCS): add rsource to center task delete

### DIFF
--- a/docs/resources/dcs_center_task_delete.md
+++ b/docs/resources/dcs_center_task_delete.md
@@ -1,0 +1,36 @@
+---
+subcategory: "Distributed Cache Service (DCS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dcs_center_task_delete"
+description: |-
+  Manages a DCS center task removal resource within HuaweiCloud.
+---
+
+# huaweicloud_dcs_center_task_delete
+
+Manages a DCS center task removal resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "task_id" {}
+
+resource "huaweicloud_dcs_center_task_delete" "test" {
+  task_id = var.task_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to delete the task. If omitted, the
+  provider-level region will be used. Changing this parameter will create a new resource.
+
+* `task_id` - (Required, String, NonUpdatable) Specifies the ID of the task to be deleted.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3382,6 +3382,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dcs_web_cli_command_execute":            dcs.ResourceDcsWebCliCommandExecute(),
 			"huaweicloud_dcs_hotkey_analysis":                    dcs.ResourceHotKeyAnalysis(),
 			"huaweicloud_dcs_bigkey_analysis":                    dcs.ResourceBigKeyAnalysis(),
+			"huaweicloud_dcs_center_task_delete":                 dcs.ResourceCenterTaskDelete(),
 			"huaweicloud_dcs_offline_key_analysis":               dcs.ResourceOfflineKeyAnalysis(),
 			"huaweicloud_dcs_account":                            dcs.ResourceDcsAccount(),
 			"huaweicloud_dcs_instance_restore":                   dcs.ResourceDcsRestore(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -770,6 +770,7 @@ var (
 	HW_DCS_OBS_BUCKET_NAME    = os.Getenv("HW_DCS_OBS_BUCKET_NAME")
 	HW_DCS_BACKUP_ID          = os.Getenv("HW_DCS_BACKUP_ID")
 	HW_DCS_BACKGROUND_TASK_ID = os.Getenv("HW_DCS_BACKGROUND_TASK_ID")
+	HW_DCS_CENTER_TASK_ID     = os.Getenv("HW_DCS_CENTER_TASK_ID")
 
 	HW_ELB_GATEWAY_TYPE = os.Getenv("HW_ELB_GATEWAY_TYPE")
 
@@ -4372,6 +4373,13 @@ func TestAccPreCheckDcsObsBucketName(t *testing.T) {
 func TestAccPreCheckDcsBackgroundTaskId(t *testing.T) {
 	if HW_DCS_BACKGROUND_TASK_ID == "" {
 		t.Skip("HW_DCS_BACKGROUND_TASK_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDcsCenterTaskId(t *testing.T) {
+	if HW_DCS_CENTER_TASK_ID == "" {
+		t.Skip("HW_DCS_CENTER_TASK_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_center_task_delete_test.go
+++ b/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_center_task_delete_test.go
@@ -1,0 +1,34 @@
+package dcs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDcsCenterTaskDelete_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDcsCenterTaskId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDcsCenterTaskDelete_basic(),
+			},
+		},
+	})
+}
+
+func testAccDcsCenterTaskDelete_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dcs_center_task_delete" "test" {
+  task_id = "%[1]s"
+}
+`, acceptance.HW_DCS_CENTER_TASK_ID)
+}

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_center_task_delete.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_center_task_delete.go
@@ -1,0 +1,105 @@
+package dcs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var dcsCenterTaskDeleteNonUpdatableParams = []string{"task_id"}
+
+// @API DCS DELETE /v2/{project_id}/tasks/{task_id}
+func ResourceCenterTaskDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCenterTaskDeleteCreate,
+		ReadContext:   resourceCenterTaskDeleteRead,
+		UpdateContext: resourceCenterTaskDeleteUpdate,
+		DeleteContext: resourceCenterTaskDeleteRemove,
+
+		CustomizeDiff: config.FlexibleForceNew(dcsCenterTaskDeleteNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"task_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceCenterTaskDeleteCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	var (
+		httpUrl = "v2/{project_id}/tasks/{task_id}"
+		product = "dcs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DCS client: %s", err)
+	}
+
+	taskID := d.Get("task_id").(string)
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{task_id}", taskID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = client.Request("DELETE", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DCS center task delete: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return nil
+}
+
+func resourceCenterTaskDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCenterTaskDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCenterTaskDeleteRemove(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting DCS center task delete resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add rsource to center task delete
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
add rsource to center task delete
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run TestAccDcsCenterTaskDelete_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccDcsCenterTaskDelete_basic -count=1 -timeout 360m -parallel 4
=== RUN   TestAccDcsCenterTaskDelete_basic
=== PAUSE TestAccDcsCenterTaskDelete_basic
=== CONT  TestAccDcsCenterTaskDelete_basic
--- PASS: TestAccDcsCenterTaskDelete_basic (29.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       29.153s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
