### PR TITLE
feat(dataarts): supports new data source to query architecture code tables

### DIFF
--- a/docs/data-sources/dataarts_architecture_code_tables.md
+++ b/docs/data-sources/dataarts_architecture_code_tables.md
@@ -1,0 +1,118 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_architecture_code_tables"
+description: |-
+  Use this data source to query DataArts Architecture code tables within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_architecture_code_tables
+
+Use this data source to query DataArts Architecture code tables within HuaweiCloud.
+
+## Example Usage
+
+### Query all code tables under a specified workspace
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_architecture_code_tables" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+### Query the code tables under a specified workspace and belongs a time range
+
+```hcl
+variable "workspace_id" {}
+variable "begin_time" {
+  default = "2026-01-01T00:00:00+08:00"
+}
+variable "end_time" {
+  default = "2026-12-31T23:59:59+08:00"
+}
+
+data "huaweicloud_dataarts_architecture_code_tables" "test" {
+  workspace_id = var.workspace_id
+  begin_time   = var.begin_time
+  end_time     = var.end_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the code tables are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the code tables belong.
+
+* `name` - (Optional, String) Specifies the Chinese name of the code table to be exactly queried.
+
+* `code` - (Optional, String) Specifies the English name of the code table to be exactly queried.
+
+* `create_by` - (Optional, String) Specifies the creator name of the code table to be queried.
+
+* `directory_id` - (Optional, String) Specifies the directory ID of the code table to be queried.
+
+* `status` - (Optional, String) Specifies the status of the code table to be queried.
+
+* `begin_time` - (Optional, String) Specifies the start time of the code table to be queried, in RFC3339 format.
+
+* `end_time` - (Optional, String) Specifies the end time of the code table to be queried, in RFC3339 format.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `code_tables` - The list of code tables that matched filter parameters.  
+  The [code_tables](#dataarts_architecture_code_tables_attr) structure is documented below.
+
+<a name="dataarts_architecture_code_tables_attr"></a>
+The `code_tables` block supports:
+
+* `id` - The ID of the code table.
+
+* `name` - The name of the code table.
+
+* `code` - The code of the code table.
+
+* `directory_id` - The directory ID of the code table.
+
+* `fields` - The fields information of the code table.  
+  The [fields](#dataarts_architecture_code_tables_fields_attr) structure is documented below.
+
+* `description` - The description of the code table.
+
+* `directory_path` - The directory path of the code table.
+
+* `created_by` - The user who created the code table.
+
+* `created_at` - The time when the code table was created.
+
+* `updated_at` - The time when the code table was updated.
+
+* `status` - The status of the code table.
+  + **DRAFT**
+  + **PUBLISHED**
+  + **OFFLINE**
+  + **REJECT**
+
+<a name="dataarts_architecture_code_tables_fields_attr"></a>
+The `fields` block supports:
+
+* `name` - The name of the field.
+
+* `code` - The code of the field.
+
+* `type` - The type of the field.
+
+* `description` - The description of the field.
+
+* `ordinal` - The ordinal of the field.
+
+* `id` - The ID of the field.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1088,6 +1088,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_aggregation_logic_tables":         dataarts.DataSourceArchitectureAggregationLogicTables(),
 			"huaweicloud_dataarts_architecture_approvals":                        dataarts.DataSourceArchitectureApprovals(),
 			"huaweicloud_dataarts_architecture_business_metrics":                 dataarts.DataSourceArchitectureBusinessMetrics(),
+			"huaweicloud_dataarts_architecture_code_tables":                      dataarts.DataSourceArchitectureCodeTables(),
 			"huaweicloud_dataarts_architecture_data_standard_template_customs":   dataarts.DataSourceArchitectureDataStandardTemplateCustoms(),
 			"huaweicloud_dataarts_architecture_data_standard_template_optionals": dataarts.DataSourceArchitectureDataStandardTemplateOptionals(),
 			"huaweicloud_dataarts_architecture_directories":                      dataarts.DataSourceArchitectureDirectories(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_code_tables_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_code_tables_test.go
@@ -1,0 +1,306 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataArchitectureCodeTables_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_architecture_code_tables.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_dataarts_architecture_code_tables.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byCode   = "data.huaweicloud_dataarts_architecture_code_tables.filter_by_code"
+		dcByCode = acceptance.InitDataSourceCheck(byCode)
+
+		byCreateBy   = "data.huaweicloud_dataarts_architecture_code_tables.filter_by_create_by"
+		dcByCreateBy = acceptance.InitDataSourceCheck(byCreateBy)
+
+		byDirectoryId   = "data.huaweicloud_dataarts_architecture_code_tables.filter_by_directory_id"
+		dcByDirectoryId = acceptance.InitDataSourceCheck(byDirectoryId)
+
+		byStatus   = "data.huaweicloud_dataarts_architecture_code_tables.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byBeginTime   = "data.huaweicloud_dataarts_architecture_code_tables.filter_by_begin_time"
+		dcByBeginTime = acceptance.InitDataSourceCheck(byBeginTime)
+
+		byEndTime   = "data.huaweicloud_dataarts_architecture_code_tables.filter_by_end_time"
+		dcByEndTime = acceptance.InitDataSourceCheck(byEndTime)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataArchitectureCodeTables_nonExistentWorkspace(),
+				ExpectError: regexp.MustCompile("error querying DataArts Architecture code tables"),
+			},
+			{
+				Config: testAccDataArchitectureCodeTables_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "code_tables.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.id"),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.name"),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.code"),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.directory_id"),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.directory_path"),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.description"),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.created_by"),
+					resource.TestMatchResourceAttr(all, "code_tables.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(all, "code_tables.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.status"),
+					resource.TestMatchResourceAttr(all, "code_tables.0.fields.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.fields.0.id"),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.fields.0.name"),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.fields.0.code"),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.fields.0.type"),
+					resource.TestCheckResourceAttrSet(all, "code_tables.0.fields.0.ordinal"),
+					// Filter by name.
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+
+					// Filter by code.
+					dcByCode.CheckResourceExists(),
+					resource.TestCheckOutput("is_code_filter_useful", "true"),
+
+					// Filter by create by.
+					dcByCreateBy.CheckResourceExists(),
+					resource.TestCheckOutput("is_create_by_filter_useful", "true"),
+
+					// Filter by directory ID.
+					dcByDirectoryId.CheckResourceExists(),
+					resource.TestCheckOutput("is_directory_id_filter_useful", "true"),
+
+					// Filter by status.
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+
+					// Filter by begin time.
+					dcByBeginTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_begin_time_filter_useful", "true"),
+
+					// Filter by end time.
+					dcByEndTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_end_time_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataArchitectureCodeTables_nonExistentWorkspace() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_architecture_code_tables" "test" {
+  workspace_id = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataArchitectureCodeTables_basic_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_directory" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  type         = "CODE"
+}
+
+resource "huaweicloud_dataarts_architecture_code_table" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  code         = "%[2]s_code"
+  directory_id = huaweicloud_dataarts_architecture_directory.test.id
+  description  = "Created by acceptance test"
+
+  fields {
+    name        = "field"
+    code        = "field_code"
+    type        = "BIGINT"
+    description = "Created by acceptance test"
+  }
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccDataArchitectureCodeTables_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dataarts_architecture_code_tables" "all" {
+  depends_on = [huaweicloud_dataarts_architecture_code_table.test]
+
+  workspace_id = "%[2]s"
+}
+
+# Filter by name (exact match).
+locals {
+  code_table_name = huaweicloud_dataarts_architecture_code_table.test.name
+}
+
+data "huaweicloud_dataarts_architecture_code_tables" "filter_by_name" {
+  depends_on = [huaweicloud_dataarts_architecture_code_table.test]
+
+  workspace_id = "%[2]s"
+  name         = local.code_table_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_code_tables.filter_by_name.code_tables :
+      v.name == local.code_table_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by code (exact match).
+locals {
+  code_table_code = huaweicloud_dataarts_architecture_code_table.test.code
+}
+
+data "huaweicloud_dataarts_architecture_code_tables" "filter_by_code" {
+  depends_on = [huaweicloud_dataarts_architecture_code_table.test]
+
+  workspace_id = "%[2]s"
+  code         = local.code_table_code
+
+}
+
+locals {
+  code_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_code_tables.filter_by_code.code_tables :
+      v.code == local.code_table_code
+  ]
+}
+
+output "is_code_filter_useful" {
+  value = contains(data.huaweicloud_dataarts_architecture_code_tables.filter_by_code.code_tables[*].id,
+    huaweicloud_dataarts_architecture_code_table.test.id)
+}
+
+# Filter by create by.
+locals {
+  code_table_creator = huaweicloud_dataarts_architecture_code_table.test.created_by
+}
+
+data "huaweicloud_dataarts_architecture_code_tables" "filter_by_create_by" {
+  depends_on = [huaweicloud_dataarts_architecture_code_table.test]
+
+  workspace_id = "%[2]s"
+  create_by    = local.code_table_creator
+}
+
+locals {
+  create_by_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_code_tables.filter_by_create_by.code_tables :
+      v.created_by == local.code_table_creator
+  ]
+}
+
+output "is_create_by_filter_useful" {
+  value = length(local.create_by_filter_result) > 0 && alltrue(local.create_by_filter_result)
+}
+
+# Filter by directory ID.
+locals {
+  code_table_directory_id = huaweicloud_dataarts_architecture_code_table.test.directory_id
+}
+
+data "huaweicloud_dataarts_architecture_code_tables" "filter_by_directory_id" {
+  depends_on = [huaweicloud_dataarts_architecture_code_table.test]
+
+  workspace_id = "%[2]s"
+  directory_id = local.code_table_directory_id
+}
+
+locals {
+  directory_id_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_code_tables.filter_by_directory_id.code_tables :
+      v.directory_id == local.code_table_directory_id
+  ]
+}
+
+output "is_directory_id_filter_useful" {
+  value = length(local.directory_id_filter_result) > 0 && alltrue(local.directory_id_filter_result)
+}
+
+# Filter by status.
+locals {
+  code_table_status = huaweicloud_dataarts_architecture_code_table.test.status
+}
+
+data "huaweicloud_dataarts_architecture_code_tables" "filter_by_status" {
+  depends_on = [huaweicloud_dataarts_architecture_code_table.test]
+
+  workspace_id = "%[2]s"
+  status       = local.code_table_status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_code_tables.filter_by_status.code_tables :
+      v.status == local.code_table_status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+# Filter by begin time.
+locals {
+  code_table_begin_time = timeadd(huaweicloud_dataarts_architecture_directory.test.created_at, "-10m")
+}
+
+data "huaweicloud_dataarts_architecture_code_tables" "filter_by_begin_time" {
+  depends_on = [huaweicloud_dataarts_architecture_code_table.test]
+
+  workspace_id = "%[2]s"
+  begin_time   = local.code_table_begin_time
+}
+
+output "is_begin_time_filter_useful" {
+  value = contains(data.huaweicloud_dataarts_architecture_code_tables.filter_by_begin_time.code_tables[*].id,
+    huaweicloud_dataarts_architecture_code_table.test.id)
+}
+
+# Filter by end time.
+locals {
+  code_table_end_time = timeadd(huaweicloud_dataarts_architecture_directory.test.created_at, "10m")
+}
+
+data "huaweicloud_dataarts_architecture_code_tables" "filter_by_end_time" {
+  depends_on = [huaweicloud_dataarts_architecture_code_table.test]
+
+  workspace_id = "%[2]s"
+  end_time     = local.code_table_end_time
+}
+
+output "is_end_time_filter_useful" {
+  value = contains(data.huaweicloud_dataarts_architecture_code_tables.filter_by_end_time.code_tables[*].id,
+    huaweicloud_dataarts_architecture_code_table.test.id)
+}
+`, testAccDataArchitectureCodeTables_basic_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_code_tables.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_code_tables.go
@@ -1,0 +1,314 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/design/code-tables
+func DataSourceArchitectureCodeTables() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceArchitectureCodeTablesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the code tables are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the code tables belong.`,
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The Chinese name of the code table to be exactly queried.`,
+			},
+			"code": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The English name of the code table to be exactly queried.`,
+			},
+			"create_by": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The creator name of the code table to be queried.`,
+			},
+			"directory_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The directory ID of the code table to be queried.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The status of the code table to be queried.`,
+			},
+			"begin_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The start time of the code table to be queried, in RFC3339 format.`,
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The end time of the code table to be queried, in RFC3339 format.`,
+			},
+
+			// Attributes.
+			"code_tables": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureCodeTable(),
+				Description: `The list of code tables that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureCodeTable() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the code table.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the code table.`,
+			},
+			"code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The code of the code table.`,
+			},
+			"directory_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The directory ID of the code table.`,
+			},
+			"fields": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureCodeTableField(),
+				Description: `The fields information of the code table.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the code table.`,
+			},
+			"directory_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The directory path of the code table.`,
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user who created the code table.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the code table was created.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the code table was updated.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the code table.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureCodeTableField() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the field.`,
+			},
+			"code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The code of the field.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the field.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the field.`,
+			},
+			"ordinal": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The ordinal of the field.`,
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the field.`,
+			},
+		},
+	}
+}
+
+func buildArchitectureCodeTablesQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name_ch=%v", res, v)
+	}
+	if v, ok := d.GetOk("code"); ok {
+		res = fmt.Sprintf("%s&name_en=%v", res, v)
+	}
+	if v, ok := d.GetOk("create_by"); ok {
+		res = fmt.Sprintf("%s&create_by=%v", res, v)
+	}
+	if v, ok := d.GetOk("approver"); ok {
+		res = fmt.Sprintf("%s&approver=%v", res, v)
+	}
+	if v, ok := d.GetOk("directory_id"); ok {
+		res = fmt.Sprintf("%s&directory_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("begin_time"); ok {
+		res = fmt.Sprintf("%s&begin_time=%s", res, url.QueryEscape(v.(string)))
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		res = fmt.Sprintf("%s&end_time=%s", res, url.QueryEscape(v.(string)))
+	}
+
+	return res
+}
+
+func listArchitectureCodeTables(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/design/code-tables?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildArchitectureCodeTablesQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildArchitectureMoreHeaders(d.Get("workspace_id").(string)),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		records := utils.PathSearch("data.value.records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, records...)
+
+		if len(records) < limit {
+			break
+		}
+		offset += len(records)
+	}
+
+	return result, nil
+}
+
+func flattenArchitectureCodeTables(codeTables []interface{}) []map[string]interface{} {
+	if len(codeTables) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(codeTables))
+	for _, codeTable := range codeTables {
+		result = append(result, map[string]interface{}{
+			"id":             utils.PathSearch("id", codeTable, nil),
+			"name":           utils.PathSearch("name_ch", codeTable, nil),
+			"code":           utils.PathSearch("name_en", codeTable, nil),
+			"directory_id":   utils.PathSearch("directory_id", codeTable, nil),
+			"directory_path": utils.PathSearch("directory_path", codeTable, nil),
+			"description":    utils.PathSearch("description", codeTable, nil),
+			"created_by":     utils.PathSearch("create_by", codeTable, nil),
+			"created_at":     utils.PathSearch("create_time", codeTable, nil),
+			"updated_at":     utils.PathSearch("update_time", codeTable, nil),
+			"status":         utils.PathSearch("status", codeTable, nil),
+			"fields":         flattenCodeTableFields(codeTable),
+		})
+	}
+	return result
+}
+
+func dataSourceArchitectureCodeTablesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	codeTables, err := listArchitectureCodeTables(client, d)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Architecture code tables: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("code_tables", flattenArchitectureCodeTables(codeTables)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source `huaweicloud_dataarts_architecture_code_tables` that used to query the architecture code tables, and supports some of filter parameters.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1108" height="64" alt="image" src="https://github.com/user-attachments/assets/9cc373d4-e2cd-4e86-914d-a271fbd1352e" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to query architecture code tables.
2. support corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataArchitectureCodeTables_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataArchitectureCodeTables_basic -timeout 360m -parallel 10
=== RUN   TestAccDataArchitectureCodeTables_basic
=== PAUSE TestAccDataArchitectureCodeTables_basic
=== CONT  TestAccDataArchitectureCodeTables_basic
--- PASS: TestAccDataArchitectureCodeTables_basic (18.82s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  18.915s coverage: 6.1% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
