### PR TITLE
feat(drs): support `drs_object_compare` resource

### DIFF
--- a/docs/resources/drs_object_compare.md
+++ b/docs/resources/drs_object_compare.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_object_compare"
+description: |-
+  Manages a resource to start a DRS object compare task within HuaweiCloud.
+---
+
+# huaweicloud_drs_object_compare
+
+Manages a resource to start a DRS object compare task within HuaweiCloud.
+
+-> This resource is a one-time action resource used to start an object compare task. Deleting this resource will not
+  undo the compare operation, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "job_id" {} 
+variable "compare_task_num" {}
+
+resource "huaweicloud_drs_object_compare" "test" { 
+  job_id           = var.job_id 
+  compare_task_num = var.compare_task_num
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `job_id` - (Required, String, NonUpdatable) Specifies the DRS job ID.
+
+* `compare_task_num` - (Required, Int, NonUpdatable) Specifies the number of concurrent compare task threads.
+  This parameter is currently effective only for cloudDataGuard-cassandra and
+  cloudDataGuard-gausscassandra-to-gausscassandra links.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3618,6 +3618,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_jobs_batch_stop":                drs.ResourceJobsBatchStop(),
 			"huaweicloud_drs_lts_config":                     drs.ResourceDrsLtsConfig(),
 			"huaweicloud_drs_name_validation":                drs.ResourceDrsNameValidation(),
+			"huaweicloud_drs_object_compare":                 drs.ResourceObjectCompare(),
 			"huaweicloud_drs_pwd_batch_modify":               drs.ResourcePwdBatchModify(),
 			"huaweicloud_drs_smn_batch_set":                  drs.ResourceDrsSmnBatchSet(),
 			"huaweicloud_drs_stop_job":                       drs.ResourceStopJob(),

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_object_compare_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_object_compare_test.go
@@ -1,0 +1,42 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccObjectCompare_basic(t *testing.T) {
+	resourceName := "huaweicloud_drs_object_compare.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testObjectCompare_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "job_id"),
+					resource.TestCheckResourceAttr(resourceName, "compare_task_num", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testObjectCompare_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_drs_object_compare" "test" {
+  job_id           = "%s"
+  compare_task_num = 2
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_object_compare.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_object_compare.go
@@ -1,0 +1,118 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var objectCompareNonUpdatableParams = []string{
+	"job_id",
+	"compare_task_num",
+}
+
+// @API DRS POST /v3/{project_id}/jobs/{job_id}/object/compare
+func ResourceObjectCompare() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceObjectCompareCreate,
+		ReadContext:   resourceObjectCompareRead,
+		UpdateContext: resourceObjectCompareUpdate,
+		DeleteContext: resourceObjectCompareDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(objectCompareNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"compare_task_num": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildObjectCompareBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"compare_task_num": d.Get("compare_task_num"),
+	}
+}
+
+func resourceObjectCompareCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/jobs/{job_id}/object/compare"
+	)
+
+	client, err := cfg.NewServiceClient("drs", region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", d.Get("job_id").(string))
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildObjectCompareBodyParams(d),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error starting DRS object compare task: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	return nil
+}
+
+func resourceObjectCompareRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceObjectCompareUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceObjectCompareDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to start a DRS object compare task. Deleting this 
+resource will not undo the compare operation, but will only remove the resource information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_object_compare` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `drs_object_compare` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccObjectCompare_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs-v -run TestAccObjectCompare_basic -timeout 360m -parallel 4
=== RUN   TestAccObjectCompare_basic
=== PAUSE TestAccObjectCompare_basic
=== CONT  TestAccObjectCompare_basic
--- PASS: TestAccObjectCompare_basic (13.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       21.311s
```
<img width="639" height="27" alt="image" src="https://github.com/user-attachments/assets/ef6dffcd-127d-47b4-9e96-7a0e55d27c98" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
