### PR TITLE
feat(drs): add drs health compare jobs datasource

### DIFF
--- a/docs/data-sources/drs_health_compare_jobs.md
+++ b/docs/data-sources/drs_health_compare_jobs.md
@@ -1,0 +1,90 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_health_compare_jobs"
+description: |-
+  Use this data source to get the list of health compare jobs for a specified DRS task within a region.
+---
+
+# huaweicloud_drs_health_compare_jobs
+
+Use this data source to get the list of health compare jobs for a specified DRS task within a region.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+data "huaweicloud_drs_health_compare_jobs" "all_jobs" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `job_id` - (Required, String) Specifies the ID of the DRS task.
+
+* `status` - (Optional, String) Specifies the status of the compare jobs. If omitted, all jobs will be queried.
+  The valid values are as follows:
+  + **WAITING_FOR_RUNNING**: Waiting to start.
+  + **RUNNING**: Running.
+  + **SUCCESSFUL**: Succeeded.
+  + **FAILED**: Failed.
+  + **CANCELLED**: Cancelled.
+  + **TIMEOUT_INTERRUPT**: Timeout interrupted.
+  + **FULL_DOING**: Full comparison in progress.
+  + **INCRE_DOING**: Incremental comparison in progress.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `compare_jobs` - The list of health compare jobs.
+
+  The [compare_jobs](#compare_jobs_struct) structure is documented below.
+
+<a name="compare_jobs_struct"></a>
+The `compare_jobs` block supports:
+
+* `id` - The compare job ID.
+
+* `type` - The comparison type.
+  The valid values are as follows:
+  + **object_comparison**: Object comparison.
+  + **lines**: Row comparison.
+  + **account**: User comparison.
+
+* `start_time` - The start time of the comparison.
+
+* `end_time` - The end time of the comparison.
+
+* `status` - The status of the comparison.
+  The valid values are as follows:
+  + **WAITING_FOR_RUNNING**: Waiting to start.
+  + **RUNNING**: Running.
+  + **SUCCESSFUL**: Succeeded.
+  + **FAILED**: Failed.
+  + **CANCELLED**: Cancelled.
+  + **TIMEOUT_INTERRUPT**: Timeout interrupted.
+  + **FULL_DOING**: Full comparison in progress.
+  + **INCRE_DOING**: Incremental comparison in progress.
+
+* `compute_type` - The compute resource type used for the comparison.
+
+* `database_info` - The database information involved in the comparison.
+
+  The [database_info](#database_info_struct) structure is documented below.
+
+<a name="database_info_struct"></a>
+The `database_info` block supports:
+
+* `service_database` - The service database information.
+
+* `disaster_recovery_database` - The disaster recovery database information.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1353,6 +1353,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_data_processing_rules":    drs.DataSourceDrsDataProcessingRules(),
 			"huaweicloud_drs_dirty_data":               drs.DataSourceDrsDirtyData(),
 			"huaweicloud_drs_disaster_monitoring_data": drs.DataSourceDrsDisasterMonitoringData(),
+			"huaweicloud_drs_health_compare_jobs":      drs.DataSourceDrsHealthCompareJobs(),
 			"huaweicloud_drs_health_compare_overview":  drs.DataSourceDrsHealthCompareOverview(),
 			"huaweicloud_drs_instances_by_tags":        drs.DataSourceDrsInstancesByTags(),
 			"huaweicloud_drs_job_configurations":       drs.DataSourceDrsJobConfigurations(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_health_compare_jobs_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_health_compare_jobs_test.go
@@ -1,0 +1,42 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceDrsHealthCompareJobs_basic(t *testing.T) {
+	var (
+		datasource = "data.huaweicloud_drs_health_compare_jobs.test"
+		dc         = acceptance.InitDataSourceCheck(datasource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDrsHealthCompareJobs_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(datasource, "compare_jobs.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceDrsHealthCompareJobs_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_health_compare_jobs" "test" {
+  job_id = "%s"
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_health_compare_jobs.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_health_compare_jobs.go
@@ -1,0 +1,206 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v5/{project_id}/jobs/{job_id}/health-compare-jobs
+func DataSourceDrsHealthCompareJobs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsHealthCompareJobsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"compare_jobs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     compareJobsSchema(),
+			},
+		},
+	}
+}
+
+func compareJobsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"compute_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"database_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     compareJobsdatabaseInfoSchema(),
+			},
+		},
+	}
+}
+
+func compareJobsdatabaseInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"service_database": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disaster_recovery_database": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildHealthCompareJobsQueryParams(d *schema.ResourceData, limit, offset int) string {
+	queryParams := fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
+
+	if v, ok := d.GetOk("status"); ok {
+		queryParams = fmt.Sprintf("%s&status=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceDrsHealthCompareJobsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v5/{project_id}/jobs/{job_id}/health-compare-jobs"
+		jobId   = d.Get("job_id").(string)
+		limit   = 1000
+		offset  = 0
+		result  = make([]interface{}, 0)
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobId)
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		currentPath := requestPath + buildHealthCompareJobsQueryParams(d, limit, offset)
+
+		resp, err := client.Request("GET", currentPath, &reqOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving DRS health compare jobs: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		jobs := utils.PathSearch("compare_jobs", respBody, make([]interface{}, 0)).([]interface{})
+		if len(jobs) == 0 {
+			break
+		}
+
+		result = append(result, jobs...)
+		offset += len(jobs)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("compare_jobs", flattenHealthCompareJobs(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenHealthCompareJobs(compareJobs []interface{}) []interface{} {
+	if len(compareJobs) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(compareJobs))
+	for _, v := range compareJobs {
+		result = append(result, map[string]interface{}{
+			"id":           utils.PathSearch("id", v, nil),
+			"type":         utils.PathSearch("type", v, nil),
+			"start_time":   utils.PathSearch("start_time", v, nil),
+			"end_time":     utils.PathSearch("end_time", v, nil),
+			"status":       utils.PathSearch("status", v, nil),
+			"compute_type": utils.PathSearch("compute_type", v, nil),
+			"database_info": flattenCompareJobsDatabaseInfo(
+				utils.PathSearch("database_info", v, nil)),
+		})
+	}
+	return result
+}
+
+func flattenCompareJobsDatabaseInfo(databaseInfo interface{}) []interface{} {
+	if databaseInfo == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"service_database":           utils.PathSearch("service_database", databaseInfo, nil),
+			"disaster_recovery_database": utils.PathSearch("disaster_recovery_database", databaseInfo, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add datasource `huaweicloud_drs_health_compare_jobs` for the Data Replication Service (DRS).
This datasource supports querying the list of health compare jobs under a specified DRS task, including job details such as job ID, type, status, start time, end time, compute type and database info.
It meets the user's demand for querying health comparison job information of DRS tasks.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add data source huaweicloud_drs_health_compare_jobs for a specified DRS task within a region.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/drs' TESTARGS='-run=TestAccDatasourceDrsHealthCompareJobs_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run=TestAccDatasourceDrsHealthCompareJobs_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceDrsHealthCompareJobs_basic
=== PAUSE TestAccDatasourceDrsHealthCompareJobs_basic
=== CONT  TestAccDatasourceDrsHealthCompareJobs_basic
--- PASS: TestAccDatasourceDrsHealthCompareJobs_basic (24.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       24.655s
```
<img width="481" height="16" alt="Snipaste_2026-05-29_09-03-38" src="https://github.com/user-attachments/assets/ddb9d2cc-7c8d-419e-a195-9e318a993835" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
