### PR TITLE
feat(modelarts): devserver supports update name

### DIFF
--- a/docs/resources/modelarts_devserver.md
+++ b/docs/resources/modelarts_devserver.md
@@ -50,8 +50,7 @@ The following arguments are supported:
   If omitted, the provider-level region will be used.
   Changing this creates a new resource.
 
-* `name` - (Required, String, ForceNew) Specifies the name of the DevServer.
-  Changing this creates a new resource.  
+* `name` - (Required, String) Specifies the name of the DevServer.  
   The name valid length is limited from `1` to `64`, only English letters, digits, underscores (_) and hyphens (-) are
   allowed.
 

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_devserver_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_devserver_test.go
@@ -31,7 +31,8 @@ func TestAccDevServer_basic(t *testing.T) {
 		resourceName = "huaweicloud_modelarts_devserver.test"
 		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDevServerResourceFunc)
 
-		name = acceptance.RandomAccResourceName()
+		name        = acceptance.RandomAccResourceName()
+		updatedName = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -70,42 +71,43 @@ func TestAccDevServer_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDevServer_basic(name, false),
+				Config: testAccDevServer_basic(updatedName, false),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
 					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
 				),
 			},
 			// Stopping the DevServer.
 			{
-				Config: testAccDevServer_doAction(name, "stop", false),
+				Config: testAccDevServer_doAction(updatedName, "stop", false),
 			},
 			// Stopping the stopped DevServer.
 			{
-				Config:      testAccDevServer_doAction(name, "stop", true),
+				Config:      testAccDevServer_doAction(updatedName, "stop", true),
 				ExpectError: regexp.MustCompile(`unable to stop DevServer \([a-f0-9-]+\)`),
 			},
 			// Reinstalling the DevServer OS.
 			{
-				Config: testAccDevServer_doAction(name, "reinstallos", false),
+				Config: testAccDevServer_doAction(updatedName, "reinstallos", false),
 			},
 			// After reinstalling the DevServer OS, the status be changed to "RUNNING", and if we want to test the start
 			// action, we need to stop the DevServer first.
 			{
-				Config: testAccDevServer_doAction(name, "stop", false),
+				Config: testAccDevServer_doAction(updatedName, "stop", false),
 			},
 			// Starting the DevServer (after reinstall OS image).
 			{
-				Config: testAccDevServer_doAction(name, "start", false),
+				Config: testAccDevServer_doAction(updatedName, "start", false),
 			},
 			// Starting the running DevServer.
 			{
-				Config:      testAccDevServer_doAction(name, "start", true),
+				Config:      testAccDevServer_doAction(updatedName, "start", true),
 				ExpectError: regexp.MustCompile(`unable to start DevServer \([a-f0-9-]+\)`),
 			},
 			// Rebooting the DevServer.
 			{
-				Config: testAccDevServer_doAction(name, "reboot", false),
+				Config: testAccDevServer_doAction(updatedName, "reboot", false),
 			},
 			{
 				ResourceName:      resourceName,

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_devserver.go
@@ -26,6 +26,7 @@ var devServerNotExistCode = "ModelArts.6404" // DevServer does not exist.
 // @API ModelArts POST /v1/{project_id}/dev-servers
 // @API ModelArts GET /v1/{project_id}/dev-servers
 // @API ModelArts GET /v1/{project_id}/dev-servers/{id}
+// @API ModelArts PUT /v1/{project_id}/dev-servers/{id}
 // @API ModelArts DELETE /v1/{project_id}/dev-servers/{id}
 func ResourceDevServer() *schema.Resource {
 	return &schema.Resource{
@@ -52,7 +53,6 @@ func ResourceDevServer() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The name of the DevServer.`,
 			},
 			"resource_flavor": {
@@ -532,13 +532,45 @@ func resourceDevServerRead(_ context.Context, d *schema.ResourceData, meta inter
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
+func buildUpdateDevServerBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name": d.Get("name"),
+	}
+}
+
+func updateDevServerName(client *golangsdk.ServiceClient, devServerId string, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/dev-servers/{id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{id}", devServerId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateDevServerBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
 func resourceDevServerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		devServerId = d.Id()
+	)
+
+	if d.HasChange("name") {
+		client, err := cfg.NewServiceClient("modelarts", region)
+		if err != nil {
+			return diag.Errorf("error creating ModelArts client: %s", err)
+		}
+
+		if err = updateDevServerName(client, devServerId, d); err != nil {
+			return diag.Errorf("error updating the name of the DevServer (%s): %s", devServerId, err)
+		}
+	}
+
 	if d.HasChange("auto_renew") {
-		var (
-			cfg         = meta.(*config.Config)
-			region      = cfg.GetRegion(d)
-			devServerId = d.Id()
-		)
 		bssClient, err := cfg.NewServiceClient("bssv2", region)
 		if err != nil {
 			return diag.Errorf("error creating BSS client: %s", err)
@@ -547,6 +579,7 @@ func resourceDevServerUpdate(ctx context.Context, d *schema.ResourceData, meta i
 			return diag.Errorf("error updating the auto_renew of the DevServer (%s): %s", devServerId, err)
 		}
 	}
+
 	return resourceDevServerRead(ctx, d, meta)
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports update name for the devserver resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1059" height="272" alt="image" src="https://github.com/user-attachments/assets/043027f6-6cd9-4c06-926b-3ab3eb08dc90" />
(Currently, the prepaid devserver can only be created)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. devserver supports update name.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDevServer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDevServer_basic -timeout 360m -parallel 10
=== RUN   TestAccDevServer_basic
=== PAUSE TestAccDevServer_basic
=== CONT  TestAccDevServer_basic
--- PASS: TestAccDevServer_basic (770.63s)
PASS
coverage: 7.2% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 770.764s        coverage: 7.2% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
