### PR TITLE
feat(dataarts): supports new data source to query data standards

### DIFF
--- a/docs/data-sources/dataarts_architecture_data_standards.md
+++ b/docs/data-sources/dataarts_architecture_data_standards.md
@@ -1,0 +1,146 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_architecture_data_standards"
+description: |-
+  Use this data source to query DataArts Architecture data standards within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_architecture_data_standards
+
+Use this data source to query DataArts Architecture data standards within HuaweiCloud.
+
+## Example Usage
+
+### Query all data standards under a specified workspace
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_architecture_data_standards" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+### Query the data standards under a specified workspace and belongs a time range
+
+```hcl
+variable "workspace_id" {}
+variable "begin_time" {
+  default = "2026-01-01T00:00:00+08:00"
+}
+variable "end_time" {
+  default = "2026-12-31T23:59:59+08:00"
+}
+
+data "huaweicloud_dataarts_architecture_data_standards" "test" {
+  workspace_id = var.workspace_id
+  begin_time   = var.begin_time
+  end_time     = var.end_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the data standards are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the data standards belong.
+
+* `name_ch` - (Optional, String) Specifies the Chinese name of the data standard to be exactly queried.
+
+* `name_en` - (Optional, String) Specifies the English code of the data standard to be exactly queried.
+
+* `directory_id` - (Optional, String) Specifies the directory ID of the data standard to be queried.
+
+* `begin_time` - (Optional, String) Specifies the start time of the data standard to be queried, in RFC3339 format.
+
+* `end_time` - (Optional, String) Specifies the end time of the data standard to be queried, in RFC3339 format.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data_standards` - The list of data standards that matched filter parameters.  
+  The [data_standards](#dataarts_architecture_data_standards_attr) structure is documented below.
+
+<a name="dataarts_architecture_data_standards_attr"></a>
+The `data_standards` block supports:
+
+* `id` - The ID of the data standard.
+
+* `directory_id` - The directory ID of the data standard.
+
+* `directory_path` - The directory path of the data standard.
+
+* `values` - The value of data standard attributes.  
+  The [values](#dataarts_architecture_data_standards_values_attr) structure is documented below.
+
+* `status` - The status of the data standard.
+  + **DRAFT**
+  + **PUBLISHED**
+  + **OFFLINE**
+  + **REJECT**
+
+* `created_by` - The name of data standard creator.
+
+* `updated_by` - The name of data standard updater.
+
+* `created_at` - The creation time of the data standard, in RFC3339 format.
+
+* `updated_at` - The latest update time of the data standard, in RFC3339 format.
+
+* `new_biz` - The biz info of the data standard.  
+  The [new_biz](#dataarts_architecture_data_standards_new_biz_attr) structure is documented below.
+
+<a name="dataarts_architecture_data_standards_values_attr"></a>
+The `values` block supports:
+
+* `fd_name` - The name of the data standard attribute.
+
+* `fd_value` - The value of the data standard attribute.
+
+* `id` - The ID of the data standard attribute.
+
+* `fd_id` - The ID of the data standard attribute definition.
+
+* `row_id` - The row ID of the data standard attribute.
+
+* `directory_id` - The directory ID to which the attribute belongs.
+
+* `status` - The status of the data standard attribute.
+  + **DRAFT**
+  + **PUBLISHED**
+  + **OFFLINE**
+  + **REJECT**
+
+* `created_by` - The name of attribute creator.
+
+* `updated_by` - The name of attribute updater.
+
+* `created_at` - The creation time of the data standard attribute, in RFC3339 format.
+
+* `updated_at` - The latest update time of the data standard attribute, in RFC3339 format.
+
+<a name="dataarts_architecture_data_standards_new_biz_attr"></a>
+The `new_biz` block supports:
+
+* `id` - The ID of the new biz.
+
+* `biz_type` - The type of the new biz.
+
+* `biz_id` - The ID of the new biz.
+
+* `biz_info` - The info of the new biz.
+
+* `status` - The status of the new biz.
+
+* `biz_version` - The version of the new biz.
+
+* `created_at` - The time when the new biz was created, in RFC3339 format.
+
+* `updated_at` - The time when the new biz was updated, in RFC3339 format.

--- a/docs/resources/dataarts_architecture_data_standard.md
+++ b/docs/resources/dataarts_architecture_data_standard.md
@@ -40,18 +40,18 @@ resource "huaweicloud_dataarts_architecture_data_standard" "test"{
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+* `region` - (Optional, String, ForceNew) Specifies the region where the data standard is located.  
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `workspace_id` - (Required, String) Specifies the workspace ID of DataArts Architecture. Changing this parameter will
-  create a new resource.
+* `workspace_id` - (Required, String, ForceNew) Specifies the ID of the workspace to which the data standard belongs.  
+  Changing this parameter will create a new resource.
 
-* `directory_id` - (Required, String) Specifies the directory ID that the data standard belongs to.
+* `directory_id` - (Required, String) Specifies the directory ID to which the data standard belongs.
 
-* `values` - (Required, List) Specifies the value of data standard attributes.
-The [values](#DataStandard_Value) structure is documented below.
+* `values` - (Required, List) Specifies the value of data standard attributes.  
+  The [values](#dataarts_architecture_data_standard_values) structure is documented below.
 
-<a name="DataStandard_Value"></a>
+<a name="dataarts_architecture_data_standard_values"></a>
 The `values` block supports:
 
 * `fd_name` - (Required, String) Specifies the name of the data standard attribute.
@@ -64,65 +64,75 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
 
-* `values` - Indicates the value of data standard attributes.
-  The [values](#DataStandard_Value) structure is documented below.
+* `directory_path` - The directory path of the data standard.
 
-* `directory_path` - Indicates the path of the directory.
+* `status` - The status of the data standard.
+  + **DRAFT**
+  + **PUBLISHED**
+  + **OFFLINE**
+  + **REJECT**
 
-* `status` - Indicates the status of the data standard. The value can be: **DRAFT**, **PUBLISH_DEVELOPING**,
-  **PUBLISHED**, **OFFLINE_DEVELOPING**, **OFFLINE**, **REJECT**.
+* `created_by` - The name of data standard creator.
 
-* `created_by` - Indicates the name of creator.
+* `updated_by` - The name of data standard updater.
 
-* `updated_by` - Indicates the name of updater.
+* `created_at` - The creation time of the data standard, in RFC3339 format.
 
-* `created_at` - Indicates the creation time of the data standard.
+* `updated_at` - The latest update time of the data standard, in RFC3339 format.
 
-* `updated_at` - Indicates the latest update time of the data standard.
+* `values` - The value of data standard attributes.  
+  The [values](#dataarts_architecture_data_standard_values_attr) structure is documented below.
 
-* `new_biz` - Specifies the biz info of manager.
-  The [new_biz](#DataStandard_NewBiz) structure is documented below.
+* `new_biz` - The biz info of the data standard.  
+  The [new_biz](#dataarts_architecture_data_standard_new_biz_attr) structure is documented below.
 
-<a name="DataStandard_Value"></a>
+<a name="dataarts_architecture_data_standard_values_attr"></a>
 The `values` block supports:
 
-* `id` - Indicates the ID of the data standard attribute.
+* `fd_name` - The name of the data standard attribute.
 
-* `fd_id` - Indicates the ID of the data standard attribute definition.
+* `fd_value` - The value of the data standard attribute.
 
-* `directory_id` - Indicates the directory ID that the attribute belongs to.
+* `id` - The ID of the data standard attribute.
 
-* `row_id` - Indicates the ID of data standard.
+* `fd_id` - The ID of the data standard attribute definition.
 
-* `status` - Indicates the status of the data standard. The value can be: **DRAFT**, **PUBLISH_DEVELOPING**,
-  **PUBLISHED**, **OFFLINE_DEVELOPING**, **OFFLINE**, **REJECT**.
+* `row_id` - The row ID of the data standard attribute.
 
-* `created_by` - Indicates the name of creator.
+* `directory_id` - The directory ID to which the attribute belongs.
 
-* `updated_by` - Indicates the name of updater.
+* `status` - The status of the data standard attribute.
+  + **DRAFT**
+  + **PUBLISHED**
+  + **OFFLINE**
+  + **REJECT**
 
-* `created_at` - Indicates the creation time of the data standard.
+* `created_by` - The name of attribute creator.
 
-* `updated_at` - Indicates the latest update time of the data standard.
+* `updated_by` - The name of attribute updater.
 
-<a name="DataStandard_NewBiz"></a>
+* `created_at` - The creation time of the data standard attribute, in RFC3339 format.
+
+* `updated_at` - The latest update time of the data standard attribute, in RFC3339 format.
+
+<a name="dataarts_architecture_data_standard_new_biz_attr"></a>
 The `new_biz` block supports:
 
-* `id` - Indicates the ID of the new biz.
+* `id` - The ID of the new biz.
 
-* `biz_type` - Indicates the type of the new biz.
+* `biz_type` - The type of the new biz.
 
-* `biz_id` - Indicates the ID of data standard.
+* `biz_id` - The ID of the new biz.
 
-* `biz_info` - Indicates the info of the new biz.
+* `biz_info` - The info of the new biz.
 
-* `status` - Indicates the status of the new biz.
+* `status` - The status of the new biz.
 
-* `biz_version` - Indicates the version of the new biz.
+* `biz_version` - The version of the new biz.
 
-* `created_by` - Indicates the creation time of the new biz.
+* `created_at` - The time when the new biz was created, in RFC3339 format.
 
-* `updated_at` - Indicates the latest update time of the new biz.
+* `updated_at` - The time when the new biz was updated, in RFC3339 format.
 
 ## Import
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1089,6 +1089,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_approvals":                        dataarts.DataSourceArchitectureApprovals(),
 			"huaweicloud_dataarts_architecture_business_metrics":                 dataarts.DataSourceArchitectureBusinessMetrics(),
 			"huaweicloud_dataarts_architecture_code_tables":                      dataarts.DataSourceArchitectureCodeTables(),
+			"huaweicloud_dataarts_architecture_data_standards":                   dataarts.DataSourceArchitectureDataStandards(),
 			"huaweicloud_dataarts_architecture_data_standard_template_customs":   dataarts.DataSourceArchitectureDataStandardTemplateCustoms(),
 			"huaweicloud_dataarts_architecture_data_standard_template_optionals": dataarts.DataSourceArchitectureDataStandardTemplateOptionals(),
 			"huaweicloud_dataarts_architecture_directories":                      dataarts.DataSourceArchitectureDirectories(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_data_standards_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_data_standards_test.go
@@ -1,0 +1,243 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataArchitectureDataStandards_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_architecture_data_standards.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byDirectoryId   = "data.huaweicloud_dataarts_architecture_data_standards.filter_by_directory_id"
+		dcByDirectoryId = acceptance.InitDataSourceCheck(byDirectoryId)
+
+		byNameCh   = "data.huaweicloud_dataarts_architecture_data_standards.filter_by_name_ch"
+		dcByNameCh = acceptance.InitDataSourceCheck(byNameCh)
+
+		byNameEn   = "data.huaweicloud_dataarts_architecture_data_standards.filter_by_name_en"
+		dcByNameEn = acceptance.InitDataSourceCheck(byNameEn)
+
+		byBeginTime   = "data.huaweicloud_dataarts_architecture_data_standards.filter_by_begin_time"
+		dcByBeginTime = acceptance.InitDataSourceCheck(byBeginTime)
+
+		byEndTime   = "data.huaweicloud_dataarts_architecture_data_standards.filter_by_end_time"
+		dcByEndTime = acceptance.InitDataSourceCheck(byEndTime)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataArchitectureDataStandards_nonExistentWorkspace(),
+				ExpectError: regexp.MustCompile("error querying DataArts Architecture data standards"),
+			},
+			{
+				Config: testAccDataArchitectureDataStandards_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "data_standards.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.id"),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.directory_id"),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.status"),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.created_by"),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.updated_by"),
+					resource.TestMatchResourceAttr(all, "data_standards.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(all, "data_standards.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(all, "data_standards.0.values.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.values.0.fd_name"),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.values.0.fd_value"),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.values.0.id"),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.values.0.fd_id"),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.values.0.directory_id"),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.values.0.row_id"),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.values.0.status"),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.values.0.created_by"),
+					resource.TestCheckResourceAttrSet(all, "data_standards.0.values.0.updated_by"),
+					resource.TestMatchResourceAttr(all, "data_standards.0.values.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(all, "data_standards.0.values.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+
+					// Filter by directory ID.
+					dcByDirectoryId.CheckResourceExists(),
+					resource.TestCheckOutput("is_directory_id_filter_useful", "true"),
+
+					// Filter by Chinese name.
+					dcByNameCh.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_ch_filter_useful", "true"),
+
+					// Filter by English code.
+					dcByNameEn.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_en_filter_useful", "true"),
+
+					// Filter by begin time.
+					dcByBeginTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_begin_time_filter_useful", "true"),
+
+					// Filter by end time.
+					dcByEndTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_end_time_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataArchitectureDataStandards_nonExistentWorkspace() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_architecture_data_standards" "test" {
+  workspace_id = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataArchitectureDataStandards_basic_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_directory" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  type         = "STANDARD_ELEMENT"
+}
+
+resource "huaweicloud_dataarts_architecture_data_standard" "test" {
+  workspace_id = "%[1]s"
+  directory_id = huaweicloud_dataarts_architecture_directory.test.id
+
+  values {
+    fd_name  = "nameCh"
+    fd_value = "%[2]s"
+  }
+
+  values {
+    fd_name  = "nameEn"
+    fd_value = "%[2]s_en"
+  }
+
+  values {
+    fd_name  = "description"
+    fd_value = "Created by acceptance test"
+  }
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccDataArchitectureDataStandards_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dataarts_architecture_data_standards" "all" {
+  depends_on = [huaweicloud_dataarts_architecture_data_standard.test]
+
+  workspace_id = "%[2]s"
+}
+
+# Filter by directory ID.
+locals {
+  data_standard_directory_id = huaweicloud_dataarts_architecture_data_standard.test.directory_id
+}
+
+data "huaweicloud_dataarts_architecture_data_standards" "filter_by_directory_id" {
+  depends_on = [huaweicloud_dataarts_architecture_data_standard.test]
+
+  workspace_id = "%[2]s"
+  directory_id = local.data_standard_directory_id
+}
+
+locals {
+  directory_id_filter_result = [
+    for v in data.huaweicloud_dataarts_architecture_data_standards.filter_by_directory_id.data_standards :
+    v.directory_id == local.data_standard_directory_id
+  ]
+}
+
+output "is_directory_id_filter_useful" {
+  value = length(local.directory_id_filter_result) > 0 && alltrue(local.directory_id_filter_result)
+}
+
+# Filter by Chinese name (exact match).
+locals {
+  data_standard_name_ch = "%[3]s"
+}
+
+data "huaweicloud_dataarts_architecture_data_standards" "filter_by_name_ch" {
+  depends_on = [huaweicloud_dataarts_architecture_data_standard.test]
+
+  workspace_id = "%[2]s"
+  name_ch      = local.data_standard_name_ch
+}
+
+output "is_name_ch_filter_useful" {
+  value = contains(data.huaweicloud_dataarts_architecture_data_standards.filter_by_name_ch.data_standards[*].id,
+    huaweicloud_dataarts_architecture_data_standard.test.id)
+}
+
+# Filter by English code (exact match).
+locals {
+  data_standard_name_en = "%[3]s_en"
+}
+
+data "huaweicloud_dataarts_architecture_data_standards" "filter_by_name_en" {
+  depends_on = [huaweicloud_dataarts_architecture_data_standard.test]
+
+  workspace_id = "%[2]s"
+  name_en      = local.data_standard_name_en
+}
+
+output "is_name_en_filter_useful" {
+  value = contains(data.huaweicloud_dataarts_architecture_data_standards.filter_by_name_en.data_standards[*].id,
+    huaweicloud_dataarts_architecture_data_standard.test.id)
+}
+
+# Filter by begin time.
+locals {
+  data_standard_begin_time = timeadd(huaweicloud_dataarts_architecture_directory.test.created_at, "-10m")
+}
+
+data "huaweicloud_dataarts_architecture_data_standards" "filter_by_begin_time" {
+  depends_on = [huaweicloud_dataarts_architecture_data_standard.test]
+
+  workspace_id = "%[2]s"
+  begin_time   = local.data_standard_begin_time
+}
+
+output "is_begin_time_filter_useful" {
+  value = contains(data.huaweicloud_dataarts_architecture_data_standards.filter_by_begin_time.data_standards[*].id,
+    huaweicloud_dataarts_architecture_data_standard.test.id)
+}
+
+# Filter by end time.
+locals {
+  data_standard_end_time = timeadd(huaweicloud_dataarts_architecture_directory.test.created_at, "10m")
+}
+
+data "huaweicloud_dataarts_architecture_data_standards" "filter_by_end_time" {
+  depends_on = [huaweicloud_dataarts_architecture_data_standard.test]
+
+  workspace_id = "%[2]s"
+  end_time     = local.data_standard_end_time
+}
+
+output "is_end_time_filter_useful" {
+  value = contains(data.huaweicloud_dataarts_architecture_data_standards.filter_by_end_time.data_standards[*].id,
+    huaweicloud_dataarts_architecture_data_standard.test.id)
+}
+`, testAccDataArchitectureDataStandards_basic_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_data_standards.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_data_standards.go
@@ -1,0 +1,362 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/design/standards
+func DataSourceArchitectureDataStandards() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceArchitectureDataStandardsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the data standards are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the data standards belong.`,
+			},
+
+			// Optional parameters.
+			"name_ch": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The Chinese name of the data standard to be exactly queried.`,
+			},
+			"name_en": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The English code of the data standard to be exactly queried.`,
+			},
+			"directory_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The directory ID of the data standard to be queried.`,
+			},
+			"begin_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The start time of the data standard to be queried, in RFC3339 format.`,
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The end time of the data standard to be queried, in RFC3339 format.`,
+			},
+
+			// Attributes.
+			"data_standards": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureDataStandard(),
+				Description: `The list of data standards that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureDataStandard() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the data standard.`,
+			},
+			"directory_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The directory ID of the data standard.`,
+			},
+			"directory_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The directory path of the data standard.`,
+			},
+			"values": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureDataStandardValue(),
+				Description: `The value of data standard attributes.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the data standard.`,
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of data standard creator.`,
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of data standard updater.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the data standard, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the data standard, in RFC3339 format.`,
+			},
+			"new_biz": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataArchitectureDataStandardNewBiz(),
+				Description: `The biz info of the data standard.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureDataStandardValue() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"fd_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the data standard attribute.`,
+			},
+			"fd_value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the data standard attribute.`,
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the data standard attribute.`,
+			},
+			"fd_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the data standard attribute definition.`,
+			},
+			"row_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The row ID of the data standard attribute.`,
+			},
+			"directory_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The directory ID to which the attribute belongs.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the data standard attribute.`,
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of attribute creator.`,
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of attribute updater.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the data standard attribute, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the data standard attribute, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func dataArchitectureDataStandardNewBiz() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the new biz.`,
+			},
+			"biz_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the new biz.`,
+			},
+			"biz_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the new biz.`,
+			},
+			"biz_info": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The info of the new biz.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the new biz.`,
+			},
+			"biz_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The version of the new biz.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the new biz was created, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the new biz was updated, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func buildArchitectureDataStandardsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("directory_id"); ok {
+		res = fmt.Sprintf("%s&directory_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name_ch"); ok {
+		res = fmt.Sprintf("%s&name_ch=%v", res, v)
+	}
+	if v, ok := d.GetOk("name_en"); ok {
+		res = fmt.Sprintf("%s&name_en=%v", res, v)
+	}
+	if v, ok := d.GetOk("begin_time"); ok {
+		res = fmt.Sprintf("%s&begin_time=%s", res, url.QueryEscape(v.(string)))
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		res = fmt.Sprintf("%s&end_time=%s", res, url.QueryEscape(v.(string)))
+	}
+
+	return res
+}
+
+func listArchitectureDataStandards(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/design/standards?limit={limit}&need_path=true"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildArchitectureDataStandardsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildArchitectureMoreHeaders(d.Get("workspace_id").(string)),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		records := utils.PathSearch("data.value.records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, records...)
+
+		if len(records) < limit {
+			break
+		}
+		offset += len(records)
+	}
+
+	return result, nil
+}
+
+func flattenArchitectureDataStandards(standards []interface{}) []map[string]interface{} {
+	if len(standards) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(standards))
+	for _, standard := range standards {
+		result = append(result, map[string]interface{}{
+			"id":             utils.PathSearch("id", standard, nil),
+			"directory_id":   utils.PathSearch("directory_id", standard, nil),
+			"directory_path": utils.PathSearch("directory_path", standard, nil),
+			"status":         utils.PathSearch("status", standard, nil),
+			"created_by":     utils.PathSearch("create_by", standard, nil),
+			"updated_by":     utils.PathSearch("update_by", standard, nil),
+			"created_at":     utils.PathSearch("create_time", standard, nil),
+			"updated_at":     utils.PathSearch("update_time", standard, nil),
+			"values":         flattenGetDataStandardResponseBodyValue(standard),
+			"new_biz":        flattenGetDataStandardResponseBodyNewBiz(standard),
+		})
+	}
+	return result
+}
+
+func dataSourceArchitectureDataStandardsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	standards, err := listArchitectureDataStandards(client, d)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Architecture data standards: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_standards", flattenArchitectureDataStandards(standards)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_data_standard.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_data_standard.go
@@ -38,62 +38,68 @@ func ResourceArchitectureDataStandard() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the data standard is located.`,
 			},
