### PR TITLE
feat(geminidb): add new data source to query geminidb parameter template applicable instances

### DIFF
--- a/docs/data-sources/geminidb_pt_applicable_instances.md
+++ b/docs/data-sources/geminidb_pt_applicable_instances.md
@@ -1,0 +1,52 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_pt_applicable_instances"
+description: |-
+  Use this data source to get the list of instances that a GeminiDB parameter template can be applied to.
+---
+
+# huaweicloud_geminidb_pt_applicable_instances
+
+Use this data source to get the list of instances that a GeminiDB parameter template can be applied to.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+variable "config_id" {}
+
+data "huaweicloud_geminidb_pt_applicable_instances" "test" {
+  config_id = var.config_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the applicable instances.
+  If omitted, the provider-level region will be used.
+
+* `config_id` - (Required, String) Specifies the ID of the parameter template.
+
+* `instance_name` - (Optional, String) Specifies the instance name to filter.
+
+* `instance_id` - (Optional, String) Specifies the instance ID to filter.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances` - The list of instances that the parameter template can be applied to.
+  The [instances](#geminidb_applicable_instances_instances) structure is documented below.
+
+<a name="geminidb_applicable_instances_instances"></a>
+The `instances` block supports:
+
+* `id` - The instance ID.
+
+* `name` - The instance name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1481,6 +1481,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_memory_rules":             geminidb.DataSourceMemoryRules(),
 			"huaweicloud_geminidb_node_sessions":            geminidb.DataSourceNodeSessions(),
 			"huaweicloud_geminidb_node_session_statistics":  geminidb.DataSourceNodeSessionStatistics(),
+			"huaweicloud_geminidb_pt_applicable_instances":  geminidb.DataSourceGeminiDBPtApplicableInstances(),
 			"huaweicloud_geminidb_quotas":                   geminidb.DataSourceQuotas(),
 			"huaweicloud_geminidb_recycling_instances":      geminidb.DataSourceGeminiDBRecyclingInstances(),
 			"huaweicloud_geminidb_restorable_time_window":   geminidb.DataSourceGeminiDBRestorableTimeWindow(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_pt_applicable_instances_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_pt_applicable_instances_test.go
@@ -1,0 +1,83 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGeminiDBPtApplicableInstances_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceNameWithDash()
+	dataSourceName := "data.huaweicloud_geminidb_pt_applicable_instances.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGeminiDBPtApplicableInstances_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.name"),
+
+					resource.TestCheckOutput("instance_id_filter_useful", "true"),
+					resource.TestCheckOutput("instance_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGeminiDBPtApplicableInstances_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_geminidb_parameter_template" "test" {
+  name        = "%[2]s"
+  description = "configuration based on instance"
+  instance_id = huaweicloud_geminidb_instance.test.id
+
+  depends_on = [huaweicloud_geminidb_instance.test]
+}
+
+data "huaweicloud_geminidb_pt_applicable_instances" "test" {
+  config_id = huaweicloud_geminidb_parameter_template.test.id
+
+  depends_on = [huaweicloud_geminidb_parameter_template.test]
+}
+
+data "huaweicloud_geminidb_pt_applicable_instances" "instance_id_filter" {
+  config_id   = huaweicloud_geminidb_parameter_template.test.id
+  instance_id = huaweicloud_geminidb_instance.test.id
+
+  depends_on = [huaweicloud_geminidb_parameter_template.test]
+}
+
+output "instance_id_filter_useful" {
+  value = length(data.huaweicloud_geminidb_pt_applicable_instances.instance_id_filter.instances) > 0 && alltrue(
+    [for v in data.huaweicloud_geminidb_pt_applicable_instances.instance_id_filter.instances[*].id : v == huaweicloud_geminidb_instance.test.id]
+  )
+}
+
+data "huaweicloud_geminidb_pt_applicable_instances" "instance_name_filter" {
+  config_id     = huaweicloud_geminidb_parameter_template.test.id
+  instance_name = huaweicloud_geminidb_instance.test.name
+
+  depends_on = [huaweicloud_geminidb_parameter_template.test]
+}
+
+output "instance_name_filter_useful" {
+  value = length(data.huaweicloud_geminidb_pt_applicable_instances.instance_name_filter.instances) > 0 && alltrue(
+    [for v in data.huaweicloud_geminidb_pt_applicable_instances.instance_name_filter.instances[*].name : v == huaweicloud_geminidb_instance.test.name]
+  )
+}
+`, testAccGeminiDbInstance_basic(rName), rName)
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_pt_geminidb_applicable_instances.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_pt_geminidb_applicable_instances.go
@@ -1,0 +1,158 @@
+package geminidb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GeminiDB GET /v3/{project_id}/configurations/{config_id}/applicable-instances
+func DataSourceGeminiDBPtApplicableInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGeminiDBPtApplicableInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"config_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     geminiDBPtApplicableInstanceSchema(),
+			},
+		},
+	}
+}
+
+func geminiDBPtApplicableInstanceSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGeminiDBPtApplicableInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	httpUrl := "v3/{project_id}/configurations/{config_id}/applicable-instances"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{config_id}", d.Get("config_id").(string))
+	getPath += buildListGeminiDBPtApplicableInstancesQueryParams(d)
+
+	getResp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		getPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return diag.Errorf("error retrieving GeminiDB applicable instances: %s", err)
+	}
+	getRespJson, err := json.Marshal(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var getRespBody interface{}
+	err = json.Unmarshal(getRespJson, &getRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("instances", flattenListGeminiDBPtApplicableInstances(getRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildListGeminiDBPtApplicableInstancesQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+
+	if v, ok := d.GetOk("instance_name"); ok {
+		queryParams = fmt.Sprintf("%s&instance_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("instance_id"); ok {
+		queryParams = fmt.Sprintf("%s&instance_id=%v", queryParams, v)
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func flattenListGeminiDBPtApplicableInstances(resp interface{}) []map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	instancesRaw := utils.PathSearch("instances", resp, nil)
+	if instancesRaw == nil {
+		return nil
+	}
+
+	instancesSlice, ok := instancesRaw.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	instances := make([]map[string]interface{}, 0, len(instancesSlice))
+	for _, instanceRaw := range instancesSlice {
+		instanceMap := map[string]interface{}{
+			"id":   utils.PathSearch("id", instanceRaw, nil),
+			"name": utils.PathSearch("name", instanceRaw, nil),
+		}
+		instances = append(instances, instanceMap)
+	}
+
+	return instances
+}


### PR DESCRIPTION
…nstances

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new data source to query geminidb parameter template applicable instances
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new data source to query geminidb parameter template applicable instances
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/geminidb' TESTARGS='-run=TestAccDataSourceGeminiDBApplicableInstances_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run=TestAccDataSourceGeminiDBApplicableInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceGeminiDBApplicableInstances_basic
=== PAUSE TestAccDataSourceGeminiDBApplicableInstances_basic
=== CONT  TestAccDataSourceGeminiDBApplicableInstances_basic
--- PASS: TestAccDataSourceGeminiDBApplicableInstances_basic (1402.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1403.014s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
