### PR TITLE
feat(modelarts): devserver supports operate OS image

### DIFF
--- a/docs/resources/modelarts_devserver_action.md
+++ b/docs/resources/modelarts_devserver_action.md
@@ -35,6 +35,21 @@ The following arguments are supported:
   + **start**: The DevServer can be started only when the DevServer is stopped, stop failure, or start failure.
   + **stop**: The DevServer can be stopped only when it is running or stop failure.
   + **reboot**: The DevServer can be rebooted only when it is running.
+  + **changeos**: The DevServer OS image can be changed only when the DevServer is stopped.
+  + **reinstallos**: The DevServer OS image can be reinstalled only when the DevServer is stopped.
+
+* `admin_pass` - (Optional, String, NonUpdatable) Specifies the login password of the DevServer.
+
+* `key_pair_name` - (Optional, String, NonUpdatable) Specifies the key pair name of the DevServer.  
+  
+-> Exactly one of `admin_pass` and `key_pair_name` must be set if the value of `action` parameter is **changeos** or
+   **reinstallos**.
+
+* `image_id` - (Optional, String, NonUpdatable) Specifies the image ID used to change the OS image.  
+  This parameter is required when the value of `action` parameter is **changeos**.
+
+* `user_data` - (Optional, String, NonUpdatable) Specifies the user data to be injected into the DevServer during the OS
+  operation.
 
 ## Attribute Reference
 

--- a/docs/resources/modelarts_devserver_action.md
+++ b/docs/resources/modelarts_devserver_action.md
@@ -28,11 +28,9 @@ The following arguments are supported:
   If omitted, the provider-level region will be used.
   Changing this creates a new resource.
 
-* `devserver_id` - (Required, String, ForceNew) Specifies the ID of the DevServer.
-  Changing this creates a new resource.
+* `devserver_id` - (Required, String, NonUpdatable) Specifies the ID of the DevServer.
 
