### PR TITLE
feat(GeminiDB): the instance support new APIs

### DIFF
--- a/docs/resources/geminidb_instance.md
+++ b/docs/resources/geminidb_instance.md
@@ -141,6 +141,17 @@ The following arguments are supported:
   <br/>2. the `policy` supports update only when the `switch_option` is set to **on**.
   <br/>3. Currently, only **GeminiDB Cassandra** and **GeminiDB Redis** instances are supported.
 
+* `second_level_monitoring_enabled` - (Optional, String) Specifies whether second-level monitoring is enabled.
+  The valid values are **true** and **false**.
+
+  -> Currently, only for a proxy cluster GeminiDB Redis instances with `4` or more CPUs can be configuration.
+
+* `config_ips` - (Optional, List) Specifies the list of IP addresses and CIDR blocks for which password-free
+  configurations need to be set.
+  If the list is empty, the password-free configurations are cleared.
+
+  -> This parameter is valid and available for **GeminiDB Redis** instance.
+
 * `delete_node_list` - (Optional, List) Specifies the ID of the nodes to be deleted. Make sure that the node
   can be deleted. This parameter can not be specified when add nodes. When delete nodes, if this parameter is specified,
   then the nodes specified by this parameter will be deleted, and id this parameter is not transferred, the nodes will be

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
@@ -351,7 +351,7 @@ func TestAccGeminiDbInstance_dynamodb(t *testing.T) {
 	})
 }
 
-func TestAccGeminiDbInstance_autoEnlargePolicy(t *testing.T) {
+func TestAccGeminiDbInstance_configuration(t *testing.T) {
 	var obj interface{}
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_geminidb_instance.test"
@@ -370,7 +370,7 @@ func TestAccGeminiDbInstance_autoEnlargePolicy(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGeminiDBAutoEnlargePolicy_basic(rName),
+				Config: testAccGeminiDBConfiguration_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -392,6 +392,8 @@ func TestAccGeminiDbInstance_autoEnlargePolicy(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "flavor.0.spec_code",
 						"data.huaweicloud_gaussdb_nosql_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "switch_option", "on"),
+					resource.TestCheckResourceAttr(resourceName, "second_level_monitoring_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "config_ips.#", "2"),
 
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
 					resource.TestCheckResourceAttrSet(resourceName, "policy.#"),
@@ -401,20 +403,23 @@ func TestAccGeminiDbInstance_autoEnlargePolicy(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGeminiDBAutoEnlargePolicy_update_step1(rName),
+				Config: testAccGeminiDBConfiguration_update_step1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "switch_option", "on"),
 					resource.TestCheckResourceAttr(resourceName, "policy.0.threshold", "85"),
 					resource.TestCheckResourceAttr(resourceName, "policy.0.step", "15"),
 					resource.TestCheckResourceAttr(resourceName, "policy.0.size", "20"),
+					resource.TestCheckResourceAttr(resourceName, "second_level_monitoring_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "config_ips.#", "3"),
 				),
 			},
 			{
-				Config: testAccGeminiDBAutoEnlargePolicy_upate_step2(rName),
+				Config: testAccGeminiDBConfiguration_update_step2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "switch_option", "off"),
+					resource.TestCheckResourceAttr(resourceName, "config_ips.#", "0"),
 				),
 			},
 			{
@@ -795,20 +800,20 @@ resource "huaweicloud_geminidb_instance" "test" {
 `, testAccGeminiDbInstance_base(rName), updateName)
 }
 
-func testAccGeminiDBAutoEnlargePolicy_basic(name string) string {
+func testAccGeminiDBConfiguration_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_gaussdb_nosql_flavors" "test" {
-  vcpus             = 2
+  vcpus             = 4
   engine            = "redis"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
 }
 
 resource "huaweicloud_geminidb_instance" "test" {
-  name                  = "%[2]s"
+  name              = "%[2]s"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
@@ -829,19 +834,26 @@ resource "huaweicloud_geminidb_instance" "test" {
     spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
   }
 
+  # setting auto enlarge policy
   switch_option = "on"
+
+  # enable second level monitor
+  second_level_monitoring_enabled = "true"
+
+  # enable password-free configuration
+  config_ips = ["192.168.1.15","192.168.1.23/24"]
 }
 `, common.TestBaseNetwork(name), name)
 }
 
-func testAccGeminiDBAutoEnlargePolicy_update_step1(name string) string {
+func testAccGeminiDBConfiguration_update_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_gaussdb_nosql_flavors" "test" {
-  vcpus             = 2
+  vcpus             = 4
   engine            = "redis"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
 }
@@ -875,18 +887,21 @@ resource "huaweicloud_geminidb_instance" "test" {
     step      = 15
     size      = 20
   }
+
+  second_level_monitoring_enabled = "false"
+  config_ips                      = ["192.168.1.15","192.168.1.23/24","192.168.1.38"]
 }
 `, common.TestBaseNetwork(name), name)
 }
 
-func testAccGeminiDBAutoEnlargePolicy_upate_step2(name string) string {
+func testAccGeminiDBConfiguration_update_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_gaussdb_nosql_flavors" "test" {
-  vcpus             = 2
+  vcpus             = 4
   engine            = "redis"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
 }
@@ -913,7 +928,9 @@ resource "huaweicloud_geminidb_instance" "test" {
     spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
   }
 
-  switch_option = "off"
+  switch_option                   = "off"
+  second_level_monitoring_enabled = false
+  config_ips                      = []
 }
 `, common.TestBaseNetwork(name), name)
 }