+
+			// Required parameters.
 			"workspace_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `Specifies the workspace ID of DataArts Architecture.`,
+				ForceNew:    true,
+				Description: `The ID of the workspace to which the data standard belongs.`,
 			},
 			"directory_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `Specifies the directory ID that the data standard belongs to.`,
+				Description: `The directory ID to which the data standard belongs.`,
 			},
 			"values": {
 				Type:        schema.TypeSet,
 				Elem:        dataStandardValueSchema(),
 				Required:    true,
-				Description: `Specifies the value of data standard attributes.`,
+				Description: `The value of data standard attributes.`,
 			},
+
+			// Attributes.
 			"directory_path": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the path of the directory.`,
+				Description: `The directory path of the data standard.`,
 			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the status of the data standard.`,
+				Description: `The status of the data standard.`,
 			},
 			"created_by": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the name of creator.`,
+				Description: `The name of data standard creator.`,
 			},
 			"updated_by": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the name of updater.`,
+				Description: `The name of data standard updater.`,
 			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the creation time of the data standard.`,
+				Description: `The creation time of the data standard, in RFC3339 format.`,
 			},
 			"updated_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the latest update time of the data standard.`,
+				Description: `The latest update time of the data standard, in RFC3339 format.`,
 			},
 			"new_biz": {
 				Type:        schema.TypeList,
 				Elem:        dataStandardNewBizSchema(),
 				Computed:    true,
-				Description: `Indicates the biz info of manager.`,
+				Description: `The biz info of the data standard.`,
 			},
 		},
 	}
