### PR TITLE
refactor(modelarts): adjust the resource coding for dataset

### DIFF
--- a/docs/data-sources/modelarts_datasets.md
+++ b/docs/data-sources/modelarts_datasets.md
@@ -11,29 +11,42 @@ Use this data source to get a list of ModelArts datasets.
 
 ## Example Usage
 
+### Query all datasets but each dataset does not contain lables
+
 ```hcl
+data "huaweicloud_modelarts_datasets" "test" {}
+```
+
+### Querying a list of datasets by fuzzy matching of names
+
+```hcl
+variable "matched_name_word" {}
+
 data "huaweicloud_modelarts_datasets" "test" {
-  name = "your_dataset_name"
-  type = 1
+  name = var.matched_name_word
 }
 ```
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available datasets in the current region.
- All datasets that meet the filter criteria will be exported as attributes.
+The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to obtain datasets. If omitted, the provider-level region
- will be used.
+* `region` - (Optional, String) Specifies the region where the datasets are located.  
+  If omitted, the provider-level region will be used.
 
-* `name` - (Optional, String) Specifies the name of datasets.
+* `name` - (Optional, String) Specifies the name of datasets, in fuzzy match.
 
-* `type` - (Optional, Int) Specifies the type of datasets. The options are:
+  -> When querying a specific dataset by name, labels information will be returned.
+
+* `type` - (Optional, Int) Specifies the type of datasets.  
+  The valid values are as follows:
   + **0**: Image classification, supported formats: `.jpg`, `.png`, `.jpeg`, `.bmp`.
   + **1**: Object detection, supported formats: `.jpg`, `.png`, `.jpeg`, `.bmp`.
   + **3**: Image segmentation, supported formats: `.jpg`, `.png`, `.jpeg`, `.bmp`.
   + **100**: Text classification, supported formats: `.txt`, `.csv`.
   + **200**: Sound classification, Supported formats: `.wav`.
+  + **201**: Speech content.
+  + **202**: Speech paragraph labeling.
   + **400**: Table type, supported formats: Carbon type.
   + **600**: Video, supported formats: `.mp4`
   + **900**: Free format.
@@ -44,8 +57,10 @@ The following attributes are exported:
 
 * `id` - Indicates a data source ID.
 
