### PR TITLE
feat(GeminiDB): add new resource to manage instance or node restart

### DIFF
--- a/docs/resources/geminidb_instance_restart.md
+++ b/docs/resources/geminidb_instance_restart.md
@@ -1,0 +1,68 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_instance_restart"
+description: |-
+  Manages a resource to restart GeminiDB instance or node within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_instance_restart
+
+Manages a resource to restart GeminiDB instance or node within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource. Deleting this resource will not clear the corresponding request record,
+  but will only remove the resource information from the tf state file.
+  <br/>2. The instance types that support the instance restart operation are as follows:
+  **GeminiDB Cassandra**, **GeminiDB Mongo**, **GeminiDB Influx** and **GeminiDB Redis**.
+  <br/>3. The instance type that supports the node restart operation are as follows:
+  GeminiDB Redis instance with cloud native storage.
+
+## Example Usage
+
+### Restart instance
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_geminidb_instance_restart" "test" {
+  instance_id = var.instance_id
+}
+```
+
+### Restart instance node
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+
+resource "huaweicloud_geminidb_instance_restart" "test" {
+  instance_id = var.instance_id
+  node_id     = var.node_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the instance ID.
+
+* `node_id` - (Optional, String, NonUpdatable) Specifies the ID of a node to be restarted.
+  -> 1. Only GeminiDB Redis instances with cloud native storage can be restarted based on the node ID.
+  <br/>2. If this parameter is not specified, the entire instance is restarted.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3721,6 +3721,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_backup_stop":                geminidb.ResourceGeminiDBBackupStop(),
 			"huaweicloud_geminidb_database_operation":         geminidb.ResourceGeminiDBDatabaseOperation(),
 			"huaweicloud_geminidb_instance":                   geminidb.ResourceGeminiDbInstance(),
+			"huaweicloud_geminidb_instance_restart":           geminidb.ResourceInstanceRestart(),
 			"huaweicloud_geminidb_memory_mapping":             geminidb.ResourceMemoryMapping(),
 			"huaweicloud_geminidb_memory_rule":                geminidb.ResourceMemoryRule(),
 			"huaweicloud_geminidb_node_session_kill":          geminidb.ResourceNodeSessionKill(),

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_restart_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_restart_test.go
@@ -1,0 +1,102 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccInstanceRestart_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testInstanceRestart_basic(name),
+			},
+		},
+	})
+}
+
+func TestAccInstanceRestart_node_restart(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceRestart_node_restart(name),
+			},
+		},
+	})
+}
+
+func testInstanceRestart_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_geminidb_flavors" "test" {
+  engine_name  = "redis"
+  mode         = "CloudNativeCluster"
+  product_type = "Capacity"
+}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[1]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "test_1234"
+  mode              = "CloudNativeCluster"
+  product_type      = "Capacity"
+
+  datastore {
+    type           = "redis"
+    version        = "5.0"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "3"
+    size      = "16"
+    storage   = "ULTRAHIGH"
+    spec_code = data.huaweicloud_geminidb_flavors.test.flavors[1].spec_code
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testInstanceRestart_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_geminidb_instance_restart" "test" {
+  instance_id = huaweicloud_geminidb_instance.test.id
+}
+`, testInstanceRestart_base(name))
+}
+
+func testAccInstanceRestart_node_restart(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_geminidb_instance_restart" "test" {
+  instance_id = huaweicloud_geminidb_instance.test.id
+  node_id     = huaweicloud_geminidb_instance.test.groups[0].nodes[0].id
+}
+`, testInstanceRestart_base(name))
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance_restart.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance_restart.go
@@ -1,0 +1,162 @@
+package geminidb
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var instanceRestartNonUpdatableParams = []string{
+	"instance_id",
+	"node_id",
+}
+
+// @API GeminiDB POST /v3/{project_id}/instances/{instance_id}/restart
+// @API GeminiDB POST /v3/{project_id}/instances
+// @API GeminiDB GET /v3/{project_id}/jobs
+func ResourceInstanceRestart() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInstanceRestartCreate,
+		ReadContext:   resourceInstanceRestartRead,
+		UpdateContext: resourceInstanceRestartUpdate,
+		DeleteContext: resourceInstanceRestartDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(instanceRestartNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildInstanceRestartBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"node_id": utils.ValueIgnoreEmpty(d.Get("node_id")),
+	}
+
+	return bodyParams
+}
+
+func resourceInstanceRestartCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	respBody, err := restartInstanceOrNode(ctx, client, d, instanceId)
+	if err != nil {
+		return diag.Errorf("error restarting GeminiDb instance or node: %s", err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error restarting instance or node: unable to find job ID from API response")
+	}
+
+	d.SetId(jobId)
+
+	err = checkGeminiDbInstanceJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for instance or node to restart to complete: %s", err)
+	}
+
+	return nil
+}
+
+func restartInstanceOrNode(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	instanceId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/instances/{instance_id}/restart"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildInstanceRestartBodyParams(d)),
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		r, err := client.Request("POST", createPath, &createOpt)
+		retry, err := handleMultiOperationsError(err)
+		return r, retry, err
+	}
+	resp, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     geminiDbInstanceStatusRefreshFunc(client, d.Id()),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp.(*http.Response))
+}
+
+func resourceInstanceRestartRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceInstanceRestartUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceInstanceRestartDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GeminiDB restart instance or node resource is not supported. The resource is only removed from the " +
+		"state, the resource remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to manage instance or node restart.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new resource to manage instance or node restart.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccInstanceRestart_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccInstanceRestart_basic -timeout 360m -parallel 4
=== RUN   TestAccInstanceRestart_basic
=== PAUSE TestAccInstanceRestart_basic
=== CONT  TestAccInstanceRestart_basic
--- PASS: TestAccInstanceRestart_basic (159.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  160.020s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccInstanceNodeRestart_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccInstanceNodeRestart_basic -timeout 360m -parallel 4
=== RUN   TestAccInstanceNodeRestart_basic
=== PAUSE TestAccInstanceNodeRestart_basic
=== CONT  TestAccInstanceNodeRestart_basic
--- PASS: TestAccInstanceNodeRestart_basic (78.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  78.179s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
