### PR TITLE
feat(modelarts): supports new data source to query devserver plugins

### DIFF
--- a/docs/data-sources/modelarts_devserver_plugins.md
+++ b/docs/data-sources/modelarts_devserver_plugins.md
@@ -1,0 +1,66 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_devserver_plugins"
+description: |-
+  Use this data source to get the list of available DevServer plugins of ModelArts within Huaweicloud.
+---
+
+# huaweicloud_modelarts_devserver_plugins
+
+Use this data source to get the list of available DevServer plugins of ModelArts within Huaweicloud.
+
+## Example Usage
+
+### Query all DevServer plugins and without any filter
+
+```hcl
+data "huaweicloud_modelarts_devserver_plugins" "test" {}
+```
+
+### Query the DevServer plugins and using name filter
+
+```hcl
+variable "plugin_name" {}
+
+data "huaweicloud_modelarts_devserver_plugins" "test" {
+  name = var.plugin_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the DevServer plugins are located.  
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the DevServer plugin to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `plugins` - The list of DevServer plugins that matched filter parameters.  
+  The [plugins](#modelarts_devserver_plugins_attr) structure is documented below.
+
+<a name="modelarts_devserver_plugins_attr"></a>
+The `plugins` block supports:
+
+* `name` - The name of the plugin.
+
+* `infos` - The list of plugin details.  
+  The [infos](#modelarts_devserver_plugins_infos) structure is documented below.
+
+<a name="modelarts_devserver_plugins_infos"></a>
+The `infos` block supports:
+
+* `id` - The ID of the plugin.
+
+* `version` - The version of the plugin.
+
+* `status` - The status of the plugin.
+
+* `url` - The download URL of the plugin.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1963,6 +1963,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_dataset_versions":  modelarts.DataSourceDatasetVerions(),
 			"huaweicloud_modelarts_datasets":          modelarts.DataSourceDatasets(),
 			"huaweicloud_modelarts_devserver_flavors": modelarts.DataSourceDevServerFlavors(),
+			"huaweicloud_modelarts_devserver_plugins": modelarts.DataSourceDevServerPlugins(),
 			"huaweicloud_modelarts_model_templates":   modelarts.DataSourceModelTemplates(),
 			"huaweicloud_modelarts_models":            modelarts.DataSourceModels(),
 			"huaweicloud_modelarts_networks":          modelarts.DataSourceNetworks(),

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_devserver_plugins_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_devserver_plugins_test.go
@@ -1,0 +1,70 @@
+package modelarts
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataDevServerPlugins_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_modelarts_devserver_plugins.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_modelarts_devserver_plugins.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataDevServerPlugins_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "plugins.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckResourceAttrSet(all, "plugins.0.name"),
+					resource.TestMatchResourceAttr(all, "plugins.0.infos.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckResourceAttrSet(all, "plugins.0.infos.0.id"),
+					resource.TestCheckResourceAttrSet(all, "plugins.0.infos.0.version"),
+					resource.TestCheckResourceAttrSet(all, "plugins.0.infos.0.status"),
+					resource.TestCheckResourceAttrSet(all, "plugins.0.infos.0.url"),
+
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataDevServerPlugins_basic() string {
+	return `
+# Query all DevServer plugins and without any filter
+data "huaweicloud_modelarts_devserver_plugins" "all" {}
+
+# Filter by name
+locals {
+  plugin_name = data.huaweicloud_modelarts_devserver_plugins.all.plugins[0].name
+}
+
+data "huaweicloud_modelarts_devserver_plugins" "filter_by_name" {
+  name = local.plugin_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_modelarts_devserver_plugins.filter_by_name.plugins[*].name :
+      v == local.plugin_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+`
+}

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_devserver_plugins.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_devserver_plugins.go
@@ -1,0 +1,183 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ModelArts GET /v1/{project_id}/dev-servers/plugins
+func DataSourceDevServerPlugins() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDevServerPluginsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the DevServer plugins are located.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the DevServer plugin to be queried.`,
+			},
+
+			// Attributes.
+			"plugins": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of DevServer plugins that matched filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the plugin.`,
+						},
+						"infos": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of plugin details.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The ID of the plugin.`,
+									},
+									"version": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The version of the plugin.`,
+									},
+									"status": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The status of the plugin.`,
+									},
+									"url": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The download URL of the plugin.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildDevServerPluginsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}
+
+func listDevServerPlugins(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	httpUrl := "v1/{project_id}/dev-servers/plugins"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildDevServerPluginsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenDevServerPluginInfos(infos []interface{}) []map[string]interface{} {
+	if len(infos) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(infos))
+	for _, info := range infos {
+		result = append(result, map[string]interface{}{
+			"id":      utils.PathSearch("id", info, nil),
+			"version": utils.PathSearch("version", info, nil),
+			"status":  utils.PathSearch("status", info, nil),
+			"url":     utils.PathSearch("url", info, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenDevServerPlugins(plugins []interface{}) []map[string]interface{} {
+	if len(plugins) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(plugins))
+	for _, plugin := range plugins {
+		result = append(result, map[string]interface{}{
+			"name": utils.PathSearch("name", plugin, nil),
+			"infos": flattenDevServerPluginInfos(utils.PathSearch("infos", plugin,
+				make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func dataSourceDevServerPluginsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	plugins, err := listDevServerPlugins(client, d)
+	if err != nil {
+		return diag.Errorf("error querying DevServer plugins: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("plugins", flattenDevServerPlugins(plugins)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source to query devserver plugins.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1052" height="63" alt="image" src="https://github.com/user-attachments/assets/0e2fede7-076e-476c-b9fe-c2091b7414ff" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query DevServer plugins
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDataDevServerPlugins_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataDevServerPlugins_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDevServerPlugins_basic
=== PAUSE TestAccDataDevServerPlugins_basic
=== CONT  TestAccDataDevServerPlugins_basic
--- PASS: TestAccDataDevServerPlugins_basic (12.28s)
PASS
coverage: 5.1% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 12.398s coverage: 5.1% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
