### PR TITLE
feat(TaurusDB): add action resource to restart a node of Htap instance

### DIFF
--- a/docs/resources/taurusdb_htap_starrocks_node_restart.md
+++ b/docs/resources/taurusdb_htap_starrocks_node_restart.md
@@ -1,0 +1,53 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_htap_starrocks_node_restart"
+description: |-
+  Manages restart a node of a TaurusDB Htap StarRocks instance resource within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_htap_starrocks_node_restart
+
+Manages restart a node of a TaurusDB Htap StarRocks instance resource within HuaweiCloud.
+
+-> This resource is a one-time action resource to restart a node of a StarRocks instance. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "taurusdb_instance_id" {}
+variable "starrocks_instance_id" {}
+variable "starrocks_node_id" {}
+
+resource "huaweicloud_taurusdb_htap_starrocks_node_restart" "test" {
+  taurusdb_instance_id  = var.taurusdb_instance_id
+  starrocks_instance_id = var.starrocks_instance_id
+  starrocks_node_id     = var.starrocks_node_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `taurusdb_instance_id` - (Required, String, NoneUpdatable) Specifies the TaurusDB instance ID.
+
+* `starrocks_instance_id` - (Required, String, NoneUpdatable) Specifies the StarRocks instance ID.
+
+* `starrocks_node_id` - (Required, String, NoneUpdatable) Specifies the StarRocks node ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is `starrocks_node_id`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4431,6 +4431,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_instant_task_delete":             taurusdb.ResourceTaurusDBInstantTaskDelete(),
 			"huaweicloud_taurusdb_node_sessions_kill":              taurusdb.ResourceTaurusDBNodeSessionsKill(),
 			"huaweicloud_taurusdb_htap_starrocks_instance_restart": taurusdb.ResourceTaurusDBHtapStarrocksInstanceRestart(),
+			"huaweicloud_taurusdb_htap_starrocks_node_restart":     taurusdb.ResourceTaurusDBHtapStarrocksNodeRestart(),
 
 			"huaweicloud_tms_resource_tags": tms.ResourceResourceTags(),
 			"huaweicloud_tms_tags":          tms.ResourceTmsTag(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -273,6 +273,7 @@ var (
 
 	HW_TAURUSDB_INSTANCE_ID               = os.Getenv("HW_TAURUSDB_INSTANCE_ID")
 	HW_TAURUSDB_HTAP_INSTANCE_ID          = os.Getenv("HW_TAURUSDB_HTAP_INSTANCE_ID")
+	HW_TAURUSDB_HTAP_NODE_ID              = os.Getenv("HW_TAURUSDB_HTAP_NODE_ID")
 	HW_TAURUSDB_NODE_ID                   = os.Getenv("HW_TAURUSDB_NODE_ID")
 	HW_TAURUSDB_NODE_SESSION_ID           = os.Getenv("HW_TAURUSDB_NODE_SESSION_ID")
 	HW_TAURUSDB_DATABASE_NAME             = os.Getenv("HW_TAURUSDB_DATABASE_NAME")
@@ -2300,6 +2301,13 @@ func TestAccPreCheckTaurusDBInstanceId(t *testing.T) {
 func TestAccPreCheckTaurusDBHtapInstanceId(t *testing.T) {
 	if HW_TAURUSDB_HTAP_INSTANCE_ID == "" {
 		t.Skip("HW_TAURUSDB_HTAP_INSTANCE_ID must be set for TaurusDB Htap acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckTaurusDBHtapNodeId(t *testing.T) {
+	if HW_TAURUSDB_HTAP_NODE_ID == "" {
+		t.Skip("HW_TAURUSDB_HTAP_NODE_ID must be set for TaurusDB Htap acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_node_restart_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_node_restart_test.go
@@ -1,0 +1,43 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTaurusDBHtapStarrocksNodeRestart_basic(t *testing.T) {
+	resourceName := "huaweicloud_taurusdb_htap_starrocks_node_restart.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBInstanceId(t)
+			acceptance.TestAccPreCheckTaurusDBHtapInstanceId(t)
+			acceptance.TestAccPreCheckTaurusDBHtapNodeId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaurusDBHtapStarrocksNodeRestart_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", acceptance.HW_TAURUSDB_HTAP_NODE_ID),
+				),
+			},
+		},
+	})
+}
+
+func testAccTaurusDBHtapStarrocksNodeRestart_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_taurusdb_htap_starrocks_node_restart" "test" {
+  taurusdb_instance_id  = "%[1]s"
+  starrocks_instance_id = "%[2]s"
+  starrocks_node_id     = "%[3]s"
+}
+`, acceptance.HW_TAURUSDB_INSTANCE_ID, acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID, acceptance.HW_TAURUSDB_HTAP_NODE_ID)
+}

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_node_restart.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_node_restart.go
@@ -1,0 +1,233 @@
+package taurusdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var starrocksNodeRestartNoneUpdatableParams = []string{
+	"taurusdb_instance_id", "starrocks_instance_id", "starrocks_node_id",
+}
+
+// @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/starrocks/{starrocks_instance_id}
+// @API TaurusDB PUT /v3/{project_id}/instances/{starrocks_instance_id}/starrocks/{starrocks_node_id}/restart
+// @API TaurusDB GET /v3/{project_id}/jobs
+func ResourceTaurusDBHtapStarrocksNodeRestart() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTaurusDBHtapStarrocksNodeRestartCreate,
+		ReadContext:   resourceTaurusDBHtapStarrocksNodeRestartRead,
+		UpdateContext: resourceTaurusDBHtapStarrocksNodeRestartUpdate,
+		DeleteContext: resourceTaurusDBHtapStarrocksNodeRestartDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(starrocksNodeRestartNoneUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"taurusdb_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"starrocks_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"starrocks_node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceTaurusDBHtapStarrocksNodeRestartCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	starrocksInstanceId := d.Get("starrocks_instance_id").(string)
+	starrocksNodeId := d.Get("starrocks_node_id").(string)
+
+	jobId, err := restartStarrocksNode(ctx, d, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(starrocksNodeId)
+
+	err = checkGaussDBMySQLJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for restarting StarRocks instance(%s) node(%s) job to complete: %s",
+			starrocksInstanceId, starrocksNodeId, err)
+	}
+
+	return nil
+}
+
+func restartStarrocksNode(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) (string, error) {
+	var (
+		httpUrl = "v3/{project_id}/instances/{starrocks_instance_id}/starrocks/{starrocks_node_id}/restart"
+	)
+
+	instanceId := d.Get("taurusdb_instance_id").(string)
+	starrocksInstanceId := d.Get("starrocks_instance_id").(string)
+	starrocksNodeId := d.Get("starrocks_node_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{starrocks_instance_id}", starrocksInstanceId)
+	createPath = strings.ReplaceAll(createPath, "{starrocks_node_id}", starrocksNodeId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		res, err := client.Request("PUT", createPath, &createOpt)
+		retry, err := handleMultiOperationsError(err)
+		return res, retry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     htapInstanceNodeStateRefreshFunc(client, instanceId, starrocksInstanceId, starrocksNodeId),
+		WaitTarget:   []string{"normal"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error restarting TaurusDB instance(%s) node(%s): %s", starrocksInstanceId, starrocksNodeId, err)
+	}
+	createRespBody, err := utils.FlattenResponse(r.(*http.Response))
+	if err != nil {
+		return "", err
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
+	if jobId == "" {
+		return "", fmt.Errorf("error restarting StarRocks instance(%s) node(%s), job_id is not found in the response",
+			starrocksInstanceId, starrocksNodeId)
+	}
+
+	return jobId, nil
+}
+
+func htapInstanceNodeStateRefreshFunc(client *golangsdk.ServiceClient, instanceId, htapInstanceId, htapNodeId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		// Check TaurusDB HTAP instance status is normal and actions is empty list
+		htapInstanceDetail, err := GetHtapInstanceDetail(client, instanceId, htapInstanceId)
+		if err != nil {
+			return nil, "", err
+		}
+		htapInstanceStatus := utils.PathSearch("status", htapInstanceDetail, "").(string)
+		// If the status is abnormal or createfail, return error directly without retry
+		if htapInstanceStatus == "abnormal" || htapInstanceStatus == "createfail" {
+			return nil, "", fmt.Errorf("TaurusDB HTAP instance(%s) is in %s state, cannot proceed with restart",
+				htapInstanceId, htapInstanceStatus)
+		}
+		if htapInstanceStatus != "normal" {
+			return htapInstanceDetail, htapInstanceStatus, nil
+		}
+		htapActions := utils.PathSearch("actions", htapInstanceDetail, make([]interface{}, 0)).([]interface{})
+		if len(htapActions) == 0 {
+			// Check TaurusDB instance node status is normal and actions is empty list
+			nodeDetail, err := GetHtapInstanceNodeDetail(htapInstanceDetail, htapNodeId)
+			if err != nil {
+				return nil, "", err
+			}
+			nodeStatus := utils.PathSearch("status", nodeDetail, "").(string)
+			// If the node status is abnormal or createfail, return error directly without retry
+			if nodeStatus == "abnormal" || nodeStatus == "createfail" {
+				return nil, "", fmt.Errorf("StarRocks node(%s) is in %s state, cannot proceed with restart",
+					htapNodeId, nodeStatus)
+			}
+			if nodeStatus != "normal" {
+				return nodeDetail, nodeStatus, nil
+			}
+			nodeActions := utils.PathSearch("actions", nodeDetail, make([]interface{}, 0)).([]interface{})
+			if len(nodeActions) == 0 {
+				return nodeDetail, "normal", nil
+			}
+			nodeAction := utils.PathSearch("actions[0].action", nodeDetail, "").(string)
+			if nodeAction != "" {
+				return nodeDetail, nodeAction, nil
+			}
+			return nodeDetail, "normal", nil
+		}
+		htapAction := utils.PathSearch("actions[0].action", htapInstanceDetail, "").(string)
+		return htapInstanceDetail, htapAction, nil
+	}
+}
+
+func GetHtapInstanceNodeDetail(instanceDetail interface{}, htapNodeId string) (interface{}, error) {
+	groups := utils.PathSearch("groups", instanceDetail, make([]interface{}, 0)).([]interface{})
+	if len(groups) == 0 {
+		return nil, errors.New("no groups found in TaurusDB StarRocks instance")
+	}
+	for _, group := range groups {
+		nodes := utils.PathSearch("nodes", group, make([]interface{}, 0)).([]interface{})
+		if len(nodes) == 0 {
+			continue
+		}
+
+		for _, node := range nodes {
+			nodeId := utils.PathSearch("id", node, "").(string)
+			if nodeId == htapNodeId {
+				return node, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("node (%s) not found in HTAP instance", htapNodeId)
+}
+
+func resourceTaurusDBHtapStarrocksNodeRestartRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceTaurusDBHtapStarrocksNodeRestartUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceTaurusDBHtapStarrocksNodeRestartDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting restart resource is not supported. The restart resource is only removed from the state," +
+		" the StarRocks instance node remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add action resource to restart a node of Htap instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add action resource to restart a node of Htap instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccTaurusDBHtapStarrocksNodeRestart'
=== RUN   TestAccTaurusDBHtapStarrocksNodeRestart_basic
=== PAUSE TestAccTaurusDBHtapStarrocksNodeRestart_basic
=== CONT  TestAccTaurusDBHtapStarrocksNodeRestart_basic
--- PASS: TestAccTaurusDBHtapStarrocksNodeRestart_basic (46.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb  46.712s
```
**Waitting for other jobs of the node completed:**
```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccTaurusDBHtapStarrocksNodeRestart'
=== RUN   TestAccTaurusDBHtapStarrocksNodeRestart_basic
=== PAUSE TestAccTaurusDBHtapStarrocksNodeRestart_basic
=== CONT  TestAccTaurusDBHtapStarrocksNodeRestart_basic
--- PASS: TestAccTaurusDBHtapStarrocksNodeRestart_basic (89.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb  89.415s
```
<img width="893" height="214" alt="image" src="https://github.com/user-attachments/assets/179a5bb5-f62f-407a-8042-1b6ecd1ad48a" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