-* `datasets` - Indicates a list of all datasets found. Structure is documented below.
+* `datasets` - The list of datasets that match the filter parameters.  
+  The [datasets](#modelarts_datasets_attr) structure is documented below.
 
+<a name="modelarts_datasets_attr"></a>
 The `datasets` block contains:
 
 * `id` - The ID of the dataset.
@@ -56,58 +71,81 @@ The `datasets` block contains:
 
 * `description` - The description of the dataset.
 
-* `output_path` - The OBS path for storing output files such as labeled files.
+* `output_path` - The OBS storage path that used to store output files.
 
-* `data_source` - The data sources which is used to imported the source data (such as pictures/files/audio, etc.) in
- this directory and subdirectories to the dataset. Structure is documented below.
+* `data_source` - The data sources which be used to imported the source data (such as pictures/files/audio, etc.) in
+  this directory and subdirectories to the dataset.  
+  The [data_source](#modelarts_datasets_datasource_attr) structure is documented below.
 
-* `schemas` - The schema information of source data when `type` is `400`(Table Type). Structure is documented below.
+* `schemas` - The schema configurations of the dataset.  
+  Returns if the value of `type` parameter is `400` (table Type).  
+  The [schemas](#modelarts_datasets_schemas_attr) structure is documented below.
 
-* `labels` - The labels information. Structure is documented below.
+* `labels` - The labels of the dataset.  
+  The [labels](#modelarts_datasets_labels_attr) structure is documented below.
 
-* `data_format` - The dataset format. Valid values include: `Default`, `CarbonData`: Carbon format(Supported only for
- table type dataset.).
+* `data_format` - The dataset format.
+  + **Default**
+  + **CarbonData**: Carbon format(Supported only for table type datasets).
 
-* `created_at` - The dataset creation time.
+* `created_at` - The creation time of the dataset, in RFC3339 format.
 
-* `status` - Dataset status. Valid values are as follows:
-  + **0**: Creating.
-  + **1**: Completed.
-  + **2**: Deleting.
-  + **3**: Deleted.
-  + **4**: Exception.
-  + **5**: Syncing.
-  + **6**: Releasing.
-  + **7**: Version switching.
-  + **8**: Importing.
+* `status` - The status of the dataset.
 
+<a name="modelarts_datasets_datasource_attr"></a>
 The `data_source` block contains:
 
-* `data_type` - The type of data source. Valid values are as follows:
-  + *0*: OBS.
-  + *1*: GaussDB(DWS).
-  + *2*: DLI.
-  + *4*: MRS.
-  
-* `path` - The OBS path when `data_type` is `0`(OBS) or the HDFS path when `data_type` is `4`(MRS). All the file in this
- directory and subdirectories will be which be imported to the dataset.
+* `data_type` - The type of the data source.
+  + **0**: OBS.
+  + **1**: GaussDB(DWS).
+  + **2**: DLI.
+  + **4**: MRS.
 
-* `with_column_header` - Whether the data contains table header when the type of dataset is `400`(Table type).
+* `path` - The OBS storage path or MRS HDFS path.
 
+* `cluster_id` - The ID of the DWS/MRS cluster.
+
+* `database_name` - The name of the DWS/DLI database.
+
+* `table_name` - The name of the DWS/DLI table.
+
+* `user_name` - The name of the DWS database user.
+
+* `queue_name` - The name of the DLI queue.
+
+* `with_column_header` - Whether the data contains table header when the type of dataset is `400` (table type).
+
+<a name="modelarts_datasets_schemas_attr"></a>
 The `schemas` block contains:
 
-* `type` - The field type. Valid values include: `String`, `Short`, `Int`, `Long`, `Double`, `Float`, `Byte`,
- `Date`, `Timestamp`, `Bool`.
+* `type` - The field type of the schema.
+  + **String**
+  + **Short**
+  + **Int**
+  + **Long**
+  + **Double**
+  + **Float**
+  + **Byte**
+  + **Date**
+  + **Timestamp**
+  + **Bool**
 
-* `name` - The field name.
+* `name` - The field name of the schema.
 
+<a name="modelarts_datasets_labels_attr"></a>
 The `labels` block contains:
 
-* `name` - The name of label.
+* `name` - The name of the label.
 
-* `property_color` - The color of label.
+* `property_color` - The color of the label.
 
-* `property_shape` - The shape of label. Valid values include: `bndbox`, `polygon`, `circle`, `line`, `dashed`,
- `point`, `polyline`.
+* `property_shape` - The shape of the label.
+  + **bndbox**
+  + **polygon**
+  + **circle**
+  + **line**
+  + **dashed**
+  + **point**
+  + **polyline**
 
-* `property_shortcut` - The shortcut of label.
+* `property_shortcut` - The shortcut of the label.

--- a/docs/resources/modelarts_dataset.md
+++ b/docs/resources/modelarts_dataset.md
@@ -2,22 +2,23 @@
 subcategory: "AI Development Platform (ModelArts)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_modelarts_dataset"
-description: ""
+description: |-
+  Manages a ModelArts dataset resource within HuaweiCloud.
 ---
 
 # huaweicloud_modelarts_dataset
 
-Manages ModelArts dataset resource within HuaweiCloud.
+Manages a ModelArts dataset resource within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
-variable "name" {}
+variable "dataset_name" {}
 variable "output_obs_path" {}
 variable "input_obs_path" {}
 
 resource "huaweicloud_modelarts_dataset" "test" {
-  name        = var.name
+  name        = var.dataset_name
   type        = 1
   output_path = var.output_obs_path
   description = "Terraform Demo"
@@ -36,117 +37,141 @@ resource "huaweicloud_modelarts_dataset" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the resource. If omitted, the
- provider-level region will be used. Changing this parameter will create a new resource.
+* `region` - (Optional, String, ForceNew) The region where the dataset is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `name` - (Required, String) Specifies the name of the dataset. The name consists of `1` to `100` characters,
- starting with a letter. Only letters, chinese characters, digits underscores (_) and hyphens (-) are allowed.
+* `name` - (Required, String) Specifies the name of the dataset.  
+  The valid length is limited from `1` to `100`, only letters, chinese characters, digits underscores (_) and
+  hyphens (-) are allowed. The name must start with a letter.
 
-* `type` - (Required, Int, ForceNew) Specifies the type of dataset. The options are as follows:
+* `type` - (Required, Int, NonUpdatable) Specifies the type of dataset.  
+  The valid values are as follows:
   + **0**: Image classification, supported formats: `.jpg`, `.png`, `.jpeg`, `.bmp`.
   + **1**: Object detection, supported formats: `.jpg`, `.png`, `.jpeg`, `.bmp`.
   + **3**: Image segmentation, supported formats: `.jpg`, `.png`, `.jpeg`, `.bmp`.
   + **100**: Text classification, supported formats: `.txt`, `.csv`.
   + **200**: Sound classification, Supported formats: `.wav`.
+  + **201**: Speech content.
+  + **202**: Speech paragraph labeling.
   + **400**: Table type, supported formats: Carbon type.
   + **600**: Video, supported formats: `.mp4`.
   + **900**: Free format.
 
- Changing this parameter will create a new resource.
+* `output_path` - (Required, String, NonUpdatable) Specifies the OBS storage path that used to store output files.  
+  The path cannot be the same as the import path or subdirectory of the import path.
 
-* `output_path` - (Required, String, ForceNew) Specifies the OBS path for storing output files such as labeled files.
- The path cannot be the same as the import path or subdirectory of the import path.
- Changing this parameter will create a new resource.
+* `data_source` - (Required, List, NonUpdatable) Specifies the data sources which be used to imported the source data
+  (such as pictures/files/audio, etc.) in this directory and subdirectories to the dataset.  
+  The [data_source](#modelarts_dataset_datasource) structure is documented below.
 
-* `data_source` - (Required, List, ForceNew)Specifies the data sources which be used to imported the source data (such
- as pictures/files/audio, etc.) in this directory and subdirectories to the dataset. Structure is documented below.
- Changing this parameter will create a new resource.
+* `description` - (Optional, String) Specifies the description of the dataset.  
+  The valid length is limited from `0` to `256`, and the description cannot contain special characters `!<>=&"'`.
 
-* `description` - (Optional, String) Specifies the description of dataset. It contains a maximum of `256` characters and
- cannot contain special characters `!<>=&"'`.
+* `schemas` - (Optional, List, NonUpdatable) Specifies the schema configurations of the dataset.  
+  Required if the value of `type` parameter is **400**.  
+  The [schemas](#modelarts_dataset_schema) structure is documented below.
 
-* `import_labeled_enabled` - (Optional, Bool, ForceNew) Specifies whether to import labeled files.
- Default value is `true`. Changing this parameter will create a new resource.
+* `import_labeled_enabled` - (Optional, Bool, NonUpdatable) Specifies whether to enable the import labeled features.  
+  Defaults to **true**.
 
-* `schemas` - (Optional, List, ForceNew) Specifies the schema information of source data when `type` is `400`.
- Structure is documented below. Changing this parameter will create a new resource.
+* `label_format` - (Optional, List, NonUpdatable) Specifies the custom format information of labeled features when
+  import labeled files for Text classification.  
+  The [label_format](#modelarts_dataset_label_format) structure is documented below.
 
-* `label_format` - (Optional, List, ForceNew) Specifies the custom format information of labeled files when import
- labeled files for Text classification. Structure is documented below.
- Changing this parameter will create a new resource.
+* `labels` - (Optional, List) Specifies labels of the dataset.  
+  The [labels](#modelarts_dataset_labels) structure is documented below.
 
-* `labels` - (Optional, List) Specifies labels information. Structure is documented below.
-
+<a name="modelarts_dataset_datasource"></a>
 The `data_source` block supports:
 
-* `data_type` - (Optional, Int, ForceNew) Specifies the type of data source. The options are as follows:
+* `data_type` - (Optional, Int, NonUpdatable) Specifies the type of data source.  
+  The valid values are as follows:
   + **0**: OBS.
   + **1**: GaussDB(DWS).
   + **2**: DLI.
   + **4**: MRS.
-  
- Default value is 0. Changing this parameter will create a new resource.
 
-* `path` - (Optional, String, ForceNew) Specifies the OBS path when `data_type` is `0`
- or the hdsf path when `data_type` is `4`. All the file in this directory and subdirectories will be which be imported
- to the dataset. Changing this parameter will create a new resource.
+  Defaults to **0**.
 
-* `with_column_header` - (Optional, Bool, ForceNew) Specifies whether the data contains table header when the type
- of dataset is `400`(Table type). Default value is `true`. Changing this parameter will create a new resource.
+* `path` - (Optional, String, NonUpdatable) Specifies the OBS storage path or MRS HDFS path.  
+  All files in this directory and its subdirectories will be imported into the dataset.  
+  Required if the value of `data_source.data_type` parameter is **0** or **4**.
 
-* `queue_name` - (Optional, String, ForceNew) Specifies the queue name of DLI when `data_type` is `2`.
- Changing this parameter will create a new resource.
+* `cluster_id` - (Optional, String, NonUpdatable) Specifies the cluster ID of the DWS/MRS cluster.  
+  Required if the value of `data_source.data_type` parameter is **1** or **4**.
 
-* `database_name` - (Optional, String, ForceNew) Specifies the database name of DWS/DLI when `data_type` is `1` or `2`.
- Changing this parameter will create a new resource.
+* `database_name` - (Optional, String, NonUpdatable) Specifies the name of the DWS/DLI database.  
+  Required if the value of `data_source.data_type` parameter is **1** or **2**.
 
-* `table_name` - (Optional, String, ForceNew) Specifies the table name of DWS/DLI when `data_type` is `1` or `2`.
- Changing this parameter will create a new resource.
+* `table_name` - (Optional, String, NonUpdatable) Specifies the name of the DWS/DLI table.  
+  Required if the value of `data_source.data_type` parameter is **1** or **2**.
 
-* `cluster_id` - (Optional, String, ForceNew) Specifies the cluster ID of DWS/MRS when `data_type` is `1` or `4`.
- Changing this parameter will create a new resource.
+* `user_name` - (Optional, String, NonUpdatable) Specifies the name of the DWS database user.  
+  Required if the value of `data_source.data_type` parameter is **1**.
 
-* `user_name` - (Optional, String, ForceNew) Specifies the user name of database when `data_type` is `1`.
- Changing this parameter will create a new resource.
+* `password` - (Optional, String, NonUpdatable) Specifies the password of the DWS database user.  
+  Required if the value of `data_source.data_type` parameter is **1**.
 
-* `password` - (Optional, String, ForceNew) Specifies the password of database when `data_type` is `1`.
- Changing this parameter will create a new resource.
+* `queue_name` - (Optional, String, NonUpdatable) Specifies the name of the DLI queue.  
+  Required if the value of `data_source.data_type` parameter is **2**.
 
+* `with_column_header` - (Optional, Bool, NonUpdatable) Specifies whether the data contains table header when the type
+ of dataset is **400** (table type).  
+  Defaults to **true**.
+
+<a name="modelarts_dataset_schema"></a>
 The `schemas` block supports:
 
-* `type` - (Required, String, ForceNew) Specifies the field type. Valid values include: `String`, `Short`, `Int`,
- `Long`, `Double`, `Float`, `Byte`, `Date`, `Timestamp`, `Bool`. Changing this parameter will create a new resource.
+* `type` - (Required, String, NonUpdatable) Specifies the field type of the schema.  
+  The valid values are as follows:
+  + **String**
+  + **Short**
+  + **Int**
+  + **Long**
+  + **Double**
+  + **Float**
+  + **Byte**
+  + **Date**
+  + **Timestamp**
+  + **Bool**
 
-* `name` - (Required, String, ForceNew) Specifies the field name. Changing this parameter will create a new resource.
+* `name` - (Required, String, NonUpdatable) Specifies the field name of the schema.
 
+<a name="modelarts_dataset_label_format"></a>
 The `label_format` block supports:
 
-* `type` - (Optional, String, ForceNew) Specifies Label type for text classification.
- The optional values are as follows:
-
+* `type` - (Optional, String, NonUpdatable) Specifies the type of the label format.  
+  The valid values are as follows:
   + **0**: Label and text are separated, distinguished by the suffix `_result`.
-   For example: the text file is *abc.txt*, and the label file is *abc_result.txt*.
-  + **1**: Default, labels and text are in one file, separated by a delimiter. The separator between text and labels,
-   the separator between label and label can be specified by `label_separator` and `text_label_separator`.
-  
- Default value is `1`.
+    For example: the text file is *abc.txt*, and the label file is *abc_result.txt*.
+  + **1**: Default, labels and text are in one file, separated by a delimiter.
+    The separator between text and labels, the separator between label and label can be specified by `label_separator`
+    and `text_label_separator`.
 
-* `text_label_separator` - (Optional, String, ForceNew) Specifies the separator between text and label.
- Changing this parameter will create a new resource.
+  Defaults to **1**.
 
-* `label_separator` - (Optional, String, ForceNew) Specifies the separator between label and label.
- Changing this parameter will create a new resource.
+* `text_label_separator` - (Optional, String, NonUpdatable) Specifies the separator between text and label.
 
+* `label_separator` - (Optional, String, NonUpdatable) Specifies the separator between label and label.
+
+<a name="modelarts_dataset_labels"></a>
 The `labels` block supports:
 
-* `name` - (Required, String) Specifies the name of label.
+* `name` - (Required, String) Specifies the name of the label.
 
-* `property_color` - (Optional, String) Specifies color of label.
+* `property_color` - (Optional, String) Specifies the color of the label.
 
-* `property_shape` - (Optional, String) Specifies shape of label. Valid values include: `bndbox`, `polygon`,
- `circle`, `line`, `dashed`, `point`, `polyline`.
+* `property_shape` - (Optional, String) Specifies the shape of the label.  
+  The valid values are as follows:
+  + **bndbox**
+  + **polygon**
+  + **circle**
+  + **line**
+  + **dashed**
+  + **point**
+  + **polyline**
 
-* `property_shortcut` - (Optional, String) Specifies shortcut of label.
+* `property_shortcut` - (Optional, String) Specifies shortcut of the label.
 
 ## Attribute Reference
 
@@ -154,21 +179,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
 
-* `data_format` - dataset format. Valid values include: `Default`, `CarbonData`: Carbon format(Supported only for
- table type datasets).
+* `data_format` - The data format of the dataset.
+  + **Default**
+  + **CarbonData**: Carbon format(Supported only for table type datasets).
 
-* `status` - Dataset status. Valid values are as follows:
-  + **0**: Creating.
-  + **1**: Completed.
-  + **2**: Deleting.
-  + **3**: Deleted.
-  + **4**: Exception.
-  + **5**: Syncing.
-  + **6**: Releasing.
-  + **7**: Version switching.
-  + **8**: Importing.
+* `created_at` - The creation time of the dataset, in RFC3339 format.
 
-* `created_at` - The dataset creation time.
+* `status` - The status of the dataset.
 
 ## Timeouts
 
@@ -179,27 +196,25 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-The datasets can be imported by `id`.
+The datasets can be imported by `id`, e.g.
 
 ```bash
-terraform import huaweicloud_modelarts_dataset.test yiROKoTTjtwjvP71yLG
+$ terraform import huaweicloud_modelarts_dataset.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `data_source.0.path`,
-`data_source.0.queue_name`, `data_source.0.database_name`, `data_source.0.table_name`, `data_source.0.cluster_id`,
-`data_source.0.user_name` and `data_source.0.password`. It is generally recommended running `terraform plan` after
-importing a dataset. You can then decide if changes should be applied to the dataset, or the resource definition
-should be updated to align with the dataset. Also you can ignore changes as below.
+API response, security or some other reason. The missing attributes include: `data_source.0.password`.
+It is generally recommended running `terraform plan` after importing a dataset. You can then decide if changes should be
+applied to the dataset, or the resource definition should be updated to align with the dataset.
+Also you can ignore changes as below.
 
 ```hcl
 resource "huaweicloud_modelarts_dataset" "test" {
-    ...
+  ...
 
   lifecycle {
     ignore_changes = [
-      data_source.0.path, data_source.0.queue_name, data_source.0.database_name, data_source.0.table_name,
-      data_source.0.cluster_id, data_source.0.user_name, data_source.0.password,
+      data_source.0.password,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_dataset_versions_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_dataset_versions_test.go
@@ -13,18 +13,14 @@ func TestAccDataSourceDatasetVersions_basic(t *testing.T) {
 	dataSourceName := "data.huaweicloud_modelarts_dataset_versions.test"
 	dc := acceptance.InitDataSourceCheck(dataSourceName)
 
-	name := acceptance.RandomAccResourceName()
-	obsName := acceptance.RandomAccResourceNameWithDash()
+	name := acceptance.RandomAccResourceNameWithDash()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckOBS(t)
-		},
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDatasetVersions_basic(name, obsName),
+				Config: testAccDataSourceDatasetVersions_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(dataSourceName, "versions.0.id",
@@ -52,7 +48,7 @@ func TestAccDataSourceDatasetVersions_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataSourceDatasetVersions_name(name, obsName),
+				Config: testAccDataSourceDatasetVersions_name(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "versions.#", "0"),
@@ -62,10 +58,20 @@ func TestAccDataSourceDatasetVersions_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceDatasetVersions_basic(rName, obsName string) string {
-	datasetVersion := testAccDatasetVersion_basic(rName, obsName)
+func testAccDataSourceDatasetVersions_base(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
+
+resource "huaweicloud_modelarts_dataset_version" "test" {
+  name       = "%[2]s"
+  dataset_id = huaweicloud_modelarts_dataset.test.id
+}
+`, testAccDatasetVersion_base(name), name)
+}
+
+func testAccDataSourceDatasetVersions_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
 
 data "huaweicloud_modelarts_dataset_versions" "test" {
   dataset_id  = huaweicloud_modelarts_dataset.test.id
@@ -75,13 +81,12 @@ data "huaweicloud_modelarts_dataset_versions" "test" {
     huaweicloud_modelarts_dataset_version.test
   ]
 }
-`, datasetVersion)
+`, testAccDataSourceDatasetVersions_base(name))
 }
 
-func testAccDataSourceDatasetVersions_name(rName, obsName string) string {
-	datasetVersion := testAccDatasetVersion_basic(rName, obsName)
+func testAccDataSourceDatasetVersions_name(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 data "huaweicloud_modelarts_dataset_versions" "test" {
   dataset_id  = huaweicloud_modelarts_dataset.test.id
@@ -92,5 +97,5 @@ data "huaweicloud_modelarts_dataset_versions" "test" {
     huaweicloud_modelarts_dataset_version.test
   ]
 }
-`, datasetVersion)
+`, testAccDataSourceDatasetVersions_base(name))
 }

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_datasets_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_datasets_test.go
@@ -2,6 +2,7 @@ package modelarts
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -10,49 +11,151 @@ import (
 )
 
 func TestAccDataSourceDatasets_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_modelarts_datasets.test"
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	var (
+		all = "data.huaweicloud_modelarts_datasets.all"
+		dc  = acceptance.InitDataSourceCheck(all)
 
-	name := acceptance.RandomAccResourceName()
-	obsName := acceptance.RandomAccResourceNameWithDash()
+		byName   = "data.huaweicloud_modelarts_datasets.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byType   = "data.huaweicloud_modelarts_datasets.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		name = acceptance.RandomAccResourceNameWithDash()
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDatasets_basic(name, obsName),
+				Config: testAccDataSourceDatasets_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(dataSourceName, "datasets.0.id",
+					resource.TestMatchResourceAttr(all, "datasets.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckResourceAttrPair(byName, "datasets.0.id",
 						"huaweicloud_modelarts_dataset.test", "id"),
-					resource.TestCheckResourceAttr(dataSourceName, "datasets.0.name", name),
-					resource.TestCheckResourceAttr(dataSourceName, "datasets.0.type", "1"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "datasets.0.description",
+					resource.TestCheckResourceAttr(byName, "datasets.0.name", name),
+					resource.TestCheckResourceAttr(byName, "datasets.0.type", "1"),
+					resource.TestCheckResourceAttrPair(byName, "datasets.0.description",
 						"huaweicloud_modelarts_dataset.test", "description"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "datasets.0.output_path",
+					resource.TestCheckResourceAttrPair(byName, "datasets.0.output_path",
 						"huaweicloud_modelarts_dataset.test", "output_path"),
-					resource.TestCheckResourceAttr(dataSourceName, "datasets.0.data_source.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "datasets.0.labels.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "datasets.0.schemas.#", "0"),
+					resource.TestCheckResourceAttr(byName, "datasets.0.data_source.#", "1"),
+					resource.TestCheckResourceAttr(byName, "datasets.0.labels.#", "1"),
+					resource.TestCheckResourceAttr(byName, "datasets.0.schemas.#", "0"),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceDatasets_basic(rName, obsName string) string {
-	datasets := testAccDateset_basic(rName, obsName)
+func testAccDataSourceDatasets_base(name string) string {
 	return fmt.Sprintf(`
-%s
+resource "huaweicloud_obs_bucket" "bucket" {
+  bucket        = "%[1]s"
+  acl           = "private"
+  force_destroy = true
 
-data "huaweicloud_modelarts_datasets" "test" {
-  name = "%s"
-  type = 1
+  lifecycle {
+    ignore_changes = [
+      cors_rule,
+    ]
+  }
+}
 
+resource "huaweicloud_obs_bucket_object" "input" {
+  bucket  = huaweicloud_obs_bucket.bucket.bucket
+  key     = "input/t1"
+  content = "some_bucket_content"
+}
+
+resource "huaweicloud_obs_bucket_object" "output" {
+  bucket  = huaweicloud_obs_bucket.bucket.bucket
+  key     = "output/t2"
+  content = "some_bucket_content"
+}
+
+resource "huaweicloud_modelarts_dataset" "test" {
+  name        = "%[1]s"
+  type        = 1
+  output_path = "/${huaweicloud_obs_bucket.bucket.bucket}/output/"
+  description = "Created by terraform script"
+  data_source {
+    path = "/${huaweicloud_obs_bucket.bucket.bucket}/input/"
+  }
+
+  labels {
+    name = "%[1]s"
+  }
+
+  depends_on = [
+    huaweicloud_obs_bucket_object.input,
+    huaweicloud_obs_bucket_object.output
+  ]
+}
+`, name)
+}
+
+func testAccDataSourceDatasets_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all datasets without any filter
+data "huaweicloud_modelarts_datasets" "all" {
   depends_on = [
     huaweicloud_modelarts_dataset.test
   ]
 }
-`, datasets, rName)
+
+# Filter by name
+locals {
+  dataset_name = huaweicloud_modelarts_dataset.test.name
+}
+
+data "huaweicloud_modelarts_datasets" "filter_by_name" {
+  depends_on = [
+    huaweicloud_modelarts_dataset.test
+  ]
+
+  name = local.dataset_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_modelarts_datasets.filter_by_name.datasets[*].name : v == local.dataset_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by type
+locals {
+  dataset_type = huaweicloud_modelarts_dataset.test.type
+}
+
+data "huaweicloud_modelarts_datasets" "filter_by_type" {
+  depends_on = [
+    huaweicloud_modelarts_dataset.test
+  ]
+
+  type = local.dataset_type
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_modelarts_datasets.filter_by_type.datasets[*].type : v == local.dataset_type
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+`, testAccDataSourceDatasets_base(name), name)
 }

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_dataset_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_dataset_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getDatesetResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getDatasetResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := cfg.ModelArtsV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ModelArts v1 client, err=%s", err)
@@ -22,17 +22,14 @@ func getDatesetResourceFunc(cfg *config.Config, state *terraform.ResourceState) 
 	return dataset.Get(client, state.Primary.ID, dataset.GetOpts{})
 }
 
-func TestAccResourceDateset_basic(t *testing.T) {
-	var instance dataset.CreateOpts
-	resourceName := "huaweicloud_modelarts_dataset.test"
-	name := acceptance.RandomAccResourceName()
-	updateName := acceptance.RandomAccResourceName()
-	obsName := acceptance.RandomAccResourceNameWithDash()
+func TestAccDataset_basic(t *testing.T) {
+	var (
+		obj interface{}
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&instance,
-		getDatesetResourceFunc,
+		resourceName = "huaweicloud_modelarts_dataset.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDatasetResourceFunc)
+
+		name = acceptance.RandomAccResourceNameWithDash()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -44,34 +41,34 @@ func TestAccResourceDateset_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDateset_basic(name, obsName),
+				Config: testAccDataset_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "type", "1"),
 					resource.TestCheckResourceAttr(resourceName, "status", "1"),
 					resource.TestCheckResourceAttr(resourceName, "data_format", "Default"),
-					resource.TestCheckResourceAttr(resourceName, "output_path", fmt.Sprintf("/%s/%s/", obsName, "output")),
-					resource.TestCheckResourceAttr(resourceName, "description", name),
+					resource.TestCheckResourceAttr(resourceName, "output_path", fmt.Sprintf("/%s/%s/", name, "output")),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
 					resource.TestCheckResourceAttr(resourceName, "data_source.0.data_type", "0"),
-					resource.TestCheckResourceAttr(resourceName, "data_source.0.path", fmt.Sprintf("/%s/%s/", obsName, "input")),
+					resource.TestCheckResourceAttr(resourceName, "data_source.0.path", fmt.Sprintf("/%s/%s/", name, "input")),
 					resource.TestCheckResourceAttr(resourceName, "labels.0.name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 				),
 			},
 			{
-				Config: testAccDateset_basic(updateName, obsName),
+				Config: testAccDataset_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-update", name)),
 					resource.TestCheckResourceAttr(resourceName, "type", "1"),
 					resource.TestCheckResourceAttr(resourceName, "status", "1"),
 					resource.TestCheckResourceAttr(resourceName, "data_format", "Default"),
-					resource.TestCheckResourceAttr(resourceName, "output_path", fmt.Sprintf("/%s/%s/", obsName, "output")),
-					resource.TestCheckResourceAttr(resourceName, "description", updateName),
+					resource.TestCheckResourceAttr(resourceName, "output_path", fmt.Sprintf("/%s/%s/", name, "output")),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "data_source.0.data_type", "0"),
-					resource.TestCheckResourceAttr(resourceName, "data_source.0.path", fmt.Sprintf("/%s/%s/", obsName, "input")),
-					resource.TestCheckResourceAttr(resourceName, "labels.0.name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "data_source.0.path", fmt.Sprintf("/%s/%s/", name, "input")),
+					resource.TestCheckResourceAttr(resourceName, "labels.0.name", fmt.Sprintf("%s-update", name)),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 				),
 			},
@@ -84,10 +81,10 @@ func TestAccResourceDateset_basic(t *testing.T) {
 	})
 }
 
-func testAccDatesetObs(obsName string) string {
+func testAccDataset_basic_base(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_obs_bucket" "bucket" {
-  bucket        = "%s"
+  bucket        = "%[1]s"
   acl           = "private"
   force_destroy = true
 
@@ -109,25 +106,24 @@ resource "huaweicloud_obs_bucket_object" "output" {
   key     = "output/t2"
   content = "some_bucket_content"
 }
-`, obsName)
+`, name)
 }
 
-func testAccDateset_basic(rName, obsName string) string {
-	obsConfig := testAccDatesetObs(obsName)
+func testAccDataset_basic_step1(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_modelarts_dataset" "test" {
-  name        = "%s"
+  name        = "%[2]s"
   type        = 1
   output_path = "/${huaweicloud_obs_bucket.bucket.bucket}/output/"
-  description = "%s"
+  description = "Created by terraform script"
   data_source {
     path = "/${huaweicloud_obs_bucket.bucket.bucket}/input/"
   }
 
   labels {
-    name = "%s"
+    name = "%[2]s"
   }
 
   depends_on = [
@@ -135,5 +131,29 @@ resource "huaweicloud_modelarts_dataset" "test" {
     huaweicloud_obs_bucket_object.output
   ]
 }
-`, obsConfig, rName, rName, rName)
+`, testAccDataset_basic_base(name), name)
+}
+
+func testAccDataset_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelarts_dataset" "test" {
+  name        = "%[2]s-update"
+  type        = 1
+  output_path = "/${huaweicloud_obs_bucket.bucket.bucket}/output/"
+  data_source {
+    path = "/${huaweicloud_obs_bucket.bucket.bucket}/input/"
+  }
+
+  labels {
+    name = "%[2]s-update"
+  }
+
+  depends_on = [
+    huaweicloud_obs_bucket_object.input,
+    huaweicloud_obs_bucket_object.output
+  ]
+}
+`, testAccDataset_basic_base(name), name)
 }

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_dataset_version_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_dataset_version_test.go
@@ -29,11 +29,10 @@ func getDatasetVersionResourceFunc(cfg *config.Config, state *terraform.Resource
 	return version.Get(client, datasetId, versionId)
 }
 
-func TestAccDatasetVersionResource_basic(t *testing.T) {
+func TestAccDatasetVersion_basic(t *testing.T) {
 	var instance dataset.CreateOpts
 	resourceName := "huaweicloud_modelarts_dataset_version.test"
-	name := acceptance.RandomAccResourceName()
-	obsName := acceptance.RandomAccResourceNameWithDash()
+	name := acceptance.RandomAccResourceNameWithDash()
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -42,19 +41,16 @@ func TestAccDatasetVersionResource_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckOBS(t)
-		},
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasetVersion_basic(name, obsName),
+				Config: testAccDatasetVersion_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "description", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
 					resource.TestCheckResourceAttr(resourceName, "split_ratio", "1.00"),
 					resource.TestCheckResourceAttr(resourceName, "hard_example", "false"),
 					resource.TestCheckResourceAttr(resourceName, "status", "1"),
@@ -80,15 +76,61 @@ func TestAccDatasetVersionResource_basic(t *testing.T) {
 	})
 }
 
-func testAccDatasetVersion_basic(rName, obsName string) string {
-	datasetConfig := testAccDateset_basic(rName, obsName)
+func testAccDatasetVersion_base(name string) string {
 	return fmt.Sprintf(`
-%s
+resource "huaweicloud_obs_bucket" "bucket" {
+  bucket        = "%[1]s"
+  acl           = "private"
+  force_destroy = true
+
+  lifecycle {
+    ignore_changes = [
+      cors_rule,
+    ]
+  }
+}
+
+resource "huaweicloud_obs_bucket_object" "input" {
+  bucket  = huaweicloud_obs_bucket.bucket.bucket
+  key     = "input/t1"
+  content = "some_bucket_content"
+}
+
+resource "huaweicloud_obs_bucket_object" "output" {
+  bucket  = huaweicloud_obs_bucket.bucket.bucket
+  key     = "output/t2"
+  content = "some_bucket_content"
+}
+
+resource "huaweicloud_modelarts_dataset" "test" {
+	name        = "%[1]s"
+	type        = 1
+	output_path = "/${huaweicloud_obs_bucket.bucket.bucket}/output/"
+	description = "Created by terraform script"
+	data_source {
+	  path = "/${huaweicloud_obs_bucket.bucket.bucket}/input/"
+	}
+  
+	labels {
+	  name = "%[1]s"
+	}
+  
+	depends_on = [
+	  huaweicloud_obs_bucket_object.input,
+	  huaweicloud_obs_bucket_object.output
+	]
+  }
+`, name)
+}
+
+func testAccDatasetVersion_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
 
 resource "huaweicloud_modelarts_dataset_version" "test" {
   name        = "%[2]s"
   dataset_id  = huaweicloud_modelarts_dataset.test.id
-  description = "%[2]s"
+  description = "Created by terraform script"
 }
-`, datasetConfig, rName)
+`, testAccDatasetVersion_base(name), name)
 }

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_datasets.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_datasets.go
@@ -2,15 +2,18 @@ package modelarts
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/chnsz/golangsdk/openstack/modelarts/v2/dataset"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -21,238 +24,279 @@ func DataSourceDatasets() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the datasets are located.`,
 			},
 
+			// Optional parameters.
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the dataset to be queried.`,
 			},
-
 			"type": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntInSlice([]int{0, 1, 3, 100, 101, 102, 200, 201, 202, 400, 600, 900}),
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `The type of the dataset to be queried.`,
 			},
 
+			// Attributes.
 			"datasets": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the dataset.`,
 						},
-
 						"name": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the dataset.`,
 						},
-
 						"type": {
-							Type:     schema.TypeInt,
-							Computed: true,
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The type of the dataset.`,
 						},
-
 						"description": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the dataset.`,
 						},
-
 						"output_path": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The OBS storage path that used to store output files.`,
 						},
-
 						"data_source": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"data_type": {
-										Type:     schema.TypeInt,
-										Computed: true,
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The type of the data source.`,
 									},
-
 									"path": {
-										Type:     schema.TypeString,
-										Computed: true,
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The OBS storage path or MRS HDFS path.`,
 									},
-
+									"cluster_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the DWS/MRS cluster.`,
+									},
+									"database_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the DWS/DLI database.`,
+									},
+									"table_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the DWS/DLI table.`,
+									},
+									"user_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the DWS database user.`,
+									},
+									"queue_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the DLI queue.`,
+									},
 									"with_column_header": {
-										Type:     schema.TypeBool,
-										Computed: true,
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: `Whether the data contains table header when the type of dataset is 400 (table type).`,
 									},
 								},
 							},
