### PR TITLE
feat(eg): supports new data source to query eventrouter clusters

### DIFF
--- a/docs/data-sources/eg_eventrouter_clusters.md
+++ b/docs/data-sources/eg_eventrouter_clusters.md
@@ -1,0 +1,80 @@
+---
+subcategory: "EventGrid (EG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eg_eventrouter_clusters"
+description: |-
+  Use this data source to query EG event router clusters within HuaweiCloud.
+---
+
+# huaweicloud_eg_eventrouter_clusters
+
+Use this data source to query EG event router clusters within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "fuzzy_match_keywrod" {}
+
+data "huaweicloud_eg_eventrouter_clusters" "test" {
+  name = var.fuzzy_match_keywrod
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the event router clusters are located.  
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the event router cluster to be queried for fuzzy matching.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `clusters` - The list of the event router clusters that matched filter parameters.  
+  The [clusters](#eg_eventrouter_clusters_attr) structure is documented below.
+
+<a name="eg_eventrouter_clusters_attr"></a>
+The `clusters` block supports:
+
+* `id` - The ID of the event router cluster.
+
+* `name` - The name of the event router cluster.
+
+* `description` - The description of the event router cluster.
+
+* `source_type` - The source type of the event router cluster.
+
+* `sink_type` - The sink type of the event router cluster.
+
+* `vpc_id` - The VPC ID to which the event router cluster belongs.
+
+* `subnet_id` - The subnet ID to which the event router cluster belongs.
+
+* `availability_zones` - The availability zone names of the event router cluster.
+
+* `flavor` - The flavor of the event router cluster.
+
+* `charging_mode` - The charging mode of the event router cluster.
+
+* `status` - The status of the event router cluster.
+
+* `job_count` - The number of jobs running in the event router cluster.
+
+* `err_code` - The error code of the event router cluster.
+
+* `err_message` - The error message of the event router cluster.
+
+* `public_access_enabled` - Whether public access is enabled for the event router cluster.
+
+* `nat_id` - The NAT gateway ID of the event router cluster.
+
+* `eip_id` - The EIP ID of the event router cluster.
+
+* `created_at` - The creation time of the event router cluster, in RFC3339 format.
+
+* `updated_at` - The latest update time of the event router cluster, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1399,6 +1399,7 @@ func Provider() *schema.Provider {
 
 			// Professional EventRouter
 			"huaweicloud_eg_eventrouter_availability_zones": eg.DataSourceEventRouterAvailabilityZones(),
+			"huaweicloud_eg_eventrouter_clusters":           eg.DataSourceEventRouterClusters(),
 
 			"huaweicloud_enterprise_project":                      eps.DataSourceEnterpriseProject(),
 			"huaweicloud_enterprise_projects":                     eps.DataSourceEnterpriseProjects(),

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_eventrouter_clusters_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_eventrouter_clusters_test.go
@@ -1,0 +1,97 @@
+package eg
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataEventRouterClusters_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_eg_eventrouter_clusters.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_eg_eventrouter_clusters.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataEventRouterClusters_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "clusters.#", regexp.MustCompile(`^[0-9]+$`)),
+
+					// Filter by 'name' parameter.
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataEventRouterClusters_basic_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+%[1]s
+
+resource "huaweicloud_eg_eventrouter_cluster" "test" {
+  count = 2
+
+  name               = format("%[2]s-%%d", count.index)
+  source_type        = "KAFKA"
+  sink_type          = "KAFKA"
+  vpc_id             = huaweicloud_vpc.test.id
+  subnet_id          = huaweicloud_vpc_subnet.test.id
+  description        = "Created by terraform script"
+  availability_zones = join(",", slice(data.huaweicloud_availability_zones.test.names, 0, 2))
+  flavor             = "small"
+}
+`, common.TestVpc(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), name)
+}
+
+func testAccDataEventRouterClusters_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_eg_eventrouter_clusters" "all" {
+  depends_on = [huaweicloud_eg_eventrouter_cluster.test]
+}
+
+# Filter by 'name' parameter.
+locals {
+  cluster_name_keyword = "%[2]s"
+}
+
+data "huaweicloud_eg_eventrouter_clusters" "filter_by_name" {
+  depends_on = [huaweicloud_eg_eventrouter_cluster.test]
+
+  name = local.cluster_name_keyword
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_eg_eventrouter_clusters.filter_by_name.clusters[*].name :
+      strcontains(v, local.cluster_name_keyword)
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+`, testAccDataEventRouterClusters_basic_base(name), name)
+}

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_eventrouter_clusters.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_eventrouter_clusters.go
@@ -1,0 +1,257 @@
+package eg
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EG GET /v1/{project_id}/eventrouter/clusters
+func DataSourceEventRouterClusters() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEventRouterClustersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the event router clusters are located.",
+			},
+
+			// Optional parameters.
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the event router cluster to be queried for fuzzy matching.",
+			},
+
+			// Attributes.
+			"clusters": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The list of the event router clusters that matched filter parameters.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the event router cluster.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the event router cluster.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The description of the event router cluster.",
+						},
+						"source_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The source type of the event router cluster.",
+						},
+						"sink_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The sink type of the event router cluster.",
+						},
+						"vpc_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The VPC ID to which the event router cluster belongs.",
+						},
+						"subnet_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The subnet ID to which the event router cluster belongs.",
+						},
+						"availability_zones": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The availability zone names of the event router cluster.",
+						},
+						"flavor": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The flavor of the event router cluster.",
+						},
+						"charging_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The charging mode of the event router cluster.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The status of the event router cluster.",
+						},
+						"job_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of jobs running in the event router cluster.",
+						},
+						"err_code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The error code of the event router cluster.",
+						},
+						"err_message": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The error message of the event router cluster.",
+						},
+						"public_access_enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether public access is enabled for the event router cluster.",
+						},
+						"nat_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The NAT gateway ID of the event router cluster.",
+						},
+						"eip_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The EIP ID of the event router cluster.",
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The creation time of the event router cluster, in RFC3339 format.",
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The latest update time of the event router cluster, in RFC3339 format.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildEventRouterClustersQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&fuzzy_name=%v", res, v)
+	}
+	return res
+}
+
+func listEventRouterClusters(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/eventrouter/clusters?limit={limit}"
+		offset  = 0
+		limit   = 100
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildEventRouterClustersQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		clusters := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, clusters...)
+		if len(clusters) < limit {
+			break
+		}
+		offset += len(clusters)
+	}
+
+	return result, nil
+}
+
+func flattenEventRouterClusters(clusters []interface{}) []map[string]interface{} {
+	if len(clusters) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(clusters))
+	for _, cluster := range clusters {
+		result = append(result, map[string]interface{}{
+			"id":                    utils.PathSearch("cluster_id", cluster, nil),
+			"name":                  utils.PathSearch("name", cluster, nil),
+			"description":           utils.PathSearch("description", cluster, nil),
+			"source_type":           utils.PathSearch("source_type", cluster, nil),
+			"sink_type":             utils.PathSearch("sink_type", cluster, nil),
+			"vpc_id":                utils.PathSearch("vpc_id", cluster, nil),
+			"subnet_id":             utils.PathSearch("subnet_id", cluster, nil),
+			"availability_zones":    utils.PathSearch("zone_names", cluster, nil),
+			"flavor":                utils.PathSearch("flavor", cluster, nil),
+			"charging_mode":         utils.PathSearch("charging_mode", cluster, nil),
+			"status":                utils.PathSearch("status", cluster, nil),
+			"job_count":             utils.PathSearch("job_count", cluster, nil),
+			"err_code":              utils.PathSearch("err_code", cluster, nil),
+			"err_message":           utils.PathSearch("err_message", cluster, nil),
+			"public_access_enabled": utils.PathSearch("public_access_enabled", cluster, nil),
+			"nat_id":                utils.PathSearch("nat_id", cluster, nil),
+			"eip_id":                utils.PathSearch("eip_id", cluster, nil),
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("created_time",
+				cluster, "").(string))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("updated_time",
+				cluster, "").(string))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceEventRouterClustersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("eg", region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	clusters, err := listEventRouterClusters(client, d)
+	if err != nil {
+		return diag.Errorf("error querying event router clusters: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("clusters", flattenEventRouterClusters(clusters)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source `huaweicloud_eg_eventrouter_clusters` that used to query eventrouter clusters.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="939" height="65" alt="image" src="https://github.com/user-attachments/assets/48e36c1b-c292-4a61-8815-02e78033a227" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new data source to query eventrouter clusters.
2. support corresponding document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o eg -f TestAccDataEventRouterClusters_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eg" -v -coverprofile="./huaweicloud/services/acceptance/eg/eg_coverage.cov" -coverpkg="./huaweicloud/services/eg" -run TestAccDataEventRouterClusters_basic -timeout 360m -parallel 10
=== RUN   TestAccDataEventRouterClusters_basic
=== PAUSE TestAccDataEventRouterClusters_basic
=== CONT  TestAccDataEventRouterClusters_basic
--- PASS: TestAccDataEventRouterClusters_basic (232.67s)
PASS
coverage: 10.0% of statements in ./huaweicloud/services/eg
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        232.753s        coverage: 10.0% of statements in ./huaweicloud/services/eg
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
