### PR TITLE
feat(GeminiDB): the instance supports modify loadbalancer IP address

### DIFF
--- a/docs/resources/geminidb_instance.md
+++ b/docs/resources/geminidb_instance.md
@@ -152,6 +152,11 @@ The following arguments are supported:
 
   -> This parameter is valid and available for **GeminiDB Redis** instance.
 
+* `lb_ip_address` - (Optional, String) Specifies the load balancer IP address.
+
+  -> This parameter is valid and available for **GeminiDB Influx** and **GeminiDB Redis** instances.
+    The instances across subnets are not supported.
+
 * `delete_node_list` - (Optional, List) Specifies the ID of the nodes to be deleted. Make sure that the node
   can be deleted. This parameter can not be specified when add nodes. When delete nodes, if this parameter is specified,
   then the nodes specified by this parameter will be deleted, and id this parameter is not transferred, the nodes will be
@@ -298,9 +303,6 @@ In addition to all arguments above, the following attributes are exported:
 * `time_zone` - Indicates the time zone.
 
 * `actions` - Indicates the operation that is executed on the instance.
-
-* `lb_ip_address` - Indicates the load balancer IP address. This parameter is returned only when a load balancer IP
-  address is assigned.
 
 * `lb_port` - Indicates the load balancer port. This parameter is returned only when a load balancer IP address is assigned.
 

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
@@ -394,6 +394,7 @@ func TestAccGeminiDbInstance_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "switch_option", "on"),
 					resource.TestCheckResourceAttr(resourceName, "second_level_monitoring_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "config_ips.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "lb_ip_address", "192.168.0.153"),
 
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
 					resource.TestCheckResourceAttrSet(resourceName, "policy.#"),
@@ -412,6 +413,7 @@ func TestAccGeminiDbInstance_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy.0.size", "20"),
 					resource.TestCheckResourceAttr(resourceName, "second_level_monitoring_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "config_ips.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "lb_ip_address", "192.168.0.118"),
 				),
 			},
 			{
@@ -842,6 +844,9 @@ resource "huaweicloud_geminidb_instance" "test" {
 
   # enable password-free configuration
   config_ips = ["192.168.1.15","192.168.1.23/24"]
+
+  # update loadbalancer IP address
+  lb_ip_address = "192.168.0.153"
 }
 `, common.TestBaseNetwork(name), name)
 }
@@ -890,6 +895,7 @@ resource "huaweicloud_geminidb_instance" "test" {
 
   second_level_monitoring_enabled = "false"
   config_ips                      = ["192.168.1.15","192.168.1.23/24","192.168.1.38"]
+  lb_ip_address                   = "192.168.0.118"
 }
 `, common.TestBaseNetwork(name), name)
 }
@@ -931,6 +937,7 @@ resource "huaweicloud_geminidb_instance" "test" {
   switch_option                   = "off"
   second_level_monitoring_enabled = false
   config_ips                      = []
+  lb_ip_address                   = "192.168.0.118"
 }
 `, common.TestBaseNetwork(name), name)
 }

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
@@ -53,6 +53,7 @@ var geminiDbInstanceNonUpdatableParams = []string{"datastore", "datastore.*.type
 // @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/monitoring-by-seconds/switch
 // @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/passwordless-config
 // @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/passwordless-config
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/lb
 // @API BSS GET /v2/orders/customer-orders/details/{order_id}
 // @API BSS POST /v2/orders/subscriptions/resources/autorenew/{instance_id}
 // @API BSS DELETE /v2/orders/subscriptions/resources/autorenew/{instance_id}
@@ -196,6 +197,11 @@ func ResourceGeminiDbInstance() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"lb_ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"delete_node_list": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -252,10 +258,6 @@ func ResourceGeminiDbInstance() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"lb_ip_address": {
-				Type:     schema.TypeString,
-				Computed: true,
 			},
 			"lb_port": {
 				Type:     schema.TypeString,
@@ -594,7 +596,32 @@ func resourceGeminiDbInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
+	// Update loadbalancer IP address
+	if err = modifyLoadbalancerIpAddress(ctx, client, d); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return resourceGeminiDbInstanceRead(ctx, d, meta)
+}
+
+func modifyLoadbalancerIpAddress(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	targetIpAddress, ok := d.GetOk("lb_ip_address")
+	if !ok {
+		return nil
+	}
+
+	instanceInfo, err := getGeminiDbInstance(client, d.Id())
+	if err != nil {
+		return fmt.Errorf("error query the instance information: %s", err)
+	}
+
+	sourceIpAddress := utils.PathSearch("lb_ip_address", instanceInfo, "").(string)
+	if targetIpAddress.(string) == sourceIpAddress {
+		return nil
+	}
+
+	err = updateLoadbalancerIpAddress(ctx, d, client)
+	return err
 }
 
 func updateAutoEnlargePolicy(client *golangsdk.ServiceClient, d *schema.ResourceData, instanceId string) error {
@@ -1210,6 +1237,12 @@ func resourceGeminiDbInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
+	// Update loadbalancer IP address
+	err = updateLoadbalancerIpAddress(ctx, d, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	return resourceGeminiDbInstanceRead(ctx, d, meta)
 }
 
@@ -1579,6 +1612,35 @@ func buildUpdateGeminiDbInstanceBackupStrategyBodyParams(d *schema.ResourceData)
 			"period":     "1,2,3,4,5,6,7",
 		},
 	}
+	return bodyParams
+}
+
+func updateLoadbalancerIpAddress(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	if !d.HasChange("lb_ip_address") {
+		return nil
+	}
+
+	_, err := updateGeminiDbInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:             "v3/{project_id}/instances/{instance_id}/lb",
+		httpMethod:          "PUT",
+		pathParams:          map[string]string{"instance_id": d.Id()},
+		updateBodyParams:    buildUpdateLoadbalancerIpAddressBodyParams(d),
+		isRetry:             true,
+		timeout:             schema.TimeoutUpdate,
+		checkJobExpression:  "job_id",
+		isWaitInstanceReady: true,
+	})
+	if err != nil {
+		return fmt.Errorf("error updating GeminiDB instance loadbalancer IP address: %s", err)
+	}
+	return nil
+}
+
+func buildUpdateLoadbalancerIpAddressBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"ip": d.Get("lb_ip_address"),
+	}
+
 	return bodyParams
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The instance supports modify loadbalancer IP address.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
The instance supports modify loadbalancer IP address.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDbInstance_configuration"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDbInstance_configuration -timeout 360m -parallel 4
=== RUN   TestAccGeminiDbInstance_configuration
=== PAUSE TestAccGeminiDbInstance_configuration
=== CONT  TestAccGeminiDbInstance_configuration
--- PASS: TestAccGeminiDbInstance_configuration (1550.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1550.374s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
