### PR TITLE
feat(drs): add data source for agency permissions query

### DIFF
--- a/docs/data-sources/drs_agency_permissions.md
+++ b/docs/data-sources/drs_agency_permissions.md
@@ -1,0 +1,91 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_agency_permissions"
+description: |-
+  Use this data source to get the list of agency permissions required by DRS service.
+---
+
+# huaweicloud_drs_agency_permissions
+
+Use this data source to get the list of agency permissions required by DRS service.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_drs_agency_permissions" "test" {
+  is_non_dbs = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `is_non_dbs` - (Required, Bool) Specifies whether the database is a self-built database.
+
+* `source_type` - (Optional, String) Specifies the type of the source database.
+  The valid values are:
+  + **mysql**: MySQL.
+  + **sqlserver**: Microsoft SQL Server.
+  + **postgresql**: PostgreSQL.
+  + **mongodb**: MongoDB, DDS.
+  + **oracle**: Oracle.
+  + **taurus**: TaurusDB.
+  + **ddm**: DDM.
+  + **kafka**: Kafka.
+  + **gaussdbv5**: GaussDB distributed edition.
+  + **gaussdbv5ha**: GaussDB centralized edition.
+  + **gaussmongodb**: GeminiDB Mongo.
+  + **db2**: DB2.
+  + **tidb**: TiDB.
+  + **redis**: Redis.
+  + **rediscluster**: Redis cluster.
+  + **gaussredis**: GeminiDB Redis.
+  + **mariadb**: MariaDB.
+  + **informix**: Informix.
+  + **dynamo**: Dynamo.
+
+* `target_type` - (Optional, String) Specifies the type of the target database.
+  The valid values are:
+  + **mysql**: MySQL.
+  + **sqlserver**: Microsoft SQL Server.
+  + **postgresql**: PostgreSQL.
+  + **mongodb**: MongoDB, DDS.
+  + **oracle**: Oracle.
+  + **taurus**: TaurusDB.
+  + **ddm**: DDM.
+  + **kafka**: Kafka.
+  + **gaussdbv5**: GaussDB distributed edition.
+  + **gaussdbv5ha**: GaussDB centralized edition.
+  + **gaussmongodb**: GeminiDB Mongo.
+  + **db2**: DB2.
+  + **tidb**: TiDB.
+  + **redis**: Redis.
+  + **rediscluster**: Redis cluster.
+  + **gaussredis**: GeminiDB Redis.
+  + **mariadb**: MariaDB.
+  + **informix**: Informix.
+  + **dynamo**: Dynamo.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `common_permissions` - The list of common permissions required by DRS service.
+  The valid values are as follows:
+  + **DRS FullAccess**: Full access to Data Replication Service.
+
+* `engine_permissions` - The list of database engine specific permissions.
+  The valid values are as follows:
+  + **GaussDB ReadOnlyAccess**: Read-only access to GaussDB.
+  + **GeminiDB ReadOnlyAccess**: Read-only access to GeminiDB.
+  + **DDM ReadOnlyAccess**: Read-only access to DDM.
+  + **DDS ReadOnlyPolicy**: Read-only access to DDS.
+  + **RDS ReadOnlyAccess**: Read-only access to RDS.
+  + **MRS ReadOnlyAccess**: Read-only access to MRS.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1328,6 +1328,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dnsv21_ptrrecords":                dns.DataSourceDNSV21PtrRecords(),
 
 			"huaweicloud_drs_actions":                  drs.DataSourceDrsActions(),
+			"huaweicloud_drs_agency_permissions":       drs.DataSourceDrsAgencyPermissions(),
 			"huaweicloud_drs_availability_zones":       drs.DataSourceAvailabilityZones(),
 			"huaweicloud_drs_batch_get_params":         drs.DataSourceDrsBatchGetParams(),
 			"huaweicloud_drs_batch_progresses":         drs.DataSourceDrsBatchProgresses(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_agency_permissions_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_agency_permissions_test.go
@@ -1,0 +1,37 @@
+package drs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsAgencyPermissions_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_agency_permissions.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgencyPermissions_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "common_permissions.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "engine_permissions.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccAgencyPermissions_basic = `
+data "huaweicloud_drs_agency_permissions" "test" {
+  is_non_dbs = false
+}
+`

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_agency_permissions.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_agency_permissions.go
@@ -1,0 +1,116 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v5/{project_id}/agency/permissions
+func DataSourceDrsAgencyPermissions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsAgencyPermissionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"is_non_dbs": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"source_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"target_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"common_permissions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"engine_permissions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func buildAgencyPermissionsQueryParams(d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("?is_non_dbs=%t", d.Get("is_non_dbs").(bool))
+
+	if v, ok := d.GetOk("source_type"); ok {
+		queryParams += fmt.Sprintf("&source_type=%s", v.(string))
+	}
+	if v, ok := d.GetOk("target_type"); ok {
+		queryParams += fmt.Sprintf("&target_type=%s", v.(string))
+	}
+
+	return queryParams
+}
+
+func dataSourceDrsAgencyPermissionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v5/{project_id}/agency/permissions"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAgencyPermissionsQueryParams(d)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DRS agency permissions: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("common_permissions", utils.PathSearch("common_permissions", respBody, nil)),
+		d.Set("engine_permissions", utils.PathSearch("engine_permissions", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a new data source `huaweicloud_drs_agency_permissions` for HuaweiCloud Data Replication Service (DRS). This data source is used to query the agency permissions required by the DRS service, supports filtering by source database type, target database type and whether it is a self-built database. It helps users quickly obtain the required permission policies when configuring DRS tasks.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add data source huaweicloud_drs_agency_permissions for querying DRS agency permissions
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/drs' TESTARGS='-run=TestAccDataSourceDrsAgencyPermissions_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run=TestAccDataSourceDrsAgencyPermissions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDrsAgencyPermissions_basic
=== PAUSE TestAccDataSourceDrsAgencyPermissions_basic
=== CONT  TestAccDataSourceDrsAgencyPermissions_basic
--- PASS: TestAccDataSourceDrsAgencyPermissions_basic (26.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs     
```
<img width="474" height="18" alt="Snipaste_2026-05-26_09-41-31" src="https://github.com/user-attachments/assets/54081bc1-7f0a-4d0f-a383-885f0add2f2c" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
