### PR TITLE
feat(dataarts): supports new data source to query architecture directories

### DIFF
--- a/docs/data-sources/dataarts_architecture_directories.md
+++ b/docs/data-sources/dataarts_architecture_directories.md
@@ -1,0 +1,72 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_architecture_directories"
+description: |-
+  Use this data source to query DataArts Architecture directories within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_architecture_directories
+
+Use this data source to query DataArts Architecture directories within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_architecture_directories" "test" {
+  workspace_id = var.workspace_id
+  type         = "STANDARD_ELEMENT"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the directories are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the directories belong.
+
+* `type` - (Required, String) Specifies the type of directory to be queried.  
+  The valid values are as follows:
+  + **STANDARD_ELEMENT**
+  + **CODE**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `directories` - The list of directories that matched filter parameters.  
+  The [directories](#dataarts_architecture_directories_attr) structure is documented below.
+
+<a name="dataarts_architecture_directories_attr"></a>
+The `directories` block supports:
+
+* `id` - The ID of the directory.
+
+* `name` - The name of the directory.
+
+* `type` - The type of the directory.
+
+* `description` - The description of the directory.
+
+* `parent_id` - The parent ID of the directory.
+
+* `root_id` - The root directory ID.
+
+* `qualified_name` - The qualified name of the directory.
+
+* `created_at` - The creation time of the directory, in RFC3339 format.
+
+* `updated_at` - The latest update time of the directory, in RFC3339 format.
+
+* `created_by` - The user who created the directory.
+
+* `updated_by` - The user who updated the directory.
+
+* `children` - The name list of sub-directories.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1089,6 +1089,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_business_metrics":                 dataarts.DataSourceArchitectureBusinessMetrics(),
 			"huaweicloud_dataarts_architecture_data_standard_template_customs":   dataarts.DataSourceArchitectureDataStandardTemplateCustoms(),
 			"huaweicloud_dataarts_architecture_data_standard_template_optionals": dataarts.DataSourceArchitectureDataStandardTemplateOptionals(),
+			"huaweicloud_dataarts_architecture_directories":                      dataarts.DataSourceArchitectureDirectories(),
 			"huaweicloud_dataarts_architecture_models":                           dataarts.DataSourceArchitectureModels(),
 			"huaweicloud_dataarts_architecture_model_statistic":                  dataarts.DataSourceArchitectureModelStatistic(),
 			"huaweicloud_dataarts_architecture_processes":                        dataarts.DataSourceArchitectureProcesses(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_directories_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_directories_test.go
@@ -1,0 +1,95 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataArchitectureDirectories_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_architecture_directories.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataArchitectureDirectories_nonExistentWorkspace(),
+				ExpectError: regexp.MustCompile("error querying DataArts Architecture directories"),
+			},
+			{
+				Config: testAccDataArchitectureDirectories_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Query all directories
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "directories.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckOutput("is_all_directories_queried", "true"),
+					resource.TestCheckResourceAttrSet(all, "directories.0.id"),
+					resource.TestCheckResourceAttrSet(all, "directories.0.name"),
+					resource.TestCheckResourceAttr(all, "directories.0.type", "STANDARD_ELEMENT"),
+					resource.TestCheckResourceAttrSet(all, "directories.0.qualified_name"),
+					resource.TestCheckResourceAttrSet(all, "directories.0.created_by"),
+					resource.TestCheckResourceAttrSet(all, "directories.0.updated_by"),
+					resource.TestMatchResourceAttr(all, "directories.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(all, "directories.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataArchitectureDirectories_nonExistentWorkspace() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_architecture_directories" "test" {
+  workspace_id = "%[1]s"
+  type         = "STANDARD_ELEMENT"
+}
+`, randUUID)
+}
+
+func testAccDataArchitectureDirectories_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_directory" "test" {
+  count = 2
+
+  workspace_id = "%[1]s"
+  name         = format("%[2]s_standard_%%d", count.index)
+  type         = "STANDARD_ELEMENT"
+}
+
+data "huaweicloud_dataarts_architecture_directories" "all" {
+  depends_on = [huaweicloud_dataarts_architecture_directory.test]
+
+  workspace_id = "%[1]s"
+  type         = "STANDARD_ELEMENT"
+}
+
+locals {
+  all_directories_queried = [
+    for v in huaweicloud_dataarts_architecture_directory.test[*].id :
+      contains(data.huaweicloud_dataarts_architecture_directories.all.directories[*].id, v)
+  ]
+}
+
+output "is_all_directories_queried" {
+  value = length(local.all_directories_queried) > 0 && alltrue(local.all_directories_queried)
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_directories.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_directories.go
@@ -1,0 +1,233 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/design/directorys
+func DataSourceArchitectureDirectories() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceArchitectureDirectoriesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the directories are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the directories belong.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The type of directory to be queried.`,
+			},
+
+			// Attributes.
+			"directories": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureDirectory(),
+				Description: `The list of directories that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureDirectory() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the directory.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the directory.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the directory.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the directory.`,
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The parent ID of the directory.`,
+			},
+			"root_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The root directory ID.`,
+			},
+			"qualified_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The qualified name of the directory.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the directory, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the directory, in RFC3339 format.`,
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user who created the directory.`,
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user who updated the directory.`,
+			},
+			"children": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The name list of sub-directories.`,
+			},
+		},
+	}
+}
+
+func listArchitectureDirectories(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		//nolint:misspell
+		httpUrl = "v2/{project_id}/design/directorys?type={type}&limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{type}", d.Get("type").(string))
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildArchitectureMoreHeaders(d.Get("workspace_id").(string)),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		directories := utils.PathSearch("data.value", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, directories...)
+
+		if len(directories) < limit {
+			break
+		}
+		offset += len(directories)
+	}
+
+	return result, nil
+}
+
+func flattenArchitectureDirectoryNode(directory interface{}) []map[string]interface{} {
+	result := []map[string]interface{}{
+		{
+			"id":             utils.PathSearch("id", directory, nil),
+			"name":           utils.PathSearch("name", directory, nil),
+			"type":           utils.PathSearch("type", directory, nil),
+			"description":    utils.PathSearch("description", directory, nil),
+			"parent_id":      utils.PathSearch("parent_id", directory, nil),
+			"root_id":        utils.PathSearch("root_id", directory, nil),
+			"qualified_name": utils.PathSearch("qualified_name", directory, nil),
+			"created_at":     utils.PathSearch("create_time", directory, nil),
+			"updated_at":     utils.PathSearch("update_time", directory, nil),
+			"created_by":     utils.PathSearch("create_by", directory, nil),
+			"updated_by":     utils.PathSearch("update_by", directory, nil),
+			"children":       utils.PathSearch(`children[*].name`, directory, make([]interface{}, 0)),
+		},
+	}
+
+	children := utils.PathSearch("children", directory, make([]interface{}, 0)).([]interface{})
+	for _, child := range children {
+		result = append(result, flattenArchitectureDirectoryNode(child)...)
+	}
+
+	return result
+}
+
+func flattenArchitectureDirectories(directories []interface{}) []map[string]interface{} {
+	if len(directories) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0)
+	for _, directory := range directories {
+		result = append(result, flattenArchitectureDirectoryNode(directory)...)
+	}
+	return result
+}
+
+func dataSourceArchitectureDirectoriesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	directories, err := listArchitectureDirectories(client, d)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Architecture directories: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("directories", flattenArchitectureDirectories(directories)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new data source `huaweicloud_dataarts_architecture_directories` that used to query the existing directory list.
Currently, there are not any filter can be used to query.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of acceptance test:
<img width="1131" height="80" alt="image" src="https://github.com/user-attachments/assets/672e1718-0933-4beb-b76e-1cf0c2657165" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to query architecture directories
2. supports corresponding document and acceptance test
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataArchitectureDirectories_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataArchitectureDirectories_basic -timeout 360m -parallel 10
=== RUN   TestAccDataArchitectureDirectories_basic
=== PAUSE TestAccDataArchitectureDirectories_basic
=== CONT  TestAccDataArchitectureDirectories_basic
--- PASS: TestAccDataArchitectureDirectories_basic (18.37s)
PASS
coverage: 4.9% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  18.471s coverage: 4.9% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
