### PR TITLE
feat(GeminiDB): the instance support auto enlarge policy

### DIFF
--- a/docs/resources/geminidb_instance.md
+++ b/docs/resources/geminidb_instance.md
@@ -129,6 +129,18 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the instance.
 
+* `switch_option` - (Optional, String) Specifies whether the autoscaling is enabled.
+  The valid values are as follows:
+  + **on**: Storage autoscaling is enabled.
+  + **off**: Storage autoscaling is disabled.
+
+* `policy` - (Optional, List) Specifies the autoscaling policy for storage space.
+  The [policy](#policy_struct) structure is documented below.
+
+-> 1. The parameters `switch_option` and `policy` are used to configuration autoscaling policy for GeminiDB instance.
+  <br/>2. the `policy` supports update only when the `switch_option` is set to **on**.
+  <br/>3. Currently, only **GeminiDB Cassandra** and **GeminiDB Redis** instances are supported.
+
 * `delete_node_list` - (Optional, List) Specifies the ID of the nodes to be deleted. Make sure that the node
   can be deleted. This parameter can not be specified when add nodes. When delete nodes, if this parameter is specified,
   then the nodes specified by this parameter will be deleted, and id this parameter is not transferred, the nodes will be
@@ -220,6 +232,34 @@ The `availability_zone_detail` block supports:
 
 * `secondary_availability_zone` - (Required, String, NonUpdatable) Specifies the standby AZ, which must be a single AZ
   and be different from the primary AZ.
+
+<a name="policy_struct"></a>
+The `policy` block supports:
+
+* `threshold` - (Optional, Int) Specifies the threshold for triggering autoscaling.
+  + For GeminiDB Cassandra instances, the value can be `80`, `85`, or `90`, and the default value is `90`.
+  + For GeminiDB Redis instances, the value can be `60`, `65`, `70`, `75`, `80`, `85`, or `90`, and the
+  default value is `80`.
+
+* `step` - (Optional, Int) Specifies the autoscaling step (s%).
+  + For GeminiDB Cassandra instances, the value can be `10`, `15`, or `20`, and the default value is `10`.
+  After autoscaling is enabled, storage space will increase by s% automatically.
+  + For GeminiDB Redis instances, the value can be `10`, `15`, or `20`, and the default value is `20`.
+  When the storage usage is greater than 98%: If the total storage is less than 600 GB, the storage usage
+  after autoscaling (used storage space/total storage space) will be less than 85%. If the total storage is greater
+  than or equal to 600 GB, the system automatically scales up the storage space by over 90 GB.
+  + For GeminiDB Cassandra instances, if the autoscaling step is not a multiple of 10, round it up.
+  The value after the decimal point is rounded. The minimum step is 100 GB by default.
+  + For GeminiDB Redis instances, the value after the decimal point is rounded. The minimum step is 1 GB by default.
+  + If there is insufficient balance in your account, the autoscaling may failed for yearly/monthly instances.
+
+* `size` - (Optional, Int) Specifies the storage limit in GB that autoscaling can increase storage space to.
+  + For GeminiDB Cassandra instances, the storage upper limit ≥ current storage + 100 GB. The storage upper limit
+  cannot exceed the maximum storage supported by the current specifications. Learn more details , refer to
+  [Instance Specifications](https://support.huaweicloud.com/intl/en-us/cassandraug-nosql/nosql_05_0017.html).
+  + For GeminiDB Redis instances, the storage upper limit ≥ Current storage + 1 GB. The storage upper limit cannot
+  exceed the maximum storage supported by the current specifications. Learn more details , refer to
+  [GeminiDB Redis Instance Specifications](https://support.huaweicloud.com/intl/en-us/redisug-nosql/nosql_05_0059.html).
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -333,6 +334,87 @@ func TestAccGeminiDbInstance_dynamodb(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ssl_option", "off"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo_update", "bar_update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key_update", "value_update"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"flavor.0.storage",
+					"ssl_option",
+					"delete_node_list",
+				},
+			},
+		},
+	})
+}
+
+func TestAccGeminiDbInstance_autoEnlargePolicy(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_geminidb_instance.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getGeminiDbInstance,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDBAutoEnlargePolicy_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.type", "redis"),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.version", "5.0"),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.storage_engine", "rocksDB"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
+						"huaweicloud_networking_secgroup.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "Cluster"),
+					resource.TestCheckResourceAttr(resourceName, "flavor.0.num", "3"),
+					resource.TestCheckResourceAttr(resourceName, "flavor.0.size", "16"),
+					resource.TestCheckResourceAttr(resourceName, "flavor.0.storage", "ULTRAHIGH"),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor.0.spec_code",
+						"data.huaweicloud_gaussdb_nosql_flavors.test", "flavors.0.name"),
+					resource.TestCheckResourceAttr(resourceName, "switch_option", "on"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy.0.threshold"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy.0.step"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy.0.size"),
+				),
+			},
+			{
+				Config: testAccGeminiDBAutoEnlargePolicy_update_step1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "switch_option", "on"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.threshold", "85"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.step", "15"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.size", "20"),
+				),
+			},
+			{
+				Config: testAccGeminiDBAutoEnlargePolicy_upate_step2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "switch_option", "off"),
 				),
 			},
 			{
@@ -711,4 +793,127 @@ resource "huaweicloud_geminidb_instance" "test" {
   }
 }
 `, testAccGeminiDbInstance_base(rName), updateName)
+}
+
+func testAccGeminiDBAutoEnlargePolicy_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus             = 2
+  engine            = "redis"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name                  = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "test_1234"
+  mode              = "Cluster"
+
+  datastore {
+    type           = "redis"
+    version        = "5.0"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "3"
+    size      = "16"
+    storage   = "ULTRAHIGH"
+    spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
+  }
+
+  switch_option = "on"
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccGeminiDBAutoEnlargePolicy_update_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus             = 2
+  engine            = "redis"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "test_1234"
+  mode              = "Cluster"
+
+  datastore {
+    type           = "redis"
+    version        = "5.0"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "3"
+    size      = "16"
+    storage   = "ULTRAHIGH"
+    spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
+  }
+
+  switch_option = "on"
+
+  policy {
+    threshold = 85
+    step      = 15
+    size      = 20
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccGeminiDBAutoEnlargePolicy_upate_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus             = 2
+  engine            = "redis"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "test_1234"
+  mode              = "Cluster"
+
+  datastore {
+    type           = "redis"
+    version        = "5.0"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "3"
+    size      = "16"
+    storage   = "ULTRAHIGH"
+    spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
+  }
+
+  switch_option = "off"
+}
+`, common.TestBaseNetwork(name), name)
 }

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -30,22 +31,24 @@ var geminiDbInstanceNonUpdatableParams = []string{"datastore", "datastore.*.type
 	"availability_zone_detail.*.secondary_availability_zone", "charging_mode", "period_unit", "period",
 }
 
