### PR TITLE
feat(GeminiDB): add new data source to get list of node sessions

### DIFF
--- a/docs/data-sources/geminidb_node_sessions.md
+++ b/docs/data-sources/geminidb_node_sessions.md
@@ -1,0 +1,69 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_node_sessions"
+description: |-
+  Use this data source to get the list of node sessions.
+---
+
+# huaweicloud_geminidb_node_sessions
+
+Use this data source to get the list of node sessions.
+
+-> This data source only supports GeminiDB Redis instance.
+
+## Example Usage
+
+```hcl
+variable "node_id" {}
+
+data "huaweicloud_geminidb_node_sessions" "test" {
+  node_id = var.node_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `node_id` - (Required, String) Specifies the node ID.
+
+* `addr_prefix` - (Optional, String) Specifies the matching character string of a user address prefix.
+  The address consists of an IP address and a port number. e.g. **192.168.1.20:8080**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `sessions` - The list of node sessions.
+  The [sessions](#sessions_struct) structure is documented below.
+
+<a name="sessions_struct"></a>
+The `sessions` block supports:
+
+* `id` - The client ID.
+
+* `name` - The client name.
+
+* `cmd` - The last executed command.
+
+* `age` - The setup duration of the client connection, in seconds.
+
+* `idle` - The idle duration of the client connection, in seconds.
+
+* `db` - The ID of the currently accessed database.
+
+* `addr` - The IP address and port number of the client.
+
+* `fd` - The file descriptor for sockets.
+
+* `sub` - The number of subscribed channels (Pub/Sub).
+
+* `psub` - The number of subscribed channels (Pub/Sub) in batches.
+
+* `multi` - The number of commands contained in a MULTI or EXEC transaction.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1463,6 +1463,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_instance_sessions":        geminidb.DataSourceInstanceSessions(),
 			"huaweicloud_geminidb_memory_mappings":          geminidb.DataSourceMemoryMappings(),
 			"huaweicloud_geminidb_memory_rules":             geminidb.DataSourceMemoryRules(),
+			"huaweicloud_geminidb_node_sessions":            geminidb.DataSourceNodeSessions(),
 			"huaweicloud_geminidb_node_session_statistics":  geminidb.DataSourceNodeSessionStatistics(),
 			"huaweicloud_geminidb_quotas":                   geminidb.DataSourceQuotas(),
 			"huaweicloud_geminidb_recycling_instances":      geminidb.DataSourceGeminiDBRecyclingInstances(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_node_sessions_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_node_sessions_test.go
@@ -1,0 +1,67 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceNodeSessions_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_geminidb_node_sessions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGeminiDBNodeId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNodeSessions_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "sessions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "sessions.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "sessions.0.cmd"),
+					resource.TestCheckResourceAttrSet(dataSource, "sessions.0.age"),
+					resource.TestCheckResourceAttrSet(dataSource, "sessions.0.idle"),
+					resource.TestCheckResourceAttrSet(dataSource, "sessions.0.db"),
+					resource.TestCheckResourceAttrSet(dataSource, "sessions.0.addr"),
+					resource.TestCheckResourceAttrSet(dataSource, "sessions.0.fd"),
+					resource.TestCheckResourceAttrSet(dataSource, "sessions.0.multi"),
+
+					resource.TestCheckOutput("addr_prefix_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceNodeSessions_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_geminidb_node_sessions" "test" {
+  node_id = "%[1]s"
+}
+
+locals {
+  addr_prefix = data.huaweicloud_geminidb_node_sessions.test.sessions[0].addr
+}
+
+data "huaweicloud_geminidb_node_sessions" "addr_prefix_filter" {
+  node_id     = "%[1]s"
+  addr_prefix = local.addr_prefix
+}
+
+output "addr_prefix_filter_useful" {
+  value = length(data.huaweicloud_geminidb_node_sessions.addr_prefix_filter.sessions) > 0 && alltrue(
+    [for v in data.huaweicloud_geminidb_node_sessions.addr_prefix_filter.sessions[*].addr : v == local.addr_prefix]
+  )
+}
+`, acceptance.HW_GEMINIDB_NODE_ID)
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_node_sessions.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_node_sessions.go
@@ -1,0 +1,187 @@
+package geminidb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforNoSQL GET /v3/{project_id}/redis/nodes/{node_id}/sessions
+func DataSourceNodeSessions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNodeSessionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"addr_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sessions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cmd": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"age": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"idle": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"db": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"addr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fd": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sub": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"psub": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"multi": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildNodeSessionsQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("addr_prefix"); ok {
+		queryParams = fmt.Sprintf("%s&addr_prefix=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceNodeSessionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/redis/nodes/{node_id}/sessions?limit=100"
+		offset  = 0
+		result  = make([]interface{}, 0)
+		nodeId  = d.Get("node_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{node_id}", nodeId)
+	getPath += buildNodeSessionsQueryParams(d)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", getPath, offset)
+		getResp, err := client.Request("GET", currentPath, &getOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving the node sessions: %s", err)
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		nodeSessions := utils.PathSearch("sessions", getRespBody, make([]interface{}, 0)).([]interface{})
+		if len(nodeSessions) == 0 {
+			break
+		}
+
+		result = append(result, nodeSessions...)
+		offset += len(nodeSessions)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("sessions", flattenNodeSessions(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenNodeSessions(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"id":    utils.PathSearch("id", v, nil),
+			"name":  utils.PathSearch("name", v, nil),
+			"cmd":   utils.PathSearch("cmd", v, nil),
+			"age":   utils.PathSearch("age", v, nil),
+			"idle":  utils.PathSearch("idle", v, nil),
+			"db":    utils.PathSearch("db", v, nil),
+			"addr":  utils.PathSearch("addr", v, nil),
+			"fd":    utils.PathSearch("fd", v, nil),
+			"sub":   utils.PathSearch("sub", v, nil),
+			"psub":  utils.PathSearch("psub", v, nil),
+			"multi": utils.PathSearch("multi", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get list of node sessions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to get list of node sessions.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccDataSourceNodeSessions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccDataSourceNodeSessions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceNodeSessions_basic
=== PAUSE TestAccDataSourceNodeSessions_basic
=== CONT  TestAccDataSourceNodeSessions_basic
--- PASS: TestAccDataSourceNodeSessions_basic (26.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  26.217s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/8b44a9d7-4d42-4c4e-ba5d-f3b7de0b35a0" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
