### PR TITLE
feat(drs): support `hss_overview_risk_score` data source

### DIFF
--- a/docs/data-sources/hss_overview_risk_score.md
+++ b/docs/data-sources/hss_overview_risk_score.md
@@ -1,0 +1,42 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_overview_risk_score"
+description: |-
+  Use this data source to get the risk score of HSS within HuaweiCloud.
+---
+
+# huaweicloud_hss_overview_risk_score
+
+Use this data source to get the risk score of HSS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_overview_risk_score" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `score` - The security score.
+
+* `risk_num` - The number of security risks.
+
+* `risk_server_num` - The number of servers with security risks.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1748,6 +1748,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_change_files":                               hss.DataSourceChangeFiles(),
 			"huaweicloud_hss_overview_protection_statistics":             hss.DataSourceOverviewProtectionStatistics(),
 			"huaweicloud_hss_overview_agent_statistics":                  hss.DataSourceOverviewAgentStatistics(),
+			"huaweicloud_hss_overview_risk_score":                        hss.DataSourceOverviewRiskScore(),
 			"huaweicloud_hss_overview_hot_information":                   hss.DataSourceOverviewHotInformation(),
 			"huaweicloud_hss_agent_auto_upgrade_config":                  hss.DataSourceAgentAutoUpgradeConfig(),
 			"huaweicloud_hss_billing_version":                            hss.DataSourceBillingVersion(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_overview_risk_score_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_overview_risk_score_test.go
@@ -1,0 +1,42 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceOverviewRiskScore_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_overview_risk_score.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceOverviewRiskScore_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "score"),
+					resource.TestCheckResourceAttrSet(dataSource, "risk_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "risk_server_num"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceOverviewRiskScore_basic() string {
+	return `
+data "huaweicloud_hss_overview_risk_score" "test" {
+  enterprise_project_id = "all_granted_eps"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_overview_risk_score.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_overview_risk_score.go
@@ -1,0 +1,104 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/overview/risk/score
+func DataSourceOverviewRiskScore() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceOverviewRiskScoreRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"score": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"risk_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"risk_server_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildOverviewRiskScoreQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%v", epsId)
+	}
+
+	return ""
+}
+
+func dataSourceOverviewRiskScoreRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/overview/risk/score"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildOverviewRiskScoreQueryParams(epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving HSS overview risk score: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("score", utils.PathSearch("score", respBody, nil)),
+		d.Set("risk_num", utils.PathSearch("risk_num", respBody, nil)),
+		d.Set("risk_server_num", utils.PathSearch("risk_server_num", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_overview_risk_score` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_overview_risk_score` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o hss -f TestAccDataSourceOverviewRiskScore_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceOverviewRiskScore_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceOverviewRiskScore_basic
=== PAUSE TestAccDataSourceOverviewRiskScore_basic
=== CONT  TestAccDataSourceOverviewRiskScore_basic
--- PASS: TestAccDataSourceOverviewRiskScore_basic (12.11s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/hss  coverage: 2.8% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       12.262s coverage: 2.8% of statements in ./huaweicloud/services/hss
```
<img width="894" height="37" alt="image" src="https://github.com/user-attachments/assets/54e528a6-f64e-4ac8-b3ae-7b2816df9245" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
