### PR TITLE
feat(drs): support change_to_peroid to rds resource

### DIFF
--- a/docs/resources/drs_job.md
+++ b/docs/resources/drs_job.md
@@ -474,6 +474,28 @@ The following arguments are supported:
   for MariaDB. Defaults to **false**.
   Changing this parameter will create a new resource.
 
+* `charging_mode` - (Optional, String) Specifies the billing mode of the DRS job.
+  Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.
+
+  -> When updating from postPaid to prePaid, the following conditions must be met:
+  + `period_unit`, `period` and `auto_renew` must be specified.
+  + Only support changing from **postPaid** to **prePaid**.
+
+* `period_unit` - (Optional, String) Specifies the subscription period unit. Required when `charging_mode` is **prePaid**.
+  Valid values are **month** and **year**.
+
+  -> This parameter can be specified when changing from **postPaid** to **prePaid**. It can only be edited once during
+  the conversion.
+
+* `period` - (Optional, Int) Specifies the subscription period. Required when `charging_mode` is **prePaid**.
+
+  -> This parameter can be specified when changing from **postPaid** to **prePaid**. It can only be edited once during
+  the conversion.
+
+* `auto_renew` - (Optional, String) Specifies whether auto-renew is enabled for the subscription.
+  Valid values are **true** and **false**. Defaults to **false**.
+  This field is valid only when `charging_mode` is **prePaid**.
+
 <a name="block--db_info"></a>
 The `db_info` block supports:
 

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_job_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_job_test.go
@@ -227,7 +227,7 @@ resource "huaweicloud_networking_secgroup_rule" "ingress" {
   ethertype         = "IPv4"
   ports             = "3306,9092"
   protocol          = "tcp"
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = "192.168.0.0/16"
   security_group_id = huaweicloud_networking_secgroup.test.id
 }
 