-* `action` - (Required, String, ForceNew) Specifies the action type of the DevServer.
-  Changing this creates a new resource.  
+* `action` - (Required, String, NonUpdatable) Specifies the action type of the DevServer.
   The valid values are as follows:
   + **start**: The DevServer can be started only when the DevServer is stopped, stop failure, or start failure.
   + **stop**: The DevServer can be stopped only when it is running or stop failure.

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_devserver_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_devserver_test.go
@@ -146,11 +146,13 @@ func testAccDevServer_doAction(name, password, actionType string, doRetryAction 
 resource "huaweicloud_modelarts_devserver_action" "test" {
   devserver_id = huaweicloud_modelarts_devserver.test.id
   action       = "%[2]s"
+
+  enable_force_new = "true"
 }
 
 variable "is_retry_devserver_action" {
   type    = bool
-  default = "%[3]v"
+  default = %[3]v
 }
 
 resource "huaweicloud_modelarts_devserver_action" "expect_err" {
@@ -160,6 +162,8 @@ resource "huaweicloud_modelarts_devserver_action" "expect_err" {
 
   devserver_id = huaweicloud_modelarts_devserver.test.id
   action       = "%[2]s"
+
+  enable_force_new = "true"
 }
 `, testAccDevServer_basic(false, name, password), actionType, doRetryAction)
 }

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_devserver_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_devserver_test.go
@@ -26,15 +26,12 @@ func getDevServerResourceFunc(cfg *config.Config, state *terraform.ResourceState
 
 func TestAccDevServer_basic(t *testing.T) {
 	var (
-		obj          interface{}
+		obj interface{}
+
 		resourceName = "huaweicloud_modelarts_devserver.test"
-		name         = acceptance.RandomAccResourceName()
-		password     = acceptance.RandomPassword("!@%-_=+[{}]:,./?")
-		rc           = acceptance.InitResourceCheck(
-			resourceName,
-			&obj,
-			getDevServerResourceFunc,
-		)
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDevServerResourceFunc)
+
+		name = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -43,10 +40,17 @@ func TestAccDevServer_basic(t *testing.T) {
 			acceptance.TestAccPreCheckModelartsDevServer(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source: "hashicorp/random",
+				// The version of the random provider must be greater than 3.3.0 to support the 'numeric' parameter.
+				VersionConstraint: "3.3.0",
+			},
+		},
+		CheckDestroy: rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDevServer_basic(true, name, password),
+				Config: testAccDevServer_basic(name, true),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -66,7 +70,7 @@ func TestAccDevServer_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDevServer_basic(false, name, password),
+				Config: testAccDevServer_basic(name, false),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
@@ -74,25 +78,34 @@ func TestAccDevServer_basic(t *testing.T) {
 			},
 			// Stopping the DevServer.
 			{
-				Config: testAccDevServer_doAction(name, password, "stop", false),
+				Config: testAccDevServer_doAction(name, "stop", false),
 			},
 			// Stopping the stopped DevServer.
 			{
-				Config:      testAccDevServer_doAction(name, password, "stop", true),
+				Config:      testAccDevServer_doAction(name, "stop", true),
 				ExpectError: regexp.MustCompile(`unable to stop DevServer \([a-f0-9-]+\)`),
 			},
-			// Starting the DevServer.
+			// Reinstalling the DevServer OS.
 			{
-				Config: testAccDevServer_doAction(name, password, "start", false),
+				Config: testAccDevServer_doAction(name, "reinstallos", false),
+			},
+			// After reinstalling the DevServer OS, the status be changed to "RUNNING", and if we want to test the start
+			// action, we need to stop the DevServer first.
+			{
+				Config: testAccDevServer_doAction(name, "stop", false),
+			},
+			// Starting the DevServer (after reinstall OS image).
+			{
+				Config: testAccDevServer_doAction(name, "start", false),
 			},
 			// Starting the running DevServer.
 			{
-				Config:      testAccDevServer_doAction(name, password, "start", true),
+				Config:      testAccDevServer_doAction(name, "start", true),
 				ExpectError: regexp.MustCompile(`unable to start DevServer \([a-f0-9-]+\)`),
 			},
 			// Rebooting the DevServer.
 			{
-				Config: testAccDevServer_doAction(name, password, "reboot", false),
+				Config: testAccDevServer_doAction(name, "reboot", false),
 			},
 			{
 				ResourceName:      resourceName,
@@ -112,9 +125,19 @@ func TestAccDevServer_basic(t *testing.T) {
 	})
 }
 
-func testAccDevServer_basic(isAutoRenew bool, name, password string) string {
+func testAccDevServer_basic(name string, isAutoRenew bool) string {
 	return fmt.Sprintf(`
 %[1]s
+
+resource "random_password" "test" {
+  length           = 12
+  min_numeric      = 1
+  min_upper        = 1
+  min_lower        = 1
+  special          = true
+  min_special      = 1
+  override_special = "!@"
+}
 
 resource "huaweicloud_modelarts_devserver" "test" {
   name              = "%[2]s"
@@ -123,7 +146,7 @@ resource "huaweicloud_modelarts_devserver" "test" {
   subnet_id         = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
   image_id          = "%[4]s"
-  admin_pass        = "%[5]s"
+  admin_pass        = random_password.test.result
 
   root_volume {
     size = 100
@@ -133,19 +156,25 @@ resource "huaweicloud_modelarts_devserver" "test" {
   charging_mode = "PRE_PAID"
   period_unit   = "MONTH"
   period        = 1
-  auto_renew    = "%[6]v"
+  auto_renew    = "%[5]v"
 }
 `, common.TestBaseNetwork(name), name,
-		acceptance.HW_MODELARTS_DEVSERVER_FLAVOR, acceptance.HW_MODELARTS_DEVSERVER_IMAGE_ID, password, isAutoRenew)
+		acceptance.HW_MODELARTS_DEVSERVER_FLAVOR, acceptance.HW_MODELARTS_DEVSERVER_IMAGE_ID, isAutoRenew)
 }
 
-func testAccDevServer_doAction(name, password, actionType string, doRetryAction bool) string {
+func testAccDevServer_doAction(name, actionType string, doRetryAction bool) string {
 	return fmt.Sprintf(`
 %[1]s
 
+variable "action_type" {
+  type    = string
+  default = "%[2]s"
+}
+
 resource "huaweicloud_modelarts_devserver_action" "test" {
   devserver_id = huaweicloud_modelarts_devserver.test.id
-  action       = "%[2]s"
+  action       = var.action_type
+  admin_pass   = var.action_type == "reinstallos" ? random_password.test.result : null
 
   enable_force_new = "true"
 }
@@ -161,9 +190,9 @@ resource "huaweicloud_modelarts_devserver_action" "expect_err" {
   depends_on = [huaweicloud_modelarts_devserver_action.test]
 
   devserver_id = huaweicloud_modelarts_devserver.test.id
-  action       = "%[2]s"
+  action       = var.action_type
 
   enable_force_new = "true"
 }
-`, testAccDevServer_basic(false, name, password), actionType, doRetryAction)
+`, testAccDevServer_basic(name, false), actionType, doRetryAction)
 }

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver_action.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver_action.go
@@ -20,12 +20,25 @@ var (
 	devserverActionNonUpdatableParams = []string{
 		"devserver_id",
 		"action",
+		"admin_pass",
+		"key_pair_name",
+		"image_id",
+		"user_data",
+	}
+	actionCompletedMap = map[string][]string{
+		"start":       {"RUNNING"},
+		"stop":        {"STOPPED"},
+		"reboot":      {"RUNNING"},
+		"changeos":    {"RUNNING"},
+		"reinstallos": {"RUNNING"},
 	}
 )
 
 // @API ModelArts PUT /v1/{project_id}/dev-servers/{id}/start
 // @API ModelArts PUT /v1/{project_id}/dev-servers/{id}/stop
 // @API ModelArts PUT /v1/{project_id}/dev-servers/{id}/reboot
+// @API ModelArts POST /v1/{project_id}/dev-servers/{id}/changeos
+// @API ModelArts POST /v1/{project_id}/dev-servers/{id}/reinstallos
 // @API ModelArts GET /v1/{project_id}/dev-servers/{id}
 func ResourceDevServerAction() *schema.Resource {
 	return &schema.Resource{
@@ -60,6 +73,29 @@ func ResourceDevServerAction() *schema.Resource {
 				Description: `The action type of the DevServer.`,
 			},
 
+			// Optional parameters.
+			"admin_pass": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `The login password of the DevServer.`,
+			},
+			"key_pair_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The key pair name used to log in to the DevServer.`,
+			},
+			"image_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The image ID used to change the operating system.`,
+			},
+			"user_data": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The user data to be injected into the DevServer during the OS operation.`,
+			},
+
 			// Internal parameters.
 			"enable_force_new": {
 				Type:         schema.TypeString,
@@ -74,35 +110,58 @@ func ResourceDevServerAction() *schema.Resource {
 	}
 }
 
-func operateDevServerAction(client *golangsdk.ServiceClient, devServerId, action string) error {
-	httpUrl := "v1/{project_id}/dev-servers/{id}/{action}"
-	httpUrl = strings.ReplaceAll(httpUrl, "{project_id}", client.ProjectID)
-	httpUrl = strings.ReplaceAll(httpUrl, "{id}", devServerId)
-	httpUrl = strings.ReplaceAll(httpUrl, "{action}", action)
+func parseDevServerActionRequestMethod(action string) string {
+	switch action {
+	case "changeos", "reinstallos":
+		return "POST"
+	default:
+		return "PUT"
+	}
+}
+
+func buildDevServerActionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"admin_pass":    utils.ValueIgnoreEmpty(d.Get("admin_pass")),
+		"key_pair_name": utils.ValueIgnoreEmpty(d.Get("key_pair_name")),
+		"image_id":      utils.ValueIgnoreEmpty(d.Get("image_id")),
+		"user_data":     utils.ValueIgnoreEmpty(d.Get("user_data")),
+	}
+}
+
+func operateDevServerAction(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		devServerId = d.Get("devserver_id").(string)
+		action      = d.Get("action").(string)
+		httpUrl     = "v1/{project_id}/dev-servers/{id}/{action}"
+	)
+
+	actionPath := client.Endpoint + httpUrl
+	actionPath = strings.ReplaceAll(actionPath, "{project_id}", client.ProjectID)
+	actionPath = strings.ReplaceAll(actionPath, "{id}", devServerId)
+	actionPath = strings.ReplaceAll(actionPath, "{action}", action)
 
 	actionOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
-	if action == "start" {
+
+	switch action {
+	case "start":
 		// For the "start" type, the request body parameter must be specified, so set an empty object for it.
 		actionOpt.JSONBody = map[string]interface{}{}
+	case "changeos", "reinstallos":
+		actionOpt.JSONBody = utils.RemoveNil(buildDevServerActionBodyParams(d))
 	}
 
-	_, err := client.Request("POST", httpUrl, &actionOpt)
+	_, err := client.Request(parseDevServerActionRequestMethod(action), actionPath, &actionOpt)
 	return err
 }
 
 func resourceDevServerActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg                = meta.(*config.Config)
-		region             = cfg.GetRegion(d)
-		devServerId        = d.Get("devserver_id").(string)
-		action             = d.Get("action").(string)
-		actionCompletedMap = map[string][]string{
-			"start":  {"RUNNING"},
-			"stop":   {"STOPPED"},
-			"reboot": {"RUNNING"},
-		}
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		devServerId = d.Get("devserver_id").(string)
+		action      = d.Get("action").(string)
 	)
 
 	client, err := cfg.NewServiceClient("modelarts", region)
@@ -110,7 +169,7 @@ func resourceDevServerActionCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error creating ModelArts client: %s", err)
 	}
 
-	err = operateDevServerAction(client, devServerId, action)
+	err = operateDevServerAction(client, d)
 	if err != nil {
 		return diag.Errorf("unable to %s DevServer (%s): %s", action, devServerId, err)
 	}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver_action.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver_action.go
@@ -2,18 +2,25 @@ package modelarts
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	devserverActionNonUpdatableParams = []string{
+		"devserver_id",
+		"action",
+	}
 )
 
 // @API ModelArts PUT /v1/{project_id}/dev-servers/{id}/start
@@ -24,7 +31,10 @@ func ResourceDevServerAction() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDevServerActionCreate,
 		ReadContext:   resourceDevServerActionRead,
+		UpdateContext: resourceDevServerActionUpdate,
 		DeleteContext: resourceDevServerActionDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(devserverActionNonUpdatableParams),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
@@ -37,45 +47,39 @@ func ResourceDevServerAction() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+
+			// Required parameters.
 			"devserver_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The ID of the DevServer.`,
 			},
 			"action": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The action type of the DevServer.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true},
