### PR TITLE
feat(modelarts): devserver supports reboot action

### DIFF
--- a/docs/resources/modelarts_devserver.md
+++ b/docs/resources/modelarts_devserver.md
@@ -23,7 +23,7 @@ variable "admin_pass" {}
 
 resource "huaweicloud_modelarts_devserver" "test" {
   name              = var.server_name
-  flavor            = var.server_flavor
+  resource_flavor   = var.server_flavor
   vpc_id            = var.vpc_id
   subnet_id         = var.subnet_id
   security_group_id = var.security_group_id
@@ -55,7 +55,7 @@ The following arguments are supported:
   The name valid length is limited from `1` to `64`, only English letters, digits, underscores (_) and hyphens (-) are
   allowed.
 
-* `flavor` - (Required, String, ForceNew) Specifies the flavor of the DevServer.
+* `resource_flavor` - (Required, String, ForceNew) Specifies the resource flavor of the DevServer.
   Changing this creates a new resource.  
   For the flavor, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/usermanual-ticket/topic_0065264094.html)
   to submit a service ticket to apply for the flavor.

--- a/docs/resources/modelarts_devserver_action.md
+++ b/docs/resources/modelarts_devserver_action.md
@@ -36,9 +36,16 @@ The following arguments are supported:
   The valid values are as follows:
   + **start**: The DevServer can be started only when the DevServer is stopped, stop failure, or start failure.
   + **stop**: The DevServer can be stopped only when it is running or stop failure.
+  + **reboot**: The DevServer can be rebooted only when it is running.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_devserver_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_devserver_test.go
@@ -90,6 +90,10 @@ func TestAccDevServer_basic(t *testing.T) {
 				Config:      testAccDevServer_doAction(name, password, "start", true),
 				ExpectError: regexp.MustCompile(`unable to start DevServer \([a-f0-9-]+\)`),
 			},
