### PR TITLE
feat(modelarts): supports new resource to manage workflow subscription

### DIFF
--- a/docs/resources/modelartsv2_workflow_subscription.md
+++ b/docs/resources/modelartsv2_workflow_subscription.md
@@ -1,0 +1,60 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelartsv2_workflow_subscription"
+description: |-
+  Manages a ModelArts workflow message subscription configuration within HuaweiCloud.
+---
+
+# huaweicloud_modelartsv2_workflow_subscription
+
+Manages a ModelArts workflow message subscription configuration within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workflow_id" {}
+variable "subscribe_topic_urns" {
+  type = list(string)
+}
+
+resource "huaweicloud_modelartsv2_workflow_subscription" "test" {
+  workflow_id = var.workflow_id
+  topic_urns  = var.subscribe_topic_urns
+
+  events = [
+    "service_step:wait_inputs,hold,completed",
+    "labeling:wait_inputs,hold,failed,create_failed",
+    "*:wait_inputs,hold,completed",
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the workflow subscription is located.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `workflow_id` - (Required, String, NonUpdatable) Specifies the ID of the workflow to which the subscription belongs.
+
+* `topic_urns` - (Required, List) Specifies the list of SMN topic URNs to subscribe.
+
+* `events` - (Optional, List) Specifies the list of workflow events to subscribe.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (subscription ID).
+
+* `created_at` - The creation time of the workflow subscription, in RFC3339 format.
+
+## Import
+
+Workflow subscriptions can be imported using `workflow_id` and `id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_modelartsv2_workflow_subscription.test <workflow_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4027,6 +4027,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelartsv2_service":                modelarts.ResourceV2Service(),
 			"huaweicloud_modelartsv2_service_action":         modelarts.ResourceV2ServiceAction(),
 			"huaweicloud_modelartsv2_workflow_schedule":      modelarts.ResourceV2WorkflowSchedule(),
+			"huaweicloud_modelartsv2_workflow_subscription":  modelarts.ResourceV2WorkflowSubscription(),
 
 			"huaweicloud_metastudio_instance": metastudio.ResourceMetaStudio(),
 

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelartsv2_workflow_subscription_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelartsv2_workflow_subscription_test.go
@@ -1,0 +1,200 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
+)
+
+func getV2WorkflowSubscriptionResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("modelarts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	return modelarts.GetV2WorkflowSubscriptionById(client, state.Primary.Attributes["workflow_id"], state.Primary.ID)
+}
+
+func TestAccV2WorkflowSubscription_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName = "huaweicloud_modelartsv2_workflow_subscription.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getV2WorkflowSubscriptionResourceFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckModelArtsWorkflowId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccV2WorkflowSubscription_nonExistentWorkflow(name),
+				ExpectError: regexp.MustCompile(`error creating ModelArts workflow subscription`),
+			},
+			{
+				Config: testAccV2WorkflowSubscription_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workflow_id", acceptance.HW_MODELARTS_WORKFLOW_ID),
+					resource.TestCheckResourceAttr(rName, "topic_urns.#", "2"),
+					resource.TestCheckResourceAttrPair(rName, "topic_urns.0", "huaweicloud_smn_topic.test.0", "topic_urn"),
+					resource.TestCheckResourceAttrPair(rName, "topic_urns.1", "huaweicloud_smn_topic.test.1", "topic_urn"),
+					resource.TestCheckResourceAttr(rName, "events.#", "3"),
+					resource.TestCheckResourceAttr(rName, "events.0", "service_step:wait_inputs,hold,completed"),
+					resource.TestCheckResourceAttr(rName, "events.1", "labeling:wait_inputs,hold,failed,create_failed"),
+					resource.TestCheckResourceAttr(rName, "events.2", "*:wait_inputs,hold,completed"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccV2WorkflowSubscription_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workflow_id", acceptance.HW_MODELARTS_WORKFLOW_ID),
+					resource.TestCheckResourceAttr(rName, "topic_urns.#", "2"),
+					resource.TestCheckResourceAttrPair(rName, "topic_urns.0", "huaweicloud_smn_topic.test.1", "topic_urn"),
+					resource.TestCheckResourceAttrPair(rName, "topic_urns.1", "huaweicloud_smn_topic.test.2", "topic_urn"),
+					resource.TestCheckResourceAttr(rName, "events.#", "3"),
+					resource.TestCheckResourceAttr(rName, "events.0", "release:wait_inputs,hold,failed,create_failed"),
+					resource.TestCheckResourceAttr(rName, "events.1", "model_step:completed,failed,create_failed"),
+					resource.TestCheckResourceAttr(rName, "events.2", "training_job:wait_inputs,hold,completed"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccV2WorkflowSubscription_basic_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workflow_id", acceptance.HW_MODELARTS_WORKFLOW_ID),
+					resource.TestCheckResourceAttr(rName, "topic_urns.#", "2"),
+					resource.TestCheckResourceAttrPair(rName, "topic_urns.0", "huaweicloud_smn_topic.test.1", "topic_urn"),
+					resource.TestCheckResourceAttrPair(rName, "topic_urns.1", "huaweicloud_smn_topic.test.0", "topic_urn"),
+					resource.TestCheckResourceAttr(rName, "events.#", "3"),
+					resource.TestCheckResourceAttr(rName, "events.0", "*:wait_inputs,hold,completed"),
+					resource.TestCheckResourceAttr(rName, "events.1", "labeling:wait_inputs,hold,failed,create_failed"),
+					resource.TestCheckResourceAttr(rName, "events.2", "service_step:wait_inputs,hold,completed"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccV2WorkflowSubscriptionImportStateIDFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccV2WorkflowSubscriptionImportStateIDFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		workflowID := rs.Primary.Attributes["workflow_id"]
+		if workflowID == "" {
+			return "", fmt.Errorf("attribute (workflow_id) of resource (%s) not found", name)
+		}
+		return fmt.Sprintf("%s/%s", workflowID, rs.Primary.ID), nil
+	}
+}
+
+func testAccV2WorkflowSubscription_smnTopics(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  count = 3
+
+  name = format("%%s-%%d", "%[1]s", count.index)
+}
+`, name)
+}
+
+func testAccV2WorkflowSubscription_nonExistentWorkflow(name string) string {
+	randomUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelartsv2_workflow_subscription" "test" {
+  workflow_id = "%[2]s"
+  topic_urns  = slice(huaweicloud_smn_topic.test[*].topic_urn, 0, 2)
+
+  events = [
+    "service_step:wait_inputs,hold,completed",
+    "labeling:wait_inputs,hold,failed,create_failed",
+    "*:wait_inputs,hold,completed",
+  ]
+}
+`, testAccV2WorkflowSubscription_smnTopics(name), randomUUID)
+}
+
+func testAccV2WorkflowSubscription_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelartsv2_workflow_subscription" "test" {
+  workflow_id = "%[2]s"
+  topic_urns  = slice(huaweicloud_smn_topic.test[*].topic_urn, 0, 2)
+
+  events = [
+    "service_step:wait_inputs,hold,completed",
+    "labeling:wait_inputs,hold,failed,create_failed",
+    "*:wait_inputs,hold,completed",
+  ]
+}
+`, testAccV2WorkflowSubscription_smnTopics(name), acceptance.HW_MODELARTS_WORKFLOW_ID)
+}
+
+func testAccV2WorkflowSubscription_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelartsv2_workflow_subscription" "test" {
+  workflow_id = "%[2]s"
+  topic_urns  = slice(huaweicloud_smn_topic.test[*].topic_urn, 1, 3)
+
+  events = [
+    "release:wait_inputs,hold,failed,create_failed",
+    "model_step:completed,failed,create_failed",
+    "training_job:wait_inputs,hold,completed",
+  ]
+}
+`, testAccV2WorkflowSubscription_smnTopics(name), acceptance.HW_MODELARTS_WORKFLOW_ID)
+}
+
+// The configuration is the same as the basic step 1, but the order of topic urns and events are different.
+func testAccV2WorkflowSubscription_basic_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelartsv2_workflow_subscription" "test" {
+  workflow_id = "%[2]s"
+  topic_urns  = reverse(slice(huaweicloud_smn_topic.test[*].topic_urn, 0, 2))
+
+  events = [
+    "*:wait_inputs,hold,completed",
+    "labeling:wait_inputs,hold,failed,create_failed",
+    "service_step:wait_inputs,hold,completed",
+  ]
+}
+`, testAccV2WorkflowSubscription_smnTopics(name), acceptance.HW_MODELARTS_WORKFLOW_ID)
+}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow_subscription.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow_subscription.go
@@ -1,0 +1,308 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	v2WorkflowSubscriptionNonUpdatableParams = []string{
+		"workflow_id",
+	}
+	v2WorkflowSubscriptionNotFoundErrCodes = []string{
+		"ModelArts.7512", // The workflow does not exist.
+		"ModelArts.7519", // The workflow subscription does not exist.
+	}
+)
+
+// @API ModelArts POST /v2/{project_id}/workflows/{workflow_id}/subscriptions
+// @API ModelArts GET /v2/{project_id}/workflows/{workflow_id}/subscriptions/{subscription_id}
+// @API ModelArts PUT /v2/{project_id}/workflows/{workflow_id}/subscriptions/{subscription_id}
+// @API ModelArts DELETE /v2/{project_id}/workflows/{workflow_id}/subscriptions/{subscription_id}
+func ResourceV2WorkflowSubscription() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV2WorkflowSubscriptionCreate,
+		ReadContext:   resourceV2WorkflowSubscriptionRead,
+		UpdateContext: resourceV2WorkflowSubscriptionUpdate,
+		DeleteContext: resourceV2WorkflowSubscriptionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceV2WorkflowSubscriptionImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(v2WorkflowSubscriptionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the workflow subscription is located.`,
+			},
+
+			// Required parameters.
+			"workflow_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workflow to which the subscription belongs.`,
+			},
+			"topic_urns": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of SMN topic URNs to subscribe.`,
+			},
+
+			// Optional parameters.
+			"events": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of workflow events to subscribe.`,
+			},
+
+			// Attributes.
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the workflow subscription, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true},
+				),
+			},
+		},
+	}
+}
+
+func buildV2WorkflowSubscriptionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"topic_urns": d.Get("topic_urns"),
+		"events":     utils.ValueIgnoreEmpty(d.Get("events")),
+	}
+}
+
+func createV2WorkflowSubscription(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl    = "v2/{project_id}/workflows/{workflow_id}/subscriptions"
+		workflowId = d.Get("workflow_id").(string)
+	)
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{workflow_id}", workflowId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildV2WorkflowSubscriptionBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceV2WorkflowSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	resp, err := createV2WorkflowSubscription(client, d)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts workflow subscription: %s", err)
+	}
+
+	subscriptionId := utils.PathSearch("subscription_id", resp, "").(string)
+	if subscriptionId == "" {
+		return diag.Errorf("unable to find the ModelArts workflow subscription ID from the API response")
+	}
+	d.SetId(subscriptionId)
+
+	return resourceV2WorkflowSubscriptionRead(ctx, d, meta)
+}
+
+func GetV2WorkflowSubscriptionById(client *golangsdk.ServiceClient, workflowId, subscriptionId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/workflows/{workflow_id}/subscriptions/{subscription_id}"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{workflow_id}", workflowId)
+	getPath = strings.ReplaceAll(getPath, "{subscription_id}", subscriptionId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceV2WorkflowSubscriptionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		workflowId     = d.Get("workflow_id").(string)
+		subscriptionId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	resp, err := GetV2WorkflowSubscriptionById(client, workflowId, subscriptionId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", v2WorkflowSubscriptionNotFoundErrCodes...),
+			fmt.Sprintf("error retrieving ModelArts workflow subscription (%s)", subscriptionId))
+	}
+
+	createdAt := utils.PathSearch("created_at", resp, "").(string)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("topic_urns", utils.PathSearch("topic_urns", resp, make([]interface{}, 0))),
+		d.Set("events", utils.PathSearch("events", resp, make([]interface{}, 0))),
+	)
+	if createdAt != "" {
+		mErr = multierror.Append(mErr,
+			d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(createdAt)/1000, false)),
+		)
+	}
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func updateV2WorkflowSubscription(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl        = "v2/{project_id}/workflows/{workflow_id}/subscriptions/{subscription_id}"
+		workflowId     = d.Get("workflow_id").(string)
+		subscriptionId = d.Id()
+	)
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{workflow_id}", workflowId)
+	updatePath = strings.ReplaceAll(updatePath, "{subscription_id}", subscriptionId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildV2WorkflowSubscriptionBodyParams(d)),
+	}
+
+	_, err := client.Request("PUT", updatePath, &opt)
+	return err
+}
+
+func resourceV2WorkflowSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	err = updateV2WorkflowSubscription(client, d)
+	if err != nil {
+		return diag.Errorf("error updating ModelArts workflow subscription: %s", err)
+	}
+
+	return resourceV2WorkflowSubscriptionRead(ctx, d, meta)
+}
+
+func deleteV2WorkflowSubscription(client *golangsdk.ServiceClient, workflowId, subscriptionId string) error {
+	httpUrl := "v2/{project_id}/workflows/{workflow_id}/subscriptions/{subscription_id}"
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{workflow_id}", workflowId)
+	deletePath = strings.ReplaceAll(deletePath, "{subscription_id}", subscriptionId)
+
+	opt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &opt)
+	return err
+}
+
+func resourceV2WorkflowSubscriptionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		workflowId     = d.Get("workflow_id").(string)
+		subscriptionId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	err = deleteV2WorkflowSubscription(client, workflowId, subscriptionId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", v2WorkflowSubscriptionNotFoundErrCodes...),
+			fmt.Sprintf("error deleting ModelArts workflow subscription (%s)", subscriptionId))
+	}
+
+	return nil
+}
+
+func resourceV2WorkflowSubscriptionImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.SplitN(importedId, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workflow_id>/<id>', but got '%s'", importedId)
+	}
+
+	d.SetId(parts[1])
+	mErr := multierror.Append(nil,
+		d.Set("workflow_id", parts[0]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource to manage workflow subscription.
```
huaweicloud_modelartsv2_workflow_subscription
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1027" height="138" alt="image" src="https://github.com/user-attachments/assets/41f052b8-399c-4740-b1a2-0cb5e1390bdd" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
supports new resource to manage workflow subscription
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDataV2WorkflowSchedules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataV2WorkflowSchedules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV2WorkflowSchedules_basic
--- PASS: TestAccDataV2WorkflowSchedules_basic (21.76s)
PASS
coverage: 6.0% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 21.898s coverage: 6.0% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="2010" height="904" alt="image" src="https://github.com/user-attachments/assets/b72f43e3-3d42-4fb6-8d39-df51e4cb9b30" />

    ab. Related resources (parent resources) not found
    <img width="1981" height="875" alt="image" src="https://github.com/user-attachments/assets/ce76b02d-34d9-42e7-88dd-c135ebbd525b" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="2008" height="977" alt="image" src="https://github.com/user-attachments/assets/828dd922-e770-4936-8221-ab53a652f8ec" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
