### PR TITLE
feat(GeminiDB): add new data source to get SSL certificate download link

### DIFF
--- a/docs/data-sources/geminidb_ssl_cert_download_link.md
+++ b/docs/data-sources/geminidb_ssl_cert_download_link.md
@@ -1,0 +1,49 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_ssl_cert_download_links"
+description: |-
+  Use this data source to get the SSL certificate download link.
+---
+
+# huaweicloud_geminidb_ssl_cert_download_links
+
+Use this data source to get the SSL certificate download link.
+
+-> This data source does not support query the SSL certificate and private download addresses of CCM.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_geminidb_ssl_cert_download_links" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `certs` - The list of the certificate information.
+  The [certs](#certs_struct) structure is documented below.
+
+<a name="certs_struct"></a>
+The `certs` block supports:
+
+* `category` - The certificate type.
+  + **international**: international certificate.
+
+* `download_link` - The certificate download link.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1467,6 +1467,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_quotas":                   geminidb.DataSourceQuotas(),
 			"huaweicloud_geminidb_recycling_instances":      geminidb.DataSourceGeminiDBRecyclingInstances(),
 			"huaweicloud_geminidb_restorable_time_window":   geminidb.DataSourceGeminiDBRestorableTimeWindow(),
+			"huaweicloud_geminidb_ssl_cert_download_links":  geminidb.DataSourceSslCertDownloadLinks(),
 			"huaweicloud_geminidb_table_restored_databases": geminidb.DataSourceGeminiDBTableRestoredDatabases(),
 
 			"huaweicloud_gaussdb_storage_types":             gaussdb.DataSourceGaussDbStorageTypes(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_ssl_cert_download_links_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_ssl_cert_download_links_test.go
@@ -1,0 +1,44 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSslCertDownloadLinks_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_geminidb_ssl_cert_download_links.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccCheckGeminidbInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSslCertDownloadLinks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "certs.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "certs.0.category"),
+					resource.TestCheckResourceAttrSet(dataSource, "certs.0.download_link"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceSslCertDownloadLinks_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_geminidb_ssl_cert_download_links" "test" {
+  instance_id = "%s"
+}
+`, acceptance.HW_GEMINIDB_INSATNCE_ID)
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_ssl_cert_download_links.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_ssl_cert_download_links.go
@@ -1,0 +1,114 @@
+package geminidb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/ssl-cert/download-link
+func DataSourceSslCertDownloadLinks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSslCertDownloadLinksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"certs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"download_link": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSslCertDownloadLinksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/ssl-cert/download-link"
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the GeminiDB SSL certificate download link: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("certs", flattenSslCertDownloadLinks(
+			utils.PathSearch("certs", getRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSslCertDownloadLinks(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"category":      utils.PathSearch("category", v, nil),
+			"download_link": utils.PathSearch("download_link", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get SSL certificate download link.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to get SSL certificate download link.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccDataSourceSslCertDownloadLinks_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccDataSourceSslCertDownloadLinks_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSslCertDownloadLinks_basic
=== PAUSE TestAccDataSourceSslCertDownloadLinks_basic
=== CONT  TestAccDataSourceSslCertDownloadLinks_basic
--- PASS: TestAccDataSourceSslCertDownloadLinks_basic (21.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  22.111s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/4633fe70-d536-4a3f-ab11-3cfe8533583e" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
