### PR TITLE
feat(drs): add data source for resource instances query by tags

### DIFF
--- a/docs/data-sources/drs_resource_instances.md
+++ b/docs/data-sources/drs_resource_instances.md
@@ -1,0 +1,88 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_instances_by_tags"
+description: |-
+  Use this data source to get the list of DRS resource instances by tags.
+---
+
+# huaweicloud_drs_instances_by_tags
+
+Use this data source to get the list of DRS resource instances by tags.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_drs_instances_by_tags" "test" {
+  resource_type = "sync"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `resource_type` - (Required, String) Specifies the resource type of the DRS job.
+  The valid values are:
+  + **migration**: Online migration.
+  + **sync**: Data synchronization.
+  + **cloudDataGuard**: Disaster recovery.
+  + **subscription**: Data subscription.
+  + **backupMigration**: Backup migration.
+  + **replay**: Replay.
+
+* `without_any_tag` - (Optional, Bool) Specifies whether to query resources without any tags. If set to **true**,
+  the tags parameter will be ignored, and only resources without tags will be returned.
+
+* `tags` - (Optional, List) Specifies the list of tags to filter resources.
+
+  The [tags](#tags_struct) structure is documented below.
+
+* `matches` - (Optional, List) Specifies the search criteria to filter resources.
+
+  The [matches](#matches_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - (Required, String) Specifies the tag key.
+
+* `values` - (Required, List) Specifies the list of tag values.
+
+<a name="matches_struct"></a>
+The `matches` block supports:
+
+* `key` - (Required, String) Specifies the field to match.
+
+* `value` - (Required, String) Specifies the value to match.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resources` - The list of DRS resource instances.
+  The [resources](#resources_struct) structure is documented below.
+
+<a name="resources_struct"></a>
+The `resources` block supports:
+
+* `resource_id` - The resource ID.
+
+* `resource_name` - The resource name.
+
+* `resource_detail` - The resource details.
+
+* `tags` - The list of tags associated with the resource.
+  The [tags](#tags_response_struct) structure is documented below.
+
+<a name="tags_response_struct"></a>  
+The `tags` block supports:
+
+* `key` - The tag key.
+
+* `value` - The tag value.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1352,6 +1352,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_dirty_data":               drs.DataSourceDrsDirtyData(),
 			"huaweicloud_drs_disaster_monitoring_data": drs.DataSourceDrsDisasterMonitoringData(),
 			"huaweicloud_drs_health_compare_overview":  drs.DataSourceDrsHealthCompareOverview(),
+			"huaweicloud_drs_instances_by_tags":        drs.DataSourceDrsInstancesByTags(),
 			"huaweicloud_drs_job_configurations":       drs.DataSourceDrsJobConfigurations(),
 			"huaweicloud_drs_job_links":                drs.DataSourceJobLinks(),
 			"huaweicloud_drs_job_metering":             drs.DataSourceDrsJobMetering(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -488,6 +488,7 @@ var (
 
 	HW_DRS_COMPARE_JOB_ID = os.Getenv("HW_DRS_COMPARE_JOB_ID")
 	HW_DRS_DB_PASSWORD    = os.Getenv("HW_DRS_DB_PASSWORD")
+	HW_DRS_ENABLE_FLAG    = os.Getenv("HW_DRS_ENABLE_FLAG")
 	HW_DRS_JOB_ID         = os.Getenv("HW_DRS_JOB_ID")
 	HW_DRS_JOB_IDS        = os.Getenv("HW_DRS_JOB_IDS")
 
@@ -2977,6 +2978,13 @@ func TestAccPreCheckDrsCompareJobId(t *testing.T) {
 func TestAccPreCheckDrsDbPassword(t *testing.T) {
 	if HW_DRS_DB_PASSWORD == "" {
 		t.Skip("HW_DRS_DB_PASSWORD must be set for DRS acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDRSEnableFlag(t *testing.T) {
+	if HW_DRS_ENABLE_FLAG == "" {
+		t.Skip("Skip the DRS acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_instances_by_tags_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_instances_by_tags_test.go
@@ -1,0 +1,76 @@
+package drs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceInstancesByTags_basic(t *testing.T) {
+	var (
+		datasource         = "data.huaweicloud_drs_instances_by_tags.test"
+		filterDatasource   = "data.huaweicloud_drs_instances_by_tags.filter_by_name"
+		nonExistDatasource = "data.huaweicloud_drs_instances_by_tags.non_exist"
+		dc                 = acceptance.InitDataSourceCheck(datasource)
+		dcFilter           = acceptance.InitDataSourceCheck(filterDatasource)
+		dcNonExist         = acceptance.InitDataSourceCheck(nonExistDatasource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Note: Please ensure that test data (DRS instances) is prepared in the test environment.
+			acceptance.TestAccPreCheckDRSEnableFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceInstancesByTags_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					dcFilter.CheckResourceExists(),
+					dcNonExist.CheckResourceExists(),
+					resource.TestCheckOutput("filter_result_matches", "true"),
+					resource.TestCheckOutput("non_exist_result_is_empty", "true"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.#"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_id"),
+					resource.TestCheckResourceAttrSet(datasource, "resources.0.resource_name"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDatasourceInstancesByTags_basic = `
+data "huaweicloud_drs_instances_by_tags" "test" {
+  resource_type = "sync"
+}
+
+data "huaweicloud_drs_instances_by_tags" "filter_by_name" {
+  resource_type = "sync"
+  
+  matches {
+    key   = "resource_name"
+    value = data.huaweicloud_drs_instances_by_tags.test.resources[0].resource_name
+  }
+}
+
+data "huaweicloud_drs_instances_by_tags" "non_exist" {
+  resource_type = "sync"
+  
+  tags {
+    key    = "non-exist-tag-key"
+    values = ["non-exist-tag-value"]
+  }
+}
+
+output "filter_result_matches" {
+  value = length(data.huaweicloud_drs_instances_by_tags.filter_by_name.resources) >= 1
+}
+
+output "non_exist_result_is_empty" {
+  value = length(data.huaweicloud_drs_instances_by_tags.non_exist.resources) == 0
+}
+`

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_instances_by_tags.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_instances_by_tags.go
@@ -1,0 +1,267 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS POST /v5/{project_id}/{resource_type}/resource-instances/filter
+func DataSourceDrsInstancesByTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DataSourceDrsInstancesByTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"resource_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"without_any_tag": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     instancesByTagsTagsSchema(),
+			},
+			"matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     instancesByTagsMatchesSchema(),
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     instancesByTagsResourcesSchema(),
+			},
+		},
+	}
+}
+
+func instancesByTagsMatchesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func instancesByTagsTagsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"values": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func instancesByTagsResourcesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_detail": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     instancesByTagsResourcesTagsSchema(),
+			},
+		},
+	}
+}
+
+func instancesByTagsResourcesTagsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildInstancesByTagsTagsBodyParams(rawArray []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, raw := range rawArray {
+		rawMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"key":    rawMap["key"],
+			"values": rawMap["values"],
+		})
+	}
+
+	return rst
+}
+
+func buildInstancesByTagsMatchesBodyParams(rawArray []interface{}) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, raw := range rawArray {
+		rawMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"key":   rawMap["key"],
+			"value": rawMap["value"],
+		})
+	}
+
+	return rst
+}
+
+func buildListResourceInstancesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"without_any_tag": d.Get("without_any_tag"),
+		"tags":            buildInstancesByTagsTagsBodyParams(d.Get("tags").([]interface{})),
+		"matches":         buildInstancesByTagsMatchesBodyParams(d.Get("matches").([]interface{})),
+	}
+}
+
+func DataSourceDrsInstancesByTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v5/{project_id}/{resource_type}/resource-instances/filter"
+		result  = make([]interface{}, 0)
+		limit   = 1000
+		offset  = 0
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{resource_type}", d.Get("resource_type").(string))
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildListResourceInstancesBodyParams(d)),
+	}
+
+	for {
+		queryParams := fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
+		currentListPath := listPath + queryParams
+
+		listResp, err := client.Request("POST", currentListPath, &reqOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DRS resource instances: %s", err)
+		}
+
+		listRespBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		resources := utils.PathSearch("resources", listRespBody, make([]interface{}, 0)).([]interface{})
+		if len(resources) == 0 {
+			break
+		}
+
+		result = append(result, resources...)
+
+		offset += len(resources)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("resources", flattenResources(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenResources(resourcesResp []interface{}) []interface{} {
+	if len(resourcesResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resourcesResp))
+	for _, v := range resourcesResp {
+		rst = append(rst, map[string]interface{}{
+			"resource_id":     utils.PathSearch("resource_id", v, nil),
+			"resource_name":   utils.PathSearch("resource_name", v, nil),
+			"resource_detail": utils.PathSearch("resource_detail", v, nil),
+			"tags":            flattenResourceTags(utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return rst
+}
+
+func flattenResourceTags(tagsResp []interface{}) []interface{} {
+	if len(tagsResp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(tagsResp))
+	for _, v := range tagsResp {
+		rst = append(rst, map[string]interface{}{
+			"key":   utils.PathSearch("key", v, nil),
+			"value": utils.PathSearch("value", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a new data source `huaweicloud_drs_instances_by_tags` for HuaweiCloud Data Replication Service (DRS). This data source supports querying DRS resource instances by resource type, tags and resource name, and can automatically paginate to obtain all data. It helps users quickly filter and query DRS job resources through Terraform.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add data source huaweicloud_drs_instances_by_tags for querying DRS resource instances by tags
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/drs' TESTARGS='-run=TestAccDatasourceInstancesByTags_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run=TestAccDatasourceInstancesByTags_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceInstancesByTags_basic
=== PAUSE TestAccDatasourceInstancesByTags_basic
=== CONT  TestAccDatasourceInstancesByTags_basic
--- PASS: TestAccDatasourceInstancesByTags_basic (52.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       52.396s
```
<img width="469" height="20" alt="Snipaste_2026-05-28_10-24-13" src="https://github.com/user-attachments/assets/7f871d24-9875-4cd4-8a55-805a538f707a" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
