### PR TITLE
feat(drs): support `drs_health_compare_overview` data source

### DIFF
--- a/docs/data-sources/drs_health_compare_overview.md
+++ b/docs/data-sources/drs_health_compare_overview.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_health_compare_overview"
+description: |-
+  Use this data source to get the health compare object-level overview of specified DRS job within HuaweiCloud.
+---
+
+# huaweicloud_drs_health_compare_overview
+
+Use this data source to get the health compare object-level overview of specified DRS job within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+variable "compare_job_id" {}
+
+data "huaweicloud_drs_health_compare_overview" "test" {
+  job_id         = var.job_id
+  compare_job_id = var.compare_job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the job ID.
+
+* `compare_job_id` - (Required, String) Specifies the compare job ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `compare_result` - The health compare object-level comparison result list.
+
+  The [compare_result](#compare_result_struct) structure is documented below.
+
+<a name="compare_result_struct"></a>
+The `compare_result` block supports:
+
+* `type` - The object type.  
+  The valid values are as follows:
+  + **DB**
+  + **TABLE**
+  + **VIEW**
+  + **EVENT**
+  + **ROUTINE**
+  + **INDEX**
+  + **TRIGGER**
+  + **SYNONYM**
+  + **FUNCTION**
+  + **PROCEDURE**
+  + **TYPE**
+  + **RULE**
+  + **DEFAULT_TYPE**
+  + **PLAN_GUIDE**
+  + **CONSTRAINT**
+  + **FILE_GROUP**
+  + **PARTITION_FUNCTION**
+  + **PARTITION_SCHEME**
+  + **TABLE_COLLATION**
+  + **EXTENSIONS**
+
+* `source_count` - The source count.
+
+* `target_count` - The target count.
+
+* `status` - The comparison result.  
+  The valid values are as follows:
+  + **0**: Inconsistent.
+  + **2**: Consistent.
+  + **3**: Incomplete.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1344,6 +1344,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_db_object":                drs.DataSourceDrsDbObject(),
 			"huaweicloud_drs_data_processing_rules":    drs.DataSourceDrsDataProcessingRules(),
 			"huaweicloud_drs_dirty_data":               drs.DataSourceDrsDirtyData(),
+			"huaweicloud_drs_health_compare_overview":  drs.DataSourceDrsHealthCompareOverview(),
 			"huaweicloud_drs_job_configurations":       drs.DataSourceDrsJobConfigurations(),
 			"huaweicloud_drs_job_links":                drs.DataSourceJobLinks(),
 			"huaweicloud_drs_job_metering":             drs.DataSourceDrsJobMetering(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_health_compare_overview_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_health_compare_overview_test.go
@@ -1,0 +1,44 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsHealthCompareOverview_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_health_compare_overview.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+			acceptance.TestAccPreCheckDrsCompareJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDrsHealthCompareOverview_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "compare_result.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDrsHealthCompareOverview_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_health_compare_overview" "test" {
+  job_id         = "%[1]s"
+  compare_job_id = "%[2]s"
+}
+`, acceptance.HW_DRS_JOB_ID, acceptance.HW_DRS_COMPARE_JOB_ID)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_health_compare_overview.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_health_compare_overview.go
@@ -1,0 +1,132 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v5/{project_id}/jobs/{job_id}/health-compare-jobs/object/{compare_job_id}
+func DataSourceDrsHealthCompareOverview() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsHealthCompareOverviewRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"compare_job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"compare_result": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"target_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDrsHealthCompareOverviewRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		product      = "drs"
+		httpUrl      = "v5/{project_id}/jobs/{job_id}/health-compare-jobs/object/{compare_job_id}"
+		jobId        = d.Get("job_id").(string)
+		compareJobId = d.Get("compare_job_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobId)
+	requestPath = strings.ReplaceAll(requestPath, "{compare_job_id}", compareJobId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DRS health compare overview: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("compare_result", flattenHealthCompareResult(
+			utils.PathSearch("compare_result", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenHealthCompareResult(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(respArray))
+	for _, item := range respArray {
+		result = append(result, map[string]interface{}{
+			"type":         utils.PathSearch("type", item, nil),
+			"source_count": utils.PathSearch("source_count", item, nil),
+			"target_count": utils.PathSearch("target_count", item, nil),
+			"status":       utils.PathSearch("status", item, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_health_compare_overview` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `drs_health_compare_overview` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o drs -f TestAccDataSourceDrsHealthCompareOverview_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsHealthCompareOverview_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsHealthCompareOverview_basic
=== PAUSE TestAccDataSourceDrsHealthCompareOverview_basic
=== CONT  TestAccDataSourceDrsHealthCompareOverview_basic
--- PASS: TestAccDataSourceDrsHealthCompareOverview_basic (19.41s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs  coverage: 4.6% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       19.628s coverage: 4.6% of statements in ./huaweicloud/services/drs
```
<img width="942" height="38" alt="image" src="https://github.com/user-attachments/assets/06b0b7e5-19f2-414c-8c82-c624ebca8f91" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