+							Description: `The data sources which be used to imported the source data (such as pictures/files/audio,
+etc.) in this directory and subdirectories to the dataset.`,
 						},
-
 						"schemas": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"type": {
-										Type:     schema.TypeString,
-										Computed: true,
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The field type of the schema.`,
 									},
-
 									"name": {
-										Type:     schema.TypeString,
-										Computed: true,
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The field name of the schema.`,
 									},
 								},
 							},
+							Description: `The schema configurations of the dataset.`,
 						},
-
 						"labels": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"name": {
-										Type:     schema.TypeString,
-										Computed: true,
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the label.`,
 									},
-
 									"property_color": {
-										Type:     schema.TypeString,
-										Computed: true,
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The color of the label.`,
 									},
-
 									"property_shape": {
-										Type:     schema.TypeString,
-										Computed: true,
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The shape of the label.`,
 									},
-
 									"property_shortcut": {
-										Type:     schema.TypeString,
-										Computed: true,
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The shortcut of the label.`,
 									},
 								},
 							},
+							Description: `The labels of the dataset.`,
 						},
-
-						"created_at": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-
-						"status": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-
 						"data_format": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The data format of the dataset.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the dataset, in RFC3339 format.`,
+						},
+						"status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The status of the dataset.`,
 						},
 					},
 				},