@@ -235,7 +235,7 @@ resource "huaweicloud_networking_secgroup_rule" "egress" {
   direction         = "egress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = "192.168.0.0/16"
   security_group_id = huaweicloud_networking_secgroup.test.id
 }
 `
@@ -807,6 +807,243 @@ func TestAccResourceDrsJob_mysql_to_kafka(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccResourceDrsJob_billingModeChange(t *testing.T) {
+	var obj jobs.BatchCreateJobReq
+	resourceName := "huaweicloud_drs_job.test"
+	name := acceptance.RandomAccResourceName()
+	dbName := acceptance.RandomAccResourceName()
+	pwd := "TestDrs@123"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDrsJobResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDrsJob_billingModeChange_step1(name, dbName, pwd),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "sync"),
+					resource.TestCheckResourceAttr(resourceName, "direction", "up"),
+					resource.TestCheckResourceAttr(resourceName, "net_type", "vpc"),
+					resource.TestCheckResourceAttr(resourceName, "destination_db_readnoly", "true"),
+					resource.TestCheckResourceAttr(resourceName, "migration_type", "FULL_INCR_TRANS"),
+					resource.TestCheckResourceAttr(resourceName, "description", name),
+					resource.TestCheckResourceAttr(resourceName, "source_db.0.engine_type", "mysql"),
+					resource.TestCheckResourceAttr(resourceName, "source_db.0.ip", "192.168.0.58"),
+					resource.TestCheckResourceAttr(resourceName, "source_db.0.port", "3306"),
+					resource.TestCheckResourceAttr(resourceName, "source_db.0.user", "root"),
+					resource.TestCheckResourceAttrPair(resourceName, "source_db.0.vpc_id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "source_db.0.subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "destination_db.0.engine_type", "mysql"),
+					resource.TestCheckResourceAttr(resourceName, "destination_db.0.ip", "192.168.0.59"),
+					resource.TestCheckResourceAttr(resourceName, "destination_db.0.port", "3306"),
+					resource.TestCheckResourceAttr(resourceName, "destination_db.0.user", "root"),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_db.0.subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_db.0.instance_id",
+						"huaweicloud_rds_instance.test2", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_db.0.region",
+						"huaweicloud_rds_instance.test2", "region"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "progress"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
+					waitForJobStatus(resourceName),
+				),
+			},
+			{
+				Config: testAccDrsJob_billingModeChange_step2(name, dbName, pwd),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "period", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "order_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"source_db.0.password", "destination_db.0.password",
+					"expired_days", "migrate_definer", "force_destroy", "status", "auto_renew", "updated_at", "policy_config",
+					"source_db.0.ip", "destination_db.0.ip", "engine_type"},
+			},
+		},
+	})
+}
+
+func testAccDrsJob_billingModeChange_step1(name, dbName, pwd string) string {
+	netConfig := common.TestBaseNetwork(name)
+	sourceDb := testAccDrsJob_mysql(1, dbName, pwd, "192.168.0.58")
+	destDb := testAccDrsJob_mysql(2, dbName, pwd, "192.168.0.59")
+	database1 := testAccRdsMysqlDatabse(dbName, 1)
+	database2 := testAccRdsMysqlDatabse(dbName, 2)
+
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_drs_node_types" "test" {
+  engine_type = "mysql"
+  type        = "sync"
+  direction   = "up"
+}
+
+%[3]s
+
+%[4]s
+
+%[5]s
+
+%[6]s
+
+resource "huaweicloud_drs_job" "test" {
+  name           = "%[7]s"
+  type           = "sync"
+  engine_type    = "mysql"
+  direction      = "up"
+  node_type      = data.huaweicloud_drs_node_types.test.node_types[0]
+  net_type       = "vpc"
+  migration_type = "FULL_INCR_TRANS"
+  description    = "%[7]s"
+  force_destroy  = true
+
+  source_db {
+    engine_type = "mysql"
+    ip          = huaweicloud_rds_instance.test1.fixed_ip
+    port        = 3306
+    user        = "root"
+    password    = "%[8]s"
+    vpc_id      = huaweicloud_rds_instance.test1.vpc_id
+    subnet_id   = huaweicloud_rds_instance.test1.subnet_id
+  }
+
+  destination_db {
+    region      = huaweicloud_rds_instance.test2.region
+    ip          = huaweicloud_rds_instance.test2.fixed_ip
+    port        = 3306
+    engine_type = "mysql"
+    user        = "root"
+    password    = "%[8]s"
+    instance_id = huaweicloud_rds_instance.test2.id
+    subnet_id   = huaweicloud_rds_instance.test2.subnet_id
+  }
+
+  databases = [huaweicloud_rds_mysql_database.test1.name]
+
+  policy_config {
+    filter_ddl_policy = "drop_database"
+    conflict_policy   = "overwrite"
+    index_trans       = true
+  }
+
+  lifecycle {
+    ignore_changes = [
+      source_db.0.password, destination_db.0.password, force_destroy,
+    ]
+  }
+}
+`, netConfig, testAccSecgroupRule, sourceDb, destDb, database1, database2, name, pwd)
+}
+
+func testAccDrsJob_billingModeChange_step2(name, dbName, pwd string) string {
+	netConfig := common.TestBaseNetwork(name)
+	sourceDb := testAccDrsJob_mysql(1, dbName, pwd, "192.168.0.58")
+	destDb := testAccDrsJob_mysql(2, dbName, pwd, "192.168.0.59")
+	database1 := testAccRdsMysqlDatabse(dbName, 1)
+	database2 := testAccRdsMysqlDatabse(dbName, 2)
+
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_drs_node_types" "test" {
+  engine_type = "mysql"
+  type        = "sync"
+  direction   = "up"
+}
+
+%[3]s
+
+%[4]s
+
+%[5]s
+
+%[6]s
+
+resource "huaweicloud_drs_job" "test" {
+  name           = "%[7]s"
+  type           = "sync"
+  engine_type    = "mysql"
+  direction      = "up"
+  node_type      = data.huaweicloud_drs_node_types.test.node_types[0]
+  net_type       = "vpc"
+  migration_type = "FULL_INCR_TRANS"
+  description    = "%[7]s"
+  force_destroy  = true
+
+  source_db {
+    engine_type = "mysql"
+    ip          = huaweicloud_rds_instance.test1.fixed_ip
+    port        = 3306
+    user        = "root"
+    password    = "%[8]s"
+    vpc_id      = huaweicloud_rds_instance.test1.vpc_id
+    subnet_id   = huaweicloud_rds_instance.test1.subnet_id
+  }
+
+  destination_db {
+    region      = huaweicloud_rds_instance.test2.region
+    ip          = huaweicloud_rds_instance.test2.fixed_ip
+    port        = 3306
+    engine_type = "mysql"
+    user        = "root"
+    password    = "%[8]s"
+    instance_id = huaweicloud_rds_instance.test2.id
+    subnet_id   = huaweicloud_rds_instance.test2.subnet_id
+  }
+
+  databases = [huaweicloud_rds_mysql_database.test1.name]
+
+  policy_config {
+    filter_ddl_policy = "drop_database"
+    conflict_policy   = "overwrite"
+    index_trans       = true
+  }
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = "false"
+
+  lifecycle {
+    ignore_changes = [
+      source_db.0.password, destination_db.0.password, force_destroy,
+    ]
+  }
+}
+`, netConfig, testAccSecgroupRule, sourceDb, destDb, database1, database2, name, pwd)
 }
 
 func testAccDrsJob_mysql_to_kafka(name, dbName, pwd string) string {

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
@@ -46,6 +46,7 @@ var notFoundErrCode = []string{
 // @API DRS POST /v5/{project_id}/jobs/{job_id}/action
 // @API DRS PUT /v5/{project_id}/jobs/{job_id}
 // @API DRS POST /v3/{project_id}/jobs/batch-sync-policy
+// @API DRS POST /v5/{project_id}/job/{job_id}/change-to-period
 // @API BSS POST /v2/orders/suscriptions/resources/query
 // @API BSS POST /v2/orders/subscriptions/resources/unsubscribe
 // @API BSS POST /v2/orders/subscriptions/resources/autorenew/{instance_id}
@@ -368,29 +369,23 @@ func ResourceDrsJob() *schema.Resource {
 			"charging_mode": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"prePaid", "postPaid",
 				}, false),
-				Description: "schema: Internal",
 			},
 			"period_unit": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				RequiredWith: []string{"period"},
 				ValidateFunc: validation.StringInSlice([]string{
 					"month", "year",
 				}, false),
-				Description: "schema: Internal",
 			},
 			"period": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ForceNew:     true,
 				RequiredWith: []string{"period_unit"},
-				Description:  "schema: Internal",
 			},
 			"auto_renew": {
 				Type:     schema.TypeString,
@@ -398,7 +393,6 @@ func ResourceDrsJob() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"true", "false",
 				}, false),
-				Description: "schema: Internal",
 			},
 
 			"alarm_notify": {
@@ -1250,7 +1244,22 @@ func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 	}
 
-	if d.HasChange("auto_renew") {
+	if d.HasChange("charging_mode") {
+		// only support changing billing mode from postPaid to prePaid
+		if d.Get("charging_mode").(string) != "prePaid" {
+			return diag.Errorf("only support changing billing mode from postPaid to prePaid")
+		}
+
+		periodUnit := d.Get("period_unit").(string)
+		period := d.Get("period").(int)
+		autoRenew := d.Get("auto_renew").(string)
+		if periodUnit == "" || period == 0 || autoRenew == "" {
+			return diag.Errorf("period_unit, period and auto_renew are required when changing billing mode to prePaid")
+		}
+		if err := changeJobBillingToPrePaid(ctx, d, clientV5, bssClient); err != nil {
+			return diag.FromErr(err)
+		}
+	} else if d.HasChange("auto_renew") {
 		// resource_id is different from job_id
 		resourceIDs, err := cbc.GetResourceIDsByOrder(bssClient, d.Get("order_id").(string), 1)
 		if err != nil || len(resourceIDs) == 0 {
@@ -1262,6 +1271,50 @@ func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	return resourceJobRead(ctx, d, meta)
+}
+
+func buildChangeToPeriodBodyParams(d *schema.ResourceData) map[string]interface{} {
+	periodType := "2"
+	if d.Get("period_unit").(string) == "year" {
+		periodType = "3"
+	}
+	return map[string]interface{}{
+		"period_type":   periodType,
+		"period_num":    d.Get("period").(int),
+		"is_auto_renew": d.Get("auto_renew").(string) == "true",
+		"is_auto_pay":   true,
+	}
+}
+
+func changeJobBillingToPrePaid(ctx context.Context, d *schema.ResourceData, client, bssClient *golangsdk.ServiceClient) error {
+	changeToPeriodPath := client.Endpoint + "v5/{project_id}/job/{job_id}/change-to-period"
+	changeToPeriodPath = strings.ReplaceAll(changeToPeriodPath, "{project_id}", client.ProjectID)
+	changeToPeriodPath = strings.ReplaceAll(changeToPeriodPath, "{job_id}", d.Id())
+	changeToPeriodOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildChangeToPeriodBodyParams(d),
+	}
+	resp, err := client.Request("POST", changeToPeriodPath, &changeToPeriodOpt)
+	if err != nil {
+		return fmt.Errorf("error changing DRS job to period billing: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return err
+	}
+	orderId := utils.PathSearch("order_id", respBody, "").(string)
+
+	if orderId != "" {
+		if err = common.WaitOrderComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return fmt.Errorf("the order is not completed while changing DRS job to period billing: %s", err)
+		}
+		if _, err = common.WaitOrderAllResourceComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func updateObjectsSelection(ctx context.Context, d *schema.ResourceData, client, clientV5 *golangsdk.ServiceClient) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `change_to_peroid` to rds resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `change_to_peroid` to rds resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccResourceDrsJob_billingModeChange"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs-v -run TestAccResourceDrsJob_billingModeChange -timeout 360m -parallel 4
=== RUN   TestAccResourceDrsJob_billingModeChange
=== PAUSE TestAccResourceDrsJob_billingModeChange
=== CONT  TestAccResourceDrsJob_billingModeChange
--- PASS: TestAccResourceDrsJob_billingModeChange (1581.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       21.311s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
