### PR TITLE
feat(drs): support `drs_disaster_monitoring_data` data source

### DIFF
--- a/docs/data-sources/drs_disaster_monitoring_data.md
+++ b/docs/data-sources/drs_disaster_monitoring_data.md
@@ -1,0 +1,94 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_disaster_monitoring_data"
+description: |-
+  Use this data source to get disaster recovery monitoring data for specified DRS jobs within HuaweiCloud.
+---
+
+# huaweicloud_drs_disaster_monitoring_data
+
+Use this data source to get disaster recovery monitoring data for specified DRS jobs within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "job_ids" { 
+  type = list(string)
+}
+
+data "huaweicloud_drs_disaster_monitoring_data" "test" {
+  job_ids = var.job_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_ids` - (Required, List) Specifies the list of DRS job IDs to query monitoring data for.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `results` - The collection of disaster recovery monitoring data response bodies.
+
+  The [results](#results_struct) structure is documented below.
+
+<a name="results_struct"></a>
+The `results` block supports:
+
+* `id` - The job ID.
+
+* `data_guard_monitor` - The disaster recovery task monitoring data.
+
+  The [data_guard_monitor](#data_guard_monitor_struct) structure is documented below.
+
+<a name="data_guard_monitor_struct"></a>
+The `data_guard_monitor` block supports:
+
+* `bandwidth` - The bandwidth.
+
+* `cpu_used_percent` - The CPU usage percentage.
+
+* `dst_delay` - The destination database delay.
+
+* `dst_io` - The destination IO.
+
+* `dst_normal` - The destination database connection status.
+
+* `dst_offset` - The destination database offset position.
+
+* `dst_rps` - The destination RPS.
+
+* `mem_used_in_mb` - The memory usage.
+
+* `node_mem_in_mb` - The total node memory size.
+
+* `node_offset` - The migration instance offset position.
+
+* `node_volume_in_gb` - The total node disk size.
+
+* `sr_delay` - The source database delay.
+
+* `sr_offset` - The source database offset position.
+
+* `src_io` - The source IO.
+
+* `src_normal` - The source database connection status.
+
+* `src_rps` - The source RPS.
+
+* `trans_in_mb` - The migration data volume.
+
+* `trans_lines` - The number of migrated data rows.
+
+* `volume_used_in_gb` - The disk usage.
+
+* `migration_bytes_per_second` - The number of bytes migrated per second.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1346,6 +1346,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_db_object":                drs.DataSourceDrsDbObject(),
 			"huaweicloud_drs_data_processing_rules":    drs.DataSourceDrsDataProcessingRules(),
 			"huaweicloud_drs_dirty_data":               drs.DataSourceDrsDirtyData(),
+			"huaweicloud_drs_disaster_monitoring_data": drs.DataSourceDrsDisasterMonitoringData(),
 			"huaweicloud_drs_health_compare_overview":  drs.DataSourceDrsHealthCompareOverview(),
 			"huaweicloud_drs_job_configurations":       drs.DataSourceDrsJobConfigurations(),
 			"huaweicloud_drs_job_links":                drs.DataSourceJobLinks(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_disaster_monitoring_data_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_disaster_monitoring_data_test.go
@@ -1,0 +1,52 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsDisasterMonitoringData_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_disaster_monitoring_data.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobIds(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDrsDisasterMonitoringData_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.data_guard_monitor.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.data_guard_monitor.0.src_normal"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.data_guard_monitor.0.dst_normal"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.data_guard_monitor.0.sr_delay"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.data_guard_monitor.0.dst_delay"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.data_guard_monitor.0.src_rps"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.data_guard_monitor.0.dst_rps"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.data_guard_monitor.0.bandwidth"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.data_guard_monitor.0.cpu_used_percent"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDrsDisasterMonitoringData_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_disaster_monitoring_data" "test" {
+  job_ids = split(",", "%s")
+}
+`, acceptance.HW_DRS_JOB_IDS)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_disaster_monitoring_data.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_disaster_monitoring_data.go
@@ -1,0 +1,249 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS POST /v3/{project_id}/jobs/disaster-recovery-monitoring-data
+func DataSourceDrsDisasterMonitoringData() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsDisasterMonitoringDataRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     disasterRecoveryMonitoringResultSchema(),
+			},
+		},
+	}
+}
+
+func disasterRecoveryMonitoringResultSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_guard_monitor": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataGuardMonitorSchema(),
+			},
+		},
+	}
+}
+
+func dataGuardMonitorSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"bandwidth": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cpu_used_percent": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_delay": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"dst_io": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_normal": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"dst_offset": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_rps": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mem_used_in_mb": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"node_mem_in_mb": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"node_offset": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"node_volume_in_gb": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"sr_delay": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"sr_offset": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"src_io": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"src_normal": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"src_rps": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"trans_in_mb": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"trans_lines": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"volume_used_in_gb": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"migration_bytes_per_second": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildDisasterMonitoringDataBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"jobs": utils.ExpandToStringList(d.Get("job_ids").([]interface{})),
+	}
+}
+
+func dataSourceDrsDisasterMonitoringDataRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v3/{project_id}/jobs/disaster-recovery-monitoring-data"
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildDisasterMonitoringDataBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DRS disaster recovery monitoring data: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resultsRaw := utils.PathSearch("results", respBody, make([]interface{}, 0)).([]interface{})
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("results", flattenDisasterMonitoringResults(resultsRaw)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDisasterMonitoringResults(results []interface{}) []interface{} {
+	if len(results) == 0 {
+		return nil
+	}
+
+	resultList := make([]interface{}, 0, len(results))
+	for _, result := range results {
+		resultList = append(resultList, map[string]interface{}{
+			"id":                 utils.PathSearch("id", result, nil),
+			"data_guard_monitor": flattenDataGuardMonitor(utils.PathSearch("data_guard_minitor", result, nil)),
+		})
+	}
+
+	return resultList
+}
+
+func flattenDataGuardMonitor(monitor interface{}) []interface{} {
+	if monitor == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"bandwidth":                  utils.PathSearch("bandwidth", monitor, nil),
+			"cpu_used_percent":           utils.PathSearch("cpuUsed_percent", monitor, nil),
+			"dst_delay":                  utils.PathSearch("dst_delay", monitor, nil),
+			"dst_io":                     utils.PathSearch("dst_io", monitor, nil),
+			"dst_normal":                 utils.PathSearch("dst_normal", monitor, nil),
+			"dst_offset":                 utils.PathSearch("dst_offset", monitor, nil),
+			"dst_rps":                    utils.PathSearch("dst_rps", monitor, nil),
+			"mem_used_in_mb":             utils.PathSearch("mem_used_inMB", monitor, nil),
+			"node_mem_in_mb":             utils.PathSearch("node_mem_inMB", monitor, nil),
+			"node_offset":                utils.PathSearch("node_offset", monitor, nil),
+			"node_volume_in_gb":          utils.PathSearch("node_volume_inGB", monitor, nil),
+			"sr_delay":                   utils.PathSearch("sr_delay", monitor, nil),
+			"sr_offset":                  utils.PathSearch("sr_offset", monitor, nil),
+			"src_io":                     utils.PathSearch("src_io", monitor, nil),
+			"src_normal":                 utils.PathSearch("src_normal", monitor, nil),
+			"src_rps":                    utils.PathSearch("src_rps", monitor, nil),
+			"trans_in_mb":                utils.PathSearch("trans_inMB", monitor, nil),
+			"trans_lines":                utils.PathSearch("trans_lines", monitor, nil),
+			"volume_used_in_gb":          utils.PathSearch("volume_used_inGB", monitor, nil),
+			"migration_bytes_per_second": utils.PathSearch("migration_bytes_per_second", monitor, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_disaster_monitoring_data` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `drs_disaster_monitoring_data` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccDataSourceDrsDisasterMonitoringData_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs-v -run TestAccDataSourceDrsDisasterMonitoringData_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDrsDisasterMonitoringData_basic
=== PAUSE TestAccDataSourceDrsDisasterMonitoringData_basic
=== CONT  TestAccDataSourceDrsDisasterMonitoringData_basic
--- PASS: TestAccDataSourceDrsDisasterMonitoringData_basic (16.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       21.311s
```
<img width="608" height="24" alt="image" src="https://github.com/user-attachments/assets/32278598-b6d1-4edd-a707-b5b8aa9aa42b" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
