### PR TITLE
feat(hss): support `hss_security_reports` data source

### DIFF
--- a/docs/data-sources/hss_security_reports.md
+++ b/docs/data-sources/hss_security_reports.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_security_reports"
+description: |-
+  Use this data source to get the security report list of HSS within HuaweiCloud.
+---
+
+# huaweicloud_hss_security_reports
+
+Use this data source to get the security report list of HSS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_security_reports" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `report_category` - (Optional, String) Specifies the report category.  
+  The valid values are as follows:
+  + **daily_report**: Daily security report.
+  + **weekly_report**: Weekly security report.
+  + **monthly_report**: Monthly security report.
+  + **custom_report**: Custom report.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data_list` - The security report list.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `report_id` - The report ID.
+
+* `report_sub_id` - The report sub ID.
+
+* `default_report` - Whether it is the default report. Default reports cannot be deleted.
+
+* `latest_create_time` - The latest creation time in milliseconds. A null value indicates that the report has not been
+  generated yet.
+
+* `report_name` - The report name.
+
+* `report_category` - The report category.  
+  The valid values are as follows:
+  + **daily_report**: Daily security report.
+  + **weekly_report**: Weekly security report.
+  + **monthly_report**: Monthly security report.
+  + **custom_report**: Custom report.
+
+* `report_status` - The report status.  
+  The valid values are as follows:
+  + **opened**: Opened.
+  + **closed**: Closed.
+
+* `report_create_time` - The report creation time in milliseconds.
+
+* `sending_period` - The report sending period.  
+  The valid values are as follows:
+  + **morning**: From `0:00` to `6:00`.
+  + **noon**: From `6:00` to `12:00`.
+  + **afternoon**: From `12:00` to `18:00`.
+  + **evening**: From `18:00` to `24:00`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1759,6 +1759,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_agent_auto_upgrade_config":                  hss.DataSourceAgentAutoUpgradeConfig(),
 			"huaweicloud_hss_billing_version":                            hss.DataSourceBillingVersion(),
 			"huaweicloud_hss_security_check_config":                      hss.DataSourceSecurityCheckConfig(),
+			"huaweicloud_hss_security_reports":                           hss.DataSourceSecurityReports(),
 			"huaweicloud_hss_baseline_security_checks_directories":       hss.DataSourceBaselineSecurityChecksDirectories(),
 			"huaweicloud_hss_baseline_security_checks_default_policy":    hss.DataSourceBaselineSecurityChecksDefaultPolicy(),
 			"huaweicloud_hss_baseline_security_checks_details":           hss.DataSourceBaselineSecurityChecksDetails(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_security_reports_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_security_reports_test.go
@@ -1,0 +1,67 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSecurityReports_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_security_reports.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSecurityReports_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.report_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.report_sub_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.default_report"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.latest_create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.report_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.report_category"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.report_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.report_create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.sending_period"),
+
+					resource.TestCheckOutput("is_report_category_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSecurityReports_basic() string {
+	return `
+data "huaweicloud_hss_security_reports" "test" {
+  enterprise_project_id = "all_granted_eps"
+}
+
+# Filter by report_category
+locals {
+  report_category = data.huaweicloud_hss_security_reports.test.data_list[0].report_category
+}
+
+data "huaweicloud_hss_security_reports" "report_category_filter" {
+  enterprise_project_id = "all_granted_eps"
+  report_category       = local.report_category
+}
+
+output "is_report_category_filter_useful" {
+  value = length(data.huaweicloud_hss_security_reports.report_category_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_security_reports.report_category_filter.data_list[*].report_category : v == local.report_category]
+  )
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_security_reports.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_security_reports.go
@@ -1,0 +1,180 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/report/report-list
+func DataSourceSecurityReports() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityReportsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"report_category": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"report_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"report_sub_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"default_report": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"latest_create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"report_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"report_category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"report_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"report_create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"sending_period": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildSecurityReportsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := "?limit=200"
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("report_category"); ok {
+		queryParams = fmt.Sprintf("%s&report_category=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceSecurityReportsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		result  = make([]interface{}, 0)
+		offset  = 0
+		httpUrl = "v5/{project_id}/report/report-list"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildSecurityReportsQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"region": region},
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS security reports: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenSecurityReportsDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSecurityReportsDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"report_id":          utils.PathSearch("report_id", v, nil),
+			"report_sub_id":      utils.PathSearch("report_sub_id", v, nil),
+			"default_report":     utils.PathSearch("default_report", v, nil),
+			"latest_create_time": utils.PathSearch("latest_create_time", v, nil),
+			"report_name":        utils.PathSearch("report_name", v, nil),
+			"report_category":    utils.PathSearch("report_category", v, nil),
+			"report_status":      utils.PathSearch("report_status", v, nil),
+			"report_create_time": utils.PathSearch("report_create_time", v, nil),
+			"sending_period":     utils.PathSearch("sending_period", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_security_reports` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_security_reports` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o hss -f TestAccDataSourceSecurityReports_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceSecurityReports_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSecurityReports_basic
=== PAUSE TestAccDataSourceSecurityReports_basic
=== CONT  TestAccDataSourceSecurityReports_basic
--- PASS: TestAccDataSourceSecurityReports_basic (13.90s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/hss  coverage: 2.9% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       14.053s coverage: 2.9% of statements in ./huaweicloud/services/hss
```
<img width="874" height="39" alt="image" src="https://github.com/user-attachments/assets/2a8c5a47-886a-43d3-9630-34d8069f6906" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
