### PR TITLE
feat(drs): support `drs_db_object` data source

### DIFF
--- a/docs/data-sources/drs_db_object.md
+++ b/docs/data-sources/drs_db_object.md
@@ -1,0 +1,154 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_db_object"
+description: |-
+  Use this data source to get the database object information of specified DRS job within HuaweiCloud.
+---
+
+# huaweicloud_drs_db_object
+
+Use this data source to get the database object information of specified DRS job within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+data "huaweicloud_drs_db_object" "test" {
+  job_id = var.job_id
+  type   = "modified"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the job ID.
+
+* `type` - (Required, String) Specifies the query object information type.  
+  The valid values are as follows:
+  + **modified**: Query selected (synchronized and not delivered) object information.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `target_root_db` - The target database information for database object migration or synchronization.
+
+  The [target_root_db](#target_root_db_struct) structure is documented below.
+
+* `object_info` - The database object migration or synchronization information list.
+
+  The [object_info](#object_info_struct) structure is documented below.
+
+* `max_table_num` - The threshold of the number of tables under a database.
+
+* `status` - The status of obtaining submitted query object selection information.
+
+* `object_scope` - The database type in real-time synchronization scenarios.
+
+<a name="target_root_db_struct"></a>
+The `target_root_db` block supports:
+
+* `db_name` - The database name.
+
+* `db_encoding` - The default encoding format is utf8.
+
+<a name="object_info_struct"></a>
+The `object_info` block supports:
+
+* `key` - The key of the object info map.
+
+* `sync_type` - The database type in real-time synchronization scenarios.
+
+* `name` - The database name in the target database (database name mapping).
+
+* `all` - Whether to migrate or synchronize the entire database.
+
+* `schemas` - The schemas to be migrated or synchronized.
+
+  The [schemas](#schemas_struct) structure is documented below.
+
+* `tables` - The tables to be migrated or synchronized.
+
+  The [tables](#tables_struct) structure is documented below.
+
+* `total_table_num` - The number of tables under the database.
+
+* `is_synchronized` - Whether it has been synchronized.
+
+<a name="schemas_struct"></a>
+The `schemas` block supports:
+
+* `key` - The key of the schemas map.
+
+* `sync_type` - The schema type in real-time synchronization scenarios.
+
+* `name` - The schema name in the target database (schema name mapping).
+
+* `all` - Whether to migrate or synchronize the entire schema.
+
+* `tables` - The tables to be migrated or synchronized.
+
+  The [tables](#tables_struct) structure is documented below.
+
+<a name="tables_struct"></a>
+The `tables` block supports:
+
+* `key` - The key of the tables map.
+
+* `sync_type` - The table type in real-time synchronization scenarios.
+
+* `type` - The object type.
+
+* `name` - The table name in the target database (table name mapping).
+
+* `all` - Whether to migrate or synchronize the entire table.
+
+* `db_alias_name` - The database name mapping at the table level in one-to-many scenarios.
+
+* `schema_alias_name` - The schema name mapping at the table level in one-to-many scenarios.
+
+* `filtered` - Whether data filtering is performed on the table.
+
+* `filter_conditions` - The filter conditions for the table data.
+
+* `config_conditions` - The configuration conditions for advanced data filtering settings of the table.
+
+* `is_synchronized` - Whether it has been synchronized.
+
+* `columns` - The columns to be synchronized, mapped, filtered, or added.
+
+  The [columns](#columns_struct) structure is documented below.
+
+<a name="columns_struct"></a>
+The `columns` block supports:
+
+* `key` - The key of the columns map.
+
+* `sync_type` - The column type in real-time synchronization scenarios.
+
+* `primary_key_for_data_filtering` - The primary key column name in advanced data filtering scenarios.
+
+* `index_for_data_filtering` - The index required for query optimization.
+
+* `name` - The column name in the target database (column name mapping).
+
+* `type` - The data type of the column field.
+
+* `primary_key_for_column_filtering` - Whether the column is the primary key in column mapping scenarios.
+
+* `filtered` - Whether the column is filtered.
+
+* `additional` - Whether the column is an additional column.
+
+* `operation_type` - The operation type.
+
+* `value` - The value of the additional column.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1334,6 +1334,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_compare_policy":           drs.DataSourceDrsComparePolicy(),
 			"huaweicloud_drs_compare_progress":         drs.DataSourceDrsCompareProgress(),
 			"huaweicloud_drs_compare_result":           drs.DataSourceDrsCompareResult(),
+			"huaweicloud_drs_db_object":                drs.DataSourceDrsDbObject(),
 			"huaweicloud_drs_job_configurations":       drs.DataSourceDrsJobConfigurations(),
 			"huaweicloud_drs_job_links":                drs.DataSourceJobLinks(),
 			"huaweicloud_drs_job_metering":             drs.DataSourceDrsJobMetering(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_db_object_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_db_object_test.go
@@ -1,0 +1,45 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsDbObject_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_db_object.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDrsDbObject_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "max_table_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "object_scope"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "object_info.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDrsDbObject_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_db_object" "test" {
+  job_id = "%s"
+  type   = "modified"
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_db_object.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_db_object.go
@@ -1,0 +1,433 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v5.1/{project_id}/jobs/{job_id}/db-object
+func DataSourceDrsDbObject() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsDbObjectRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"target_root_db": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dbObjectTargetRootDbSchema(),
+			},
+			"object_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sync_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"all": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"schemas": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"sync_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"all": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"tables": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     dbObjectTargetTablesSchema(),
+									},
+								},
+							},
+						},
+						"tables": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     dbObjectTargetTablesSchema(),
+						},
+						"total_table_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"is_synchronized": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"max_table_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"object_scope": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dbObjectTargetRootDbSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"db_encoding": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dbObjectTargetTablesSchema() *schema.Resource {
+	return &schema.Resource{
+
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sync_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"all": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"db_alias_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"schema_alias_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"filtered": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"filter_conditions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"config_conditions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"is_synchronized": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"columns": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sync_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"primary_key_for_data_filtering": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"index_for_data_filtering": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"primary_key_for_column_filtering": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"filtered": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"additional": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"operation_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildDbObjectQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?type=%s", d.Get("type").(string))
+}
+
+func dataSourceDrsDbObjectRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v5.1/{project_id}/jobs/{job_id}/db-object"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", d.Get("job_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath+buildDbObjectQueryParams(d), &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DRS database object: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("target_root_db", flattenDbObjectTargetRootDb(
+			utils.PathSearch("target_root_db", respBody, nil))),
+		d.Set("object_info", flattenObjectInfo(
+			utils.PathSearch("object_info", respBody, nil))),
+		d.Set("max_table_num", utils.PathSearch("max_table_num", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("object_scope", utils.PathSearch("object_scope", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDbObjectTargetRootDb(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"db_name":     utils.PathSearch("db_name", resp, nil),
+			"db_encoding": utils.PathSearch("db_encoding", resp, nil),
+		},
+	}
+}
+
+func flattenObjectInfo(resp interface{}) []interface{} {
+	objectInfoMap, ok := resp.(map[string]interface{})
+	if !ok || len(objectInfoMap) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(objectInfoMap))
+	for key, value := range objectInfoMap {
+		item, ok := value.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		result = append(result, map[string]interface{}{
+			"key":             key,
+			"sync_type":       utils.PathSearch("sync_type", item, nil),
+			"name":            utils.PathSearch("name", item, nil),
+			"all":             utils.PathSearch("all", item, nil),
+			"schemas":         flattenDbObjectSchemas(utils.PathSearch("schemas", item, nil)),
+			"tables":          flattenDbObjectTables(utils.PathSearch("tables", item, nil)),
+			"total_table_num": utils.PathSearch("total_table_num", item, nil),
+			"is_synchronized": utils.PathSearch("is_synchronized", item, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenDbObjectSchemas(resp interface{}) []interface{} {
+	schemasMap, ok := resp.(map[string]interface{})
+	if !ok || len(schemasMap) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(schemasMap))
+	for key, value := range schemasMap {
+		item, ok := value.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		result = append(result, map[string]interface{}{
+			"key":       key,
+			"sync_type": utils.PathSearch("sync_type", item, nil),
+			"name":      utils.PathSearch("name", item, nil),
+			"all":       utils.PathSearch("all", item, nil),
+			"tables":    flattenDbObjectTables(utils.PathSearch("tables", item, nil)),
+		})
+	}
+
+	return result
+}
+
+func flattenDbObjectTables(resp interface{}) []interface{} {
+	tablesMap, ok := resp.(map[string]interface{})
+	if !ok || len(tablesMap) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(tablesMap))
+	for key, value := range tablesMap {
+		item, ok := value.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		result = append(result, map[string]interface{}{
+			"key":               key,
+			"sync_type":         utils.PathSearch("sync_type", item, nil),
+			"type":              utils.PathSearch("type", item, nil),
+			"name":              utils.PathSearch("name", item, nil),
+			"all":               utils.PathSearch("all", item, nil),
+			"db_alias_name":     utils.PathSearch("db_alias_name", item, nil),
+			"schema_alias_name": utils.PathSearch("schema_alias_name", item, nil),
+			"filtered":          utils.PathSearch("filtered", item, nil),
+			"filter_conditions": utils.PathSearch("filter_conditions", item, nil),
+			"config_conditions": utils.PathSearch("config_conditions", item, nil),
+			"is_synchronized":   utils.PathSearch("is_synchronized", item, nil),
+			"columns":           flattenDbObjectColumns(utils.PathSearch("columns", item, nil)),
+		})
+	}
+
+	return result
+}
+
+func flattenDbObjectColumns(resp interface{}) []interface{} {
+	columnsMap, ok := resp.(map[string]interface{})
+	if !ok || len(columnsMap) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(columnsMap))
+	for key, value := range columnsMap {
+		item, ok := value.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		result = append(result, map[string]interface{}{
+			"key":       key,
+			"sync_type": utils.PathSearch("sync_type", item, nil),
+			"primary_key_for_data_filtering": utils.PathSearch(
+				"primary_key_for_data_filtering", item, nil),
+			"index_for_data_filtering": utils.PathSearch(
+				"index_for_data_filtering", item, nil),
+			"name": utils.PathSearch("name", item, nil),
+			"type": utils.PathSearch("type", item, nil),
+			"primary_key_for_column_filtering": utils.PathSearch(
+				"primary_key_for_column_filtering", item, nil),
+			"filtered":       utils.PathSearch("filtered", item, nil),
+			"additional":     utils.PathSearch("additional", item, nil),
+			"operation_type": utils.PathSearch("operation_type", item, nil),
+			"value":          utils.PathSearch("value", item, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_db_object` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `drs_db_object` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o drs -f TestAccDataSourceDrsDbObject_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsDbObject_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsDbObject_basic
=== PAUSE TestAccDataSourceDrsDbObject_basic
=== CONT  TestAccDataSourceDrsDbObject_basic
--- PASS: TestAccDataSourceDrsDbObject_basic (15.31s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs  coverage: 5.3% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       15.403s coverage: 5.3% of statements in ./huaweicloud/services/drs
```
<img width="845" height="34" alt="image" src="https://github.com/user-attachments/assets/911e8111-6741-4cf6-9110-0c050c2a824a" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