+			// Rebooting the DevServer.
+			{
+				Config: testAccDevServer_doAction(name, password, "reboot", false),
+			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_devserver_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_devserver_test.go
@@ -50,7 +50,7 @@ func TestAccDevServer_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "flavor", acceptance.HW_MODELARTS_DEVSERVER_FLAVOR),
+					resource.TestCheckResourceAttr(resourceName, "resource_flavor", acceptance.HW_MODELARTS_DEVSERVER_FLAVOR),
 					resource.TestCheckResourceAttrSet(resourceName, "architecture"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
@@ -61,6 +61,8 @@ func TestAccDevServer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
 					resource.TestMatchResourceAttr(resourceName, "created_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Deprecated parameters.
+					resource.TestCheckResourceAttrSet(resourceName, "flavor"),
 				),
 			},
 			{
@@ -77,7 +79,7 @@ func TestAccDevServer_basic(t *testing.T) {
 			// Stopping the stopped DevServer.
 			{
 				Config:      testAccDevServer_doAction(name, password, "stop", true),
-				ExpectError: regexp.MustCompile(`Resource.Server '[a-f0-9-]+' is not allowed STOP: STOPPED`),
+				ExpectError: regexp.MustCompile(`unable to stop DevServer \([a-f0-9-]+\)`),
 			},
 			// Starting the DevServer.
 			{
@@ -86,7 +88,7 @@ func TestAccDevServer_basic(t *testing.T) {
 			// Starting the running DevServer.
 			{
 				Config:      testAccDevServer_doAction(name, password, "start", true),
-				ExpectError: regexp.MustCompile(`Resource.Server '[a-f0-9-]+' is not allowed START: RUNNING`),
+				ExpectError: regexp.MustCompile(`unable to start DevServer \([a-f0-9-]+\)`),
 			},
 			{
 				ResourceName:      resourceName,
@@ -112,7 +114,7 @@ func testAccDevServer_basic(isAutoRenew bool, name, password string) string {
 
 resource "huaweicloud_modelarts_devserver" "test" {
   name              = "%[2]s"
-  flavor            = "%[3]s"
+  resource_flavor   = "%[3]s"
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver.go
@@ -55,11 +55,18 @@ func ResourceDevServer() *schema.Resource {
 				ForceNew:    true,
 				Description: `The name of the DevServer.`,
 			},
-			"flavor": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: `The flavor of the DevServer.`,
+			"resource_flavor": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Description: utils.SchemaDesc(
+					`The resource flavor of the DevServer.`,
+					utils.SchemaDescInput{
+						Required: true,
+					},
+				),
+				ExactlyOneOf: []string{"flavor"},
 			},
 			"architecture": {
 				Type:        schema.TypeString,
@@ -193,6 +200,21 @@ func ResourceDevServer() *schema.Resource {
 				Computed:    true,
 				Description: `The creation time of the DevServer, in RFC3339 format.`,
 			},
+
+			// Deprecated parameters.
+			"flavor": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Description: utils.SchemaDesc(
+					`The flavor of the DevServer.`,
+					utils.SchemaDescInput{
+						Required:   true,
+						Deprecated: true,
+					},
+				),
+			},
 		},
 	}
 }
@@ -200,7 +222,7 @@ func ResourceDevServer() *schema.Resource {
 func buildCreateDevServerBodyParams(d *schema.ResourceData, epsId string) map[string]interface{} {
 	params := map[string]interface{}{
 		"name":                  d.Get("name"),
-		"flavor":                d.Get("flavor"),
+		"resource_flavor":       utils.ValueIgnoreEmpty(d.Get("resource_flavor")),
 		"network":               buildDevServerNetwork(d),
 		"image_id":              d.Get("image_id"),
 		"server_type":           utils.ValueIgnoreEmpty(d.Get("type")),
@@ -211,6 +233,8 @@ func buildCreateDevServerBodyParams(d *schema.ResourceData, epsId string) map[st
 		"enterprise_project_id": utils.ValueIgnoreEmpty(epsId),
 		"key_pair_name":         utils.ValueIgnoreEmpty(d.Get("key_pair_name")),
 		"userdata":              utils.ValueIgnoreEmpty(d.Get("user_data")),
+		// Deprecated parameters.
+		"flavor": utils.ValueIgnoreEmpty(d.Get("flavor")),
 	}
 
 	if d.Get("charging_mode").(string) == "PRE_PAID" {
@@ -339,14 +363,24 @@ func refreshDevServerStatusFunc(client *golangsdk.ServiceClient, serverId string
 	return func() (interface{}, string, error) {
 		respBody, err := GetDevServerById(client, serverId)
 		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
 				return "deleted", "DELETED", nil
 			}
 			return nil, "ERROR", err
 		}
 
 		status := utils.PathSearch("status", respBody, "").(string)
-		if utils.StrSliceContains([]string{"CREATE_FAILED", "ERROR", "DELETE_FAILED"}, status) {
+		unexpectedStatuses := []string{
+			"CREATE_FAILED",
+			"ERROR",
+			"DELETE_FAILED",
+			"START_FAILED",
+			"STOP_FAILED",
+			"REBOOT_FAILED",
+			"CHANGINGOS_FAILED",
+			"REINSTALLINGOS_FAILED",
+		}
+		if utils.StrSliceContains(unexpectedStatuses, status) {
 			return respBody, "ERROR", fmt.Errorf("unexpected status (%s)", status)
 		}
 
@@ -482,7 +516,7 @@ func resourceDevServerRead(_ context.Context, d *schema.ResourceData, meta inter
 	mErr := multierror.Append(
 		d.Set("region", region),
 		d.Set("name", utils.PathSearch("name", respBody, nil)),
-		d.Set("flavor", utils.PathSearch("flavor", respBody, nil)),
+		d.Set("resource_flavor", utils.PathSearch("resource_flavor", respBody, nil)),
 		d.Set("architecture", utils.PathSearch("image.arch", respBody, nil)),
 		d.Set("vpc_id", utils.PathSearch("vpc_id", respBody, nil)),
 		d.Set("image_id", utils.PathSearch("image.image_id", respBody, nil)),
@@ -491,6 +525,8 @@ func resourceDevServerRead(_ context.Context, d *schema.ResourceData, meta inter
 		d.Set("charging_mode", utils.PathSearch("charging_mode", respBody, nil)),
 		d.Set("created_at",
 			utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_at", respBody, float64(0)).(float64))/1000, false)),
+		// Deprecated parameters.
+		d.Set("flavor", utils.PathSearch("flavor", respBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -597,8 +633,8 @@ func deleteDevServerById(client *golangsdk.ServiceClient, devServerId string) er
 
 func waitForDevServerDeleted(ctx context.Context, client *golangsdk.ServiceClient, devServerId string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"RUNNING", "DELETING"},
-		Target:       []string{"DELETED"},
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
 		Refresh:      refreshDevServerStatusFunc(client, devServerId, nil),
 		Timeout:      timeout,
 		Delay:        5 * time.Second,

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver_action.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver_action.go
@@ -18,12 +18,17 @@ import (
 
 // @API ModelArts PUT /v1/{project_id}/dev-servers/{id}/start
 // @API ModelArts PUT /v1/{project_id}/dev-servers/{id}/stop
+// @API ModelArts PUT /v1/{project_id}/dev-servers/{id}/reboot
 // @API ModelArts GET /v1/{project_id}/dev-servers/{id}
 func ResourceDevServerAction() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDevServerActionCreate,
 		ReadContext:   resourceDevServerActionRead,
 		DeleteContext: resourceDevServerActionDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -56,8 +61,9 @@ func resourceDevServerActionCreate(ctx context.Context, d *schema.ResourceData, 
 		devServerId        = d.Get("devserver_id").(string)
 		action             = d.Get("action").(string)
 		actionCompletedMap = map[string]string{
-			"start": "RUNNING",
-			"stop":  "STOPPED",
+			"start":  "RUNNING",
+			"stop":   "STOPPED",
+			"reboot": "RUNNING",
 		}
 	)
 
@@ -109,7 +115,7 @@ func refreshDevServerActionStatusFunc(client *golangsdk.ServiceClient, devServer
 		}
 
 		status := utils.PathSearch("status", respBody, "").(string)
-		if utils.StrSliceContains([]string{"START_FAILED", "ERROR", "STOP_FAILED"}, status) {
+		if utils.StrSliceContains([]string{"START_FAILED", "ERROR", "STOP_FAILED", "REBOOT_FAILED"}, status) {
 			return respBody, "ERROR", fmt.Errorf("unexpected status (%s)", status)
 		}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The devserver resource supports new parameter 'resource_flavor' and replace the old one.
Adjust the refresh logic for deleted status check.
Supports reboot action type for devserver action resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using 'resource_flaovr' parameter to replace 'flavor' parameter.
2. supports reboot action type for devserver action resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDevServer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDevServer_basic -timeout 360m -parallel 10
=== RUN   TestAccDevServer_basic
=== PAUSE TestAccDevServer_basic
=== CONT  TestAccDevServer_basic
--- PASS: TestAccDevServer_basic (539.70s)
PASS
coverage: 7.6% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 539.787s        coverage: 7.6% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
