### PR TITLE
feat(modelarts): supports new data source to query business metrics

### DIFF
--- a/docs/data-sources/dataarts_architecture_business_metrics.md
+++ b/docs/data-sources/dataarts_architecture_business_metrics.md
@@ -1,0 +1,139 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_architecture_business_metrics"
+description: |-
+  Use this data source to query DataArts Architecture business metrics within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_architecture_business_metrics
+
+Use this data source to query DataArts Architecture business metrics within HuaweiCloud.
+
+## Example Usage
+
+### Query all business metrics under a specified workspace
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_architecture_business_metrics" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+### Query all business metrics under a specified workspace and using name filter
+
+```hcl
+variable "workspace_id" {}
+variable "metric_name" {}
+
+data "huaweicloud_dataarts_architecture_business_metrics" "test" {
+  workspace_id = var.workspace_id
+  name         = var.metric_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the business metrics are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the business metrics belong.
+
+* `name` - (Optional, String) Specifies the name or code of the business metric to be fuzzy queried.
+
+* `create_by` - (Optional, String) Specifies the creator of the business metric to be queried.
+
+* `owner` - (Optional, String) Specifies the owner of the business metric to be queried.
+
+* `status` - (Optional, String) Specifies the publishing status of the business metric to be queried.  
+  The valid values are as follows:
+  + **DRAFT**
+  + **PUBLISH_DEVELOPING**
+  + **PUBLISHED**
+  + **OFFLINE_DEVELOPING**
+  + **OFFLINE**
+  + **REJECT**
+
+* `biz_catalog_id` - (Optional, String) Specifies the process architecture ID to which the business metric belongs.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `metrics` - The list of business metrics that matched filter parameters.  
+  The [metrics](#dataarts_architecture_business_metrics_attr) structure is documented below.
+
+<a name="dataarts_architecture_business_metrics_attr"></a>
+The `metrics` block supports:
+
+* `id` - The ID of the business metric.
+
+* `name` - The name of the business metric.
+
+* `biz_catalog_id` - The process architecture ID.
+
+* `time_filters` - The statistical frequency.
+
+* `interval_type` - The refresh frequency.
+
+* `owner` - The name of person responsible for the indicator.
+
+* `owner_department` - The indicator management department name.
+
+* `destination` - The purpose of setting.
+
+* `definition` - The indicator definition.
+
+* `expression` - The calculation formula.
+
+* `description` - The description.
+
+* `apply_scenario` - The application scenarios.
+
+* `technical_metric` - The related technical indicators.
+
+* `measure` - The measurement object.
+
+* `dimensions` - The statistical dimension.
+
+* `general_filters` - The statistical caliber and modifiers.
+
+* `data_origin` - The data sources.
+
+* `unit` - The unit of measurement.
+
+* `name_alias` - The indicator alias.
+
+* `code` - The indicator encoding.
+
+* `status` - The status of the business metric.
+
+* `biz_catalog_path` - The process architecture path.
+
+* `created_by` - The creator of the business metric.
+
+* `updated_by` - The editor of the business metric.
+
+* `created_at` - The creation time of the metric, in RFC3339 format.
+
+* `updated_at` - The latest update time of the metric, in RFC3339 format.
+
+* `technical_metric_type` - The related technical indicator type.
+
+* `technical_metric_name` - The related technical indicator name.
+
+* `l1` - The subject domain grouping Chinese name.
+
+* `l2` - The subject field Chinese name.
+
+* `l3` - The business object Chinese name.
+
+* `biz_metric` - The business indicator synchronization status.
+
+* `summary_status` - The synchronize statistics status.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1085,6 +1085,7 @@ func Provider() *schema.Provider {
 			// DataArts Architecture
 			"huaweicloud_dataarts_architecture_aggregation_logic_tables":         dataarts.DataSourceArchitectureAggregationLogicTables(),
 			"huaweicloud_dataarts_architecture_approvals":                        dataarts.DataSourceArchitectureApprovals(),
+			"huaweicloud_dataarts_architecture_business_metrics":                 dataarts.DataSourceArchitectureBusinessMetrics(),
 			"huaweicloud_dataarts_architecture_data_standard_template_customs":   dataarts.DataSourceArchitectureDataStandardTemplateCustoms(),
 			"huaweicloud_dataarts_architecture_data_standard_template_optionals": dataarts.DataSourceArchitectureDataStandardTemplateOptionals(),
 			"huaweicloud_dataarts_architecture_models":                           dataarts.DataSourceArchitectureModels(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_business_metrics_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_business_metrics_test.go
@@ -1,0 +1,288 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataArchitectureBusinessMetrics_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_architecture_business_metrics.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		filterByName   = "data.huaweicloud_dataarts_architecture_business_metrics.filter_by_name"
+		dcFilterByName = acceptance.InitDataSourceCheck(filterByName)
+
+		filterByCreateBy   = "data.huaweicloud_dataarts_architecture_business_metrics.filter_by_create_by"
+		dcFilterByCreateBy = acceptance.InitDataSourceCheck(filterByCreateBy)
+
+		filterByOwner   = "data.huaweicloud_dataarts_architecture_business_metrics.filter_by_owner"
+		dcFilterByOwner = acceptance.InitDataSourceCheck(filterByOwner)
+
+		filterByStatus   = "data.huaweicloud_dataarts_architecture_business_metrics.filter_by_status"
+		dcFilterByStatus = acceptance.InitDataSourceCheck(filterByStatus)
+
+		filterByBizCatalogId   = "data.huaweicloud_dataarts_architecture_business_metrics.filter_by_biz_catalog_id"
+		dcFilterByBizCatalogId = acceptance.InitDataSourceCheck(filterByBizCatalogId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsBizCatalogID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataArchitectureBusinessMetrics_nonExistentWorkspace(),
+				ExpectError: regexp.MustCompile("error querying DataArts Architecture business metrics"),
+			},
+			{
+				Config: testAccDataSourceArchitectureBusinessMetrics_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "metrics.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+
+					// filter by name
+					dcFilterByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckResourceAttrSet(filterByName, "metrics.0.id"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.name",
+						"huaweicloud_dataarts_architecture_business_metric.test", "name"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.biz_catalog_id",
+						"huaweicloud_dataarts_architecture_business_metric.test", "biz_catalog_id"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.time_filters",
+						"huaweicloud_dataarts_architecture_business_metric.test", "time_filters"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.interval_type",
+						"huaweicloud_dataarts_architecture_business_metric.test", "interval_type"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.owner",
+						"huaweicloud_dataarts_architecture_business_metric.test", "owner"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.owner_department",
+						"huaweicloud_dataarts_architecture_business_metric.test", "owner_department"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.destination",
+						"huaweicloud_dataarts_architecture_business_metric.test", "destination"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.definition",
+						"huaweicloud_dataarts_architecture_business_metric.test", "definition"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.expression",
+						"huaweicloud_dataarts_architecture_business_metric.test", "expression"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.description",
+						"huaweicloud_dataarts_architecture_business_metric.test", "description"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.apply_scenario",
+						"huaweicloud_dataarts_architecture_business_metric.test", "apply_scenario"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.technical_metric",
+						"huaweicloud_dataarts_architecture_business_metric.test", "technical_metric"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.measure",
+						"huaweicloud_dataarts_architecture_business_metric.test", "measure"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.general_filters",
+						"huaweicloud_dataarts_architecture_business_metric.test", "general_filters"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.data_origin",
+						"huaweicloud_dataarts_architecture_business_metric.test", "data_origin"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.unit",
+						"huaweicloud_dataarts_architecture_business_metric.test", "unit"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.name_alias",
+						"huaweicloud_dataarts_architecture_business_metric.test", "name_alias"),
+					resource.TestCheckResourceAttrPair(filterByName, "metrics.0.code",
+						"huaweicloud_dataarts_architecture_business_metric.test", "code"),
+					resource.TestCheckResourceAttrSet(filterByName, "metrics.0.status"),
+					resource.TestCheckResourceAttrSet(filterByName, "metrics.0.biz_catalog_path"),
+					resource.TestCheckResourceAttrSet(filterByName, "metrics.0.created_by"),
+					resource.TestCheckResourceAttrSet(filterByName, "metrics.0.updated_by"),
+					resource.TestMatchResourceAttr(filterByName, "metrics.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$`)),
+					resource.TestMatchResourceAttr(filterByName, "metrics.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$`)),
+					resource.TestCheckResourceAttrSet(filterByName, "metrics.0.l1"),
+
+					// filter by create by
+					dcFilterByCreateBy.CheckResourceExists(),
+					resource.TestCheckOutput("is_create_by_filter_useful", "true"),
+
+					// filter by owner
+					dcFilterByOwner.CheckResourceExists(),
+					resource.TestCheckOutput("is_owner_filter_useful", "true"),
+
+					// filter by status
+					dcFilterByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+
+					// filter by biz catalog ID
+					dcFilterByBizCatalogId.CheckResourceExists(),
+					resource.TestCheckOutput("is_biz_catalog_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataArchitectureBusinessMetrics_nonExistentWorkspace() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_architecture_business_metrics" "test" {
+  workspace_id = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataSourceArchitectureBusinessMetrics_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_business_metric" "test" {
+  workspace_id     = "%[1]s"
+  biz_catalog_id   = "%[2]s"
+  owner            = "test-owner"
+  owner_department = "test-department"
+  name             = "%[3]s"
+  name_alias       = "addition_of_three_numbers"
+  time_filters     = "双周"
+  interval_type    = "HOUR"
+  destination      = "test destination"
+  definition       = "test definition"
+  expression       = "a+b+c"
+  description      = "Addition of three numbers"
+  apply_scenario   = "test apply scenario"
+  technical_metric = 100
+  measure          = "test measure"
+  general_filters  = "test general filters"
+  data_origin      = "test data origin"
+  unit             = "test unit"
+  code             = "testCode"
+}
+
+data "huaweicloud_dataarts_architecture_business_metrics" "all" {
+  depends_on = [
+    huaweicloud_dataarts_architecture_business_metric.test,
+  ]
+
+  workspace_id = "%[1]s"
+}
+
+# Filter by name
+locals {
+  metric_name = huaweicloud_dataarts_architecture_business_metric.test.name
+}
+
+data "huaweicloud_dataarts_architecture_business_metrics" "filter_by_name" {
+  depends_on = [
+    huaweicloud_dataarts_architecture_business_metric.test,
+  ]
+
+  workspace_id = "%[1]s"
+  name         = local.metric_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_business_metrics.filter_by_name.metrics : v.name == local.metric_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by create by
+locals {
+  create_by = huaweicloud_dataarts_architecture_business_metric.test.created_by
+}
+
+data "huaweicloud_dataarts_architecture_business_metrics" "filter_by_create_by" {
+  depends_on = [
+    huaweicloud_dataarts_architecture_business_metric.test,
+  ]
+
+  workspace_id = "%[1]s"
+  create_by    = local.create_by
+}
+
+locals {
+  create_by_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_business_metrics.filter_by_create_by.metrics : v.created_by == local.create_by
+  ]
+}
+
+output "is_create_by_filter_useful" {
+  value = length(local.create_by_filter_result) > 0 && alltrue(local.create_by_filter_result)
+}
+
+# Filter by owner
+locals {
+  metric_owner = huaweicloud_dataarts_architecture_business_metric.test.owner
+}
+
+data "huaweicloud_dataarts_architecture_business_metrics" "filter_by_owner" {
+  depends_on = [
+    huaweicloud_dataarts_architecture_business_metric.test,
+  ]
+
+  workspace_id = "%[1]s"
+  owner        = local.metric_owner
+}
+
+locals {
+  owner_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_business_metrics.filter_by_owner.metrics : v.owner == local.metric_owner
+  ]
+}
+
+output "is_owner_filter_useful" {
+  value = length(local.owner_filter_result) > 0 && alltrue(local.owner_filter_result)
+}
+
+# Filter by status
+locals {
+  metric_status = huaweicloud_dataarts_architecture_business_metric.test.status
+}
+
+data "huaweicloud_dataarts_architecture_business_metrics" "filter_by_status" {
+  depends_on = [
+    huaweicloud_dataarts_architecture_business_metric.test,
+  ]
+
+  workspace_id = "%[1]s"
+  status       = local.metric_status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_business_metrics.filter_by_status.metrics : v.status == local.metric_status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+# Filter by biz catalog ID
+locals {
+  biz_catalog_id = huaweicloud_dataarts_architecture_business_metric.test.biz_catalog_id
+}
+
+data "huaweicloud_dataarts_architecture_business_metrics" "filter_by_biz_catalog_id" {
+  depends_on = [
+    huaweicloud_dataarts_architecture_business_metric.test,
+  ]
+
+  workspace_id   = "%[1]s"
+  biz_catalog_id = local.biz_catalog_id
+}
+
+locals {
+  biz_catalog_id_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_business_metrics.filter_by_biz_catalog_id.metrics : v.biz_catalog_id == local.biz_catalog_id
+  ]
+}
+
+output "is_biz_catalog_id_filter_useful" {
+  value = length(local.biz_catalog_id_filter_result) > 0 && alltrue(local.biz_catalog_id_filter_result)
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_BIZ_CATALOG_ID, name)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_business_metrics.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_business_metrics.go
@@ -1,0 +1,389 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/design/biz-metrics
+func DataSourceArchitectureBusinessMetrics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceArchitectureBusinessMetricsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the business metrics are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the business metrics belong.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name or code of the business metric to be fuzzy queried.`,
+			},
+			"create_by": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The creator of the business metric to be queried.`,
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The owner of the business metric to be queried.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The publishing status of the business metric to be queried.`,
+			},
+			"biz_catalog_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The process architecture ID to which the business metric belongs.`,
+			},
+
+			// Attributes.
+			"metrics": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureBusinessMetricsElem(),
+				Description: `The list of business metrics that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureBusinessMetricsElem() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the business metric.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the business metric.`,
+			},
+			"biz_catalog_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The process architecture ID.`,
+			},
+			"time_filters": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The statistical frequency.`,
+			},
+			"interval_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The refresh frequency.`,
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of person responsible for the indicator.`,
+			},
+			"owner_department": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The indicator management department name.`,
+			},
+			"destination": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The purpose of setting.`,
+			},
+			"definition": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The indicator definition.`,
+			},
+			"expression": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The calculation formula.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description.`,
+			},
+			"apply_scenario": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The application scenarios.`,
+			},
+			"technical_metric": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The related technical indicators.`,
+			},
+			"measure": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The measurement object.`,
+			},
+			"dimensions": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The statistical dimension.`,
+			},
+			"general_filters": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The statistical caliber and modifiers.`,
+			},
+			"data_origin": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data sources.`,
+			},
+			"unit": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The unit of measurement.`,
+			},
+			"name_alias": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The indicator alias.`,
+			},
+			"code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The indicator encoding.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the business metric.`,
+			},
+			"biz_catalog_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The process architecture path.`,
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the business metric.`,
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The editor of the business metric.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the metric, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the metric, in RFC3339 format.`,
+			},
+			"technical_metric_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The related technical indicator type.`,
+			},
+			"technical_metric_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The related technical indicator name.`,
+			},
+			"l1": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subject domain grouping Chinese name.`,
+			},
+			"l2": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subject field Chinese name.`,
+			},
+			"l3": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The business object Chinese name.`,
+			},
+			"biz_metric": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The business indicator synchronization status.`,
+			},
+			"summary_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The synchronize statistics status.`,
+			},
+		},
+	}
+}
+
+func buildArchitectureBusinessMetricsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("create_by"); ok {
+		res = fmt.Sprintf("%s&create_by=%v", res, v)
+	}
+	if v, ok := d.GetOk("owner"); ok {
+		res = fmt.Sprintf("%s&owner=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("biz_catalog_id"); ok {
+		res = fmt.Sprintf("%s&biz_catalog_id=%v", res, v)
+	}
+
+	return res
+}
+
+func listArchitectureBusinessMetrics(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/design/biz-metrics?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildArchitectureBusinessMetricsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildArchitectureMoreHeaders(d.Get("workspace_id").(string)),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		metrics := utils.PathSearch("data.value.records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, metrics...)
+
+		if len(metrics) < limit {
+			break
+		}
+		offset += len(metrics)
+	}
+
+	return result, nil
+}
+
+func flattenArchitectureBusinessMetrics(metrics []interface{}) []map[string]interface{} {
+	if len(metrics) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(metrics))
+	for _, metric := range metrics {
+		technicalMetricResp := utils.PathSearch("technical_metric", metric, "").(string)
+		technicalMetric := utils.StringToInt(&technicalMetricResp)
+
+		result = append(result, map[string]interface{}{
+			"id":                    utils.PathSearch("id", metric, nil),
+			"name":                  utils.PathSearch("name", metric, nil),
+			"biz_catalog_id":        utils.PathSearch("biz_catalog_id", metric, nil),
+			"time_filters":          utils.PathSearch("time_filters", metric, nil),
+			"interval_type":         utils.PathSearch("interval_type", metric, nil),
+			"owner":                 utils.PathSearch("owner", metric, nil),
+			"owner_department":      utils.PathSearch("owner_department", metric, nil),
+			"destination":           utils.PathSearch("destination", metric, nil),
+			"definition":            utils.PathSearch("definition", metric, nil),
+			"expression":            utils.PathSearch("expression", metric, nil),
+			"description":           utils.PathSearch("remark", metric, nil),
+			"apply_scenario":        utils.PathSearch("apply_scenario", metric, nil),
+			"technical_metric":      technicalMetric,
+			"measure":               utils.PathSearch("measure", metric, nil),
+			"dimensions":            utils.PathSearch("dimensions", metric, nil),
+			"general_filters":       utils.PathSearch("general_filters", metric, nil),
+			"data_origin":           utils.PathSearch("data_origin", metric, nil),
+			"unit":                  utils.PathSearch("unit", metric, nil),
+			"name_alias":            utils.PathSearch("name_alias", metric, nil),
+			"code":                  utils.PathSearch("code", metric, nil),
+			"status":                utils.PathSearch("status", metric, nil),
+			"biz_catalog_path":      utils.PathSearch("biz_catalog_path", metric, nil),
+			"created_by":            utils.PathSearch("create_by", metric, nil),
+			"updated_by":            utils.PathSearch("update_by", metric, nil),
+			"created_at":            utils.PathSearch("create_time", metric, nil),
+			"updated_at":            utils.PathSearch("update_time", metric, nil),
+			"technical_metric_type": utils.PathSearch("technical_metric_type", metric, nil),
+			"technical_metric_name": utils.PathSearch("technical_metric_name", metric, nil),
+			"l1":                    utils.PathSearch("l1", metric, nil),
+			"l2":                    utils.PathSearch("l2", metric, nil),
+			"l3":                    utils.PathSearch("l3", metric, nil),
+			"biz_metric":            utils.PathSearch("biz_metric", metric, nil),
+			"summary_status":        utils.PathSearch("summary_status", metric, nil),
+		})
+	}
+	return result
+}
+
+func dataSourceArchitectureBusinessMetricsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	metrics, err := listArchitectureBusinessMetrics(client, d)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Architecture business metrics: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("metrics", flattenArchitectureBusinessMetrics(metrics)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source to query business metrics:
```
data.huaweicloud_dataarts_architecture_business_metrics
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1113" height="58" alt="image" src="https://github.com/user-attachments/assets/335059b8-306e-47ec-80c7-2390be6611a2" />


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to query business metrics.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataArchitectureBusinessMetrics_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataArchitectureBusinessMetrics_basic -timeout 360m -parallel 10
=== RUN   TestAccDataArchitectureBusinessMetrics_basic
=== PAUSE TestAccDataArchitectureBusinessMetrics_basic
=== CONT  TestAccDataArchitectureBusinessMetrics_basic
--- PASS: TestAccDataArchitectureBusinessMetrics_basic (17.44s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  17.531s coverage: 4.7% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
