### PR TITLE
feat(dataarts): supports new data source to query instances

### DIFF
--- a/docs/data-sources/dataarts_studio_instances.md
+++ b/docs/data-sources/dataarts_studio_instances.md
@@ -1,0 +1,66 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_studio_instances"
+description: |-
+  Use this data source to get the list of DataArts Studio instances.
+---
+
+# huaweicloud_dataarts_studio_instances
+
+Use this data source to get the list of DataArts Studio instances.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dataarts_studio_instances" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the DataArts Studio instances are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances` - The list of the DataArts Studio instances.
+  The [instances](#dataarts_studio_instances_attr) structure is documented below.
+
+<a name="dataarts_studio_instances_attr"></a>
+The `instances` block supports:
+
+* `id` - The ID of the DataArts Studio instance.
+
+* `name` - The name of the DataArts Studio instance.
+
+* `version` - The version (spec code) of the DataArts Studio instance.
+
+* `order_id` - The order ID of the DataArts Studio instance.
+
+* `product_id` - The product ID of the DataArts Studio instance.
+
+* `auto_renew` - Whether auto renew is enabled for the DataArts Studio instance.
+
+* `status` - The status of the DataArts Studio instance.
+
+* `vpc_id` - The VPC ID of the DataArts Studio instance.
+
+* `subnet_id` - The subnet ID of the DataArts Studio instance.
+
+* `availability_zone` - The availability zone of the DataArts Studio instance.
+
+* `enterprise_project_id` - The enterprise project ID to which the DataArts Studio instance belongs.
+
+* `effective_time` - The effective time of the DataArts Studio instance, in RFC3339 format.
+
+* `created_by` - The creator of the DataArts Studio instance.
+
+* `created_at` - The creation time of the DataArts Studio instance, in RFC3339 format.
+
+* `workspace_mode` - The workspace mode of the DataArts Studio instance.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1080,6 +1080,7 @@ func Provider() *schema.Provider {
 
 			// DataArts Studio Management Center
 			"huaweicloud_dataarts_studio_data_connections":     dataarts.DataSourceStudioDataConnections(),
+			"huaweicloud_dataarts_studio_instances":            dataarts.DataSourceDataArtsStudioInstances(),
 			"huaweicloud_dataarts_studio_workspaces":           dataarts.DataSourceDataArtsStudioWorkspaces(),
 			"huaweicloud_dataarts_studio_workspace_users":      dataarts.DataSourceStudioWorkspaceUsers(),
 			"huaweicloud_dataarts_studio_workspace_user_roles": dataarts.DataSourceStudioWorkspaceUserRoles(),

--- a/huaweicloud/services/acceptance/common/resources.go
+++ b/huaweicloud/services/acceptance/common/resources.go
@@ -42,14 +42,14 @@ resource "huaweicloud_vpc_subnet" "test" {
 }
 
 // TestBaseNetwork vpc, subnet, security group
-func TestBaseNetwork(name string) string {
+func TestBaseNetwork(name string, enterpriseProjectId ...string) string {
 	return fmt.Sprintf(`
 # base security group without default rules
 %s
 
 # base vpc and subnet
 %s
-`, TestSecGroup(name), TestVpc(name))
+`, TestSecGroup(name), TestVpc(name, enterpriseProjectId...))
 }
 
 // TestBaseComputeResources vpc, subnet, security group, availability zone, keypair, image, flavor

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_studio_instances_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_studio_instances_test.go
@@ -1,0 +1,87 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataStudioInstances_basic(t *testing.T) {
+	var (
+		beforeInstanceCreation   = "data.huaweicloud_dataarts_studio_instances.before_instance_creation"
+		dcBeforeInstanceCreation = acceptance.InitDataSourceCheck(beforeInstanceCreation)
+
+		all = "data.huaweicloud_dataarts_studio_instances.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDataArtsStudioInstances_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dcBeforeInstanceCreation.CheckResourceExists(),
+					resource.TestCheckResourceAttr(beforeInstanceCreation, "instances.#", "0"),
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "instances.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrPair(all, "instances.0.id", "huaweicloud_dataarts_studio_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(all, "instances.0.name", "huaweicloud_dataarts_studio_instance.test", "name"),
+					resource.TestCheckResourceAttrPair(all, "instances.0.version", "huaweicloud_dataarts_studio_instance.test", "version"),
+					resource.TestCheckResourceAttrPair(all, "instances.0.order_id", "huaweicloud_dataarts_studio_instance.test", "order_id"),
+					resource.TestCheckResourceAttrSet(all, "instances.0.product_id"),
+					resource.TestCheckResourceAttrPair(all, "instances.0.auto_renew", "huaweicloud_dataarts_studio_instance.test", "auto_renew"),
+					resource.TestCheckResourceAttrPair(all, "instances.0.enterprise_project_id",
+						"huaweicloud_dataarts_studio_instance.test", "enterprise_project_id"),
+					resource.TestCheckResourceAttrPair(all, "instances.0.status", "huaweicloud_dataarts_studio_instance.test", "status"),
+					resource.TestCheckResourceAttrPair(all, "instances.0.vpc_id", "huaweicloud_dataarts_studio_instance.test", "vpc_id"),
+					resource.TestCheckResourceAttrPair(all, "instances.0.subnet_id", "huaweicloud_dataarts_studio_instance.test", "subnet_id"),
+					resource.TestCheckResourceAttrPair(all, "instances.0.availability_zone",
+						"huaweicloud_dataarts_studio_instance.test", "availability_zone"),
+					resource.TestMatchResourceAttr(all, "instances.0.effective_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(all, "instances.0.created_by"),
+					resource.TestMatchResourceAttr(all, "instances.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(all, "instances.0.workspace_mode"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDataArtsStudioInstances_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_dataarts_studio_instances" "before_instance_creation" {}
+
+resource "huaweicloud_dataarts_studio_instance" "test" {
+  name                  = "%[2]s"
+  version               = "dayu.free"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
+  period_unit = "month"
+  period      = 1
+  auto_renew  = "true"
+}
+
+data "huaweicloud_dataarts_studio_instances" "test" {
+  depends_on = [huaweicloud_dataarts_studio_instance.test]
+}
+`, common.TestBaseNetwork(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), name)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_studio_instances.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_studio_instances.go
@@ -1,0 +1,228 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/instances
+func DataSourceDataArtsStudioInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDataArtsStudioInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the DataArts Studio instances are located.`,
+			},
+
+			// Attributes.
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the DataArts Studio instance.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the DataArts Studio instance.`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version (spec code) of the DataArts Studio instance.`,
+						},
+						"order_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The order ID of the DataArts Studio instance.`,
+						},
+						"product_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The product ID of the DataArts Studio instance.`,
+						},
+						"auto_renew": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Whether auto renew is enabled for the DataArts Studio instance.`,
+						},
+						"status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The status of the DataArts Studio instance.`,
+						},
+						"vpc_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The VPC ID of the DataArts Studio instance.`,
+						},
+						"subnet_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The subnet ID of the DataArts Studio instance.`,
+						},
+						"availability_zone": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The availability zone of the DataArts Studio instance.`,
+						},
+						"enterprise_project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The enterprise project ID to which the DataArts Studio instance belongs.`,
+						},
+						"effective_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The effective time of the DataArts Studio instance, in RFC3339 format.`,
+						},
+						"created_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator of the DataArts Studio instance.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the DataArts Studio instance, in RFC3339 format.`,
+						},
+						"workspace_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The workspace mode of the DataArts Studio instance.`,
+						},
+					},
+				},
+				Description: `The list of the DataArts Studio instances.`,
+			},
+		},
+	}
+}
+
+func listDataArtsStudioInstances(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/instances?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		instances := utils.PathSearch("commodity_orders", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, instances...)
+		if len(instances) < limit {
+			break
+		}
+		offset += len(instances)
+	}
+
+	return result, nil
+}
+
+func parseStudioInstanceAutoRenew(autoRenew int) string {
+	if autoRenew == 1 {
+		return "true"
+	}
+	return "false"
+}
+
+func flattenDataArtsStudioInstances(instances []interface{}) []map[string]interface{} {
+	if len(instances) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(instances))
+	for _, instance := range instances {
+		result = append(result, map[string]interface{}{
+			"id":         utils.PathSearch("resource_id", instance, nil),
+			"name":       utils.PathSearch("resource_name", instance, nil),
+			"version":    utils.PathSearch("resource_spec_code", instance, nil),
+			"order_id":   utils.PathSearch("order_id", instance, nil),
+			"product_id": utils.PathSearch("product_id", instance, nil),
+			"auto_renew": parseStudioInstanceAutoRenew(int(utils.PathSearch("is_auto_renew",
+				instance, float64(0)).(float64))),
+			"status":                utils.PathSearch("status", instance, nil),
+			"vpc_id":                utils.PathSearch("vpc_id", instance, nil),
+			"subnet_id":             utils.PathSearch("net_id", instance, nil),
+			"availability_zone":     utils.PathSearch("availability_zone", instance, nil),
+			"enterprise_project_id": utils.PathSearch("eps_id", instance, nil),
+			"effective_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("effective_time",
+				instance, float64(0)).(float64))/1000, false),
+			"created_by": utils.PathSearch("create_user", instance, nil),
+			"created_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time",
+				instance, float64(0)).(float64))/1000, false),
+			"workspace_mode": utils.PathSearch("work_space_mode", instance, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceDataArtsStudioInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	instances, err := listDataArtsStudioInstances(client)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Studio instances: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instances", flattenDataArtsStudioInstances(instances)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source to query DataArts Studio intances.
Some of attributes does not supported, such as:
- tags
- charging_mode

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1122" height="142" alt="image" src="https://github.com/user-attachments/assets/cfb7ac13-2ed1-41a4-ad42-f0a9efe3fbe6" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to query instances
2. supports corresponding document and acceptance test
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataStudioInstances_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataStudioInstances_basic -timeout 360m -parallel 10
=== RUN   TestAccDataStudioInstances_basic
=== PAUSE TestAccDataStudioInstances_basic
=== CONT  TestAccDataStudioInstances_basic
--- PASS: TestAccDataStudioInstances_basic (1028.44s)
PASS
coverage: 4.6% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  1028.541s       coverage: 4.6% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