--- a/huaweicloud/services/geminidb/common.go
+++ b/huaweicloud/services/geminidb/common.go
@@ -328,3 +328,27 @@ func geminiDbJobRefreshFunc(client *golangsdk.ServiceClient, jobId string) resou
 		return getJobStatusRespBody, "Pending", nil
 	}
 }
+
+type getInstanceFieldParams struct {
+	httpUrl    string
+	httpMethod string
+	pathParams map[string]string
+}
+
+func getInstanceField(client *golangsdk.ServiceClient, params getInstanceFieldParams) (interface{}, error) {
+	getPath := client.Endpoint + params.httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	for pathParam, value := range params.pathParams {
+		getPath = strings.ReplaceAll(getPath, fmt.Sprintf("{%s}", pathParam), value)
+	}
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	getResp, err := client.Request(params.httpMethod, getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(getResp)
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
@@ -49,6 +49,10 @@ var geminiDbInstanceNonUpdatableParams = []string{"datastore", "datastore.*.type
 // @API GeminiDB DELETE /v3/{project_id}/instances/{instance_id}
 // @API GeminiDB PUT /v3/{project_id}/instances/disk-auto-expansion
 // @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/disk-auto-expansion
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/monitoring-by-seconds/switch
+// @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/monitoring-by-seconds/switch
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/passwordless-config
+// @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/passwordless-config
 // @API BSS GET /v2/orders/customer-orders/details/{order_id}
 // @API BSS POST /v2/orders/subscriptions/resources/autorenew/{instance_id}
 // @API BSS DELETE /v2/orders/subscriptions/resources/autorenew/{instance_id}
@@ -177,6 +181,20 @@ func ResourceGeminiDbInstance() *schema.Resource {
 				Computed: true,
 				MaxItems: 1,
 				Elem:     geminiDbInstanceAutomaticScalePolicSchema(),
+			},
+			"second_level_monitoring_enabled": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"true", "false",
+				}, false),
+			},
+			"config_ips": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"delete_node_list": {
 				Type:     schema.TypeSet,
@@ -551,11 +569,28 @@ func resourceGeminiDbInstanceCreate(ctx context.Context, d *schema.ResourceData,
 	// lintignore:R018
 	time.Sleep(360 * time.Second)
 
-	// setting auto enlarge policy
+	// Setting auto enlarge policy
 	if v, ok := d.GetOk("switch_option"); ok && v.(string) == "on" {
 		err = updateAutoEnlargePolicy(client, d, d.Id())
 		if err != nil {
 			return diag.Errorf("error setting GeminiDB auto enlarge policy: %s", err)
+		}
+	}
+
+	// Enable second level monitor
+	if v, ok := d.GetOk("second_level_monitoring_enabled"); ok && v.(string) == "true" {
+		err = updateSecondLevelMonitor(ctx, d, client)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Enable password-free configuration
+	configIps := utils.ExpandToStringList(d.Get("config_ips").(*schema.Set).List())
+	if len(configIps) > 0 {
+		err = updatePasswordFreeConfiguration(ctx, d, client)
+		if err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
@@ -721,6 +756,54 @@ func buildCreateGeminiDbInstanceChargeInfoBody(d *schema.ResourceData) map[strin
 	return rst
 }
 
+func updateSecondLevelMonitor(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	if !d.HasChange("second_level_monitoring_enabled") {
+		return nil
+	}
+
+	switchMonitor, _ := strconv.ParseBool(d.Get("second_level_monitoring_enabled").(string))
+
+	_, err := updateGeminiDbInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:          "v3/{project_id}/instances/{instance_id}/monitoring-by-seconds/switch",
+		httpMethod:       "PUT",
+		pathParams:       map[string]string{"instance_id": d.Id()},
+		updateBodyParams: map[string]interface{}{"enabled": switchMonitor},
+	})
+
+	if err != nil {
+		return fmt.Errorf("error updating GeminiDB instance second level monitor: %s", err)
+	}
+
+	return nil
+}
+
+func updatePasswordFreeConfiguration(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	if !d.HasChange("config_ips") {
+		return nil
+	}
+
+	_, err := updateGeminiDbInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:          "v3/{project_id}/instances/{instance_id}/passwordless-config",
+		httpMethod:       "PUT",
+		pathParams:       map[string]string{"instance_id": d.Id()},
+		updateBodyParams: buildUpdatePasswordFreeConfigurationBodyParams(d),
+	})
+
+	if err != nil {
+		return fmt.Errorf("error updating GeminiDB instance password-free configuration: %s", err)
+	}
+
+	return nil
+}
+
+func buildUpdatePasswordFreeConfigurationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"config_ips": utils.ExpandToStringList(d.Get("config_ips").(*schema.Set).List()),
+	}
+
+	return bodyParams
+}
+
 func resourceGeminiDbInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