-// @API GaussDBforNoSQL POST /v3/{project_id}/instances
-// @API GaussDBforNoSQL GET /v3/{project_id}/jobs
-// @API GaussDBforNoSQL GET /v3/{project_id}/instances
-// @API GaussDBforNoSQL PUT /v3/{project_id}/instances/{instance_id}/name
-// @API GaussDBforNoSQL PUT /v3/{project_id}/instances/{instance_id}/password
-// @API GaussDBforNoSQL POST /v3/{project_id}/instances/{instance_id}/ssl-option
-// @API GaussDBforNoSQL PUT /v3/{project_id}/instances/{instance_id}/port
-// @API GaussDBforNoSQL PUT /v3.1/{project_id}/configurations/{config_id}/apply
-// @API GaussDBforNoSQL PUT /v3/{project_id}/instances/{instance_id}/volume
-// @API GaussDBforNoSQL PUT /v3/{project_id}/instances/{instance_id}/resize
-// @API GaussDBforNoSQL POST /v3/{project_id}/instances/{instance_id}/enlarge-node
-// @API GaussDBforNoSQL POST /v3/{project_id}/instances/{instance_id}/reduce-node
-// @API GaussDBforNoSQL PUT /v3/{project_id}/instances/{instance_id}/security-group
-// @API GaussDBforNoSQL PUT /v3/{project_id}/instances/{instance_id}/backups/policy
-// @API GaussDBforNoSQL POST /v3/{project_id}/instances/{instance_id}/tags/action
-// @API GaussDBforNoSQL DELETE /v3/{project_id}/instances/{instance_id}
+// @API GeminiDB POST /v3/{project_id}/instances
+// @API GeminiDB GET /v3/{project_id}/jobs
+// @API GeminiDB GET /v3/{project_id}/instances
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/name
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/password
+// @API GeminiDB POST /v3/{project_id}/instances/{instance_id}/ssl-option
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/port
+// @API GeminiDB PUT /v3.1/{project_id}/configurations/{config_id}/apply
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/volume
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/resize
+// @API GeminiDB POST /v3/{project_id}/instances/{instance_id}/enlarge-node
+// @API GeminiDB POST /v3/{project_id}/instances/{instance_id}/reduce-node
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/security-group
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/backups/policy
+// @API GeminiDB POST /v3/{project_id}/instances/{instance_id}/tags/action
+// @API GeminiDB DELETE /v3/{project_id}/instances/{instance_id}
+// @API GeminiDB PUT /v3/{project_id}/instances/disk-auto-expansion
+// @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/disk-auto-expansion
 // @API BSS GET /v2/orders/customer-orders/details/{order_id}
 // @API BSS POST /v2/orders/subscriptions/resources/autorenew/{instance_id}
 // @API BSS DELETE /v2/orders/subscriptions/resources/autorenew/{instance_id}