+				Description: `The list of datasets that match the filter parameters.`,
 			},
 		},
 	}
 }
 
+func buildDatasetsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("name"); ok {
+		// Currently, `with_labels` can only be used when the query returns a small amount of data;
+		// large amounts of data will cause gateway timeouts.
+		res = fmt.Sprintf("%s&search_content=%v&with_labels=true", res, v)
+	}
+	if v, ok := d.GetOk("type"); ok {
+		res = fmt.Sprintf("%s&type=%v", res, v)
+	}
+	return res
+}
+
+func listDatasets(client *golangsdk.ServiceClient, queryParams string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/datasets?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	if queryParams != "" {
+		listPath += queryParams
+	}
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		datasets := utils.PathSearch("datasets", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, datasets...)
+		if len(datasets) < limit {
+			break
+		}
+	}
+	return result, nil
+}
+
+func flattenDatasets(datasets []interface{}) []map[string]interface{} {
+	if len(datasets) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(datasets))
+	for _, dataset := range datasets {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("dataset_id", dataset, nil),
+			"name":        utils.PathSearch("dataset_name", dataset, nil),
+			"type":        utils.PathSearch("dataset_type", dataset, nil),
+			"description": utils.PathSearch("description", dataset, nil),
+			"output_path": utils.PathSearch("work_path", dataset, nil),
+			"created_at":  utils.FormatTimeStampUTC(int64(utils.PathSearch("create_time", dataset, float64(0)).(float64)) / 1000),
+			"status":      utils.PathSearch("status", dataset, nil),
+			"data_format": utils.PathSearch("data_format", dataset, nil),
+			"data_source": flattenDatasetDataSource(utils.PathSearch("data_sources", dataset, make([]interface{}, 0)).([]interface{})),
+			"schemas":     flattenDatasetSchema(utils.PathSearch("schema", dataset, make([]interface{}, 0)).([]interface{})),
+			"labels":      flattenDatasetLabels(utils.PathSearch("labels", dataset, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result
+}
+
 func dataSourceDatasetsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ModelArtsV2Client(region)
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
 	if err != nil {
 		return diag.Errorf("error creating ModelArts v2 client, err=%s", err)
 	}
 
-	opts := dataset.ListOpts{
-		WithLabels:    true,
-		SearchContent: d.Get("name").(string),
-	}
-
-	if v, ok := d.GetOk("type"); ok {
-		dataType := v.(int)
-		opts.DatasetType = &dataType
-	}
-
-	page, err := dataset.List(client, opts)
+	datasets, err := listDatasets(client, buildDatasetsQueryParams(d))
 	if err != nil {
 		return diag.Errorf("error querying ModelArts datasets: %s ", err)
 	}
 
-	p, err := page.AllPages()
+	randUUID, err := uuid.GenerateUUID()
 	if err != nil {
-		return diag.Errorf("error querying ModelArts datasets: %s", err)
+		return diag.Errorf("unable to generate ID: %s", err)
 	}
+	d.SetId(randUUID)
 
-	datasets, err := dataset.ExtractDatasets(p)
-	if err != nil {
-		return diag.Errorf("error querying ModelArts datasets: %s", err)
-	}
-
-	var rst []map[string]interface{}
-	var ids []string
-	for _, v := range datasets {
-		item := map[string]interface{}{
-			"id":          v.DatasetId,
-			"name":        v.DatasetName,
-			"type":        v.DatasetType,
-			"description": v.Description,
-			"output_path": v.WorkPath,
-			"created_at":  utils.FormatTimeStampUTC(int64(v.CreateTime) / 1000),
-			"status":      v.Status,
-			"data_format": v.DataFormat,
-			"data_source": parseDataSource(v.DataSources),
-			"schemas":     parseSchemas(v.Schema),
-			"labels":      parseLabels(v.Labels),
-		}
-		rst = append(rst, item)
-		ids = append(ids, v.DatasetId)
-	}
-
-	err = d.Set("datasets", rst)
-	if err != nil {
-		return diag.Errorf("set datasets err:%s", err)
-	}
-
-	d.SetId(hashcode.Strings(ids))
-	return nil
-}
-
-func parseLabels(in []dataset.Label) []interface{} {
-	var result []interface{}
-	for _, v := range in {
-		item := map[string]interface{}{
-			"name":              v.Name,
-			"property_color":    v.Property.Color,
-			"property_shape":    v.Property.DefaultShape,
-			"property_shortcut": v.Property.Shortcut,
-		}
-
-		result = append(result, item)
-	}
-	return result
-}
-
-func parseDataSource(in []dataset.DataSource) []interface{} {
-	result := make([]interface{}, 1)
-	if len(in) >= 1 {
-		result[0] = map[string]interface{}{
-			"data_type":          in[0].DataType,
-			"path":               in[0].DataPath,
-			"with_column_header": in[0].WithColumnHeader,
-		}
-	}
-	return result
-}
-
-func parseSchemas(in []dataset.Field) []interface{} {
-	result := make([]interface{}, len(in))
-	for i, v := range in {
-		result[i] = map[string]interface{}{
-			"name": v.Name,
-			"type": v.Type,
-		}
-	}
-	return result
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("datasets", flattenDatasets(datasets)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
 }

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_dataset.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_dataset.go
@@ -2,22 +2,58 @@ package modelarts
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/modelarts/v2/dataset"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+type datasetSourceType int
+
+const (
+	datasetSourceTypeOBS datasetSourceType = 0
+	datasetSourceTypeDWS datasetSourceType = 1
+	datasetSourceTypeDLI datasetSourceType = 2
+	datasetSourceTypeMRS datasetSourceType = 4
+)
+
+var (
+	datasetNonUpdatableParams = []string{
+		"type",
+		"output_path",
+		"data_source",
+		"data_source.*.data_type",
+		"data_source.*.path",
+		"data_source.*.with_column_header",
+		"data_source.*.queue_name",
+		"data_source.*.database_name",
+		"data_source.*.table_name",
+		"data_source.*.user_name",
+		"data_source.*.password",
+		"data_source.*.cluster_id",
+		"schemas",
+		"schemas.*.type",
+		"schemas.*.name",
+		"import_labeled_enabled",
+		"label_format",
+		"label_format.*.type",
+		"label_format.*.text_label_separator",
+		"label_format.*.label_separator",
+	}
+	datasetNotFoundErrCodes = []string{
+		"ModelArts.4352",
+	}
 )
 
 // @API ModelArts DELETE /v2/{project_id}/datasets/{dataset_id}
@@ -30,161 +66,158 @@ func ResourceDataset() *schema.Resource {
 		ReadContext:   resourceDatasetRead,
 		UpdateContext: resourceDatasetUpdate,
 		DeleteContext: resourceDatasetDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(datasetNonUpdatableParams),
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the dataset is located.`,
 			},
 
+			// Required parameters.
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the dataset.`,
 			},
-
 			"type": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntInSlice([]int{0, 1, 3, 100, 101, 102, 200, 201, 202, 400, 600, 900}),
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The type of the dataset.`,
 			},
-
 			"output_path": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The OBS storage path that used to store output files.`,
 			},
-
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
 			"data_source": {
 				Type:     schema.TypeList,
 				Required: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem:     dataSourceSchemaResource(),
+				Description: `The data sources which be used to imported the source data (such as pictures/files/audio,
+etc.) in this directory and subdirectories to the dataset.`,
 			},
 
+			// Optional parameters.
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the dataset.`,
+			},
 			"schemas": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{"String", "Short", "Int", "Long", "Double",
-								"Float", "Byte", "Date", "Timestamp", "Boolean"}, false),
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The field type of the schema.`,
 						},
