### PR TITLE
feat(drs): support `drs_compare_policy` data source

### DIFF
--- a/docs/data-sources/drs_compare_policy.md
+++ b/docs/data-sources/drs_compare_policy.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_compare_policy"
+description: |-
+  Use this data source to get the compare policy information of a DRS job.
+---
+
+# huaweicloud_drs_compare_policy
+
+Use this data source to get the compare policy information of a DRS job.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+data "huaweicloud_drs_compare_policy" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the ID of the DRS job.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `interval_hour` - The interval hours between comparisons.
+
+* `period` - The comparison period schedule.
+
+* `status` - The status of the compare policy.
+  The valid values are as follows:
+  + **OPEN**: Enabled.
+  + **CLOSED**: Disabled, no comparison policy is set.
+  + **NO_SUPPORT**: No data available.
+
+* `begin_time` - The start time of the comparison window.
+
+* `end_time` - The end time of the comparison window.
+
+* `compare_type` - The list of comparison types.
+  The valid values are as follows:
+  + **object**: Object comparison.
+  + **lines**: Row count comparison.
+  + **account**: User comparison.
+
+* `next_compare_time` - The scheduled time for the next comparison in UTC format, e.g., **2023-06-12T08:00:00Z**.
+
+* `compare_policy` - The comparison policy type.
+  The valid values are as follows:
+  + **normal**: Normal comparison.
+  + **manyToOne**: Many-to-one comparison.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1325,6 +1325,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_batch_get_params":       drs.DataSourceDrsBatchGetParams(),
 			"huaweicloud_drs_batch_progresses":       drs.DataSourceDrsBatchProgresses(),
 			"huaweicloud_drs_compare_content_detail": drs.DataSourceDrsCompareContentDetail(),
+			"huaweicloud_drs_compare_policy":         drs.DataSourceDrsComparePolicy(),
 			"huaweicloud_drs_compare_progress":       drs.DataSourceDrsCompareProgress(),
 			"huaweicloud_drs_job_configurations":     drs.DataSourceDrsJobConfigurations(),
 			"huaweicloud_drs_job_links":              drs.DataSourceJobLinks(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_compare_policy_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_compare_policy_test.go
@@ -1,0 +1,49 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsComparePolicy_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_compare_policy.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDrsComparePolicy_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "interval_hour"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "period"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "begin_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "end_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "compare_type.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "next_compare_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "compare_policy"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDrsComparePolicy_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_compare_policy" "test" {
+  job_id = "%s"
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_compare_policy.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_compare_policy.go
@@ -1,0 +1,125 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v5/{project_id}/jobs/{job_id}/compare-policy
+func DataSourceDrsComparePolicy() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsComparePolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"interval_hour": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"period": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"begin_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"compare_type": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"next_compare_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"compare_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDrsComparePolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v5/{project_id}/jobs/{job_id}/compare-policy"
+		jobId   = d.Get("job_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobId)
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &reqOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DRS compare policy: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", region),
+		d.Set("interval_hour", utils.PathSearch("interval_hour", respBody, nil)),
+		d.Set("period", utils.PathSearch("period", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("begin_time", utils.PathSearch("begin_time", respBody, nil)),
+		d.Set("end_time", utils.PathSearch("end_time", respBody, nil)),
+		d.Set("compare_type", utils.PathSearch("compare_type", respBody, nil)),
+		d.Set("next_compare_time", utils.PathSearch("next_compare_time", respBody, nil)),
+		d.Set("compare_policy", utils.PathSearch("compare_policy", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_compare_policy` data source


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support `drs_compare_policy` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccDataSourceDrsComparePolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs-v -run TestAccDataSourceDrsComparePolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDrsComparePolicy_basic
=== PAUSE TestAccDataSourceDrsComparePolicy_basic
=== CONT  TestAccDataSourceDrsComparePolicy_basic
--- PASS: TestAccDataSourceDrsComparePolicy_basic (12.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       21.311s
```
<img width="529" height="30" alt="image" src="https://github.com/user-attachments/assets/e9d5c012-84aa-4e31-888a-8afe4d4d084e" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
