### PR TITLE
feat(dataarts/security): add new data source to query data secrecy level list

### DIFF
--- a/docs/data-sources/dataarts_security_data_secrecy_levels.md
+++ b/docs/data-sources/dataarts_security_data_secrecy_levels.md
@@ -1,0 +1,72 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_data_secrecy_levels"
+description: |-
+  Use this data source to get the list of DataArts Security data secrecy levels within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_data_secrecy_levels
+
+Use this data source to get the list of DataArts Security data secrecy levels within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_security_data_secrecy_levels" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the data secrecy levels are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the data secrecy levels belong.
+
+* `order_by` - (Optional, String) Specifies the field used to sort the data secrecy levels.  
+  The valid values are as follows:
+  + **name**
+  + **description**
+  + **createdAt**
+  + **updatedAt**
+  + **createdBy**
+  + **updatedBy**
+
+* `desc` - (Optional, Bool) Specifies whether to sort the data secrecy levels in descending order.
+  Default is **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `secrecy_levels` - The list of data secrecy levels that matched the filter parameters.  
+  The [secrecy_levels](#dataarts_security_data_secrecy_levels_attr) structure is documented below.
+
+<a name="dataarts_security_data_secrecy_levels_attr"></a>
+The `secrecy_levels` block supports:
+
+* `id` - The ID of the data secrecy level.
+
+* `name` - The name of the data secrecy level.
+
+* `level_number` - The level number of the data secrecy level.
+
+* `description` - The description of the data secrecy level.
+
+* `instance_id` - The instance ID to which the data secrecy level belongs.
+
+* `created_by` - The creator of the data secrecy level.
+
+* `created_at` - The creation time of the data secrecy level, in RFC3339 format.
+
+* `updated_by` - The updater of the data secrecy level.
+
+* `updated_at` - The latest update time of the data secrecy level, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1117,6 +1117,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_security_data_categories":              dataarts.DataSourceSecurityDataCategories(),
 			"huaweicloud_dataarts_security_data_recognition_rules":       dataarts.DataSourceSecurityDataRecognitionRules(),
 			"huaweicloud_dataarts_security_data_recognition_rule_groups": dataarts.DataSourceSecurityDataRecognitionRuleGroups(),
+			"huaweicloud_dataarts_security_data_secrecy_levels":          dataarts.DataSourceSecurityDataSecrecyLevels(),
 			"huaweicloud_dataarts_security_dynamic_masking_policies":     dataarts.DataSourceSecurityDynamicMaskingPolicies(),
 			"huaweicloud_dataarts_security_permission_sets":              dataarts.DataSourceSecurityPermissionSets(),
 			"huaweicloud_dataarts_security_permission_set_members":       dataarts.DataSourceSecurityPermissionSetMembers(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_data_secrecy_levels_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_data_secrecy_levels_test.go
@@ -1,0 +1,108 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSecurityDataSecrecyLevels_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_security_data_secrecy_levels.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byOrderByAsc    = "data.huaweicloud_dataarts_security_data_secrecy_levels.filter_by_order_by_asc"
+		dcByOrderByAsc  = acceptance.InitDataSourceCheck(byOrderByAsc)
+		byOrderByDesc   = "data.huaweicloud_dataarts_security_data_secrecy_levels.filter_by_order_by_desc"
+		dcByOrderByDesc = acceptance.InitDataSourceCheck(byOrderByDesc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSecurityDataSecrecyLevels_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(all, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestMatchResourceAttr(all, "secrecy_levels.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestCheckResourceAttrSet(all, "secrecy_levels.0.id"),
+					resource.TestCheckResourceAttrSet(all, "secrecy_levels.0.name"),
+					resource.TestCheckResourceAttrSet(all, "secrecy_levels.0.level_number"),
+					resource.TestCheckResourceAttrSet(all, "secrecy_levels.0.instance_id"),
+					resource.TestCheckResourceAttrSet(all, "secrecy_levels.0.created_by"),
+					resource.TestMatchResourceAttr(all, "secrecy_levels.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(all, "secrecy_levels.0.updated_by"),
+					resource.TestMatchResourceAttr(all, "secrecy_levels.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+
+					// Filter by 'order_by' parameter.
+					dcByOrderByAsc.CheckResourceExists(),
+					dcByOrderByDesc.CheckResourceExists(),
+					resource.TestCheckOutput("is_order_by_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSecurityDataSecrecyLevels_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_security_data_secrecy_level" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  description  = "Created by terraform"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccDataSecurityDataSecrecyLevels_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dataarts_security_data_secrecy_levels" "test" {
+  workspace_id = "%[2]s"
+
+  depends_on = [huaweicloud_dataarts_security_data_secrecy_level.test]
+}
+
+# Filter by 'order_by' parameter to get the data secrecy levels in ascending order
+data "huaweicloud_dataarts_security_data_secrecy_levels" "filter_by_order_by_asc" {
+  workspace_id = "%[2]s"
+  order_by     = "name"
+
+  depends_on = [huaweicloud_dataarts_security_data_secrecy_level.test]
+}
+
+
+# Filter by 'order_by' parameter to get the data secrecy levels in descending order
+data "huaweicloud_dataarts_security_data_secrecy_levels" "filter_by_order_by_desc" {
+  workspace_id = "%[2]s"
+  order_by     = "name"
+  desc         = true
+
+  depends_on = [huaweicloud_dataarts_security_data_secrecy_level.test]
+}
+
+locals {
+  secrecy_level_names_desc = data.huaweicloud_dataarts_security_data_secrecy_levels.filter_by_order_by_desc.secrecy_levels[*].name
+  secrecy_level_names_asc  = data.huaweicloud_dataarts_security_data_secrecy_levels.filter_by_order_by_asc.secrecy_levels[*].name
+}
+
+output "is_order_by_filter_useful" {
+  value = local.secrecy_level_names_desc == reverse(local.secrecy_level_names_asc)
+}
+`, testAccDataSecurityDataSecrecyLevels_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_data_secrecy_levels.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_data_secrecy_levels.go
@@ -1,0 +1,221 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/security/data-classification/secrecy-level
+func DataSourceSecurityDataSecrecyLevels() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityDataSecrecyLevelsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the data secrecy levels are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the data secrecy levels belong.`,
+			},
+
+			// Optional parameters.
+			"order_by": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the field used to sort the data secrecy levels.`,
+			},
+			"desc": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Specifies whether to sort the data secrecy levels in descending order.`,
+			},
+
+			// Attributes.
+			"secrecy_levels": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of data secrecy levels that matched the filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the data secrecy level.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the data secrecy level.`,
+						},
+						"level_number": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The level number of the data secrecy level.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the data secrecy level.`,
+						},
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The instance ID to which the data secrecy level belongs.`,
+						},
+						"created_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator of the data secrecy level.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the data secrecy level, in RFC3339 format.`,
+						},
+						"updated_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The updater of the data secrecy level.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the data secrecy level, in RFC3339 format.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSecurityDataSecrecyLevelsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("order_by"); ok {
+		res = fmt.Sprintf("%s&order_by=%v", res, v)
+	}
+	if v, ok := d.GetOk("desc"); ok {
+		res = fmt.Sprintf("%s&desc=%v", res, v)
+	}
+
+	return res
+}
+
+func listSecurityDataSecrecyLevels(client *golangsdk.ServiceClient, d *schema.ResourceData, workspaceId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/security/data-classification/secrecy-level?limit={limit}"
+		// limit: maximum is `100`, default is `10`.
+		limit  = 100
+		offset = 0
+		result = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildSecurityDataSecrecyLevelsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		levels := utils.PathSearch("content", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, levels...)
+		if len(levels) < limit {
+			break
+		}
+
+		offset += len(levels)
+	}
+
+	return result, nil
+}
+
+func dataSourceSecurityDataSecrecyLevelsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	secrecyLevels, err := listSecurityDataSecrecyLevels(client, d, workspaceId)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Security data secrecy levels: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("secrecy_levels", flattenSecurityDataSecrecyLevels(secrecyLevels)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSecurityDataSecrecyLevels(levels []interface{}) []interface{} {
+	if len(levels) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(levels))
+	for _, level := range levels {
+		result = append(result, map[string]interface{}{
+			"id":           utils.PathSearch("secrecy_level_id", level, nil),
+			"name":         utils.PathSearch("secrecy_level_name", level, nil),
+			"level_number": utils.PathSearch("secrecy_level_number", level, nil),
+			"description":  utils.PathSearch("description", level, nil),
+			"instance_id":  utils.PathSearch("instance_id", level, nil),
+			"created_by":   utils.PathSearch("created_by", level, nil),
+			"created_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("created_at",
+				level, float64(0)).(float64))/1000, false),
+			"updated_by": utils.PathSearch("updated_by", level, nil),
+			"updated_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("updated_at",
+				level, float64(0)).(float64))/1000, false),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_dataarts_security_data_secrecy_levels`) to query data secrecy level list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataSecurityDataSecrecyLevels_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataSecurityDataSecrecyLevels_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSecurityDataSecrecyLevels_basic
=== PAUSE TestAccDataSecurityDataSecrecyLevels_basic
=== CONT  TestAccDataSecurityDataSecrecyLevels_basic
--- PASS: TestAccDataSecurityDataSecrecyLevels_basic (15.81s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  15.929s coverage: 4.6% of statements in ./huaweicloud/services/dataarts

```
<img width="1155" height="59" alt="image" src="https://github.com/user-attachments/assets/28e3855d-7f9e-47be-ae1d-a2fd58b708c7" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