-
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The field name of the schema.`,
 						},
 					},
 				},
+				Description: `The schema configurations of the dataset.`,
 			},
-
 			"import_labeled_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether to enable the import labeled features.`,
 			},
-
 			"label_format": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							Default:      "1",
-							ValidateFunc: validation.StringInSlice([]string{"0", "1"}, false),
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "1",
+							Description: `The type of the label format.`,
 						},
-
 						"text_label_separator": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The separator between text and label.`,
 						},
-
 						"label_separator": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The separator between label and label.`,
 						},
 					},
 				},
-				Description: "It is required only the dataType=100",
+				Description: `The custom format of labeled features when import labeled files for Text classification.`,
 			},
-
 			"labels": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the label.`,
 						},
-
 						"property_color": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The color of the label.`,
 						},
-
 						"property_shape": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ValidateFunc: validation.StringInSlice([]string{"bndbox", "polygon", "circle", "line",
-								"dashed", "point", "polyline"}, false),
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The shape of the label.`,
 						},
-
 						"property_shortcut": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The shortcut of the label.`,
 						},
 					},
 				},
+				Description: `The labels of the dataset.`,
 			},
 
-			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"status": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-
+			// Attributes.
 			"data_format": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data format of the dataset.`,
 			},
-		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the dataset, in RFC3339 format.`,
+			},
+			"status": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The status of the dataset.`,
+			},
 		},
 	}
 }
@@ -193,61 +226,52 @@ func dataSourceSchemaResource() *schema.Resource {
 	nodeResource := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"data_type": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      0,
-				ValidateFunc: validation.IntInSlice([]int{0, 1, 2, 4}),
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     0,
+				Description: `The type of the data source.`,
 			},
-
 			"path": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The OBS storage path or MRS HDFS path.`,
 			},
