### PR TITLE
feat(drs): support `hss_ai_component_statistics` data source

### DIFF
--- a/docs/data-sources/hss_ai_component_statistics.md
+++ b/docs/data-sources/hss_ai_component_statistics.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_ai_component_statistics"
+description: |-
+  Use this data source to get the AI component statistics of HSS within HuaweiCloud.
+---
+
+# huaweicloud_hss_ai_component_statistics
+
+Use this data source to get the AI component statistics of HSS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "category" {}
+variable "catalogue" {}
+
+data "huaweicloud_hss_ai_component_statistics" "test" {
+  category  = var.category
+  catalogue = var.catalogue
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `category` - (Required, String) Specifies the asset category.  
+  The valid values are as follows:
+  + **host**: Host asset.
+  + **container**: Container asset.
+
+* `catalogue` - (Required, String) Specifies the AI component category.  
+  The valid values are as follows:
+  + **app**: Application.
+  + **tool**: Tool.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.  
+  The default value is **0**, indicating the default enterprise project.
+  If you need to query data for all enterprise projects, the value is **all_granted_eps**.
+  If you only have permissions for a specific enterprise project, you need set the enterprise project ID. Otherwise,
+  the operation may fail due to insufficient permissions.
+
+* `ai_component_name` - (Optional, String) Specifies the AI component name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data_list` - The AI component statistics list.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `ai_component_name` - The AI component name.
+
+* `num` - The number of servers where the AI component is located.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1545,6 +1545,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_hss_agent_install_script":                       hss.DataSourceAgentInstallScript(),
 			"huaweicloud_hss_agent_versions":                             hss.DataSourceAgentVersions(),
+			"huaweicloud_hss_ai_component_statistics":                    hss.DataSourceAiComponentStatistics(),
 			"huaweicloud_hss_antivirus_handle_history":                   hss.DataSourceAntivirusHandleHistory(),
 			"huaweicloud_hss_app_agent_statistics":                       hss.DataSourceAppAgentStatistics(),
 			"huaweicloud_hss_app_events":                                 hss.DataSourceHssAppEvents(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_ai_component_statistics_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_ai_component_statistics_test.go
@@ -1,0 +1,42 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAiComponentStatistics_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_ai_component_statistics.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAiComponentStatistics_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAiComponentStatistics_basic() string {
+	return `
+data "huaweicloud_hss_ai_component_statistics" "test" {
+  enterprise_project_id = "all_granted_eps"
+  category              = "host"
+  catalogue             = "app"
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_ai_component_statistics.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_ai_component_statistics.go
@@ -1,0 +1,153 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/asset/ai-component/statistics
+func DataSourceAiComponentStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAiComponentStatisticsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"catalogue": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ai_component_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ai_component_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAiComponentStatisticsQueryParams(d *schema.ResourceData, epsId string) string {
+	queryParams := fmt.Sprintf("?limit=200&category=%v&catalogue=%v", d.Get("category").(string),
+		d.Get("catalogue").(string))
+
+	if epsId != "" {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, epsId)
+	}
+	if v, ok := d.GetOk("ai_component_name"); ok {
+		queryParams = fmt.Sprintf("%s&ai_component_name=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceAiComponentStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		result  = make([]interface{}, 0)
+		offset  = 0
+		httpUrl = "v5/{project_id}/asset/ai-component/statistics"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildAiComponentStatisticsQueryParams(d, epsId)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS AI component statistics: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenAiComponentStatisticsDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAiComponentStatisticsDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"ai_component_name": utils.PathSearch("ai_component_name", v, nil),
+			"num":               utils.PathSearch("num", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `hss_ai_component_statistics` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `hss_ai_component_statistics` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o hss -f TestAccDataSourceAiComponentStatistics_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceAiComponentStatistics_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAiComponentStatistics_basic
=== PAUSE TestAccDataSourceAiComponentStatistics_basic
=== CONT  TestAccDataSourceAiComponentStatistics_basic
--- PASS: TestAccDataSourceAiComponentStatistics_basic (11.09s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/hss  coverage: 2.8% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       11.223s coverage: 2.8% of statements in ./huaweicloud/services/hss
```
<img width="917" height="39" alt="image" src="https://github.com/user-attachments/assets/cf91bb0c-0954-4420-a22a-76fd4e66b425" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
