### PR TITLE
fix(modelarts): workflow resource need internal parameter

### DIFF
--- a/docs/resources/modelartsv2_workflow_execution.md
+++ b/docs/resources/modelartsv2_workflow_execution.md
@@ -324,7 +324,7 @@ The `policy` block supports:
 <a name="modelarts_workflow_execution_conditions_execution"></a>
 The `conditions_execution` block supports:
 
-* `result` - The result of the condition execution.
+* `result` - The result of the condition execution, in JSON format.
 
 * `metric_list` - The metric list of the condition execution.  
   The [metric_list](#modelarts_workflow_execution_metric_list) structure is documented below.

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 
@@ -257,6 +258,19 @@ func ResourceV2Workflow() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `The last modified time of the workflow, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
 			},
 		},
 	}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow_execution.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_workflow_execution.go
@@ -545,7 +545,7 @@ func v2WorkflowExecutionConditionExecutionSchema() *schema.Resource {
 			"result": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `The result of the condition execution.`,
+				Description: `The result of the condition execution, in JSON format.`,
 			},
 			"metric_list": {
 				Type:        schema.TypeList,
@@ -940,7 +940,7 @@ func flattenV2WorkflowExecutionConditionExecution(conditionExecution interface{}
 
 	return []map[string]interface{}{
 		{
-			"result": utils.PathSearch("result", conditionExecution, nil),
+			"result": utils.JsonToString(utils.PathSearch("result", conditionExecution, nil)),
 			"metric_list": flattenV2WorkflowExecutionMetricPairs(
 				utils.PathSearch("metric_list", conditionExecution, make([]interface{}, 0)).([]interface{})),
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The workflow resource needs to include the internal parameter `enable_force_new`.
Since the API Document of workflow execution is wrong, the workflow execution resource attribute `condition_execution.result` need parsed by utils.JsonToString.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. Add `enable_force_new` to `workflow` schema.
2. Change the implement of provider `workflow_execution`.
3. Modify the text description corresponding to the document.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

workflow
```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccV2Workflow_basic -timeout 360m -parallel 10
=== RUN   TestAccV2Workflow_basic
--- PASS: TestAccV2Workflow_basic (29.57s)
PASS
coverage: 7.8% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 29.701s coverage: 7.8% of statements in ./huaweicloud/services/modelarts
```

workflow_execution
```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccV2WorkflowExecution_basic -timeout 360m -parallel 10
=== RUN   TestAccV2WorkflowExecution_basic
--- PASS: TestAccV2WorkflowExecution_basic (40.59s)
PASS
coverage: 6.2% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 40.750s coverage: 6.2% of statements in ./huaweicloud/services/modelarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.