### PR TITLE
feat(GeminiDB): add resource to manage node primary standby switchover

### DIFF
--- a/docs/resources/geminidb_primary_standby_switch.md
+++ b/docs/resources/geminidb_primary_standby_switch.md
@@ -1,0 +1,47 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_primary_standby_switch"
+description: |-
+  Manages a resource to switchover GeminiDB instance node primary and standby within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_primary_standby_switch
+
+Manages a resource to switchover GeminiDB instance node primary and standby within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource. Deleting this resource will not clear the corresponding request record,
+  but will only remove the resource information from the tf state file.
+  <br/>2. The resource only supports the Primary/Standby GeminiDB Redis instance.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_geminidb_primary_standby_switch" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3734,8 +3734,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_memory_rule":                geminidb.ResourceMemoryRule(),
 			"huaweicloud_geminidb_node_session_kill":          geminidb.ResourceNodeSessionKill(),
 			"huaweicloud_geminidb_parameter_template":         geminidb.ResourceGeminiDBParameterTemplate(),
-			"huaweicloud_geminidb_parameter_template_reset":   geminidb.ResourceGeminiDBParameterTemplateReset(),
 			"huaweicloud_geminidb_parameter_template_compare": geminidb.ResourceGeminiDBParameterTemplateCompare(),
+			"huaweicloud_geminidb_parameter_template_reset":   geminidb.ResourceGeminiDBParameterTemplateReset(),
+			"huaweicloud_geminidb_primary_standby_switch":     geminidb.ResourcePrimaryStandbySwitch(),
 			"huaweicloud_geminidb_recycling_policy":           geminidb.ResourceGeminiDBRecyclingPolicy(),
 
 			"huaweicloud_gaussdb_cassandra_instance":  geminidb.ResourceGeminiDBInstanceV3(),

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_primary_standby_switch_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_primary_standby_switch_test.go
@@ -1,0 +1,72 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccPrimaryStandbySwitch_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testPrimaryStandbySwitch_basic(name),
+			},
+		},
+	})
+}
+
+func testPrimaryStandbySwitch_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_geminidb_flavors" "test" {
+  engine_name = "redis"
+}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "test_1234"
+  mode              = "Replication"
+
+  datastore {
+    type           = "redis"
+    version        = "5.0"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "2"
+    size      = "4"
+    storage   = "ULTRAHIGH"
+    spec_code = data.huaweicloud_geminidb_flavors.test.flavors[0].spec_code
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testPrimaryStandbySwitch_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_geminidb_primary_standby_switch" "test" {
+  instance_id = huaweicloud_geminidb_instance.test.id
+}
+`, testPrimaryStandbySwitch_base(name))
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_primary_standby_switch.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_primary_standby_switch.go
@@ -1,0 +1,147 @@
+package geminidb
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var primaryStandbySwitchNonUpdatableParams = []string{
+	"instance_id",
+}
+
+// @API GeminiDB PUT /v3/{project_id}/instance/{instance_id}/switchover
+// @API GeminiDB POST /v3/{project_id}/instances
+// @API GeminiDB GET /v3/{project_id}/jobs
+func ResourcePrimaryStandbySwitch() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePrimaryStandbySwitchCreate,
+		ReadContext:   resourcePrimaryStandbySwitchRead,
+		UpdateContext: resourcePrimaryStandbySwitchUpdate,
+		DeleteContext: resourcePrimaryStandbySwitchDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(primaryStandbySwitchNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourcePrimaryStandbySwitchCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	respBody, err := switchoverPrimaryStandby(ctx, client, d, instanceId)
+	if err != nil {
+		return diag.Errorf("error switching the primary and standby of the GeminiDB instance: %s", err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error switching the primary and standby of the GeminiDB instance: unable to find job ID from API response")
+	}
+
+	d.SetId(jobId)
+
+	err = checkGeminiDbInstanceJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the instance primary and standby switchover to complete: %s", err)
+	}
+
+	return nil
+}
+
+func switchoverPrimaryStandby(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	instanceId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/instance/{instance_id}/switchover"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		r, err := client.Request("PUT", createPath, &createOpt)
+		retry, err := handleMultiOperationsError(err)
+		return r, retry, err
+	}
+	resp, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     geminiDbInstanceStatusRefreshFunc(client, d.Id()),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp.(*http.Response))
+}
+
+func resourcePrimaryStandbySwitchRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourcePrimaryStandbySwitchUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourcePrimaryStandbySwitchDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GeminiDB instance primary and standby switch resource is not supported. The resource is only removed from the " +
+		"state, the resource remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource to manage GeminiDB instance node primary standby switchover.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new resource to manage GeminiDB instance node primary standby switchover.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccPrimaryStandbySwitch_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccPrimaryStandbySwitch_basic -timeout 360m -parallel 4
=== RUN   TestAccPrimaryStandbySwitch_basic
=== PAUSE TestAccPrimaryStandbySwitch_basic
=== CONT  TestAccPrimaryStandbySwitch_basic
--- PASS: TestAccPrimaryStandbySwitch_basic (1389.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1389.163s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/d4cf974f-72c4-4867-aeab-2f2ca1829211" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
