### PR TITLE
feat(drs): new resource to batch retry task

### DIFF
--- a/docs/resources/drs_batch_retry_task.md
+++ b/docs/resources/drs_batch_retry_task.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_batch_retry_task"
+description: |-
+  Manages a resource to batch retry DRS tasks within HuaweiCloud.
+---
+
+# huaweicloud_drs_batch_retry_task
+
+Manages a resource to batch retry DRS tasks within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource used to retry DRS tasks. Deleting this resource will not
+  undo the retry operation, but will only remove the resource information from the tf state file.
+  <br/>2. Tasks in failed status can be retried.
+  <br/>3. A successful API call does not guarantee the operation success; please check the task status.
+
+## Example Usage
+
+```hcl
+variable "jobs" {
+  type = list(object({
+    job_id          = string
+    is_sync_re_edit = string
+  }))
+}
+
+resource "huaweicloud_drs_batch_retry_task" "test" {
+  dynamic "jobs" {
+    for_each = var.jobs
+
+    content {
+      job_id          = jobs.value.job_id
+      is_sync_re_edit = jobs.value.is_sync_re_edit
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `jobs` - (Required, List, NonUpdatable) Specifies the list of jobs to retry.
+  The [jobs](#jobs_struct) structure is documented below.
+
+<a name="jobs_struct"></a>
+The `jobs` block supports:
+
+* `job_id` - (Required, String, NonUpdatable) Specifies the job ID.
+
+* `is_sync_re_edit` - (Optional, String, NonUpdatable) Specifies whether the task is started after re-editing.
+  The valid values are as follows:
+  + **true**: The task is started after re-editing.
+  + **false**: The task is not started after re-editing.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `results` - The results of retrying tasks.
+  The [results](#results_struct) structure is documented below.
+
+<a name="results_struct"></a>
+The `results` block supports:
+
+* `id` - The job ID.
+
+* `status` - The retry operation result. Valid values are **success** and **failed**.
+
+* `error_code` - The error code.
+
+* `error_msg` - The error message.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3550,6 +3550,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_drs_batch_delete_jobs":              drs.ResourceBatchDeleteJobs(),
 			"huaweicloud_drs_batch_pause_task":               drs.ResourceBatchPauseTask(),
+			"huaweicloud_drs_batch_retry_task":               drs.ResourceBatchRetryTask(),
 			"huaweicloud_drs_download_batch_create_template": drs.ResourceDownloadBatchCreateTemplate(),
 			"huaweicloud_drs_job":                            drs.ResourceDrsJob(),
 			"huaweicloud_drs_job_clone":                      drs.ResourceDrsJobClone(),

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_batch_retry_task_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_batch_retry_task_test.go
@@ -1,0 +1,43 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchRetryTask_basic(t *testing.T) {
+	resourceName := "huaweicloud_drs_batch_retry_task.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchRetryTask_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.status"),
+				),
+			},
+		},
+	})
+}
+
+func testBatchRetryTask_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_drs_batch_retry_task" "test" {
+  jobs {
+    job_id          = "%s"
+    is_sync_re_edit = "false"
+  }
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_batch_retry_task.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_batch_retry_task.go
@@ -1,0 +1,216 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var batchRetryTaskNonUpdatableParams = []string{
+	"jobs",
+	"jobs.*.job_id",
+	"jobs.*.is_sync_re_edit",
+}
+
+// @API DRS POST /v3/{project_id}/jobs/batch-retry-task
+func ResourceBatchRetryTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBatchRetryTaskCreate,
+		ReadContext:   resourceBatchRetryTaskRead,
+		UpdateContext: resourceBatchRetryTaskUpdate,
+		DeleteContext: resourceBatchRetryTaskDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(batchRetryTaskNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"jobs": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"job_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						// Define the field type as string to handle default values ​​for boolean types.
+						"is_sync_re_edit": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_msg": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func convertStringToBool(stringValue string) interface{} {
+	if stringValue == "" {
+		return nil
+	}
+
+	if stringValue == "true" {
+		return true
+	}
+
+	return false
+}
+
+func buildRetryTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	rawArray := d.Get("jobs").([]interface{})
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"job_id":          rawMap["job_id"],
+			"is_sync_re_edit": convertStringToBool(rawMap["is_sync_re_edit"].(string)),
+		})
+	}
+
+	return map[string]interface{}{
+		"jobs": rst,
+	}
+}
+
+func resourceBatchRetryTaskCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/jobs/batch-retry-task"
+	)
+
+	client, err := cfg.NewServiceClient("drs", region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildRetryTaskBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch retrying DRS tasks: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	results := utils.PathSearch("results", respBody, make([]interface{}, 0)).([]interface{})
+	if len(results) == 0 {
+		return diag.Errorf("unable to find the results from the API response")
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("results", flattenRetryTaskResults(results)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting retry DRS task fields: %s", mErr)
+	}
+
+	return nil
+}
+
+func flattenRetryTaskResults(results []interface{}) []interface{} {
+	if len(results) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(results))
+	for _, result := range results {
+		rst = append(rst, map[string]interface{}{
+			"id":         utils.PathSearch("id", result, nil),
+			"status":     utils.PathSearch("status", result, nil),
+			"error_code": utils.PathSearch("error_code", result, nil),
+			"error_msg":  utils.PathSearch("error_msg", result, nil),
+		})
+	}
+	return rst
+}
+
+func resourceBatchRetryTaskRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchRetryTaskUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchRetryTaskDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to retry DRS tasks. Deleting this resource will not
+undo the retry operation, but will only remove the resource information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to batch retry task

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o drs -f TestAccBatchRetryTask_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccBatchRetryTask_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchRetryTask_basic
=== PAUSE TestAccBatchRetryTask_basic
=== CONT  TestAccBatchRetryTask_basic
--- PASS: TestAccBatchRetryTask_basic (18.84s)
PASS
coverage: 4.9% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       18.953s coverage: 4.9% of statements in ./huaweicloud/services/drs
```
<img width="1276" height="73" alt="image" src="https://github.com/user-attachments/assets/c27dde32-ca56-4614-ab80-2f52bf57b281" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
