### PR TITLE
feat(eg): add new resource to manage perfessional cluster

### DIFF
--- a/docs/resources/eg_eventrouter_cluster.md
+++ b/docs/resources/eg_eventrouter_cluster.md
@@ -1,0 +1,118 @@
+---
+subcategory: "EventGrid (EG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eg_eventrouter_cluster"
+description: "Manages an EG event router cluster within HuaweiCloud."
+---
+
+# huaweicloud_eg_eventrouter_cluster
+
+Using this resource to manage an EG event router cluster within HuaweiCloud.
+
+## Example Usage
+
+### Create an event router cluster with basic configuration
+
+```hcl
+variable "cluster_name" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "availability_zones" {
+  type = list(string)
+}
+
+resource "huaweicloud_eg_eventrouter_cluster" "test" {
+  name               = var.cluster_name
+  source_type        = "KAFKA"
+  sink_type          = "KAFKA"
+  vpc_id             = var.vpc_id
+  subnet_id          = var.subnet_id
+  description        = "Created by terraform script"
+  availability_zones = join(",", var.availability_zones)
+  flavor             = "small"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region where the event router cluster is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the event router cluster.  
+  The name can contain maximum of 64 characters, which may consist of letters, digits, underscores (_), and hyphens (-).
+
+* `source_type` - (Required, String, NonUpdatable) Specifies the source type of the event router cluster.  
+  The valid values are as follows:
+  + **KAFKA** - Kafka event source
+  + **DMS_ROCKETMQ** - RocketMQ event source
+  + **DMS_RABBITMQ** - RabbitMQ event source
+
+* `sink_type` - (Required, String, NonUpdatable) Specifies the sink type of the event router cluster.  
+  The valid values are as follows:
+  + **KAFKA** - Kafka event sink
+  + **DMS_ROCKETMQ** - RocketMQ event sink
+  + **DMS_RABBITMQ** - RabbitMQ event sink
+
+  -> The value of `sink_type` parameter must be same as the value of `source_type` parameter.
+
+* `vpc_id` - (Required, String, NonUpdatable) Specifies the VPC ID to which the event router cluster belongs.
+
+* `subnet_id` - (Required, String, NonUpdatable) Specifies the subnet ID to which the event router cluster belongs.
+
+* `description` - (Optional, String) Specifies the description of the event router cluster.  
+  The description can contain a maximum of `255` characters.
+
+* `availability_zones` - (Optional, String, NonUpdatable) Specifies the availability zone names of the event router
+  cluster.  
+  The multiple availability zones are separated by commas (,), e.g. **cn-north-4a,cn-north-4g**.
+
+* `flavor` - (Optional, String, NonUpdatable) Specifies the flavor of the event router cluster.  
+  The valid values are as follows:
+  + **small** - Small flavor (`1` vCPU, `2` GB memory)
+  + **medium** - Medium flavor (`2` vCPU, `4` GB memory)
+  + **large** - Large flavor (`4` vCPU, `8` GB memory)
+  + **xlarge** - Extra large flavor (`8` vCPU, `16` GB memory)
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, in UUID format.
+
+* `status` - The status of the event router cluster.
+  + **RUNNING** - The cluster is running normally
+  + **ERROR** - The cluster creation failed
+
+* `job_count` - The number of jobs running in the event router cluster.
+
+* `created_at` - The creation time of the event router cluster, in RFC3339 format.
+
+* `updated_at` - The latest update time of the event router cluster, in RFC3339 format.
+
+## Import
+
+Event router clusters can be imported using their `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_eg_eventrouter_cluster.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `flavor`.
+It is generally recommended running `terraform plan` after importing a cluster.
+You can then decide if changes should be applied to the cluster, or the resource definition should be updated to
+align with the cluster.
+
+```hcl
+resource "huaweicloud_eg_eventrouter_cluster" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      flavor,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3675,6 +3675,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_enterprise_project_action":    eps.ResourceAction(),
 			"huaweicloud_enterprise_project_authority": eps.ResourceAuthority(),
 
+			// EventGrid
 			"huaweicloud_er_association":         er.ResourceAssociation(),
 			"huaweicloud_er_attachment_accepter": er.ResourceAttachmentAccepter(),
 			"huaweicloud_er_instance":            er.ResourceInstance(),
@@ -3683,6 +3684,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_er_static_route":        er.ResourceStaticRoute(),
 			"huaweicloud_er_vpc_attachment":      er.ResourceVpcAttachment(),
 			"huaweicloud_er_flow_log":            er.ResourceFlowLog(),
+			// Professional EventGrid
+			"huaweicloud_eg_eventrouter_cluster": eg.ResourceEventRouterCluster(),
 
 			"huaweicloud_evsv5_snapshot_rollback":        evs.ResourceV5SnapshotRollBack(),
 			"huaweicloud_evs_snapshot":                   evs.ResourceEvsSnapshot(),

--- a/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_eventrouter_cluster_test.go
+++ b/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_eventrouter_cluster_test.go
@@ -1,0 +1,140 @@
+package eg
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eg"
+)
+
+func getEventRouterClusterFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("eg", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating EG client: %s", err)
+	}
+
+	return eg.GetEventRouterClusterById(client, state.Primary.ID)
+}
+
+func TestAccEventRouterCluster_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName = "huaweicloud_eg_eventrouter_cluster.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getEventRouterClusterFunc)
+
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventRouterCluster_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(rName, "source_type", "KAFKA"),
+					resource.TestCheckResourceAttr(rName, "sink_type", "KAFKA"),
+					resource.TestCheckResourceAttrPair(rName, "vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "availability_zones"),
+					resource.TestCheckResourceAttr(rName, "status", "RUNNING"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(rName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccEventRouterCluster_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "source_type", "KAFKA"),
+					resource.TestCheckResourceAttr(rName, "sink_type", "KAFKA"),
+					resource.TestCheckResourceAttrPair(rName, "vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "availability_zones"),
+					resource.TestCheckResourceAttr(rName, "status", "RUNNING"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(rName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"flavor",
+				},
+			},
+		},
+	})
+}
+
+func testAccEventRouterCluster_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name       = "%[1]s"
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 8, 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 8, 1), 1)
+  vpc_id     = huaweicloud_vpc.test.id
+}
+`, name)
+}
+
+func testAccEventRouterCluster_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_eg_eventrouter_cluster" "test" {
+  name               = "%[2]s"
+  source_type        = "KAFKA"
+  sink_type          = "KAFKA"
+  vpc_id             = huaweicloud_vpc.test.id
+  subnet_id          = huaweicloud_vpc_subnet.test.id
+  description        = "Created by terraform script"
+  availability_zones = join(",", slice(data.huaweicloud_availability_zones.test.names, 0, 2))
+  flavor             = "small"
+}
+`, testAccEventRouterCluster_base(name), name)
+}
+
+func testAccEventRouterCluster_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_eg_eventrouter_cluster" "test" {
+  name               = "%[2]s"
+  source_type        = "KAFKA"
+  sink_type          = "KAFKA"
+  vpc_id             = huaweicloud_vpc.test.id
+  subnet_id          = huaweicloud_vpc_subnet.test.id
+  availability_zones = join(",", slice(data.huaweicloud_availability_zones.test.names, 0, 2))
+  flavor             = "small"
+}
+`, testAccEventRouterCluster_base(name), name)
+}

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_eventrouter_cluster.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_eventrouter_cluster.go
@@ -1,0 +1,410 @@
+package eg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var eventRouterClusterNonUpdatableParams = []string{
+	"source_type",
+	"sink_type",
+	"vpc_id",
+	"subnet_id",
+	"availability_zones",
+	"flavor",
+}
+
+// @API EG POST /v1/{project_id}/eventrouter/clusters
+// @API EG GET /v1/{project_id}/eventrouter/clusters/{cluster_id}
+// @API EG PUT /v1/{project_id}/eventrouter/clusters/{cluster_id}
+// @API EG DELETE /v1/{project_id}/eventrouter/clusters/{cluster_id}
+func ResourceEventRouterCluster() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEventRouterClusterCreate,
+		ReadContext:   resourceEventRouterClusterRead,
+		UpdateContext: resourceEventRouterClusterUpdate,
+		DeleteContext: resourceEventRouterClusterDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(eventRouterClusterNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the event router cluster is located.",
+			},
+
+			// Required parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the event router cluster.",
+			},
+			"source_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The source type of the event router cluster.",
+			},
+			"sink_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The sink type of the event router cluster.",
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The VPC ID to which the event router cluster belongs.",
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The subnet ID to which the event router cluster belongs.",
+			},
+
+			// Optional parameters.
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the event router cluster.",
+			},
+			"availability_zones": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The availability zone names of the event router cluster.",
+			},
+			"flavor": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The flavor of the event router cluster.",
+			},
+
+			// Attributes.
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status of the event router cluster.",
+			},
+			"job_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The number of jobs running in the event router cluster.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the event router cluster, in RFC3339 format.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the event router cluster, in RFC3339 format.",
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildEventRouterClusterBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		// Required parameter(s).
+		"name":        d.Get("name"),
+		"source_type": d.Get("source_type"),
+		"sink_type":   d.Get("sink_type"),
+		"vpc_id":      d.Get("vpc_id"),
+		"subnet_id":   d.Get("subnet_id"),
+
+		// Optional parameters(s).
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+		"zone_names":  utils.ValueIgnoreEmpty(d.Get("availability_zones")),
+		"flavor":      utils.ValueIgnoreEmpty(d.Get("flavor")),
+	}
+}
+
+func createEventRouterCluster(client *golangsdk.ServiceClient, bodyParams map[string]interface{}) (interface{}, error) {
+	httpUrl := "v1/{project_id}/eventrouter/clusters"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         bodyParams,
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(resp)
+}
+
+func resourceEventRouterClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("eg", region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	respBody, err := createEventRouterCluster(client, buildEventRouterClusterBodyParams(d))
+	if err != nil {
+		return diag.Errorf("error creating event router cluster: %s", err)
+	}
+
+	clusterId := utils.PathSearch("cluster_id", respBody, "").(string)
+	if clusterId == "" {
+		return diag.Errorf("unable to find the cluster ID from the API response")
+	}
+	d.SetId(clusterId)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      eventRouterClusterStateRefreshFunc(client, clusterId, []string{"RUNNING", "RUNNING_PARTIALLY"}),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        30 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for event router cluster to become ready: %s", err)
+	}
+
+	return resourceEventRouterClusterRead(ctx, d, meta)
+}
+
+func eventRouterClusterStateRefreshFunc(client *golangsdk.ServiceClient, clusterId string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetEventRouterClusterById(client, clusterId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
+				return "not_found", "COMPLETED", nil
+			}
+			return respBody, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", respBody, "").(string)
+		unexpectStatus := []string{
+			"ERROR",           // Cluster is down
+			"FAILED",          // Create cluster failed
+			"FREEZE_FAILED",   // Failed to freeze the cluster
+			"COMPACT_FAILED",  // Failed to compact the cluster
+			"UPGRADE_FAILED",  // Failed to upgrade the cluster
+			"EXTENDED_FAILED", // Failed to extend the cluster
+			"ROLLBACK_FAILED", // Failed to rollback the cluster
+			"DELETED_FAILED",  // Failed to delete the cluster
+		}
+		if utils.StrSliceContains(unexpectStatus, status) {
+			return respBody, "ERROR", fmt.Errorf("unexpect status (%s)", status)
+		}
+
+		if utils.StrSliceContains(targets, status) {
+			return respBody, "COMPLETED", nil
+		}
+
+		// Some regions may return "DELETED" when the cluster is deleted.
+		if status == "DELETED" && len(targets) < 1 {
+			return "not_found", "COMPLETED", nil
+		}
+
+		return respBody, "PENDING", nil
+	}
+}
+
+func GetEventRouterClusterById(client *golangsdk.ServiceClient, clusterId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/eventrouter/clusters/{cluster_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	if status := utils.PathSearch("status", respBody, "").(string); status == "DELETED" {
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v1/{project_id}/eventrouter/clusters/{cluster_id}",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("The event router cluster (%s) not found", clusterId)),
+			},
+		}
+	}
+	return respBody, nil
+}
+
+func resourceEventRouterClusterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("eg", region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	cluster, err := GetEventRouterClusterById(client, clusterId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error retrieving event router cluster (%s)", clusterId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		// Required parameter(s).
+		d.Set("name", utils.PathSearch("name", cluster, nil)),
+		d.Set("source_type", utils.PathSearch("source_type", cluster, nil)),
+		d.Set("sink_type", utils.PathSearch("sink_type", cluster, nil)),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", cluster, nil)),
+		d.Set("subnet_id", utils.PathSearch("subnet_id", cluster, nil)),
+		// Optional parameter(s).
+		d.Set("description", utils.PathSearch("description", cluster, nil)),
+		d.Set("availability_zones", utils.PathSearch("zone_names", cluster, nil)),
+		// Attributer(s).
+		d.Set("status", utils.PathSearch("status", cluster, nil)),
+		d.Set("job_count", utils.PathSearch("job_count", cluster, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("created_time",
+			cluster, "").(string))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("updated_time",
+			cluster, "").(string))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildEventRouterClusterUpdateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		// Optional parameter(s).
+		"name":        utils.ValueIgnoreEmpty(d.Get("name")),
+		"description": d.Get("description"),
+	}
+}
+
+func updateEventRouterCluster(client *golangsdk.ServiceClient, clusterId string, bodyParams map[string]interface{}) error {
+	httpUrl := "v1/{project_id}/eventrouter/clusters/{cluster_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{cluster_id}", clusterId)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         bodyParams,
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
+func resourceEventRouterClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("eg", region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	err = updateEventRouterCluster(client, clusterId, buildEventRouterClusterUpdateBodyParams(d))
+	if err != nil {
+		return diag.Errorf("error updating event router cluster (%s): %s", clusterId, err)
+	}
+
+	return resourceEventRouterClusterRead(ctx, d, meta)
+}
+
+func deleteEventRouterCluster(client *golangsdk.ServiceClient, clusterId string) error {
+	httpUrl := "v1/{project_id}/eventrouter/clusters/{cluster_id}"
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", clusterId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceEventRouterClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		clusterId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("eg", region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	err = deleteEventRouterCluster(client, clusterId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting event router cluster (%s)", clusterId))
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      eventRouterClusterStateRefreshFunc(client, clusterId, nil),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        30 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for event router cluster to be deleted: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new resource `huaweicloud_eg_evenrouter_cluster` that used to manage perfessional cluster.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="943" height="92" alt="image" src="https://github.com/user-attachments/assets/12a841cd-dd55-4c46-abe3-e9f52c9e307a" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage perfessional cluster
2. add corresponding document and acceptance test
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o eg -f TestAccEventRouterCluster_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eg" -v -coverprofile="./huaweicloud/services/acceptance/eg/eg_coverage.cov" -coverpkg="./huaweicloud/services/eg" -run TestAccEventRouterCluster_basic -timeout 360m -parallel 10
=== RUN   TestAccEventRouterCluster_basic
=== PAUSE TestAccEventRouterCluster_basic
=== CONT  TestAccEventRouterCluster_basic
--- PASS: TestAccEventRouterCluster_basic (252.10s)
PASS
coverage: 8.6% of statements in ./huaweicloud/services/eg
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        252.183s        coverage: 8.6% of statements in ./huaweicloud/services/eg
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
