### PR TITLE
feat(drs): support `drs_batch_async_jobs` data source

### DIFF
--- a/docs/data-sources/drs_batch_async_jobs.md
+++ b/docs/data-sources/drs_batch_async_jobs.md
@@ -1,0 +1,69 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_batch_async_jobs"
+description: |-
+  Use this data source to get the list of DRS tasks created asynchronously in batches within HuaweiCloud.
+---
+
+# huaweicloud_drs_batch_async_jobs
+
+Use this data source to get the list of DRS tasks created asynchronously in batches within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_drs_batch_async_jobs" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `async_job_id` - (Optional, String) Specifies the ID of the tasks created asynchronously in batches.
+
+* `status` - (Optional, String) Specifies the status of the tasks created asynchronously in batches.  
+  The valid values are as follows:
+  + **ASYNC_JOB_VALIDATING**: The parameters of the tasks created asynchronously in batches are being verified.
+  + **ASYNC_JOB_VALIDATE_FAILED**: The parameters of the tasks created asynchronously in batches fail to be verified.
+  + **AUTO_PARAM_VALIDATE_SUCCESS**: The parameters of the tasks created asynchronously in batches are successfully
+    verified.
+  + **COMMIT_SUCCESS**: The tasks created asynchronously in batches are successfully submitted.
+
+* `domain_name` - (Optional, String) Specifies the tenant name of the tasks created asynchronously in batches.
+
+* `user_name` - (Optional, String) Specifies the username of the tasks created asynchronously in batches.
+
+* `sort_key` - (Optional, String) Specifies the keyword based on which the returned results are sorted.
+  The default value is **create_time**.
+
+* `sort_dir` - (Optional, String) Specifies the result sorting order.  
+  The valid values are as follows:
+  + **desc**: Descending order.
+  + **asc**: Ascending order.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `jobs` - The list of tasks created asynchronously in batches.
+
+  The [jobs](#jobs_struct) structure is documented below.
+
+<a name="jobs_struct"></a>
+The `jobs` block supports:
+
+* `async_job_id` - The ID of the tasks created asynchronously in batches.
+
+* `status` - The status of the tasks created asynchronously in batches.
+
+* `domain_name` - The tenant name of the tasks created asynchronously in batches.
+
+* `user_name` - The username of the tasks created asynchronously in batches.
+
+* `create_time` - The time when the tasks are asynchronously created in batches.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1339,6 +1339,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_subscriptions":          drs.DataSourceDrsSubscriptions(),
 			"huaweicloud_drs_table_compare":          drs.DataSourceDrsTableCompare(),
 			"huaweicloud_drs_progress_data":          drs.DataSourceDrsProgressData(),
+			"huaweicloud_drs_batch_async_jobs":       drs.DataSourceBatchAsyncJobs(),
 			"huaweicloud_drs_tags":                   drs.DataSourceDrsTags(),
 			"huaweicloud_drs_timelines":              drs.DataSourceDrsTimelines(),
 			"huaweicloud_drs_drivers":                drs.DataSourceDrsDrivers(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_batch_async_jobs_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_batch_async_jobs_test.go
@@ -1,0 +1,43 @@
+package drs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceBatchAsyncJobs_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_batch_async_jobs.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceBatchAsyncJobs_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "jobs.#"),
+				),
+			},
+		},
+	})
+}
+
+// This resource has no response data, and the filtering parameters cannot be validated in the test case.
+func testDataSourceBatchAsyncJobs_basic() string {
+	return `
+data "huaweicloud_drs_batch_async_jobs" "test" {
+  status   = "ASYNC_JOB_VALIDATING"
+  sort_key = "create_time"
+  sort_dir = "desc"
+}
+`
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_batch_async_jobs.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_batch_async_jobs.go
@@ -1,0 +1,190 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v5/{project_id}/batch-async-jobs
+func DataSourceBatchAsyncJobs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBatchAsyncJobsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"async_job_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"jobs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"async_job_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildBatchAsyncJobsQueryParams(d *schema.ResourceData, offset int) string {
+	queryParams := "?limit=1000"
+
+	if v, ok := d.GetOk("async_job_id"); ok {
+		queryParams += fmt.Sprintf("&async_job_id=%s", v.(string))
+	}
+	if v, ok := d.GetOk("status"); ok {
+		queryParams += fmt.Sprintf("&status=%s", v.(string))
+	}
+	if v, ok := d.GetOk("domain_name"); ok {
+		queryParams += fmt.Sprintf("&domain_name=%s", v.(string))
+	}
+	if v, ok := d.GetOk("user_name"); ok {
+		queryParams += fmt.Sprintf("&user_name=%s", v.(string))
+	}
+	if v, ok := d.GetOk("sort_key"); ok {
+		queryParams += fmt.Sprintf("&sort_key=%s", v.(string))
+	}
+	if v, ok := d.GetOk("sort_dir"); ok {
+		queryParams += fmt.Sprintf("&sort_dir=%s", v.(string))
+	}
+	if offset > 0 {
+		queryParams += fmt.Sprintf("&offset=%d", offset)
+	}
+
+	return queryParams
+}
+
+func dataSourceBatchAsyncJobsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v5/{project_id}/batch-async-jobs"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		requestPathWithQuery := requestPath + buildBatchAsyncJobsQueryParams(d, offset)
+		resp, err := client.Request("GET", requestPathWithQuery, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DRS batch async jobs: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		jobsResp := utils.PathSearch("jobs", respBody, make([]interface{}, 0)).([]interface{})
+		if len(jobsResp) == 0 {
+			break
+		}
+
+		result = append(result, jobsResp...)
+		offset += len(jobsResp)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("jobs", flattenBatchAsyncJobs(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenBatchAsyncJobs(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(respArray))
+	for _, item := range respArray {
+		result = append(result, map[string]interface{}{
+			"async_job_id": utils.PathSearch("async_job_id", item, nil),
+			"status":       utils.PathSearch("status", item, nil),
+			"domain_name":  utils.PathSearch("domain_name", item, nil),
+			"user_name":    utils.PathSearch("user_name", item, nil),
+			"create_time":  utils.PathSearch("create_time", item, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_batch_async_jobs` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `drs_batch_async_jobs` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o drs -f TestAccDataSourceBatchAsyncJobs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceBatchAsyncJobs_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceBatchAsyncJobs_basic
=== PAUSE TestAccDataSourceBatchAsyncJobs_basic
=== CONT  TestAccDataSourceBatchAsyncJobs_basic
--- PASS: TestAccDataSourceBatchAsyncJobs_basic (14.13s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs  coverage: 4.5% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       14.232s coverage: 4.5% of statements in ./huaweicloud/services/drs
```
<img width="879" height="38" alt="image" src="https://github.com/user-attachments/assets/64dc4e37-444b-4508-9de5-8dee7a2693db" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
