### PR TITLE
feat(geminidb): add new data source to query geminidb parameter template application records

### DIFF
--- a/docs/data-sources/geminidb_pt_application_records.md
+++ b/docs/data-sources/geminidb_pt_application_records.md
@@ -1,0 +1,55 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_pt_appliction_records"
+description: |-
+  Use this data source to get the application records of a GeminiDB parameter template.
+---
+
+# huaweicloud_geminidb_pt_appliction_records
+
+Use this data source to get the application records of a GeminiDB parameter template.
+
+## Example Usage
+
+```hcl
+variable "config_id" {}
+
+data "huaweicloud_geminidb_pt_appliction_records" "test" {
+  config_id = var.config_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the applied histories.
+  If omitted, the provider-level region will be used.
+
+* `config_id` - (Required, String) Specifies the ID of the parameter template.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `histories` - The list of parameter template application histories.
+  The [histories](#geminidb_applied_histories) structure is documented below.
+
+<a name="geminidb_applied_histories"></a>
+The `histories` block supports:
+
+* `instance_id` - The instance ID.
+
+* `instance_name` - The instance name.
+
+* `applied_at` - The applied time in the format **yyyy-MM-ddTHH:mm:ssZ**.
+
+* `apply_result` - The application result. Valid values are:
+  + **SUCCESS**: Application successful.
+  + **APPLYING**: Application in progress.
+  + **FAILED**: Application failed.
+
+* `failure_reason` - The failure reason (if the application failed).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1495,6 +1495,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_node_sessions":                 geminidb.DataSourceNodeSessions(),
 			"huaweicloud_geminidb_node_session_statistics":       geminidb.DataSourceNodeSessionStatistics(),
 			"huaweicloud_geminidb_pt_applicable_instances":       geminidb.DataSourceGeminiDBPtApplicableInstances(),
+			"huaweicloud_geminidb_pt_appliction_records":         geminidb.DataSourceGeminiDBPtApplicationRecords(),
 			"huaweicloud_geminidb_quotas":                        geminidb.DataSourceQuotas(),
 			"huaweicloud_geminidb_recycling_instances":           geminidb.DataSourceGeminiDBRecyclingInstances(),
 			"huaweicloud_geminidb_restorable_time_window":        geminidb.DataSourceGeminiDBRestorableTimeWindow(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -923,6 +923,7 @@ var (
 
 	HW_GEMINIDB_INSATNCE_ID = os.Getenv("HW_GEMINIDB_INSATNCE_ID")
 	HW_GEMINIDB_BACKUP_ID   = os.Getenv("HW_GEMINIDB_BACKUP_ID")
+	HW_GEMINIDB_CONFIG_ID   = os.Getenv("HW_GEMINIDB_CONFIG_ID")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -5435,5 +5436,12 @@ func TestAccCheckGeminidbInstanceID(t *testing.T) {
 func TestAccCheckGeminidbBackupID(t *testing.T) {
 	if HW_GEMINIDB_BACKUP_ID == "" {
 		t.Skip("HW_GEMINIDB_BACKUP_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccCheckGeminidbConfigID(t *testing.T) {
+	if HW_GEMINIDB_CONFIG_ID == "" {
+		t.Skip("HW_GEMINIDB_CONFIG_ID must be set for this acceptance test")
 	}
 }

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_pt_application_records_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_pt_application_records_test.go
@@ -1,0 +1,43 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGeminiDBPtApplicationRecords_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_geminidb_pt_appliction_records.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGeminiDBPtApplicationRecords_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "histories.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "histories.0.instance_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "histories.0.instance_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "histories.0.applied_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "histories.0.apply_result"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGeminiDBPtApplicationRecords_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_geminidb_pt_appliction_records" "test" {
+  config_id = "%[1]s"
+}
+`, acceptance.HW_GEMINIDB_CONFIG_ID)
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_pt_application_records.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_pt_application_records.go
@@ -1,0 +1,146 @@
+package geminidb
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GeminiDB GET /v3/{project_id}/configurations/{config_id}/applied-histories
+func DataSourceGeminiDBPtApplicationRecords() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGeminiDBPtApplicationRecordsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"config_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"histories": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     geminiDBPtApplicationRecordsSchema(),
+			},
+		},
+	}
+}
+
+func geminiDBPtApplicationRecordsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"applied_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"apply_result": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"failure_reason": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGeminiDBPtApplicationRecordsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	httpUrl := "v3/{project_id}/configurations/{config_id}/applied-histories"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{config_id}", d.Get("config_id").(string))
+
+	getResp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		getPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return diag.Errorf("error retrieving GeminiDB applied histories: %s", err)
+	}
+
+	getRespJson, err := json.Marshal(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var getRespBody interface{}
+	err = json.Unmarshal(getRespJson, &getRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("histories", flattenListGeminiDBPtApplicationRecords(getRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListGeminiDBPtApplicationRecords(resp interface{}) []map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	historiesRaw := utils.PathSearch("histories", resp, nil)
+	if historiesRaw == nil {
+		return nil
+	}
+
+	historiesSlice, ok := historiesRaw.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	histories := make([]map[string]interface{}, 0, len(historiesSlice))
+	for _, historyRaw := range historiesSlice {
+		historyMap := map[string]interface{}{
+			"instance_id":    utils.PathSearch("instance_id", historyRaw, nil),
+			"instance_name":  utils.PathSearch("instance_name", historyRaw, nil),
+			"applied_at":     utils.PathSearch("applied_at", historyRaw, nil),
+			"apply_result":   utils.PathSearch("apply_result", historyRaw, nil),
+			"failure_reason": utils.PathSearch("failure_reason", historyRaw, nil),
+		}
+		histories = append(histories, historyMap)
+	}
+	return histories
+}


### PR DESCRIPTION
…ate application records

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new data source to query geminidb parameter template application records
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new data source to query geminidb parameter template application records
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccDataSourceGeminiDBPtApplicationRecords_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccDataSourceGeminiDBPtApplicationRecords_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceGeminiDBPtApplicationRecords_basic
=== PAUSE TestAccDataSourceGeminiDBPtApplicationRecords_basic
=== CONT  TestAccDataSourceGeminiDBPtApplicationRecords_basic
--- PASS: TestAccDataSourceGeminiDBPtApplicationRecords_basic (13.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  13.724s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
