### PR TITLE
feat(drs): new resource to delete driver

### DIFF
--- a/docs/resources/drs_driver_delete.md
+++ b/docs/resources/drs_driver_delete.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_driver_delete"
+description: |-
+  Manages a resource to delete DRS driver files within HuaweiCloud.
+---
+
+# huaweicloud_drs_driver_delete
+
+Manages a resource to delete DRS driver files within HuaweiCloud.
+
+-> This resource is a one-time action resource used to delete DRS driver files. Deleting this resource
+   will not restore the deleted driver files or undo the delete action, but will only remove the resource information from
+   the tf state file.
+
+## Example Usage
+
+```hcl
+variable "driver_names" { 
+  type = list(string)
+}
+
+resource "huaweicloud_drs_driver_delete" "test" { 
+  driver_type  = "db2"
+  driver_names = var.driver_names
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `driver_type` - (Required, String, NonUpdatable) Specifies the type of the driver file to be deleted. Valid values are:
+  + **db2**: DB2 for LUW
+  + **informix**: Informix
+
+* `driver_names` - (Required, List, NonUpdatable) Specifies the list of JDBC driver file names. The list contains `1` to
+  `20` files. The value of `driver_name` contains `5` to `64` characters and ends with **.jar**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3575,6 +3575,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_batch_pause_task":               drs.ResourceBatchPauseTask(),
 			"huaweicloud_drs_batch_retry_task":               drs.ResourceBatchRetryTask(),
 			"huaweicloud_drs_download_batch_create_template": drs.ResourceDownloadBatchCreateTemplate(),
+			"huaweicloud_drs_driver_delete":                  drs.ResourceDriverDelete(),
 			"huaweicloud_drs_job":                            drs.ResourceDrsJob(),
 			"huaweicloud_drs_job_clone":                      drs.ResourceDrsJobClone(),
 			"huaweicloud_drs_job_configuration_update":       drs.ResourceJobConfigurationUpdate(),

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_driver_delete_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_driver_delete_test.go
@@ -1,0 +1,36 @@
+package drs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceDriverDelete_basic(t *testing.T) {
+	resourceName := "huaweicloud_drs_driver_delete.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceDriverDelete_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceDriverDelete_basic = `
+resource "huaweicloud_drs_driver_delete" "test" {
+  driver_type  = "db2"
+  driver_names = ["xxx.jar"]
+}
+`

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_driver_delete.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_driver_delete.go
@@ -1,0 +1,117 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var driverDeleteNonUpdatableParams = []string{"driver_type", "driver_names"}
+
+// @API DRS DELETE /v5/{project_id}/drivers
+func ResourceDriverDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDriverDeleteCreate,
+		ReadContext:   resourceDriverDeleteRead,
+		UpdateContext: resourceDriverDeleteUpdate,
+		DeleteContext: resourceDriverDeleteDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(driverDeleteNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"driver_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"driver_names": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildDriverDeleteBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"driver_type":  d.Get("driver_type"),
+		"driver_names": utils.ExpandToStringList(d.Get("driver_names").([]interface{})),
+	}
+}
+
+func resourceDriverDeleteCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/drivers"
+	)
+
+	client, err := cfg.NewServiceClient("drs", region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildDriverDeleteBodyParams(d),
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DRS driver files: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	return nil
+}
+
+func resourceDriverDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDriverDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDriverDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to delete DRS driver files. Deleting this resource
+    will not restore the deleted driver files or undo the delete action, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to delete driver

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o drs -f TestAccResourceDriverDelete_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccResourceDriverDelete_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceDriverDelete_basic
=== PAUSE TestAccResourceDriverDelete_basic
=== CONT  TestAccResourceDriverDelete_basic
--- PASS: TestAccResourceDriverDelete_basic (16.00s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       16.097s coverage: 4.1% of statements in ./huaweicloud/services/drs
```
<img width="1319" height="76" alt="image" src="https://github.com/user-attachments/assets/f7d65ff3-8860-46b5-8161-5bae45bfefef" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
