### PR TITLE
feat(modelarts): supports new one-time action resource to store notebook image

### DIFF
--- a/docs/resources/modelarts_notebook_image_store.md
+++ b/docs/resources/modelarts_notebook_image_store.md
@@ -1,0 +1,93 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_notebook_image_store"
+description: |-
+  Use this resource to save a notebook instance image to ModelArts within HuaweiCloud.
+---
+
+# huaweicloud_modelarts_notebook_image_store
+
+Use this resource to save a notebook instance image to ModelArts within HuaweiCloud.
+
+-> This resource is only a one-time action resource for storing the notebook image in ModelArts side.
+   Deleting this resource will not clear the corresponding image (version) record, but will only remove the resource
+   information from the tfstate file.
+
+~> Storing the image will map the original image used by the notebook to the current image, and will change the value of
+   `image_id` parameter for the corresponding notebook resource. To avoid this change, it's a recommended to use the
+   `lifecycle.ignore_changes` to ignore it.
+
+## Example Usage
+
+```hcl
+variable "image_name" {}
+variable "swr_organization_name" {}
+
+resource "huaweicloud_modelarts_notebook" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      image_id,
+    ]
+  }
+}
+
+resource "huaweicloud_modelarts_notebook_image_store" "test" {
+  notebook_id = huaweicloud_modelarts_notebook.test.id
+  name        = var.image_name
+  namespace   = var.swr_organization_name
+  tag         = "v1.0.0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the notebook is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `notebook_id` - (Required, String, NonUpdatable) Specifies the ID of the notebook instance from which the image is saved.
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the image.
+
+* `namespace` - (Required, String, NonUpdatable) Specifies the SWR organization name of the image.
+
+* `tag` - (Optional, String, NonUpdatable) Specifies the version tag of the image.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the image.
+
+* `workspace_id` - (Optional, String, NonUpdatable) Specifies the workspace ID to which the image belongs.  
+  Defaults to **0**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The image ID.
+
+* `swr_path` - The SWR path of the image.
+
+* `arch` - The processor architecture type supported by the image.
+
+* `origin` - The origin of the image.
+
+* `resource_categories` - The resource categories supported by the image.
+
+* `service_type` - The service type supported by the image.
+
+* `visibility` - The visibility of the image.
+
+* `status` - The status of the image.
+
+* `type` - The type of the image.
+
+* `created_at` - The creation time of the image, in RFC3339 format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3994,6 +3994,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_model":                           modelarts.ResourceModelartsModel(),
 			"huaweicloud_modelarts_network":                         modelarts.ResourceNetwork(),
 			"huaweicloud_modelarts_notebook":                        modelarts.ResourceNotebook(),
+			"huaweicloud_modelarts_notebook_image_store":            modelarts.ResourceNotebookImageStore(),
 			"huaweicloud_modelarts_notebook_mount_storage":          modelarts.ResourceNotebookMountStorage(),
 			"huaweicloud_modelarts_resource_pool":                   modelarts.ResourceModelartsResourcePool(),
 			"huaweicloud_modelarts_resource_pool_node_batch_resize": modelarts.ResourceResourcePoolNodeBatchResize(),

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_image_store_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_image_store_test.go
@@ -1,0 +1,109 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccNotebookImageStore_basic(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_modelarts_notebook_image_store.test"
+		name         = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		// This resource is a one-time action resource and there is no logic in the delete method.
+		// lintignore:AT001
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotebookImageStore_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "tag", "v1.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(resourceName, "notebook_id",
+						"huaweicloud_modelarts_notebook.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "namespace", acceptance.HW_DOMAIN_NAME),
+					resource.TestCheckResourceAttrSet(resourceName, "swr_path"),
+					resource.TestCheckResourceAttrSet(resourceName, "arch"),
+					resource.TestCheckResourceAttrSet(resourceName, "origin"),
+					resource.TestCheckResourceAttrSet(resourceName, "type"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccNotebookImageStore_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_modelarts_notebook_flavors" "test" {
+  type     = "MANAGED"
+  category = "CPU"
+}
+
+locals {
+  available_notebook_flavors_with_onsale = [
+    for o in data.huaweicloud_modelarts_notebook_flavors.test.flavors : o if
+    !o.sold_out && !strcontains(o.id, "free")
+  ]
+}
+
+data "huaweicloud_modelarts_notebook_images" "test" {
+  type     = "BUILD_IN"
+  cpu_arch = try(data.huaweicloud_modelarts_notebook_flavors.test.flavors[0].arch, "x86_64")
+}
+
+locals {
+  available_notebook_images_with_onsale = [
+    for o in data.huaweicloud_modelarts_notebook_images.test.images : o if
+    contains(o.resource_categories, "CPU") && o.status == "ACTIVE" && contains(o.dev_services, "NOTEBOOK")
+  ]
+}
+
+resource "huaweicloud_modelarts_notebook" "test" {
+  name      = "%[1]s"
+  flavor_id = try(local.available_notebook_flavors_with_onsale[0].id, null)
+  image_id  = try(local.available_notebook_images_with_onsale[0].id, null)
+
+  volume {
+    type      = "EVS"
+    ownership = "MANAGED"
+    size      = 40
+  }
+
+  lifecycle {
+    ignore_changes = [image_id]
+  }
+}
+`, name)
+}
+
+func testAccNotebookImageStore_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelarts_notebook_image_store" "test" {
+  notebook_id = huaweicloud_modelarts_notebook.test.id
+  name        = "%[2]s"
+  namespace   = "%[3]s"
+  tag         = "v1.0.0"
+  description = "Created by terraform script"
+
+  enable_force_new = "true"
+}
+`, testAccNotebookImageStore_base(name), name, acceptance.HW_DOMAIN_NAME)
+}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_notebook_image_store.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_notebook_image_store.go
@@ -1,0 +1,339 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	notebookImageStoreNonUpdatableParams = []string{
+		"notebook_id",
+		"name",
+		"namespace",
+		"tag",
+		"description",
+		"workspace_id",
+		"swr_instance_id",
+		"swr_instance_domain",
+	}
+	storedNotebookImageNotFoundErrCodes = []string{
+		"ModelArts.6404",
+	}
+)
+
+// @API ModelArts POST /v1/{project_id}/notebooks/{id}/create-image
+// @API ModelArts GET /v1/{project_id}/images/{id}
+func ResourceNotebookImageStore() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNotebookImageStoreCreate,
+		ReadContext:   resourceNotebookImageStoreRead,
+		UpdateContext: resourceNotebookImageStoreUpdate,
+		DeleteContext: resourceNotebookImageStoreDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(notebookImageStoreNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the notebook is located.`,
+			},
+
+			// Required parameters.
+			"notebook_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the notebook instance.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the image.`,
+			},
+			"namespace": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The namespace of the image.`,
+			},
+
+			// Optional parameters.
+			"tag": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The tag of the image.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the image.`,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The workspace ID to which the image belongs.`,
+			},
+
+			// Attributes.
+			"swr_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The SWR path of the image.`,
+			},
+			"arch": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The processor architecture type supported by the image.`,
+			},
+			"origin": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The origin of the image.`,
+			},
+			"resource_categories": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The resource categories supported by the image.`,
+			},
+			"service_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The service type supported by the image.`,
+			},
+			"visibility": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The visibility of the image.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the image.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the image.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the image, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+						Required: true,
+					}),
+			},
+		},
+	}
+}
+
+func buildNotebookImageStoreBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":         d.Get("name"),
+		"namespace":    d.Get("namespace"),
+		"tag":          utils.ValueIgnoreEmpty(d.Get("tag")),
+		"description":  utils.ValueIgnoreEmpty(d.Get("description")),
+		"workspace_id": utils.ValueIgnoreEmpty(d.Get("workspace_id")),
+	}
+}
+
+func createNotebookImageStore(client *golangsdk.ServiceClient, notebookId string, d *schema.ResourceData) (interface{}, error) {
+	httpURL := "v1/{project_id}/notebooks/{id}/create-image"
+
+	createPath := client.Endpoint + httpURL
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{id}", notebookId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildNotebookImageStoreBodyParams(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(createResp)
+}
+
+func refreshNotebookImageStoreStatusFunc(client *golangsdk.ServiceClient, imageId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := getNotebookImageStoreById(client, imageId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", respBody, "").(string)
+		unexpectedStatus := []string{
+			"CREATE_FAILED",
+			"ERROR",
+		}
+		if utils.StrSliceContains(unexpectedStatus, status) {
+			return respBody, "ERROR", fmt.Errorf("unexpected status (%s)", status)
+		}
+
+		if status == "ACTIVE" {
+			return respBody, "COMPLETED", nil
+		}
+		return "continue", "PENDING", nil
+	}
+}
+
+func waitForNotebookImageStoreStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, imageId string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshNotebookImageStoreStatusFunc(client, imageId),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceNotebookImageStoreCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		notebookId = d.Get("notebook_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	respBody, err := createNotebookImageStore(client, notebookId, d)
+	if err != nil {
+		return diag.Errorf("error saving image from notebook (%s): %s", notebookId, err)
+	}
+
+	imageId := utils.PathSearch("id", respBody, "").(string)
+	if imageId == "" {
+		return diag.Errorf("unable to find the image ID from the API response")
+	}
+	d.SetId(imageId)
+
+	if err = waitForNotebookImageStoreStatusCompleted(ctx, client, imageId, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for the image (%s) saved from notebook (%s) to complete: %s", imageId, notebookId, err)
+	}
+
+	return resourceNotebookImageStoreRead(ctx, d, meta)
+}
+
+func getNotebookImageStoreById(client *golangsdk.ServiceClient, imageId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/images/{id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", imageId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceNotebookImageStoreRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		imageId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	respBody, err := getNotebookImageStoreById(client, imageId)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", storedNotebookImageNotFoundErrCodes...),
+			fmt.Sprintf("error retrieving ModelArts notebook image storage (%s)", imageId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		// Required parameters.
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("namespace", utils.PathSearch("namespace", respBody, nil)),
+		// Optional parameters.
+		d.Set("workspace_id", utils.PathSearch("workspace_id", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("tag", utils.PathSearch("tag", respBody, nil)),
+		// Attributes.
+		d.Set("swr_path", utils.PathSearch("swr_path", respBody, nil)),
+		d.Set("arch", utils.PathSearch("arch", respBody, nil)),
+		d.Set("origin", utils.PathSearch("origin", respBody, nil)),
+		d.Set("resource_categories", utils.PathSearch("resource_categories", respBody, nil)),
+		d.Set("service_type", utils.PathSearch("service_type", respBody, nil)),
+		d.Set("visibility", utils.PathSearch("visibility", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("type", utils.PathSearch("type", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_at", respBody, float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceNotebookImageStoreUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceNotebookImageStoreDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for storing the notebook image in ModelArts side.
+Deleting this resource will not clear the corresponding image (version) record, but will only remove the resource
+information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new one-time action resource to store notebook image:
```
huaweicloud_modelarts_notebook_image
```
Deleting a notebook image requires that the image is not in use. In other words, you must first delete the notebook or switch the notebook image to another image before deleting the image. Otherwise, the image deletion interface will throw an error due to image usage issues, which can lead to a deadlock in Terraform's workflow.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1044" height="214" alt="image" src="https://github.com/user-attachments/assets/13e11a25-f518-4246-a50d-ea6fc60d1ae8" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new one-time action resource to store notebook image
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccNotebookImageStore_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccNotebookImageStore_basic -timeout 360m -parallel 10
=== RUN   TestAccNotebookImageStore_basic
=== PAUSE TestAccNotebookImageStore_basic
=== CONT  TestAccNotebookImageStore_basic
--- PASS: TestAccNotebookImageStore_basic (226.39s)
PASS
coverage: 9.4% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 226.509s        coverage: 9.4% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="911" height="709" alt="image" src="https://github.com/user-attachments/assets/8faa4662-3ceb-4e3c-8236-8f4fcdf09838" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