@@ -105,57 +111,57 @@ func dataStandardValueSchema() *schema.Resource {
 			"fd_name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `Specifies the name of the data standard attribute.`,
+				Description: `The name of the data standard attribute.`,
 			},
 			"fd_value": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: `Specifies the value of the data standard attribute.`,
+				Description: `The value of the data standard attribute.`,
 			},
 			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the ID of the data standard attribute.`,
+				Description: `The ID of the data standard attribute.`,
 			},
 			"fd_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the ID of the data standard attribute.`,
-			},
-			"directory_id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: `Indicates the directory ID that the attribute belongs to.`,
+				Description: `The ID of the data standard attribute definition.`,
 			},
 			"row_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the ID of data standard.`,
+				Description: `The row ID of the data standard attribute.`,
+			},
+			"directory_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The directory ID to which the attribute belongs.`,
 			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the status of the data standard.`,
+				Description: `The status of the data standard attribute.`,
 			},
 			"created_by": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the name of creator.`,
+				Description: `The name of attribute creator.`,
 			},
 			"updated_by": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the name of updater.`,
+				Description: `The name of attribute updater.`,
 			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the creation time of the data standard.`,
+				Description: `The creation time of the data standard attribute, in RFC3339 format.`,
 			},
 			"updated_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the latest update time of the data standard.`,
