### PR TITLE
feat(drs): support `drs_progress_data` data source

### DIFF
--- a/docs/data-sources/drs_progress_data.md
+++ b/docs/data-sources/drs_progress_data.md
@@ -1,0 +1,69 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_progress_data"
+description: |-
+  Use this data source to get the data-level streaming comparison list of specified DRS job within HuaweiCloud.
+---
+
+# huaweicloud_drs_progress_data
+
+Use this data source to get the data-level streaming comparison list of specified DRS job within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+variable "type" {}
+
+data "huaweicloud_drs_progress_data" "test" {
+  job_id = var.job_id
+  type   = var.type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the job ID.
+
+* `type` - (Required, String) Specifies the migration object type.  
+  The valid values are as follows:
+  + **table**
+  + **event**
+  + **table_structure**
+  + **procedure**
+  + **view**
+  + **function**
+  + **database**
+  + **trigger**
+  + **table_indexs**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `create_time` - The data generation time.
+
+* `flow_compare_data` - The comparison result list.
+
+  The [flow_compare_data](#flow_compare_data_struct) structure is documented below.
+
+<a name="flow_compare_data_struct"></a>
+The `flow_compare_data` block supports:
+
+* `src_db` - The source database name.
+
+* `src_tb` - The source object name.
+
+* `dst_db` - The destination database name.
+
+* `dst_tb` - The destination object name.
+
+* `progress` - The progress percentage.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1336,6 +1336,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_quotas":                 drs.DataSourceDrsQuotas(),
 			"huaweicloud_drs_subscriptions":          drs.DataSourceDrsSubscriptions(),
 			"huaweicloud_drs_table_compare":          drs.DataSourceDrsTableCompare(),
+			"huaweicloud_drs_progress_data":          drs.DataSourceDrsProgressData(),
 			"huaweicloud_drs_tags":                   drs.DataSourceDrsTags(),
 			"huaweicloud_drs_timelines":              drs.DataSourceDrsTimelines(),
 			"huaweicloud_drs_drivers":                drs.DataSourceDrsDrivers(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_progress_data_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_progress_data_test.go
@@ -1,0 +1,49 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsProgressData_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_progress_data.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDrsProgressData_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "create_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flow_compare_data.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flow_compare_data.0.src_db"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flow_compare_data.0.src_tb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flow_compare_data.0.dst_db"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flow_compare_data.0.dst_tb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flow_compare_data.0.progress"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDrsProgressData_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_progress_data" "test" {
+  job_id = "%s"
+  type   = "table"
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_progress_data.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_progress_data.go
@@ -1,0 +1,165 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v5/{project_id}/jobs/{job_id}/progress-data/{type}
+func DataSourceDrsProgressData() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsProgressDataRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"flow_compare_data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"src_db": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"src_tb": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dst_db": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dst_tb": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"progress": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildProgressDataQueryParams(offset int) string {
+	queryParams := "?limit=1000"
+	if offset > 0 {
+		queryParams += fmt.Sprintf("&offset=%d", offset)
+	}
+
+	return queryParams
+}
+
+func dataSourceDrsProgressDataRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "drs"
+		httpUrl    = "v5/{project_id}/jobs/{job_id}/progress-data/{type}"
+		offset     = 0
+		result     = make([]interface{}, 0)
+		createTime string
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", d.Get("job_id").(string))
+	requestPath = strings.ReplaceAll(requestPath, "{type}", d.Get("type").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		requestPathWithQuery := requestPath + buildProgressDataQueryParams(offset)
+		resp, err := client.Request("GET", requestPathWithQuery, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DRS progress data: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		createTime = utils.PathSearch("create_time", respBody, "").(string)
+
+		flowCompareData := utils.PathSearch("flow_compare_data", respBody, make([]interface{}, 0)).([]interface{})
+		if len(flowCompareData) == 0 {
+			break
+		}
+
+		result = append(result, flowCompareData...)
+		offset += len(flowCompareData)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("create_time", createTime),
+		d.Set("flow_compare_data", flattenFlowCompareData(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenFlowCompareData(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(respArray))
+	for _, item := range respArray {
+		result = append(result, map[string]interface{}{
+			"src_db":   utils.PathSearch("src_db", item, nil),
+			"src_tb":   utils.PathSearch("src_tb", item, nil),
+			"dst_db":   utils.PathSearch("dst_db", item, nil),
+			"dst_tb":   utils.PathSearch("dst_tb", item, nil),
+			"progress": utils.PathSearch("progress", item, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_progress_data` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `drs_progress_data` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o drs -f TestAccDataSourceDrsProgressData_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsProgressData_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsProgressData_basic
=== PAUSE TestAccDataSourceDrsProgressData_basic
=== CONT  TestAccDataSourceDrsProgressData_basic
--- PASS: TestAccDataSourceDrsProgressData_basic (18.10s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs  coverage: 4.7% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       18.195s coverage: 4.7% of statements in ./huaweicloud/services/drs
```
<img width="856" height="36" alt="image" src="https://github.com/user-attachments/assets/92c30289-a660-4cf6-9190-e4eaeef62fd4" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
