### PR TITLE
feat(drs): support `drs_configuration_histories` data source

### DIFF
--- a/docs/data-sources/drs_configuration_histories.md
+++ b/docs/data-sources/drs_configuration_histories.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_configuration_histories"
+description: |-
+  Use this data source to get the parameter configuration modification history of specified DRS job within HuaweiCloud.
+---
+
+# huaweicloud_drs_configuration_histories
+
+Use this data source to get the parameter configuration modification history of specified DRS job within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+data "huaweicloud_drs_configuration_histories" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the job ID.
+
+* `begin_time` - (Optional, String) Specifies the start time in UTC format, for example: 2020-09-01T18:50:20Z.
+
+* `end_time` - (Optional, String) Specifies the end time in UTC format, for example: 2020-09-01T19:50:20Z.
+
+* `name` - (Optional, String) Specifies the parameter name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `parameter_history_config_list` - The parameter configuration modification history list.
+
+  The [parameter_history_config_list](#parameter_history_config_list_struct) structure is documented below.
+
+<a name="parameter_history_config_list_struct"></a>
+The `parameter_history_config_list` block supports:
+
+* `name` - The parameter name.
+
+* `old_value` - The old parameter value.
+
+* `new_value` - The new parameter value.
+
+* `is_update_success` - The update result. **true** indicates success, **false** indicates failure.
+
+* `is_applied` - Whether the parameter has been applied. **true** indicates applied, **false** indicates not applied.
+
+* `update_time` - The parameter modification time.
+
+* `apply_time` - The parameter application time.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1337,6 +1337,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_compare_policy":           drs.DataSourceDrsComparePolicy(),
 			"huaweicloud_drs_compare_progress":         drs.DataSourceDrsCompareProgress(),
 			"huaweicloud_drs_compare_result":           drs.DataSourceDrsCompareResult(),
+			"huaweicloud_drs_configuration_histories":  drs.DataSourceDrsConfigurationHistories(),
 			"huaweicloud_drs_db_object":                drs.DataSourceDrsDbObject(),
 			"huaweicloud_drs_data_processing_rules":    drs.DataSourceDrsDataProcessingRules(),
 			"huaweicloud_drs_job_configurations":       drs.DataSourceDrsJobConfigurations(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_configuration_histories_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_configuration_histories_test.go
@@ -1,0 +1,44 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsConfigurationHistories_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_configuration_histories.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDrsConfigurationHistories_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "parameter_history_config_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDrsConfigurationHistories_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_configuration_histories" "test" {
+  job_id     = "%s"
+  begin_time = "2020-09-01T18:50:20Z"
+  end_time   = "2025-09-01T18:50:20Z"
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_configuration_histories.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_configuration_histories.go
@@ -1,0 +1,185 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v5/{project_id}/jobs/{job_id}/configuration-histories
+func DataSourceDrsConfigurationHistories() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsConfigurationHistoriesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"begin_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"parameter_history_config_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"old_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"new_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_update_success": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_applied": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"apply_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildConfigurationHistoriesQueryParams(d *schema.ResourceData, offset int) string {
+	queryParams := "?limit=1000"
+	if v, ok := d.GetOk("begin_time"); ok {
+		queryParams += fmt.Sprintf("&begin_time=%s", v.(string))
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		queryParams += fmt.Sprintf("&end_time=%s", v.(string))
+	}
+	if v, ok := d.GetOk("name"); ok {
+		queryParams += fmt.Sprintf("&name=%s", v.(string))
+	}
+	if offset > 0 {
+		queryParams += fmt.Sprintf("&offset=%d", offset)
+	}
+
+	return queryParams
+}
+
+func dataSourceDrsConfigurationHistoriesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v5/{project_id}/jobs/{job_id}/configuration-histories"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", d.Get("job_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		requestPathWithQuery := requestPath + buildConfigurationHistoriesQueryParams(d, offset)
+		resp, err := client.Request("GET", requestPathWithQuery, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DRS configuration histories: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		parameterHistoryConfigList := utils.PathSearch(
+			"parameter_history_config_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(parameterHistoryConfigList) == 0 {
+			break
+		}
+
+		result = append(result, parameterHistoryConfigList...)
+		offset += len(parameterHistoryConfigList)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("parameter_history_config_list", flattenParameterHistoryConfigList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenParameterHistoryConfigList(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(respArray))
+	for _, item := range respArray {
+		result = append(result, map[string]interface{}{
+			"name":              utils.PathSearch("name", item, nil),
+			"old_value":         utils.PathSearch("old_value", item, nil),
+			"new_value":         utils.PathSearch("new_value", item, nil),
+			"is_update_success": utils.PathSearch("is_update_success", item, nil),
+			"is_applied":        utils.PathSearch("is_applied", item, nil),
+			"update_time":       utils.PathSearch("update_time", item, nil),
+			"apply_time":        utils.PathSearch("apply_time", item, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_configuration_histories` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `drs_configuration_histories` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o drs -f TestAccDataSourceDrsConfigurationHistories_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsConfigurationHistories_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsConfigurationHistories_basic
=== PAUSE TestAccDataSourceDrsConfigurationHistories_basic
=== CONT  TestAccDataSourceDrsConfigurationHistories_basic
--- PASS: TestAccDataSourceDrsConfigurationHistories_basic (21.24s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs  coverage: 4.9% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       21.427s coverage: 4.9% of statements in ./huaweicloud/services/drs
```
<img width="905" height="37" alt="image" src="https://github.com/user-attachments/assets/d613c161-0f5c-4cf7-a71c-636f9dc70160" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
