### PR TITLE
feat(GeminiDB): add new data source to get table restored tables

### DIFF
--- a/docs/data-sources/geminidb_table_restored_tables.md
+++ b/docs/data-sources/geminidb_table_restored_tables.md
@@ -1,0 +1,41 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_table_restored_tables"
+description: |-
+  Use this data source to obtain GeminiDB Cassandra instance table information that is restored using tables.
+---
+
+# huaweicloud_geminidb_table_restored_tables
+
+Use this data source to obtain GeminiDB Cassandra instance table information that is restored using tables.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_geminidb_table_restored_tables" "test" {
+  instance_id   = var.instance_id
+  database_name = "test_db"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the tables.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the GeminiDB Cassandra instance.
+
+* `database_name` - (Required, String) Specifies the name of the database.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `table_names` - The list of table names.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1467,6 +1467,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_recycling_instances":      geminidb.DataSourceGeminiDBRecyclingInstances(),
 			"huaweicloud_geminidb_restorable_time_window":   geminidb.DataSourceGeminiDBRestorableTimeWindow(),
 			"huaweicloud_geminidb_table_restored_databases": geminidb.DataSourceGeminiDBTableRestoredDatabases(),
+			"huaweicloud_geminidb_table_restored_tables":    geminidb.DataSourceGeminiDBTableRestoredTables(),
 
 			"huaweicloud_gaussdb_storage_types":             gaussdb.DataSourceGaussDbStorageTypes(),
 			"huaweicloud_gaussdb_datastores":                gaussdb.DataSourceGaussDbDatastores(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_table_restored_tables_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_table_restored_tables_test.go
@@ -1,0 +1,40 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGeminiDBTableRestoredTables_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_geminidb_table_restored_tables.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGeminiDBTableRestoredTables_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "table_names.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGeminiDBTableRestoredTables_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_geminidb_table_restored_tables" "test" {
+  instance_id   = "%s"
+  database_name = "test_db"
+}
+`, acceptance.HW_GEMINIDB_INSATNCE_ID)
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_table_restored_tables.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_table_restored_tables.go
@@ -1,0 +1,114 @@
+package geminidb
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforNoSQL GET /v3/{project_id}/instances/{instance_id}/tables
+func DataSourceGeminiDBTableRestoredTables() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGeminiDBTableRestoredTablesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"table_names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceGeminiDBTableRestoredTablesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	httpUrl := "v3/{project_id}/instances/{instance_id}/tables"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", d.Get("instance_id").(string))
+	getPath += buildListGeminiDBTableRestoredTablesQueryParams(d)
+
+	getResp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		getPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return diag.Errorf("error retrieving GeminiDB table restored tables: %s", err)
+	}
+	getRespJson, err := json.Marshal(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var getRespBody interface{}
+	err = json.Unmarshal(getRespJson, &getRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("table_names", flattenListGeminiDBTableRestoredTables(getRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildListGeminiDBTableRestoredTablesQueryParams(d *schema.ResourceData) string {
+	queryParams := "?database_name=" + d.Get("database_name").(string)
+	return queryParams
+}
+
+func flattenListGeminiDBTableRestoredTables(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("table_names", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		if name, ok := v.(string); ok {
+			rst = append(rst, name)
+		}
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new data source to get table restored tables
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new data source to get table restored tables
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST='./huaweicloud/services/acceptance/geminidb' TESTARGS='-run=TestAccDataSourceGeminiDBTableRestoredTables_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run=TestAccDataSourceGeminiDBTableRestoredTables_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceGeminiDBTableRestoredTables_basic
=== PAUSE TestAccDataSourceGeminiDBTableRestoredTables_basic
=== CONT  TestAccDataSourceGeminiDBTableRestoredTables_basic
--- PASS: TestAccDataSourceGeminiDBTableRestoredTables_basic (18.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  18.614s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