+				),
 			},
 		},
 	}
 }
 
-func resourceDevServerActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg                = meta.(*config.Config)
-		region             = cfg.GetRegion(d)
-		httpUrl            = "v1/{project_id}/dev-servers/{id}/{action}"
-		devServerId        = d.Get("devserver_id").(string)
-		action             = d.Get("action").(string)
-		actionCompletedMap = map[string]string{
-			"start":  "RUNNING",
-			"stop":   "STOPPED",
-			"reboot": "RUNNING",
-		}
-	)
+func operateDevServerAction(client *golangsdk.ServiceClient, devServerId, action string) error {
+	httpUrl := "v1/{project_id}/dev-servers/{id}/{action}"
+	httpUrl = strings.ReplaceAll(httpUrl, "{project_id}", client.ProjectID)
+	httpUrl = strings.ReplaceAll(httpUrl, "{id}", devServerId)
+	httpUrl = strings.ReplaceAll(httpUrl, "{action}", action)
 
-	client, err := cfg.NewServiceClient("modelarts", region)
-	if err != nil {
-		return diag.Errorf("error creating ModelArts client: %s", err)
-	}
-
-	actionPath := client.Endpoint + httpUrl
-	actionPath = strings.ReplaceAll(actionPath, "{project_id}", client.ProjectID)
-	actionPath = strings.ReplaceAll(actionPath, "{id}", devServerId)
-	actionPath = strings.ReplaceAll(actionPath, "{action}", action)
 	actionOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
@@ -84,7 +88,29 @@ func resourceDevServerActionCreate(ctx context.Context, d *schema.ResourceData, 
 		actionOpt.JSONBody = map[string]interface{}{}
 	}
 
-	_, err = client.Request("PUT", actionPath, &actionOpt)
+	_, err := client.Request("POST", httpUrl, &actionOpt)
+	return err
+}
+
+func resourceDevServerActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                = meta.(*config.Config)
+		region             = cfg.GetRegion(d)
+		devServerId        = d.Get("devserver_id").(string)
+		action             = d.Get("action").(string)
+		actionCompletedMap = map[string][]string{
+			"start":  {"RUNNING"},
+			"stop":   {"STOPPED"},
+			"reboot": {"RUNNING"},
+		}
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	err = operateDevServerAction(client, devServerId, action)
 	if err != nil {
 		return diag.Errorf("unable to %s DevServer (%s): %s", action, devServerId, err)
 	}