@@ -775,7 +858,7 @@ func resourceGeminiDbInstanceRead(_ context.Context, d *schema.ResourceData, met
 		mErr = multierror.Append(mErr, err)
 	}
 
-	// set auto enlarge policy parameters
+	// Set auto enlarge policy parameters
 	policy, err := getAutoEnlargePolicyInfo(client, d.Id())
 	if err != nil {
 		log.Printf("[Warn] error retrieving GeminiDB auto enlarge policy information")
@@ -792,6 +875,12 @@ func resourceGeminiDbInstanceRead(_ context.Context, d *schema.ResourceData, met
 			d.Set("switch_option", "off"),
 		)
 	}
+
+	// Set second level monitor
+	mErr = multierror.Append(mErr, getSecondLevelMonitorInfo(d, client))
+
+	// Set password-free configuration
+	mErr = multierror.Append(mErr, getPasswordFreeConfigurationInfo(d, client))
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
@@ -979,6 +1068,37 @@ func flattenGaussDBProxyResponseBodyDualActiveInfo(instance interface{}) []inter
 	return rst
 }
 
+func getSecondLevelMonitorInfo(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	getRespBody, err := getInstanceField(client, getInstanceFieldParams{
+		httpUrl:    "v3/{project_id}/instances/{instance_id}/monitoring-by-seconds/switch",
+		httpMethod: "GET",
+		pathParams: map[string]string{"instance_id": d.Id()},
+	})
+
+	if err != nil {
+		log.Printf("[WARN] error retrieving GeminiDB instance second level monitor information: %s", err)
+		return nil
+	}
+
+	return d.Set("second_level_monitoring_enabled",
+		strconv.FormatBool(utils.PathSearch("enabled", getRespBody, false).(bool)))
+}
+
+func getPasswordFreeConfigurationInfo(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	getRespBody, err := getInstanceField(client, getInstanceFieldParams{
+		httpUrl:    "v3/{project_id}/instances/{instance_id}/passwordless-config",
+		httpMethod: "GET",
+		pathParams: map[string]string{"instance_id": d.Id()},
+	})
+
+	if err != nil {
+		log.Printf("[WARN] error retrieving GeminiDB instance password-free configuration: %s", err)
+		return nil
+	}
+
+	return d.Set("config_ips", utils.PathSearch("config_ips", getRespBody, make([]interface{}, 0)).([]interface{}))
+}
+
 func resourceGeminiDbInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
@@ -1070,12 +1190,24 @@ func resourceGeminiDbInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	// update auto enlarge policy
+	// Update auto enlarge policy
 	if d.HasChanges("switch_option", "policy") {
 		err = updateAutoEnlargePolicy(client, d, d.Id())
 		if err != nil {
 			return diag.Errorf("error updating GeminiDB auto enlarge policy: %s", err)
 		}
+	}
+
+	// Update second level monitor
+	err = updateSecondLevelMonitor(ctx, d, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Update password-free configuration
+	err = updatePasswordFreeConfiguration(ctx, d, client)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	return resourceGeminiDbInstanceRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The GeminiDB instance supports new APIs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.The GeminiDB instance supports configuration second level monitor.
2.The GeminiDB instance supports password-free configuration.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDbInstance_configuration"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDbInstance_configuration -timeout 360m -parallel 4
=== RUN   TestAccGeminiDbInstance_configuration
=== PAUSE TestAccGeminiDbInstance_configuration
=== CONT  TestAccGeminiDbInstance_configuration
--- PASS: TestAccGeminiDbInstance_configuration (1569.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1570.080s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
