### PR TITLE
feat(drs): new datasource to query object compare result

### DIFF
--- a/docs/data-sources/drs_object_compare.md
+++ b/docs/data-sources/drs_object_compare.md
@@ -1,0 +1,112 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_object_compare"
+description: |-
+  Use this data source to get the object comparison result of specified DRS job within HuaweiCloud.
+---
+
+# huaweicloud_drs_object_compare
+
+Use this data source to get the object comparison result of specified DRS job within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+data "huaweicloud_drs_object_compare" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the job ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `create_time` - The creation time of the comparison task, UTC time, for example: **2024-04-09T07:00:57Z**.
+
+* `start_time` - The start time of the comparison task, UTC time, for example: **2024-04-09T07:00:57Z**.
+
+* `status` - The status of the comparison task.
+  The valid values are as follows:
+  + **RUNNING**: Running.
+  + **WAITING_FOR_RUNNING**: Waiting to start.
+  + **SUCCESSFUL**: Completed.
+  + **FAILED**: Failed.
+  + **CANCELLED**: Cancelled.
+  + **TIMEOUT_INTERRUPT**: Timeout interrupted.
+  + **FULL_DOING**: Full verification in progress.
+  + **INCRE_DOING**: Incremental verification in progress.
+
+* `export_status` - The status of generating the comparison result report file.
+  The valid values are as follows:
+  + **INIT**: Initial state.
+  + **EXPORTING**: Comparison result exporting.
+  + **EXPORT_COMPLETE**: Comparison result export completed.
+  + **EXPORT_COMMON_FAILED**: Comparison result export failed.
+
+* `report_remain_seconds` - The remaining validity time of the comparison result report file, in seconds.
+  Returns `-1` when the report is not generated.
+
+* `compare_job_id` - The comparison task ID.
+
+* `error_msg` - The failure reason.
+
+* `compare_result` - The comparison results.
+
+  The [compare_result](#compare_result_struct) structure is documented below.
+
+* `database_info` - The business/disaster recovery database information during the comparison task.
+
+  The [database_info](#database_info_struct) structure is documented below.
+
+<a name="compare_result_struct"></a>
+The `compare_result` block supports:
+
+* `type` - The object type.
+  The valid values are as follows:
+  + **DB**: Database.
+  + **TABLE**: Table.
+  + **VIEW**: View.
+  + **EVENT**: Event.
+  + **ROUTINE**: Stored procedure and function.
+  + **INDEX**: Index.
+  + **TRIGGER**: Trigger.
+  + **SYNONYM**: Synonym.
+  + **FUNCTION**: Function.
+  + **PROCEDURE**: Stored procedure.
+  + **TYPE**: Custom type.
+  + **RULE**: Rule.
+  + **DEFAULT_TYPE**: Default value.
+  + **PLAN_GUIDE**: Execution plan.
+  + **CONSTRAINT**: Constraint.
+  + **FILE_GROUP**: File group.
+  + **PARTITION_FUNCTION**: Partition function.
+  + **PARTITION_SCHEME**: Partition scheme.
+  + **TABLE_COLLATION**: Table collation.
+  + **EXTENSIONS**: Plugin.
+
+* `source_count` - The number of objects of this type in the source database.
+
+* `target_count` - The number of objects of this type in the target database.
+
+* `status` - The comparison result. `0` for inconsistent, `2` for consistent, `3` for incomplete.
+
+<a name="database_info_struct"></a>
+The `database_info` block supports:
+
+* `service_database` - The business database information.
+
+* `disaster_recovery_database` - The disaster recovery database information.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1331,6 +1331,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_job_monitor_data":       drs.DataSourceDrsJobMonitorData(),
 			"huaweicloud_drs_job_object_support":     drs.DataSourceDrsJobObjectSupport(),
 			"huaweicloud_drs_node_types":             drs.DataSourceNodeTypes(),
+			"huaweicloud_drs_object_compare":         drs.DataSourceDrsObjectCompare(),
 			"huaweicloud_drs_object_mappings":        drs.DataSourceDrsObjectMappings(),
 			"huaweicloud_drs_quotas":                 drs.DataSourceDrsQuotas(),
 			"huaweicloud_drs_subscriptions":          drs.DataSourceDrsSubscriptions(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_object_compare_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_object_compare_test.go
@@ -1,0 +1,47 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsObjectCompare_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_object_compare.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDrsObjectCompare_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "create_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "start_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "export_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "report_remain_seconds"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "compare_job_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDrsObjectCompare_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_object_compare" "test" {
+  job_id = "%s"
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_object_compare.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_object_compare.go
@@ -1,0 +1,192 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v3/{project_id}/jobs/{job_id}/object/compare
+func DataSourceDrsObjectCompare() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceObjectCompareRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"export_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"report_remain_seconds": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"compare_job_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error_msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"compare_result": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"target_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"database_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"service_database": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"disaster_recovery_database": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceObjectCompareRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		jobId   = d.Get("job_id").(string)
+		httpUrl = "v3/{project_id}/jobs/{job_id}/object/compare"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DRS object compare: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("create_time", utils.PathSearch("create_time", respBody, nil)),
+		d.Set("start_time", utils.PathSearch("start_time", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("export_status", utils.PathSearch("export_status", respBody, nil)),
+		d.Set("report_remain_seconds", utils.PathSearch("report_remain_seconds", respBody, nil)),
+		d.Set("compare_job_id", utils.PathSearch("compare_job_id", respBody, nil)),
+		d.Set("error_msg", utils.PathSearch("error_msg", respBody, nil)),
+		d.Set("compare_result", flattenCompareResult(respBody)),
+		d.Set("database_info", flattenDatabaseInfo(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCompareResult(respBody interface{}) []interface{} {
+	compareResultRaw := utils.PathSearch("compare_result", respBody, make([]interface{}, 0)).([]interface{})
+	if len(compareResultRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(compareResultRaw))
+	for _, item := range compareResultRaw {
+		result = append(result, map[string]interface{}{
+			"type":         utils.PathSearch("type", item, nil),
+			"source_count": utils.PathSearch("source_count", item, nil),
+			"target_count": utils.PathSearch("target_count", item, nil),
+			"status":       utils.PathSearch("status", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenDatabaseInfo(respBody interface{}) []interface{} {
+	databaseInfoRaw := utils.PathSearch("database_info", respBody, nil)
+	if databaseInfoRaw == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"service_database":           utils.PathSearch("service_database", databaseInfoRaw, nil),
+			"disaster_recovery_database": utils.PathSearch("disaster_recovery_database", databaseInfoRaw, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query object compare result

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o drs -f TestAccDataSourceDrsObjectCompare_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsObjectCompare_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsObjectCompare_basic
=== PAUSE TestAccDataSourceDrsObjectCompare_basic
=== CONT  TestAccDataSourceDrsObjectCompare_basic
--- PASS: TestAccDataSourceDrsObjectCompare_basic (16.88s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       16.996s coverage: 4.0% of statements in ./huaweicloud/services/drs
```
<img width="1306" height="74" alt="image" src="https://github.com/user-attachments/assets/2f9eb5b2-46c5-4db9-b274-24b98c7e999e" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