-
-			"with_column_header": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  true,
-			},
-
-			"queue_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"database_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"table_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"user_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"password": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				ForceNew:  true,
-				Sensitive: true,
-			},
-
 			"cluster_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the DWS/MRS cluster.`,
+			},
+			"database_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the DWS/DLI database.`,
+			},
+			"table_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the DWS/DLI table.`,
+			},
+			"user_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the DWS database user.`,
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `The password of the DWS database user.`,
+			},
+			"queue_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the DLI queue.`,
+			},
+			"with_column_header": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether the data contains table header when the type of dataset is 400 (table type).`,
 			},
 		},
 	}
@@ -255,30 +279,320 @@ func dataSourceSchemaResource() *schema.Resource {
 	return &nodeResource
 }
 
-func resourceDatasetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ModelArtsV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating ModelArts v2 client, err=%s", err)
+func buildDatasetDataSource(dataSources []interface{}) ([]interface{}, error) {
+	var (
+		result = make([]interface{}, 0, len(dataSources))
+	)
+	for _, dataSource := range dataSources {
+		dataType := utils.PathSearch("data_type", dataSource, 0).(int)
+
+		item := map[string]interface{}{
+			"data_type":          dataType,
+			"with_column_header": utils.PathSearch("with_column_header", dataSource, true).(bool),
+		}
+		switch dataType {
+		case int(datasetSourceTypeOBS):
+			path := utils.PathSearch("path", dataSource, "").(string)
+			if path == "" {
+				return nil, errors.New("when import data from OBS, path is required")
+			}
+			item["data_path"] = path
+		case int(datasetSourceTypeDWS):
+			clusterId := utils.PathSearch("cluster_id", dataSource, "").(string)
+			databaseName := utils.PathSearch("database_name", dataSource, "").(string)
+			tableName := utils.PathSearch("table_name", dataSource, "").(string)
+			userName := utils.PathSearch("user_name", dataSource, "").(string)
+			password := utils.PathSearch("password", dataSource, "").(string)
+			if clusterId == "" || databaseName == "" || tableName == "" || userName == "" || password == "" {
+				return nil, errors.New("when import data from DWS, both cluster_id, database_name, table_name, user_name and password are required")
+			}
+			item["source_info"] = map[string]interface{}{
+				"cluster_id":    clusterId,
+				"database_name": databaseName,
+				"table_name":    tableName,
+				"user_name":     userName,
+				"user_password": password,
+			}
+		case int(datasetSourceTypeDLI):
+			queueName := utils.PathSearch("queue_name", dataSource, "").(string)
+			databaseName := utils.PathSearch("database_name", dataSource, "").(string)
+			tableName := utils.PathSearch("table_name", dataSource, "").(string)
+			if queueName == "" || databaseName == "" || tableName == "" {
+				return nil, errors.New("when import data from DLI, both queue_name, database_name and table_name are required")
+			}
+			item["source_info"] = map[string]interface{}{
+				"queue_name":    queueName,
+				"database_name": databaseName,
+				"table_name":    tableName,
+			}
+		case int(datasetSourceTypeMRS):
+			clusterId := utils.PathSearch("cluster_id", dataSource, "").(string)
+			path := utils.PathSearch("path", dataSource, "").(string)
+			if clusterId == "" || path == "" {
+				return nil, errors.New("when import data from MRS, both cluster_id and path are required")
+			}
+			item["source_info"] = map[string]interface{}{
+				"cluster_id": clusterId,
+				"input":      path,
+			}
+		}
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func buildDatasetSchema(datasetType int, schemas []interface{}) ([]interface{}, error) {
+	if datasetType == 400 && len(schemas) < 1 {
+		return nil, errors.New("the schema cannot be empty if type is 400 (table type)")
 	}
 
-	opts, err := buildCreateParamter(d)
-	if err != nil {
-		return diag.FromErr(err)
+	result := make([]interface{}, len(schemas))
+	for i, item := range schemas {
+		result[i] = map[string]interface{}{
+			"schema_id": i + 1,
+			"type":      utils.PathSearch("type", item, ""),
+			"name":      utils.PathSearch("name", item, ""),
+		}
 	}
-	rst, err := dataset.Create(client, *opts)
+	return result, nil
+}
+
+func buildDatasetLabelFormat(labelFormats []interface{}) map[string]interface{} {
+	if len(labelFormats) < 1 {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"label_type":            utils.PathSearch("type", labelFormats[0], ""),
+		"text_label_separator":  utils.PathSearch("text_label_separator", labelFormats[0], ""),
+		"text_sample_separator": utils.PathSearch("label_separator", labelFormats[0], ""),
+	}
+}
+
+func buildDatasetLabels(labels []interface{}) []interface{} {
+	if len(labels) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(labels))
+	for _, label := range labels {
+		result = append(result, map[string]interface{}{
+			"name": utils.PathSearch("name", label, ""),
+			"property": utils.RemoveNil(map[string]interface{}{
+				"@modelarts:color":         utils.ValueIgnoreEmpty(utils.PathSearch("property_color", label, "")),
+				"@modelarts:default_shape": utils.ValueIgnoreEmpty(utils.PathSearch("property_shape", label, "")),
+				"@modelarts:shortcut":      utils.ValueIgnoreEmpty(utils.PathSearch("property_shortcut", label, "")),
+			}),
+		})
+	}
+	return result
+}
+
+func buildCreateDatasetBodyParams(d *schema.ResourceData) (map[string]interface{}, error) {
+	datasetType := d.Get("type").(int)
+	dataSources, err := buildDatasetDataSource(d.Get("data_source").([]interface{}))
+	if err != nil {
+		return nil, err
+	}
+	schemas, err := buildDatasetSchema(datasetType, d.Get("schemas").([]interface{}))
+	if err != nil {
+		return nil, err
+	}
+	result := map[string]interface{}{
+		// Fixed values.
+		"work_path_type": 0,
+		"import_data":    true,
+		// Required parameters.
+		"dataset_name": d.Get("name").(string),
+		"dataset_type": datasetType,
+		"work_path":    d.Get("output_path").(string),
+		"data_sources": dataSources,
+		// Optional parameters.
+		"description":        d.Get("description").(string),
+		"import_annotations": utils.Bool(d.Get("import_labeled_enabled").(bool)),
+		"schema":             schemas,
+		"label_format":       buildDatasetLabelFormat(d.Get("label_format").([]interface{})),
+		"labels":             buildDatasetLabels(d.Get("labels").([]interface{})),
+	}
+	return result, nil
+}
+
+func createDataset(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	httpUrl := "v2/{project_id}/datasets"
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	bodyParams, err := buildCreateDatasetBodyParams(d)
+	if err != nil {
+		return nil, err
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(bodyParams),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func waitForDatasetStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, datasetId string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshDatasetStatusFunc(client, datasetId, []string{"1"}),
+		Timeout:      timeout,
+		Delay:        20 * time.Second,
+		PollInterval: 20 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for ModelArts dataset (%s) status to be completed: %s", datasetId, err)
+	}
+	return nil
+}
+
+func GetDatasetById(client *golangsdk.ServiceClient, datasetId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/datasets/{dataset_id}"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{dataset_id}", datasetId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(resp)
+}
+
+func refreshDatasetStatusFunc(client *golangsdk.ServiceClient, datasetId string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetDatasetById(client, datasetId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
+				return "RESOURCE_NOT_FOUND", "COMPLETED", nil
+			}
+			return respBody, "ERROR", err
+		}
+
+		unexpectedStatus := []string{
+			"4", // EXCEPTION
+		}
+
+		status := fmt.Sprintf("%v", utils.PathSearch("status", respBody, float64(0)).(float64))
+		if utils.StrSliceContains(unexpectedStatus, status) {
+			return respBody, "ERROR", fmt.Errorf("unexpected status (%s)", status)
+		}
+
+		if utils.StrSliceContains(targets, status) {
+			return respBody, "COMPLETED", nil
+		}
+
+		return respBody, "PENDING", nil
+	}
+}
+
+func resourceDatasetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	respBody, err := createDataset(client, d)
 	if err != nil {
 		return diag.Errorf("error creating ModelArts datasets: %s", err)
 	}
 
-	d.SetId(rst.DatasetId)
+	datasetId := utils.PathSearch("dataset_id", respBody, "").(string)
+	if datasetId == "" {
+		return diag.Errorf("unable to find the ModelArts dataset ID from the API response")
+	}
+	d.SetId(datasetId)
 
-	err = waitingforDatasetCreated(ctx, client, d.Id(), d.Timeout(schema.TimeoutCreate))
+	err = waitForDatasetStatusCompleted(ctx, client, datasetId, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	return resourceDatasetRead(ctx, d, meta)
+}
+
+func flattenDatasetDataSource(dataSources []interface{}) []interface{} {
+	if len(dataSources) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(dataSources))
+	for _, dataSource := range dataSources {
+		dataType := int(utils.PathSearch("data_type", dataSource, float64(0)).(float64))
+		elem := map[string]interface{}{
+			"data_type":          dataType,
+			"cluster_id":         utils.PathSearch("source_info.cluster_id", dataSource, "").(string),
+			"queue_name":         utils.PathSearch("source_info.queue_name", dataSource, "").(string),
+			"path":               utils.PathSearch("data_path", dataSource, "").(string),
+			"with_column_header": utils.PathSearch("with_column_header", dataSource, true).(bool),
+			"database_name":      utils.PathSearch("source_info.database_name", dataSource, "").(string),
+			"table_name":         utils.PathSearch("source_info.table_name", dataSource, "").(string),
+			"user_name":          utils.PathSearch("source_info.user_name", dataSource, "").(string),
+		}
+		if dataType == int(datasetSourceTypeMRS) {
+			elem["path"] = utils.PathSearch("source_info.input", dataSource, "").(string)
+		}
+		result = append(result, elem)
+	}
+	return result
+}
+
+func flattenDatasetSchema(schemas []interface{}) []interface{} {
+	if len(schemas) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(schemas))
+
+	for _, item := range schemas {
+		result = append(result, map[string]interface{}{
+			"type": utils.PathSearch("type", item, "").(string),
+			"name": utils.PathSearch("name", item, "").(string),
+		})
+	}
+	return result
+}
+
+func flattenDatasetLabels(labels []interface{}) []interface{} {
+	if len(labels) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(labels))
+	for _, label := range labels {
+		result = append(result, map[string]interface{}{
+			"name":              utils.PathSearch("name", label, "").(string),
+			"property_color":    utils.PathSearch("property.@modelarts:color", label, "").(string),
+			"property_shape":    utils.PathSearch("property.@modelarts:default_shape", label, "").(string),
+			"property_shortcut": utils.PathSearch("property.@modelarts:shortcut", label, "").(string),
+		})
+	}
+	return result
 }
 
 func resourceDatasetRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -286,301 +600,125 @@ func resourceDatasetRead(_ context.Context, d *schema.ResourceData, meta interfa
 	region := cfg.GetRegion(d)
 	client, err := cfg.ModelArtsV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating ModelArts v2 client, err=%s", err)
+		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	detail, err := dataset.Get(client, d.Id(), dataset.GetOpts{})
+	detail, err := GetDatasetById(client, d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, parseDatasetErrorToError404(err), "error retrieving ModelArts dataset")
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", datasetNotFoundErrCodes...),
+			"error retrieving ModelArts dataset")
 	}
 
 	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("name", detail.DatasetName),
-		d.Set("type", detail.DatasetType),
-		d.Set("data_format", detail.DataFormat),
-		d.Set("output_path", detail.WorkPath),
-		d.Set("description", detail.Description),
-		setDataSourcesToState(d, detail.DataSources[0]),
-		setSchemaToState(d, detail.Schema),
-		d.Set("import_labeled_enabled", detail.ImportData),
-		setLabelsToState(d, detail.Labels),
-		d.Set("created_at", utils.FormatTimeStampUTC(int64(detail.CreateTime)/1000)),
-		d.Set("status", detail.Status),
+		// Required parameters.
+		d.Set("name", utils.PathSearch("dataset_name", detail, nil)),
+		d.Set("type", utils.PathSearch("dataset_type", detail, nil)),
+		d.Set("output_path", utils.PathSearch("work_path", detail, nil)),
+		d.Set("data_source", flattenDatasetDataSource(utils.PathSearch("data_sources", detail, make([]interface{}, 0)).([]interface{}))),
+		// Optional parameters.
+		d.Set("description", utils.PathSearch("description", detail, nil)),
+		d.Set("schemas", flattenDatasetSchema(utils.PathSearch("schema", detail, make([]interface{}, 0)).([]interface{}))),
+		d.Set("labels", flattenDatasetLabels(utils.PathSearch("labels", detail, make([]interface{}, 0)).([]interface{}))),
+		d.Set("data_format", utils.PathSearch("data_format", detail, nil)),
+		d.Set("import_labeled_enabled", utils.PathSearch("import_data", detail, nil)),
+		d.Set("created_at", utils.FormatTimeStampUTC(int64(utils.PathSearch("create_time", detail, float64(0)).(float64))/1000)),
+		d.Set("status", int(utils.PathSearch("status", detail, float64(0)).(float64))),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceDatasetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ModelArtsV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating ModelArts v2 client, err=%s", err)
-	}
-
-	_, err = dataset.Get(client, d.Id(), dataset.GetOpts{})
-	if err != nil {
-		return common.CheckDeletedDiag(d, parseDatasetErrorToError404(err), "error retrieving ModelArts dataset")
-	}
-
-	desc := d.Get("description").(string)
-	updateParams := dataset.UpdateOpts{
-		DatasetName: d.Get("name").(string),
-		Description: &desc,
+func buildUpdateDatasetBodyParams(d *schema.ResourceData) map[string]interface{} {
+	result := map[string]interface{}{
+		// Required parameters.
+		"dataset_name": d.Get("name").(string),
+		// Optional parameters.
+		"description": d.Get("description").(string),
 	}
 
 	if d.HasChange("labels") {
-		o, n := d.GetChange("labels")
-		updateParams.AddLabels = buildLabelsParamter(n)
-		updateParams.DeleteLabels = buildLabelsParamter(o)
+		oldVal, newVal := d.GetChange("labels")
+		result["add_labels"] = utils.ValueIgnoreEmpty(buildDatasetLabels(newVal.([]interface{})))
+		result["delete_labels"] = utils.ValueIgnoreEmpty(buildDatasetLabels(oldVal.([]interface{})))
 	}
 
-	rst := dataset.Update(client, d.Id(), updateParams)
-	if rst.Err != nil {
-		return diag.Errorf("update ModelArts dataset=%s failed, error: %s", d.Id(), err)
+	return result
+}
+
+func updateDataset(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl   = "v2/{project_id}/datasets/{dataset_id}"
+		datasetId = d.Id()
+	)
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{dataset_id}", datasetId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdateDatasetBodyParams(d)),
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("PUT", updatePath, &opt)
+	return err
+}
+
+func resourceDatasetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	err = updateDataset(client, d)
+	if err != nil {
+		return diag.Errorf("error updating ModelArts dataset: %s", err)
 	}
 
 	return resourceDatasetRead(ctx, d, meta)
 }
 
-func resourceDatasetDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ModelArtsV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating ModelArts v2 client, err=%s", err)
-	}
+func deleteDataset(client *golangsdk.ServiceClient, datasetId string) error {
+	httpUrl := "v2/{project_id}/datasets/{dataset_id}"
 
-	dErr := dataset.Delete(client, d.Id())
-	if dErr.Err != nil {
-		return common.CheckDeletedDiag(d, parseDatasetErrorToError404(err), "Delete ModelArts dataset failed")
-	}
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{dataset_id}", datasetId)
 
-	return nil
-}
-
-func waitingforDatasetCreated(ctx context.Context, client *golangsdk.ServiceClient, id string,
-	timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"0", "5", "6", "7", "8"},
-		Target:  []string{"1"},
-		Refresh: func() (interface{}, string, error) {
-			resp, err := dataset.Get(client, id, dataset.GetOpts{})
-			if err != nil {
-				return nil, "", err
-			}
-			return resp, fmt.Sprint(resp.Status), nil
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
 		},
-		Timeout:      timeout,
-		PollInterval: 20 * time.Second,
-		Delay:        20 * time.Second,
 	}
 
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err := client.Request("DELETE", deletePath, &opt)
+	return err
+}
+
+func resourceDatasetDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
 	if err != nil {
-		return fmt.Errorf("error waiting for ModelArts dataset (%s) to be created: %s", id, err)
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	err = deleteDataset(client, d.Id())
+	if err != nil {
+		return diag.Errorf("error deleting ModelArts dataset: %s", err)
 	}
 	return nil
-}
-
-func buildCreateParamter(d *schema.ResourceData) (*dataset.CreateOpts, error) {
-	dataSources, err := buildDataSourceParamter(d)
-	if err != nil {
-		return nil, err
-	}
-
-	dataType := d.Get("type").(int)
-	schemas, err := buildSchemaParamter(d.Get("schemas"), dataType)
-	if err != nil {
-		return nil, err
-	}
-
-	rst := dataset.CreateOpts{
-		DatasetName:       d.Get("name").(string),
-		DatasetType:       dataType,
-		WorkPathType:      0,
-		DataSources:       dataSources,
-		WorkPath:          d.Get("output_path").(string),
-		Description:       d.Get("description").(string),
-		ImportData:        true,
-		ImportAnnotations: utils.Bool(d.Get("import_labeled_enabled").(bool)),
-		Schema:            schemas,
-		Labels:            buildLabelsParamter(d.Get("labels")),
-	}
-
-	if format := buildLabelFormatParamter(d); format != nil {
-		rst.LabelFormat = *format
-	}
-
-	return &rst, nil
-}
-
-func buildLabelFormatParamter(d *schema.ResourceData) *dataset.LabelFormat {
-	if v, ok := d.GetOk("label_format"); ok {
-		configRaw := v.([]interface{})[0].(map[string]interface{})
-		configs := dataset.LabelFormat{
-			LabelType:           configRaw["type"].(string),
-			TextLabelSeparator:  configRaw["text_label_separator"].(string),
-			TextSampleSeparator: configRaw["label_separator"].(string),
-		}
-		return &configs
-	}
-	return nil
-}
-
-func buildDataSourceParamter(d *schema.ResourceData) (dataSources []dataset.DataSource, err error) {
-	item := d.Get("data_source").([]interface{})[0].(map[string]interface{})
-
-	dataType := item["data_type"].(int)
-	dataSource := dataset.DataSource{
-		DataType:         dataType,
-		WithColumnHeader: utils.Bool(item["with_column_header"].(bool)),
-	}
-
-	path := item["path"].(string)
-	// OBS check
-	if dataType == 0 {
-		if path == "" {
-			err = fmt.Errorf("when import data from OBS, path is required")
-			return
-		}
-		dataSource.DataPath = path
-	}
-
-	clusterId := item["cluster_id"].(string)
-	databaseName := item["database_name"].(string)
-	tableName := item["table_name"].(string)
-	userName := item["user_name"].(string)
-	password := item["password"].(string)
-
-	// DWS check
-	if dataType == 1 {
-		if clusterId == "" || databaseName == "" || tableName == "" || userName == "" || password == "" {
-			err = fmt.Errorf("when import data from DWS, cluster_id, database_name, table_name, user_name and" +
-				" password are required")
-			return
-		}
-
-		dataSource.SourceInfo.ClusterId = clusterId
-		dataSource.SourceInfo.DatabaseName = databaseName
-		dataSource.SourceInfo.TableName = tableName
-		dataSource.SourceInfo.UserName = userName
-		dataSource.SourceInfo.UserPassword = password
-	}
-
-	queueName := item["queue_name"].(string)
-
-	// DLI check
-	if dataType == 2 {
-		if queueName == "" || databaseName == "" || tableName == "" {
-			err = fmt.Errorf("when import data from DLI, queue_name, database_name and table_name are required")
-		}
-
-		dataSource.SourceInfo.QueueName = queueName
-		dataSource.SourceInfo.DatabaseName = databaseName
-		dataSource.SourceInfo.TableName = tableName
-	}
-
-	// MRS check
-	if dataType == 4 {
-		if clusterId == "" || path == "" {
-			err = fmt.Errorf("when import data from MRS, cluster_id and path are required")
-		}
-
-		dataSource.SourceInfo.ClusterId = clusterId
-		dataSource.SourceInfo.Input = path
-	}
-
-	dataSources = append(dataSources, dataSource)
-	return
-}
-
-func buildLabelsParamter(v interface{}) (labels []dataset.Label) {
-	if v != nil {
-		configRaw := v.([]interface{})
-		for _, item := range configRaw {
-			tmp := item.(map[string]interface{})
-			labels = append(labels, dataset.Label{
-				Name: tmp["name"].(string),
-				Property: dataset.LabelProperty{
-					Color:        tmp["property_color"].(string),
-					DefaultShape: tmp["property_shape"].(string),
-					Shortcut:     tmp["property_shortcut"].(string),
-				},
-			})
-		}
-	}
-	return
-}
-
-func buildSchemaParamter(v interface{}, dataType int) (schemas []dataset.Field, err error) {
-	if v != nil && dataType == 400 {
-		configRaw := v.([]interface{})
-		if len(configRaw) == 0 {
-			err = fmt.Errorf("the schema cannot be empty if type is 400(Table type)")
-			return
-		}
-		for i, item := range configRaw {
-			tmp := item.(map[string]interface{})
-			schemas = append(schemas, dataset.Field{
-				SchemaId: i + 1,
-				Name:     tmp["name"].(string),
-				Type:     tmp["type"].(string),
-			})
-		}
-	}
-	return
-}
-
-func parseDatasetErrorToError404(respErr error) error {
-	var apiError dataset.CreateResp
-	if errCode, ok := respErr.(golangsdk.ErrDefault400); ok {
-		pErr := json.Unmarshal(errCode.Body, &apiError)
-		if pErr == nil && (apiError.ErrorCode == "ModelArts.4352") {
-			return golangsdk.ErrDefault404(errCode)
-		}
-	}
-	return respErr
-}
-
-func setDataSourcesToState(d *schema.ResourceData, ds dataset.DataSource) error {
-	result := make([]interface{}, 1)
-	item := map[string]interface{}{
-		"data_type":          ds.DataType,
-		"path":               ds.DataPath,
-		"with_column_header": ds.WithColumnHeader,
-	}
-	// the API lost some info: queue_name,database_name,table_name,user_name,password,cluster_id,input
-	if ds.DataType == 4 {
-		item["path"] = ds.SourceInfo.Input
-	}
-
-	result[0] = item
-	return d.Set("data_source", result)
-}
-
-func setLabelsToState(d *schema.ResourceData, labels []dataset.Label) error {
-	result := make([]interface{}, len(labels))
-	for i, v := range labels {
-		result[i] = map[string]interface{}{
-			"name":              v.Name,
-			"property_color":    v.Property.Color,
-			"property_shape":    v.Property.DefaultShape,
-			"property_shortcut": v.Property.Shortcut,
-		}
-	}
-	return d.Set("labels", result)
-}
-
-func setSchemaToState(d *schema.ResourceData, in []dataset.Field) error {
-	result := make([]interface{}, len(in))
-	for i, v := range in {
-		result[i] = map[string]interface{}{
-			"name": v.Name,
-			"type": v.Type,
-		}
-	}
-	return d.Set("schemas", result)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adjust the resource coding for dataset
currently, the resource and data source logics cannot make the corresponding acceptance tests runs well.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the resource coding for dataset (resource and data source).
2. update the parameter descriptions of the document.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDatasetVersion_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDatasetVersion_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasetVersion_basic
=== PAUSE TestAccDatasetVersion_basic
=== CONT  TestAccDatasetVersion_basic
--- PASS: TestAccDatasetVersion_basic (158.68s)
PASS
coverage: 7.6% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 158.774s        coverage: 7.6% of statements in ./huaweicloud/services/modelarts
```
```
./scripts/coverage.sh -o modelarts -f TestAccDataSourceDatasetVersions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataSourceDatasetVersions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDatasetVersions_basic
=== PAUSE TestAccDataSourceDatasetVersions_basic
=== CONT  TestAccDataSourceDatasetVersions_basic
--- PASS: TestAccDataSourceDatasetVersions_basic (194.91s)
PASS
coverage: 8.2% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 195.057s        coverage: 8.2% of statements in ./huaweicloud/services/modelarts
```
```
./scripts/coverage.sh -o modelarts -f TestAccDataSourceDatasets_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataSourceDatasets_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDatasets_basic
=== PAUSE TestAccDataSourceDatasets_basic
=== CONT  TestAccDataSourceDatasets_basic
--- PASS: TestAccDataSourceDatasets_basic (144.51s)
PASS
coverage: 7.5% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 144.615s        coverage: 7.5% of statements in ./huaweicloud/services/modelarts
```
```
./scripts/coverage.sh -o modelarts -f TestAccDataset_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataset_basic -timeout 360m -parallel 10
=== RUN   TestAccDataset_basic
=== PAUSE TestAccDataset_basic
=== CONT  TestAccDataset_basic
--- PASS: TestAccDataset_basic (159.94s)
PASS
coverage: 7.0% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 160.031s        coverage: 7.0% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
