### PR TITLE
feat(drs): new datasource to query object compare detail

### DIFF
--- a/docs/data-sources/drs_object_compare_detail.md
+++ b/docs/data-sources/drs_object_compare_detail.md
@@ -1,0 +1,83 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_object_compare_detail"
+description: |-
+  Use this data source to get the object-level comparison details of a DRS task within HuaweiCloud.
+---
+
+# huaweicloud_drs_object_compare_detail
+
+Use this data source to get the object-level comparison details of a DRS task within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_drs_object_compare_detail" "test" {
+  job_id       = "your_job_id"
+  compare_type = "DB"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the task ID.
+
+* `compare_type` - (Required, String) Specifies the object type.  
+  The valid values are as follows:
+  + **DB**: Database.
+  + **TABLE**: Table.
+  + **VIEW**: View.
+  + **EVENT**: Event.
+  + **ROUTINE**: Stored procedure and function.
+  + **INDEX**: Index.
+  + **TRIGGER**: Trigger.
+  + **SYNONYM**: Synonym.
+  + **FUNCTION**: Function.
+  + **PROCEDURE**: Stored procedure.
+  + **TYPE**: Custom type.
+  + **RULE**: Rule.
+  + **DEFAULT_TYPE**: Default value.
+  + **PLAN_GUIDE**: Execution plan.
+  + **CONSTRAINT**: Constraint.
+  + **FILE_GROUP**: File group.
+  + **PARTITION_FUNCTION**: Partition function.
+  + **PARTITION_SCHEME**: Partition scheme.
+  + **TABLE_COLLATION**: Table collation.
+
+* `compare_job_id` - (Optional, String) Specifies the comparison task ID.
+  If omitted, the latest comparison task information will be returned by default.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `compare_details` - The list of object-level comparison details.
+
+  The [compare_details](#compare_details_struct) structure is documented below.
+
+<a name="compare_details_struct"></a>
+The `compare_details` block supports:
+
+* `source_db_name` - The source database name.
+
+* `target_db_name` - The target database name.
+
+* `source_db_value` - The value in the source database.
+
+* `target_db_value` - The value in the target database.
+
+* `status` - The comparison result.  
+  The valid values are as follows:
+  + **0**: Inconsistent.
+  + **2**: Consistent.
+  + **3**: Not completed.
+
+* `error_message` - The error message.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1352,6 +1352,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_job_monitor_data":         drs.DataSourceDrsJobMonitorData(),
 			"huaweicloud_drs_job_object_support":       drs.DataSourceDrsJobObjectSupport(),
 			"huaweicloud_drs_node_types":               drs.DataSourceNodeTypes(),
+			"huaweicloud_drs_object_compare_detail":    drs.DataSourceObjectCompareDetail(),
 			"huaweicloud_drs_object_compare":           drs.DataSourceDrsObjectCompare(),
 			"huaweicloud_drs_object_mappings":          drs.DataSourceDrsObjectMappings(),
 			"huaweicloud_drs_quotas":                   drs.DataSourceDrsQuotas(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_object_compare_detail_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_object_compare_detail_test.go
@@ -1,0 +1,44 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceObjectCompareDetail_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_object_compare_detail.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobIds(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceObjectCompareDetail_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "compare_details.#"),
+				),
+			},
+		},
+	})
+}
+
+// This resource has no response data, and the filtering parameters cannot be validated in the test case.
+func testDataSourceObjectCompareDetail_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_object_compare_detail" "test" {
+  job_id       = "%s"
+  compare_type = "TABLE"
+}
+`, acceptance.HW_DRS_JOB_IDS)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_object_compare_detail.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_object_compare_detail.go
@@ -1,0 +1,173 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v3/{project_id}/jobs/{job_id}/object/compare/{compare_type}
+func DataSourceObjectCompareDetail() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceObjectCompareDetailRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"compare_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"compare_job_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"compare_details": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"source_db_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"target_db_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_db_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"target_db_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"error_message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildObjectCompareDetailQueryParams(d *schema.ResourceData, offset int) string {
+	queryParams := "?limit=1000"
+
+	if v, ok := d.GetOk("compare_job_id"); ok {
+		queryParams += fmt.Sprintf("&compare_job_id=%s", v.(string))
+	}
+	if offset > 0 {
+		queryParams += fmt.Sprintf("&offset=%d", offset)
+	}
+
+	return queryParams
+}
+
+func dataSourceObjectCompareDetailRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v3/{project_id}/jobs/{job_id}/object/compare/{compare_type}"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	jobId := d.Get("job_id").(string)
+	compareType := d.Get("compare_type").(string)
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobId)
+	requestPath = strings.ReplaceAll(requestPath, "{compare_type}", compareType)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		requestPathWithQuery := requestPath + buildObjectCompareDetailQueryParams(d, offset)
+		resp, err := client.Request("GET", requestPathWithQuery, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DRS object compare detail: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		compareDetails := utils.PathSearch("compare_detail", respBody, make([]interface{}, 0)).([]interface{})
+		if len(compareDetails) == 0 {
+			break
+		}
+
+		result = append(result, compareDetails...)
+		offset += len(compareDetails)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("compare_details", flattenObjectCompareDetails(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenObjectCompareDetails(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(respArray))
+	for _, item := range respArray {
+		result = append(result, map[string]interface{}{
+			"source_db_name":  utils.PathSearch("source_db_name", item, nil),
+			"target_db_name":  utils.PathSearch("target_db_name", item, nil),
+			"source_db_value": utils.PathSearch("source_db_value", item, nil),
+			"target_db_value": utils.PathSearch("target_db_value", item, nil),
+			"status":          utils.PathSearch("status", item, nil),
+			"error_message":   utils.PathSearch("error_message", item, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query object compare detail

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o drs -f TestAccDataSourceObjectCompareDetail_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceObjectCompareDetail_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceObjectCompareDetail_basic
=== PAUSE TestAccDataSourceObjectCompareDetail_basic
=== CONT  TestAccDataSourceObjectCompareDetail_basic
--- PASS: TestAccDataSourceObjectCompareDetail_basic (18.92s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       19.034s coverage: 5.3% of statements in ./huaweicloud/services/drs
```
<img width="1298" height="86" alt="image" src="https://github.com/user-attachments/assets/ccbfd68e-faac-4b6e-b065-c5b36b0938c5" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
