### PR TITLE
feat(GeminiDB): add new data source to get restorable time window

### DIFF
--- a/docs/data-sources/geminidb_restorable_time_window.md
+++ b/docs/data-sources/geminidb_restorable_time_window.md
@@ -1,0 +1,70 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_restorable_time_window"
+description: |-
+  Use this data source to get a list of restorable time window for a GeminiDB instance.
+---
+
+# huaweicloud_geminidb_restorable_time_window
+
+Use this data source to get a list of restorable time window for a GeminiDB instance.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_geminidb_restorable_time_window" "test" {
+  instance_id = var.instance_id
+}
+```
+
+### With Time Range
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_geminidb_restorable_time_window" "test" {
+  instance_id = var.instance_id
+  start_time  = "2024-01-01T00:00:00+0800"
+  end_time    = "2024-12-31T23:59:59+0800"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the restorable time window.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the GeminiDB instance.
+
+* `start_time` - (Optional, String) Specifies the start time for the query.
+  The format is **yyyy-mm-ddThh:mm:ssZ**.
+  Defaults to one day before the current query time.
+
+* `end_time` - (Optional, String) Specifies the end time for the query.
+  The format is **yyyy-mm-ddThh:mm:ssZ**.
+  Defaults to the current query time.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `restorable_time_periods` - The list of restorable time periods.
+  The [restorable_time_periods](#geminidb_restorable_time_periods) structure is documented below.
+
+<a name="geminidb_restorable_time_periods"></a>
+The `restorable_time_periods` block supports:
+
+* `start_time` - The start time of the restorable time period.
+  This is a UNIX timestamp in milliseconds, in UTC timezone.
+
+* `end_time` - The end time of the restorable time period.
+  This is a UNIX timestamp in milliseconds, in UTC timezone.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1461,6 +1461,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_node_session_statistics": geminidb.DataSourceNodeSessionStatistics(),
 			"huaweicloud_geminidb_quotas":                  geminidb.DataSourceQuotas(),
 			"huaweicloud_geminidb_recycling_instances":     geminidb.DataSourceGeminiDBRecyclingInstances(),
+			"huaweicloud_geminidb_restorable_time_window":  geminidb.DataSourceGeminiDBRestorableTimeWindow(),
 
 			"huaweicloud_gaussdb_storage_types":             gaussdb.DataSourceGaussDbStorageTypes(),
 			"huaweicloud_gaussdb_datastores":                gaussdb.DataSourceGaussDbDatastores(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_restorable_time_window_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_restorable_time_window_test.go
@@ -1,0 +1,58 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGeminiDBRestorableTimeWindow_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_geminidb_restorable_time_window.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGeminiDBRestorableTimeWindow_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "restorable_time_periods.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "restorable_time_periods.0.start_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "restorable_time_periods.0.end_time"),
+
+					resource.TestCheckOutput("filter_by_time_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGeminiDBRestorableTimeWindow_basic() string {
+	beginTime := time.Now().UTC()
+	beginTimeString := beginTime.Format("2006-01-02T15:04:05+0800")
+	endTime := time.Now().UTC().Add(8 * time.Hour)
+	endTimeString := endTime.Format("2006-01-02T15:04:05+0800")
+	return fmt.Sprintf(`
+data "huaweicloud_geminidb_restorable_time_window" "test" {
+  instance_id = "%[1]s"
+}
+
+data "huaweicloud_geminidb_restorable_time_window" "time_filter_is_useful" {
+  instance_id = "%[1]s"
+  start_time  = "%[2]s"
+  end_time    = "%[3]s"
+}
+
+output "filter_by_time_is_useful" {
+  value = length(data.huaweicloud_geminidb_restorable_time_window.time_filter_is_useful.restorable_time_periods) > 0
+}
+`, acceptance.HW_GEMINIDB_INSATNCE_ID, beginTimeString, endTimeString)
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_restorable_time_window.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_restorable_time_window.go
@@ -1,0 +1,148 @@
+package geminidb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforNoSQL GET /v3/{project_id}/instances/{instance_id}/backups/restorable-time-periods
+func DataSourceGeminiDBRestorableTimeWindow() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGeminiDBRestorableTimeWindowRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"restorable_time_periods": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     geminiDBRestorableTimePeriodSchema(),
+			},
+		},
+	}
+}
+
+func geminiDBRestorableTimePeriodSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"start_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGeminiDBRestorableTimeWindowRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	httpUrl := "v3/{project_id}/instances/{instance_id}/backups/restorable-time-periods"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", d.Get("instance_id").(string))
+	getPath += buildListGeminiDBRestorableTimeWindowQueryParams(d)
+
+	getResp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		getPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return diag.Errorf("error retrieving GeminiDB restorable time window: %s", err)
+	}
+	listRespJson, err := json.Marshal(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var listRespBody interface{}
+	err = json.Unmarshal(listRespJson, &listRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	restorableTimeWindow := flattenListGeminiDBRestorableTimeWindow(listRespBody)
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("restorable_time_periods", restorableTimeWindow),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildListGeminiDBRestorableTimeWindowQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("start_time"); ok {
+		queryParams = fmt.Sprintf("%s&start_time=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		queryParams = fmt.Sprintf("%s&end_time=%v", queryParams, v)
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func flattenListGeminiDBRestorableTimeWindow(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("restorable_time_periods", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"start_time": utils.PathSearch("start_time", v, nil),
+			"end_time":   utils.PathSearch("end_time", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new data source to get restorable time window
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new data source to get restorable time window
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/geminidb' TESTARGS='-run=TestAccDataSourceGeminiDBRestorableTimeWindow_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run=TestAccDataSourceGeminiDBRestorableTimeWindow_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceGeminiDBRestorableTimeWindow_basic
=== PAUSE TestAccDataSourceGeminiDBRestorableTimeWindow_basic
=== CONT  TestAccDataSourceGeminiDBRestorableTimeWindow_basic
--- PASS: TestAccDataSourceGeminiDBRestorableTimeWindow_basic (23.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  24.048s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
