### PR TITLE
feat(drs): support `drs_dirty_data` data source

### DIFF
--- a/docs/data-sources/drs_dirty_data.md
+++ b/docs/data-sources/drs_dirty_data.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_dirty_data"
+description: |-
+  Use this data source to get the dirty data list of specified DRS job within HuaweiCloud.
+---
+
+# huaweicloud_drs_dirty_data
+
+Use this data source to get the dirty data list of specified DRS job within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+data "huaweicloud_drs_dirty_data" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the job ID.
+
+* `begin_time` - (Optional, String) Specifies the start time in UTC format, for example: 2020-09-01T18:50:20Z.
+
+* `end_time` - (Optional, String) Specifies the end time in UTC format, for example: 2020-09-01T19:50:20Z.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `dirty_data_list` - The dirty data list.
+
+  The [dirty_data_list](#dirty_data_list_struct) structure is documented below.
+
+<a name="dirty_data_list_struct"></a>
+The `dirty_data_list` block supports:
+
+* `db_name` - The database name.
+
+* `schema_name` - The schema name.
+
+* `table_name` - The table name.
+
+* `error_sql` - The error SQL.
+
+* `error_time` - The error occurrence time in UTC format, for example: 2023-06-10T03:01:52Z.
+
+* `error_msg` - The error message.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1341,6 +1341,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_configuration_histories":  drs.DataSourceDrsConfigurationHistories(),
 			"huaweicloud_drs_db_object":                drs.DataSourceDrsDbObject(),
 			"huaweicloud_drs_data_processing_rules":    drs.DataSourceDrsDataProcessingRules(),
+			"huaweicloud_drs_dirty_data":               drs.DataSourceDrsDirtyData(),
 			"huaweicloud_drs_job_configurations":       drs.DataSourceDrsJobConfigurations(),
 			"huaweicloud_drs_job_links":                drs.DataSourceJobLinks(),
 			"huaweicloud_drs_job_metering":             drs.DataSourceDrsJobMetering(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_dirty_data_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_dirty_data_test.go
@@ -1,0 +1,44 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsDirtyData_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_dirty_data.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDrsDirtyData_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "dirty_data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDrsDirtyData_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_dirty_data" "test" {
+  job_id     = "%s"
+  begin_time = "2020-09-01T18:50:20Z"
+  end_time   = "2025-09-01T18:50:20Z"
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_dirty_data.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_dirty_data.go
@@ -1,0 +1,171 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v5/{project_id}/jobs/{job_id}/dirty-data
+func DataSourceDrsDirtyData() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsDirtyDataRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"begin_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"dirty_data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"db_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"schema_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"table_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_sql": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_msg": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildDirtyDataQueryParams(d *schema.ResourceData, offset int) string {
+	queryParams := "?limit=1000"
+	if v, ok := d.GetOk("begin_time"); ok {
+		queryParams += fmt.Sprintf("&begin_time=%s", v.(string))
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		queryParams += fmt.Sprintf("&end_time=%s", v.(string))
+	}
+	if offset > 0 {
+		queryParams += fmt.Sprintf("&offset=%d", offset)
+	}
+
+	return queryParams
+}
+
+func dataSourceDrsDirtyDataRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v5/{project_id}/jobs/{job_id}/dirty-data"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", d.Get("job_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		requestPathWithQuery := requestPath + buildDirtyDataQueryParams(d, offset)
+		resp, err := client.Request("GET", requestPathWithQuery, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DRS dirty data: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dirtyDataList := utils.PathSearch("dirty_data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dirtyDataList) == 0 {
+			break
+		}
+
+		result = append(result, dirtyDataList...)
+		offset += len(dirtyDataList)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("dirty_data_list", flattenDirtyDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDirtyDataList(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(respArray))
+	for _, item := range respArray {
+		result = append(result, map[string]interface{}{
+			"db_name":     utils.PathSearch("db_name", item, nil),
+			"schema_name": utils.PathSearch("schema_name", item, nil),
+			"table_name":  utils.PathSearch("table_name", item, nil),
+			"error_sql":   utils.PathSearch("error_sql", item, nil),
+			"error_time":  utils.PathSearch("error_time", item, nil),
+			"error_msg":   utils.PathSearch("error_msg", item, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_dirty_data` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `drs_dirty_data` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o drs -f TestAccDataSourceDrsDirtyData_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsDirtyData_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsDirtyData_basic
=== PAUSE TestAccDataSourceDrsDirtyData_basic
=== CONT  TestAccDataSourceDrsDirtyData_basic
--- PASS: TestAccDataSourceDrsDirtyData_basic (15.72s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs  coverage: 4.8% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       15.835s coverage: 4.8% of statements in ./huaweicloud/services/drs
```
<img width="852" height="36" alt="image" src="https://github.com/user-attachments/assets/9c14ec69-7c30-4a37-846e-e0582d35bbbc" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