+				Description: `The latest update time of the data standard attribute, in RFC3339 format.`,
 			},
 		},
 	}
@@ -168,42 +174,42 @@ func dataStandardNewBizSchema() *schema.Resource {
 			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the ID of the new biz.`,
+				Description: `The ID of the new biz.`,
 			},
 			"biz_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the type of the new biz.`,
+				Description: `The type of the new biz.`,
 			},
 			"biz_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the ID of data standard.`,
+				Description: `The ID of the new biz.`,
 			},
 			"biz_info": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the info of the new biz.`,
+				Description: `The info of the new biz.`,
 			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the status of the new biz.`,
+				Description: `The status of the new biz.`,
 			},
 			"biz_version": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the version of the new biz.`,
+				Description: `The version of the new biz.`,
 			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the creation time of the new biz.`,
+				Description: `The time when the new biz was created, in RFC3339 format.`,
 			},
 			"updated_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `Indicates the latest update time of the new biz.`,
+				Description: `The time when the new biz was updated, in RFC3339 format.`,
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source `huaweicloud_dataarts_architecture_data_standards` that used to query architecture data standards.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
<img width="1104" height="56" alt="image" src="https://github.com/user-attachments/assets/947e9c4b-6d1f-4053-b30e-2238c0e6fe74" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query data standards.
2. add corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataArchitectureDataStandards_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataArchitectureDataStandards_basic -timeout 360m -parallel 10
=== RUN   TestAccDataArchitectureDataStandards_basic
=== PAUSE TestAccDataArchitectureDataStandards_basic
=== CONT  TestAccDataArchitectureDataStandards_basic
--- PASS: TestAccDataArchitectureDataStandards_basic (18.67s)
PASS
coverage: 6.1% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  18.771s coverage: 6.1% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
