### PR TITLE
feat(drs): new datasource to query compare result

### DIFF
--- a/docs/data-sources/drs_compare_result.md
+++ b/docs/data-sources/drs_compare_result.md
@@ -1,0 +1,354 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_compare_result"
+description: |-
+  Use this data source to get the compare result for specified DRS job within HuaweiCloud.
+---
+
+# huaweicloud_drs_compare_result
+
+Use this data source to get the compare result for specified DRS job within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+data "huaweicloud_drs_compare_result" "test" { 
+  job_id       = var.job_id
+  current_page = 1
+  per_page     = 10
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the DRS job ID.
+
+* `current_page` - (Required, Int) Specifies the current page number for pagination.
+
+* `per_page` - (Required, Int) Specifies the number of items per page for pagination.
+
+* `object_level_compare_id` - (Optional, String) Specifies the object-level compare task ID.
+
+* `line_compare_id` - (Optional, String) Specifies the line compare task ID.
+
+* `content_compare_id` - (Optional, String) Specifies the content compare task ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `object_level_compare_results` - The object-level compare results.
+
+  The [object_level_compare_results](#object_level_compare_results_struct) structure is documented below.
+
+* `line_compare_results` - The line compare results.
+
+  The [line_compare_results](#line_compare_results_struct) structure is documented below.
+
+* `content_compare_results` - The content compare results.
+
+  The [content_compare_results](#content_compare_results_struct) structure is documented below.
+
+* `compare_task_list_results` - The compare task list results.
+
+  The [compare_task_list_results](#compare_task_list_results_struct) structure is documented below.
+
+<a name="object_level_compare_results_struct"></a>
+The `object_level_compare_results` block supports:
+
+* `compare_task_id` - The object-level compare task ID.
+
+* `object_compare_overview` - The object compare overview.
+
+  The [object_compare_overview](#object_compare_overview_struct) structure is documented below.
+
+* `error_code` - The error code.
+
+* `error_msg` - The error message.
+
+<a name="object_compare_overview_struct"></a>
+The `object_compare_overview` block supports:
+
+* `object_type` - The object type.
+  The valid values are as follows:
+  + **DB**: Database.
+  + **TABLE**: Table.
+  + **VIEW**: View.
+  + **EVENT**: Event.
+  + **ROUTINE**: Stored procedure and function.
+  + **INDEX**: Index.
+  + **TRIGGER**: Trigger.
+  + **SYNONYM**: Synonym.
+  + **FUNCTION**: Function.
+  + **PROCEDURE**: Stored procedure.
+  + **TYPE**: Custom type.
+  + **RULE**: Rule.
+  + **DEFAULT_TYPE**: Default value.
+  + **PLAN_GUIDE**: Execution plan.
+  + **CONSTRAINT**: Constraint.
+  + **FILE_GROUP**: File group.
+  + **PARTITION_FUNCTION**: Partition function.
+  + **PARTITION_SCHEME**: Partition scheme.
+  + **TABLE_COLLATION**: Table collation.
+  + **EXTENSIONS**: Plugin.
+
+* `object_compare_result` - The compare result.
+  The valid values are as follows:
+  + **CONSISTENT**: Consistent.
+  + **INCONSISTENT**: Inconsistent.
+  + **COMPARING**: Comparing.
+  + **WAITING_FOR_COMPARISON**: Waiting for comparison.
+  + **FAILED_TO_COMPARE**: Compare failed.
+  + **TARGET_DB_NOT_EXIT**: Target database does not exist.
+  + **CAN_NOT_COMPARE**: Cannot compare.
+
+* `target_count` - The number of objects in the target database.
+
+* `source_count` - The number of objects in the source database.
+
+* `diff_count` - The number of differences between source and target databases.
+
+<a name="line_compare_results_struct"></a>
+The `line_compare_results` block supports:
+
+* `compare_task_id` - The line compare task ID.
+
+* `line_compare_overview` - The line compare overview.
+
+  The [line_compare_overview](#line_compare_overview_struct) structure is documented below.
+
+* `line_compare_overview_count` - The total number of line compare overview results.
+
+* `line_compare_details` - The line compare details.
+
+  The [line_compare_details](#line_compare_details_struct) structure is documented below.
+
+* `error_code` - The error code.
+
+* `error_msg` - The error message.
+
+<a name="line_compare_overview_struct"></a>
+The `line_compare_overview` block supports:
+
+* `source_db_name` - The source database name.
+
+* `target_db_name` - The target database name.
+
+* `line_compare_result` - The compare result.
+  The valid values are as follows:
+  + **CONSISTENT**: Consistent.
+  + **INCONSISTENT**: Inconsistent.
+  + **COMPARING**: Comparing.
+  + **WAITING_FOR_COMPARISON**: Waiting for comparison.
+  + **FAILED_TO_COMPARE**: Compare failed.
+  + **TARGET_DB_NOT_EXIT**: Target database does not exist.
+  + **CAN_NOT_COMPARE**: Cannot compare.
+
+<a name="line_compare_details_struct"></a>
+The `line_compare_details` block supports:
+
+* `source_db_name` - The source database name.
+
+* `line_compare_detail` - The line compare detail.
+
+  The [line_compare_detail](#line_compare_detail_struct) structure is documented below.
+
+* `line_compare_detail_count` - The total number of line compare detail results.
+
+<a name="line_compare_detail_struct"></a>
+The `line_compare_detail` block supports:
+
+* `source_table_name` - The source table name.
+
+* `target_table_name` - The target table name.
+
+* `source_row_num` - The number of rows in the source table.
+
+* `target_row_num` - The number of rows in the target table.
+
+* `diff_row_num` - The number of different rows between source and target tables.
+
+* `line_compare_result` - The compare result.
+  The valid values are as follows:
+  + **CONSISTENT**: Consistent.
+  + **INCONSISTENT**: Inconsistent.
+  + **COMPARING**: Comparing.
+  + **WAITING_FOR_COMPARISON**: Waiting for comparison.
+  + **FAILED_TO_COMPARE**: Compare failed.
+  + **TARGET_DB_NOT_EXIT**: Target database does not exist.
+  + **CAN_NOT_COMPARE**: Cannot compare.
+
+* `message` - The additional information.
+
+<a name="content_compare_results_struct"></a>
+The `content_compare_results` block supports:
+
+* `compare_task_id` - The content compare task ID.
+
+* `content_compare_overview` - The content compare overview.
+
+  The [content_compare_overview](#content_compare_overview_struct) structure is documented below.
+
+* `content_compare_overview_count` - The total number of content compare overview results.
+
+* `content_compare_details` - The content compare details.
+
+  The [content_compare_details](#content_compare_details_struct) structure is documented below.
+
+* `content_compare_diffs` - The content compare differences.
+
+  The [content_compare_diffs](#content_compare_diffs_struct) structure is documented below.
+
+* `error_code` - The error code.
+
+* `error_msg` - The error message.
+
+<a name="content_compare_overview_struct"></a>
+The `content_compare_overview` block supports:
+
+* `source_db_name` - The source database name.
+
+* `target_db_name` - The target database name.
+
+* `content_compare_result` - The compare result.
+  The valid values are as follows:
+  + **CONSISTENT**: Consistent.
+  + **INCONSISTENT**: Inconsistent.
+  + **COMPARING**: Comparing.
+  + **WAITING_FOR_COMPARISON**: Waiting for comparison.
+  + **FAILED_TO_COMPARE**: Compare failed.
+  + **TARGET_DB_NOT_EXIT**: Target database does not exist.
+  + **CAN_NOT_COMPARE**: Cannot compare.
+
+<a name="content_compare_details_struct"></a>
+The `content_compare_details` block supports:
+
+* `source_db_name` - The source database name.
+
+* `content_compare_detail` - The content compare detail.
+
+  The [content_compare_detail](#content_compare_detail_struct) structure is documented below.
+
+* `content_compare_detail_count` - The total number of content compare detail results.
+
+* `content_uncompare_detail` - The content uncompare detail (tables that cannot be compared).
+
+  The [content_compare_detail](#content_compare_detail_struct) structure is documented below.
+
+* `content_uncompare_detail_count` - The total number of content uncompare detail results.
+
+<a name="content_compare_detail_struct"></a>
+The `content_compare_detail` block supports:
+
+* `source_db_name` - The source database name.
+
+* `target_db_name` - The target database name.
+
+* `source_table_name` - The source table name.
+
+* `target_table_name` - The target table name.
+
+* `source_row_num` - The number of rows in the source table.
+
+* `target_row_num` - The number of rows in the target table.
+
+* `diff_row_num` - The number of different rows between source and target tables.
+
+* `line_compare_result` - The line compare result.
+  The valid values are as follows:
+  + **CONSISTENT**: Consistent.
+  + **INCONSISTENT**: Inconsistent.
+  + **COMPARING**: Comparing.
+  + **WAITING_FOR_COMPARISON**: Waiting for comparison.
+  + **FAILED_TO_COMPARE**: Compare failed.
+  + **TARGET_DB_NOT_EXIT**: Target database does not exist.
+  + **CAN_NOT_COMPARE**: Cannot compare.
+
+* `content_compare_result` - The content compare result.
+  The valid values are as follows:
+  + **CONSISTENT**: Consistent.
+  + **INCONSISTENT**: Inconsistent.
+  + **COMPARING**: Comparing.
+  + **WAITING_FOR_COMPARISON**: Waiting for comparison.
+  + **FAILED_TO_COMPARE**: Compare failed.
+  + **TARGET_DB_NOT_EXIT**: Target database does not exist.
+  + **CAN_NOT_COMPARE**: Cannot compare.
+
+* `message` - The additional information.
+
+<a name="content_compare_diffs_struct"></a>
+The `content_compare_diffs` block supports:
+
+* `source_db_name` - The source database name.
+
+* `source_table_name` - The source table name.
+
+* `content_compare_diff` - The content compare difference.
+
+  The [content_compare_diff](#content_compare_diff_struct) structure is documented below.
+
+* `content_compare_diff_count` - The total number of content compare differences.
+
+<a name="content_compare_diff_struct"></a>
+The `content_compare_diff` block supports:
+
+* `target_select_sql` - The SQL for querying the target database.
+
+* `source_select_sql` - The SQL for querying the source database.
+
+* `source_key_value` - The list of source key values.
+
+* `target_key_value` - The list of target key values.
+
+<a name="compare_task_list_results_struct"></a>
+The `compare_task_list_results` block supports:
+
+* `compare_task_list` - The compare task list.
+
+  The [compare_task_list](#compare_task_list_struct) structure is documented below.
+
+* `compare_task_list_count` - The total number of compare tasks.
+
+* `error_msg` - The error message.
+
+* `error_code` - The error code.
+
+<a name="compare_task_list_struct"></a>
+The `compare_task_list` block supports:
+
+* `compare_task_id` - The compare task ID.
+
+* `compare_type` - The compare task type.
+  The valid values are as follows:
+  + **lines**: Line comparison.
+  + **contents**: Value comparison.
+  + **object_comparison**: Object-level comparison.
+  + **account**: Account comparison.
+  + **random**: Sampling comparison.
+  + **node**: Kernel calculation comparison result.
+  + **mgr**: Management calculation comparison result.
+
+* `compare_task_status` - The compare task status.
+  The valid values are as follows:
+  + **RUNNING**: Running.
+  + **WAITING_FOR_RUNNING**: Waiting to start.
+  + **SUCCESSFUL**: Completed.
+  + **FAILED**: Failed.
+  + **CANCELLED**: Cancelled.
+  + **TIMEOUT_INTERRUPT**: Timeout interrupted.
+  + **FULL_DOING**: Full verification in progress.
+  + **INCRE_DOING**: Incremental verification in progress.
+
+* `create_time` - The compare start time.
+
+* `end_time` - The compare end time.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1326,6 +1326,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_batch_progresses":       drs.DataSourceDrsBatchProgresses(),
 			"huaweicloud_drs_compare_content_detail": drs.DataSourceDrsCompareContentDetail(),
 			"huaweicloud_drs_compare_progress":       drs.DataSourceDrsCompareProgress(),
+			"huaweicloud_drs_compare_result":         drs.DataSourceDrsCompareResult(),
 			"huaweicloud_drs_job_configurations":     drs.DataSourceDrsJobConfigurations(),
 			"huaweicloud_drs_job_links":              drs.DataSourceJobLinks(),
 			"huaweicloud_drs_job_metering":           drs.DataSourceDrsJobMetering(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_compare_result_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_compare_result_test.go
@@ -1,0 +1,47 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsCompareResult_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_compare_result.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobIds(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDrsCompareResult_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "object_level_compare_results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "line_compare_results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "content_compare_results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "compare_task_list_results.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDrsCompareResult_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_compare_result" "test" {
+  job_id       = "%s"
+  current_page = 1
+  per_page     = 10
+}
+`, acceptance.HW_DRS_JOB_IDS)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_compare_result.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_compare_result.go
@@ -1,0 +1,811 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS POST /v3/{project_id}/jobs/query-compare-result
+func DataSourceDrsCompareResult() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsCompareResultRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"current_page": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"per_page": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"object_level_compare_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"line_compare_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"content_compare_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"object_level_compare_results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     objectLevelCompareResultsSchema(),
+			},
+			"line_compare_results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     lineCompareResultsSchema(),
+			},
+			"content_compare_results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     contentCompareResultsSchema(),
+			},
+			"compare_task_list_results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     compareTaskListResultsSchema(),
+			},
+		},
+	}
+}
+
+func objectLevelCompareResultsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"compare_task_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"object_compare_overview": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     objectCompareOverviewSchema(),
+			},
+			"error_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error_msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func objectCompareOverviewSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"object_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"object_compare_result": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"source_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"diff_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func lineCompareResultsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"compare_task_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"line_compare_overview": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     lineCompareOverviewSchema(),
+			},
+			"line_compare_overview_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"line_compare_details": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     lineCompareDetailsSchema(),
+			},
+			"error_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error_msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func lineCompareOverviewSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"source_db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"line_compare_result": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func lineCompareDetailsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"source_db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"line_compare_detail": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     lineCompareDetailSchema(),
+			},
+			"line_compare_detail_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func lineCompareDetailSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"source_table_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_table_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_row_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"target_row_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"diff_row_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"line_compare_result": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"message": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func contentCompareResultsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"compare_task_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"content_compare_overview": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     contentCompareOverviewSchema(),
+			},
+			"content_compare_overview_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"content_compare_details": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     contentCompareDetailsSchema(),
+			},
+			"content_compare_diffs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     contentCompareDiffsSchema(),
+			},
+			"error_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error_msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func contentCompareOverviewSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"source_db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"content_compare_result": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func contentCompareDetailsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"source_db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"content_compare_detail": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     contentCompareDetailSchema(),
+			},
+			"content_compare_detail_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"content_uncompare_detail": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     contentCompareDetailSchema(),
+			},
+			"content_uncompare_detail_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func contentCompareDetailSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"source_db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_table_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_table_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_row_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"target_row_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"diff_row_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"line_compare_result": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"content_compare_result": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"message": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func contentCompareDiffsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"source_db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_table_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"content_compare_diff": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     contentCompareDiffSchema(),
+			},
+			"content_compare_diff_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func contentCompareDiffSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"target_select_sql": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_select_sql": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_key_value": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"target_key_value": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func compareTaskListResultsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"compare_task_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     compareTaskListSchema(),
+			},
+			"compare_task_list_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"error_msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func compareTaskListSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"compare_task_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"compare_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"compare_task_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCompareResultBodyParams(d *schema.ResourceData) map[string]interface{} {
+	body := map[string]interface{}{
+		"job_id":       d.Get("job_id").(string),
+		"current_page": d.Get("current_page").(int),
+		"per_page":     d.Get("per_page").(int),
+	}
+
+	if v, ok := d.GetOk("object_level_compare_id"); ok {
+		body["object_level_compare_id"] = v.(string)
+	}
+	if v, ok := d.GetOk("line_compare_id"); ok {
+		body["line_compare_id"] = v.(string)
+	}
+	if v, ok := d.GetOk("content_compare_id"); ok {
+		body["content_compare_id"] = v.(string)
+	}
+
+	return body
+}
+
+func dataSourceDrsCompareResultRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v3/{project_id}/jobs/query-compare-result"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildCompareResultBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DRS compare result: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("object_level_compare_results", flattenObjectLevelCompareResults(respBody)),
+		d.Set("line_compare_results", flattenLineCompareResults(respBody)),
+		d.Set("content_compare_results", flattenContentCompareResults(respBody)),
+		d.Set("compare_task_list_results", flattenCompareTaskListResults(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenObjectLevelCompareResults(respBody interface{}) []interface{} {
+	resultMap := utils.PathSearch("object_level_compare_results", respBody, nil)
+	if resultMap == nil {
+		return nil
+	}
+
+	objectCompareOverview := utils.PathSearch("object_compare_overview", resultMap, make([]interface{}, 0))
+	return []interface{}{
+		map[string]interface{}{
+			"compare_task_id":         utils.PathSearch("compare_task_id", resultMap, nil),
+			"object_compare_overview": flattenObjectCompareOverview(objectCompareOverview),
+			"error_code":              utils.PathSearch("error_code", resultMap, nil),
+			"error_msg":               utils.PathSearch("error_msg", resultMap, nil),
+		},
+	}
+}
+
+func flattenObjectCompareOverview(overview interface{}) []interface{} {
+	overviewRaw, ok := overview.([]interface{})
+	if !ok || len(overviewRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(overviewRaw))
+	for _, item := range overviewRaw {
+		result = append(result, map[string]interface{}{
+			"object_type":           utils.PathSearch("object_type", item, nil),
+			"object_compare_result": utils.PathSearch("object_compare_result", item, nil),
+			"target_count":          utils.PathSearch("target_count", item, nil),
+			"source_count":          utils.PathSearch("source_count", item, nil),
+			"diff_count":            utils.PathSearch("diff_count", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenLineCompareResults(respBody interface{}) []interface{} {
+	resultMap := utils.PathSearch("line_compare_results", respBody, nil)
+	if resultMap == nil {
+		return nil
+	}
+
+	lineCompareOverview := utils.PathSearch("line_compare_overview", resultMap, make([]interface{}, 0))
+	lineCompareDetails := utils.PathSearch("line_compare_details", resultMap, make([]interface{}, 0))
+
+	return []interface{}{
+		map[string]interface{}{
+			"compare_task_id":             utils.PathSearch("compare_task_id", resultMap, nil),
+			"line_compare_overview":       flattenLineCompareOverview(lineCompareOverview),
+			"line_compare_overview_count": utils.PathSearch("line_compare_overview_count", resultMap, nil),
+			"line_compare_details":        flattenLineCompareDetails(lineCompareDetails),
+			"error_code":                  utils.PathSearch("error_code", resultMap, nil),
+			"error_msg":                   utils.PathSearch("error_msg", resultMap, nil),
+		},
+	}
+}
+
+func flattenLineCompareOverview(overview interface{}) []interface{} {
+	overviewRaw, ok := overview.([]interface{})
+	if !ok || len(overviewRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(overviewRaw))
+	for _, item := range overviewRaw {
+		result = append(result, map[string]interface{}{
+			"source_db_name":      utils.PathSearch("source_db_name", item, nil),
+			"target_db_name":      utils.PathSearch("target_db_name", item, nil),
+			"line_compare_result": utils.PathSearch("line_compare_result", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenLineCompareDetails(details interface{}) []interface{} {
+	detailsRaw, ok := details.([]interface{})
+	if !ok || len(detailsRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(detailsRaw))
+	for _, item := range detailsRaw {
+		lineCompareDetail := utils.PathSearch("line_compare_detail", item, make([]interface{}, 0))
+		result = append(result, map[string]interface{}{
+			"source_db_name":            utils.PathSearch("source_db_name", item, nil),
+			"line_compare_detail":       flattenLineCompareDetail(lineCompareDetail),
+			"line_compare_detail_count": utils.PathSearch("line_compare_detail_count", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenLineCompareDetail(detail interface{}) []interface{} {
+	detailRaw, ok := detail.([]interface{})
+	if !ok || len(detailRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(detailRaw))
+	for _, item := range detailRaw {
+		result = append(result, map[string]interface{}{
+			"source_table_name":   utils.PathSearch("source_table_name", item, nil),
+			"target_table_name":   utils.PathSearch("target_table_name", item, nil),
+			"source_row_num":      utils.PathSearch("source_row_num", item, nil),
+			"target_row_num":      utils.PathSearch("target_row_num", item, nil),
+			"diff_row_num":        utils.PathSearch("diff_row_num", item, nil),
+			"line_compare_result": utils.PathSearch("line_compare_result", item, nil),
+			"message":             utils.PathSearch("message", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenContentCompareResults(respBody interface{}) []interface{} {
+	resultMap := utils.PathSearch("content_compare_results", respBody, nil)
+	if resultMap == nil {
+		return nil
+	}
+
+	contentCompareOverview := utils.PathSearch("content_compare_overview", resultMap, make([]interface{}, 0))
+	contentCompareDetails := utils.PathSearch("content_compare_details", resultMap, make([]interface{}, 0))
+	contentCompareDiffs := utils.PathSearch("content_compare_diffs", resultMap, make([]interface{}, 0))
+
+	return []interface{}{
+		map[string]interface{}{
+			"compare_task_id":                utils.PathSearch("compare_task_id", resultMap, nil),
+			"content_compare_overview":       flattenContentCompareOverview(contentCompareOverview),
+			"content_compare_overview_count": utils.PathSearch("content_compare_overview_count", resultMap, nil),
+			"content_compare_details":        flattenContentCompareDetails(contentCompareDetails),
+			"content_compare_diffs":          flattenContentCompareDiffs(contentCompareDiffs),
+			"error_code":                     utils.PathSearch("error_code", resultMap, nil),
+			"error_msg":                      utils.PathSearch("error_msg", resultMap, nil),
+		},
+	}
+}
+
+func flattenContentCompareOverview(overview interface{}) []interface{} {
+	overviewRaw, ok := overview.([]interface{})
+	if !ok || len(overviewRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(overviewRaw))
+	for _, item := range overviewRaw {
+		result = append(result, map[string]interface{}{
+			"source_db_name":         utils.PathSearch("source_db_name", item, nil),
+			"target_db_name":         utils.PathSearch("target_db_name", item, nil),
+			"content_compare_result": utils.PathSearch("content_compare_result", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenContentCompareDetails(details interface{}) []interface{} {
+	detailsRaw, ok := details.([]interface{})
+	if !ok || len(detailsRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(detailsRaw))
+	for _, item := range detailsRaw {
+		contentCompareDetail := utils.PathSearch("content_compare_detail", item, make([]interface{}, 0))
+		contentUncompareDetail := utils.PathSearch("content_uncompare_detail", item, make([]interface{}, 0))
+
+		result = append(result, map[string]interface{}{
+			"source_db_name":                 utils.PathSearch("source_db_name", item, nil),
+			"content_compare_detail":         flattenContentCompareDetail(contentCompareDetail),
+			"content_compare_detail_count":   utils.PathSearch("content_compare_detail_count", item, nil),
+			"content_uncompare_detail":       flattenContentCompareDetail(contentUncompareDetail),
+			"content_uncompare_detail_count": utils.PathSearch("content_uncompare_detail_count", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenContentCompareDetail(detail interface{}) []interface{} {
+	detailRaw, ok := detail.([]interface{})
+	if !ok || len(detailRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(detailRaw))
+	for _, item := range detailRaw {
+		result = append(result, map[string]interface{}{
+			"source_db_name":         utils.PathSearch("source_db_name", item, nil),
+			"target_db_name":         utils.PathSearch("target_db_name", item, nil),
+			"source_table_name":      utils.PathSearch("source_table_name", item, nil),
+			"target_table_name":      utils.PathSearch("target_table_name", item, nil),
+			"source_row_num":         utils.PathSearch("source_row_num", item, nil),
+			"target_row_num":         utils.PathSearch("target_row_num", item, nil),
+			"diff_row_num":           utils.PathSearch("diff_row_num", item, nil),
+			"line_compare_result":    utils.PathSearch("line_compare_result", item, nil),
+			"content_compare_result": utils.PathSearch("content_compare_result", item, nil),
+			"message":                utils.PathSearch("message", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenContentCompareDiffs(diffs interface{}) []interface{} {
+	diffsRaw, ok := diffs.([]interface{})
+	if !ok || len(diffsRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(diffsRaw))
+	for _, item := range diffsRaw {
+		contentCompareDiff := utils.PathSearch("content_compare_diff", item, make([]interface{}, 0))
+
+		result = append(result, map[string]interface{}{
+			"source_db_name":             utils.PathSearch("source_db_name", item, nil),
+			"source_table_name":          utils.PathSearch("source_table_name", item, nil),
+			"content_compare_diff":       flattenContentCompareDiff(contentCompareDiff),
+			"content_compare_diff_count": utils.PathSearch("content_compare_diff_count", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenContentCompareDiff(diff interface{}) []interface{} {
+	diffRaw, ok := diff.([]interface{})
+	if !ok || len(diffRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(diffRaw))
+	for _, item := range diffRaw {
+		result = append(result, map[string]interface{}{
+			"target_select_sql": utils.PathSearch("target_select_sql", item, nil),
+			"source_select_sql": utils.PathSearch("source_select_sql", item, nil),
+			"source_key_value":  utils.PathSearch("source_key_value", item, nil),
+			"target_key_value":  utils.PathSearch("target_key_value", item, nil),
+		})
+	}
+	return result
+}
+
+func flattenCompareTaskListResults(respBody interface{}) []interface{} {
+	resultMap := utils.PathSearch("compare_task_list_results", respBody, nil)
+	if resultMap == nil {
+		return nil
+	}
+
+	compareTaskList := utils.PathSearch("compare_task_list", resultMap, make([]interface{}, 0))
+
+	return []interface{}{
+		map[string]interface{}{
+			"compare_task_list":       flattenCompareTaskList(compareTaskList),
+			"compare_task_list_count": utils.PathSearch("compare_task_list_count", resultMap, nil),
+			"error_msg":               utils.PathSearch("error_msg", resultMap, nil),
+			"error_code":              utils.PathSearch("error_code", resultMap, nil),
+		},
+	}
+}
+
+func flattenCompareTaskList(taskList interface{}) []interface{} {
+	taskListRaw, ok := taskList.([]interface{})
+	if !ok || len(taskListRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(taskListRaw))
+	for _, item := range taskListRaw {
+		result = append(result, map[string]interface{}{
+			"compare_task_id":     utils.PathSearch("compare_task_id", item, nil),
+			"compare_type":        utils.PathSearch("compare_type", item, nil),
+			"compare_task_status": utils.PathSearch("compare_task_status", item, nil),
+			"create_time":         utils.PathSearch("create_time", item, nil),
+			"end_time":            utils.PathSearch("end_time", item, nil),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query compare result

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o drs -f TestAccDataSourceDrsCompareResult_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsCompareResult_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsCompareResult_basic
=== PAUSE TestAccDataSourceDrsCompareResult_basic
=== CONT  TestAccDataSourceDrsCompareResult_basic
--- PASS: TestAccDataSourceDrsCompareResult_basic (21.64s)
PASS
coverage: 6.2% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       21.735s coverage: 6.2% of statements in ./huaweicloud/services/drs
```
<img width="1322" height="77" alt="image" src="https://github.com/user-attachments/assets/98803b71-f92f-4771-b40c-52670ec003c3" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