@@ -92,7 +118,7 @@ func resourceDevServerActionCreate(ctx context.Context, d *schema.ResourceData, 
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"PENDING"},
 		Target:       []string{"COMPLETED"},
-		Refresh:      refreshDevServerActionStatusFunc(client, devServerId, actionCompletedMap[action]),
+		Refresh:      refreshDevServerStatusFunc(client, devServerId, actionCompletedMap[action]),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
@@ -104,29 +130,14 @@ func resourceDevServerActionCreate(ctx context.Context, d *schema.ResourceData, 
 
 	d.SetId(devServerId)
 
-	return nil
-}
-
-func refreshDevServerActionStatusFunc(client *golangsdk.ServiceClient, devServerId string, target string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		respBody, err := GetDevServerById(client, devServerId)
-		if err != nil {
-			return nil, "ERROR", err
-		}
-
-		status := utils.PathSearch("status", respBody, "").(string)
-		if utils.StrSliceContains([]string{"START_FAILED", "ERROR", "STOP_FAILED", "REBOOT_FAILED"}, status) {
-			return respBody, "ERROR", fmt.Errorf("unexpected status (%s)", status)
-		}
-
-		if status == target {
-			return respBody, "COMPLETED", nil
-		}
-		return "continue", "PENDING", nil
-	}
+	return resourceDevServerActionRead(ctx, d, meta)
 }
 
 func resourceDevServerActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDevServerActionUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports more actions for the modelarts devserver action resource:
- changeos
- reinstallos

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1038" height="193" alt="image" src="https://github.com/user-attachments/assets/dc13fd87-3b8f-4118-ba73-3301041fd8bc" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports more actions for the modelarts devserver action resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDevServer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDevServer_basic -timeout 360m -parallel 10
=== RUN   TestAccDevServer_basic
=== PAUSE TestAccDevServer_basic
=== CONT  TestAccDevServer_basic
--- PASS: TestAccDevServer_basic (942.97s)
PASS
coverage: 7.0% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 943.083s        coverage: 7.0% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
