### PR TITLE
feat(drs): new datasource to query table compare

### DIFF
--- a/docs/data-sources/drs_table_compare.md
+++ b/docs/data-sources/drs_table_compare.md
@@ -1,0 +1,100 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_table_compare"
+description: |-
+  Use this data source to get the table comparison result of specified DRS job within HuaweiCloud.
+---
+
+# huaweicloud_drs_table_compare
+
+Use this data source to get the table comparison result of specified DRS job within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+data "huaweicloud_drs_table_compare" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the job ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `compare_jobs` - The table comparison task information.
+
+  The [compare_jobs](#compare_jobs_struct) structure is documented below.
+
+<a name="compare_jobs_struct"></a>
+The `compare_jobs` block supports:
+
+* `id` - The comparison task ID.
+
+* `type` - The comparison type.
+  The valid values are as follows:
+  + **lines**: Row count comparison.
+  + **contents**: Content comparison.
+  + **random**: Sample comparison, currently only supports GaussDB distributed to GaussDB distributed, GaussDB
+    distributed to PostgreSQL, GaussDB centralized to PostgreSQL synchronization links.
+
+* `options` - The comparison configuration items in key-value format.
+  Content comparison supports the following configuration items:
+  + Comparison method configuration, key: **contentCompareType**, value: **dynamic** for dynamic comparison, **static**
+    for static comparison.
+  + LOB field comparison type configuration, key: **lobCompare**, value: **ignore** for ignoring, **length** for length
+    comparison. Row count comparison supports the following configuration items:
+  + Comparison strategy configuration, applicable for multi-table merging, key: **comparePolicy**, value: **normal** for
+    normal comparison, **manyToOne** for many-to-one comparison.
+
+* `start_time` - The start time of the comparison task, UTC time, for example: **2024-04-09T18:50:20Z**.
+
+* `end_time` - The end time of the comparison task, UTC time, for example: **2024-04-09T18:50:20Z**.
+
+* `status` - The status of the comparison task.
+  The valid values are as follows:
+  + **RUNNING**: Running.
+  + **WAITING_FOR_RUNNING**: Waiting to start.
+  + **SUCCESSFUL**: Completed.
+  + **FAILED**: Failed.
+  + **CANCELLED**: Cancelled.
+  + **TIMEOUT_INTERRUPT**: Timeout interrupted.
+  + **FULL_DOING**: Full verification in progress.
+  + **INCRE_DOING**: Incremental verification in progress.
+
+* `export_status` - The status of generating the comparison result report file.
+  The valid values are as follows:
+  + **INIT**: Initial state.
+  + **EXPORTING**: Comparison result exporting.
+  + **EXPORT_COMPLETE**: Comparison result export completed.
+  + **EXPORT_COMMON_FAILED**: Comparison result export failed.
+
+* `report_remain_seconds` - The remaining validity time of the comparison result report file, in seconds.
+
+* `compare_job_tag` - The tags of the comparison task, currently only returned when the comparison strategy is involved.
+
+* `proportion_value` - The sampling proportion, filled in when the comparison type is sample comparison.
+
+* `database_info` - The business/disaster recovery database information during the comparison task.
+
+  The [database_info](#database_info_struct) structure is documented below.
+
+<a name="database_info_struct"></a>
+The `database_info` block supports:
+
+* `service_database` - The business database information.
+
+* `disaster_recovery_database` - The disaster recovery database information.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1335,6 +1335,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_object_mappings":        drs.DataSourceDrsObjectMappings(),
 			"huaweicloud_drs_quotas":                 drs.DataSourceDrsQuotas(),
 			"huaweicloud_drs_subscriptions":          drs.DataSourceDrsSubscriptions(),
+			"huaweicloud_drs_table_compare":          drs.DataSourceDrsTableCompare(),
 			"huaweicloud_drs_tags":                   drs.DataSourceDrsTags(),
 			"huaweicloud_drs_timelines":              drs.DataSourceDrsTimelines(),
 			"huaweicloud_drs_drivers":                drs.DataSourceDrsDrivers(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_table_compare_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_table_compare_test.go
@@ -1,0 +1,42 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsTableCompare_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_table_compare.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDrsTableCompare_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "compare_jobs.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDrsTableCompare_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_table_compare" "test" {
+  job_id = "%s"
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_table_compare.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_table_compare.go
@@ -1,0 +1,211 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v3/{project_id}/jobs/{job_id}/table/compare
+func DataSourceDrsTableCompare() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTableCompareRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"compare_jobs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"options": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"start_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"end_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"export_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"report_remain_seconds": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"compare_job_tag": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"proportion_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"database_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"service_database": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"disaster_recovery_database": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildTableCompareQueryParams(offset int) string {
+	if offset == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("?offset=%d", offset)
+}
+
+func dataSourceTableCompareRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		jobId   = d.Get("job_id").(string)
+		httpUrl = "v3/{project_id}/jobs/{job_id}/table/compare"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		requestPathWithOffset := requestPath + buildTableCompareQueryParams(offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DRS table compare: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		compareJobs := utils.PathSearch("compare_jobs", respBody, make([]interface{}, 0)).([]interface{})
+		if len(compareJobs) == 0 {
+			break
+		}
+
+		result = append(result, compareJobs...)
+		offset += len(compareJobs)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("compare_jobs", flattenCompareJobs(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCompareJobs(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(respArray))
+	for _, item := range respArray {
+		optionsMap := utils.PathSearch("options", item, make(map[string]interface{})).(map[string]interface{})
+		compareJobTagMap := utils.PathSearch("compare_job_tag", item, make(map[string]interface{})).(map[string]interface{})
+
+		result = append(result, map[string]interface{}{
+			"id":                    utils.PathSearch("id", item, nil),
+			"type":                  utils.PathSearch("type", item, nil),
+			"options":               utils.ExpandToStringMap(optionsMap),
+			"start_time":            utils.PathSearch("start_time", item, nil),
+			"end_time":              utils.PathSearch("end_time", item, nil),
+			"status":                utils.PathSearch("status", item, nil),
+			"export_status":         utils.PathSearch("export_status", item, nil),
+			"report_remain_seconds": utils.PathSearch("report_remain_seconds", item, nil),
+			"compare_job_tag":       utils.ExpandToStringMap(compareJobTagMap),
+			"proportion_value":      utils.PathSearch("proportion_value", item, nil),
+			"database_info":         flattenTableDatabaseInfo(utils.PathSearch("database_info", item, nil)),
+		})
+	}
+	return result
+}
+
+func flattenTableDatabaseInfo(respMap interface{}) []interface{} {
+	if respMap == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"service_database":           utils.PathSearch("service_database", respMap, nil),
+			"disaster_recovery_database": utils.PathSearch("disaster_recovery_database", respMap, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query table compare

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o drs -f TestAccDataSourceDrsTableCompare_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsTableCompare_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsTableCompare_basic
=== PAUSE TestAccDataSourceDrsTableCompare_basic
=== CONT  TestAccDataSourceDrsTableCompare_basic
--- PASS: TestAccDataSourceDrsTableCompare_basic (17.33s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       17.443s coverage: 4.2% of statements in ./huaweicloud/services/drs
```
<img width="1292" height="84" alt="image" src="https://github.com/user-attachments/assets/37c3387f-92ba-4743-b012-b30eeb962789" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