@@ -162,6 +165,18 @@ func ResourceGeminiDbInstance() *schema.Resource {
 				Optional: true,
 				MaxItems: 1,
 				Elem:     geminiDbInstanceAvailabilityZoneDetailSchema(),
+			},
+			"switch_option": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem:     geminiDbInstanceAutomaticScalePolicSchema(),
 			},
 			"delete_node_list": {
 				Type:     schema.TypeSet,
@@ -444,6 +459,29 @@ func geminiDbInstanceDualActiveInfoSchema() *schema.Resource {
 	return &sc
 }
 
+func geminiDbInstanceAutomaticScalePolicSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"threshold": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"step": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
 func resourceGeminiDbInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
@@ -513,7 +551,60 @@ func resourceGeminiDbInstanceCreate(ctx context.Context, d *schema.ResourceData,
 	// lintignore:R018
 	time.Sleep(360 * time.Second)
 
+	// setting auto enlarge policy
+	if v, ok := d.GetOk("switch_option"); ok && v.(string) == "on" {
+		err = updateAutoEnlargePolicy(client, d, d.Id())
+		if err != nil {
+			return diag.Errorf("error setting GeminiDB auto enlarge policy: %s", err)
+		}
+	}
+
 	return resourceGeminiDbInstanceRead(ctx, d, meta)
+}
+
+func updateAutoEnlargePolicy(client *golangsdk.ServiceClient, d *schema.ResourceData, instanceId string) error {
+	httpUrl := "v3/{project_id}/instances/disk-auto-expansion"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+
+	updateOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAutoEnlargePolicyBodyParams(d, instanceId)),
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+
+	return err
+}
+
+func buildAutoEnlargePolicyBodyParams(d *schema.ResourceData, instanceId string) map[string]interface{} {
+	params := map[string]interface{}{
+		"instance_ids":  []string{instanceId},
+		"switch_option": utils.ValueIgnoreEmpty(d.Get("switch_option")),
+		"policy":        buildPolicyInfoBodyParams(d.Get("policy").([]interface{})),
+	}
+
+	return params
+}
+
+func buildPolicyInfoBodyParams(policyInfo []interface{}) map[string]interface{} {
+	if len(policyInfo) == 0 {
+		return nil
+	}
+
+	policy, ok := policyInfo[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"threshold": utils.ValueIgnoreEmpty(utils.PathSearch("threshold", policy, nil)),
+		"step":      utils.ValueIgnoreEmpty(utils.PathSearch("step", policy, nil)),
+		"size":      utils.ValueIgnoreEmpty(utils.PathSearch("size", policy, nil)),
+	}
+
+	return result
 }
 
 func buildCreateGeminiDbInstanceBodyParams(d *schema.ResourceData, region, epsId string) map[string]interface{} {
@@ -684,7 +775,59 @@ func resourceGeminiDbInstanceRead(_ context.Context, d *schema.ResourceData, met
 		mErr = multierror.Append(mErr, err)
 	}
 
+	// set auto enlarge policy parameters
+	policy, err := getAutoEnlargePolicyInfo(client, d.Id())
+	if err != nil {
+		log.Printf("[Warn] error retrieving GeminiDB auto enlarge policy information")
+	}
+
+	if v, ok := policy.(map[string]interface{}); ok && len(v) > 0 {
+		mErr = multierror.Append(mErr,
+			d.Set("policy", flattenPolicyInfo(utils.PathSearch("policy", policy, nil))),
+			d.Set("switch_option", "on"),
+		)
+	} else {
+		mErr = multierror.Append(mErr,
+			d.Set("policy", make([]interface{}, 0)),
+			d.Set("switch_option", "off"),
+		)
+	}
+
 	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getAutoEnlargePolicyInfo(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/instances/{instance_id}/disk-auto-expansion"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getOpts := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func flattenPolicyInfo(policyInfo interface{}) []map[string]interface{} {
+	if policyInfo == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"threshold": utils.PathSearch("threshold", policyInfo, nil),
+		"step":      utils.PathSearch("step", policyInfo, nil),
+		"size":      utils.PathSearch("size", policyInfo, nil),
+	}
+
+	return []map[string]interface{}{result}
 }
 
 func flattenGeminiDbInstanceResponseBodyDatastore(instance interface{}) []interface{} {
@@ -924,6 +1067,14 @@ func resourceGeminiDbInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 		if err = cfg.MigrateEnterpriseProject(ctx, d, migrateOpts); err != nil {
 			return diag.FromErr(err)
+		}
+	}
+
+	// update auto enlarge policy
+	if d.HasChanges("switch_option", "policy") {
+		err = updateAutoEnlargePolicy(client, d, d.Id())
+		if err != nil {
+			return diag.Errorf("error updating GeminiDB auto enlarge policy: %s", err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The GeminiDB instance support auto enlarge policy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.The GeminDB instance supports configuration auto enlarge policy.
2.Support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDbInstance_autoEnlargePolicy"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDbInstance_autoEnlargePolicy -timeout 360m -parallel 4
=== RUN   TestAccGeminiDbInstance_autoEnlargePolicy
=== PAUSE TestAccGeminiDbInstance_autoEnlargePolicy
=== CONT  TestAccGeminiDbInstance_autoEnlargePolicy
--- PASS: TestAccGeminiDbInstance_autoEnlargePolicy (1526.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1526.531s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
