### PR TITLE
feat(drs): support `drs_compare_job_cancel` resource

### DIFF
--- a/docs/resources/drs_compare_job_cancel.md
+++ b/docs/resources/drs_compare_job_cancel.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_compare_job_cancel"
+description: |-
+  Manages a resource to cancel a DRS compare job within HuaweiCloud.
+---
+
+# huaweicloud_drs_compare_job_cancel
+
+Manages a resource to cancel a DRS compare job within HuaweiCloud.
+
+-> This resource is a one-time action resource used to cancel a compare job. Deleting this resource will not
+  undo the cancel operation, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "job_id" {} 
+variable "compare_job_id" {}
+
+resource "huaweicloud_drs_compare_job_cancel" "test" {
+  job_id         = var.job_id 
+  compare_job_id = var.compare_job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `job_id` - (Required, String, NonUpdatable) Specifies the DRS job ID.
+
+* `compare_job_id` - (Required, String, NonUpdatable) Specifies the compare job ID to be canceled.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3615,6 +3615,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_batch_pause_task":               drs.ResourceBatchPauseTask(),
 			"huaweicloud_drs_batch_retry_task":               drs.ResourceBatchRetryTask(),
 			"huaweicloud_drs_check_data_filter":              drs.ResourceDrsCheckDataFilter(),
+			"huaweicloud_drs_compare_job_cancel":             drs.ResourceCancelCompareJob(),
 			"huaweicloud_drs_compare_policy":                 drs.ResourceDrsComparePolicy(),
 			"huaweicloud_drs_download_batch_create_template": drs.ResourceDownloadBatchCreateTemplate(),
 			"huaweicloud_drs_driver_delete":                  drs.ResourceDriverDelete(),

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_compare_job_cancel_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_compare_job_cancel_test.go
@@ -1,0 +1,36 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceCancelCompareJob_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+			acceptance.TestAccPreCheckDrsCompareJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceCancelCompareJob_basic(),
+			},
+		},
+	})
+}
+
+func testAccResourceCancelCompareJob_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_drs_compare_job_cancel" "test" {
+  job_id         = "%s"
+  compare_job_id = "%s"
+}
+`, acceptance.HW_DRS_JOB_ID, acceptance.HW_DRS_COMPARE_JOB_ID)
+}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_compare_job_cancel.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_compare_job_cancel.go
@@ -1,0 +1,112 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var cancelCompareJobNonUpdatableParams = []string{
+	"job_id",
+	"compare_job_id",
+}
+
+// @API DRS DELETE /v3/{project_id}/jobs/{job_id}/compare/{compare_job_id}
+func ResourceCancelCompareJob() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCancelCompareJobCreate,
+		ReadContext:   resourceCancelCompareJobRead,
+		UpdateContext: resourceCancelCompareJobUpdate,
+		DeleteContext: resourceCancelCompareJobDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(cancelCompareJobNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"compare_job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceCancelCompareJobCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/jobs/{job_id}/compare/{compare_job_id}"
+	)
+
+	client, err := cfg.NewServiceClient("drs", region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", d.Get("job_id").(string))
+	requestPath = strings.ReplaceAll(requestPath, "{compare_job_id}", d.Get("compare_job_id").(string))
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error canceling DRS compare job: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	return nil
+}
+
+func resourceCancelCompareJobRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCancelCompareJobUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCancelCompareJobDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to cancel a DRS compare job. Deleting this
+resource will not undo the cancel operation, but will only remove the resource information from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_compare_job_cancel` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support `drs_compare_job_cancel` resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccResourceCancelCompareJob_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs-v -run TestAccResourceCancelCompareJob_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceCancelCompareJob_basic
=== PAUSE TestAccResourceCancelCompareJob_basic
=== CONT  TestAccResourceCancelCompareJob_basic
--- PASS: TestAccResourceCancelCompareJob_basic (13.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       21.311s
```
<img width="535" height="32" alt="image" src="https://github.com/user-attachments/assets/ecae988f-c48d-4cea-955a-270a4deab55d" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
