### PR TITLE
fix(iam): csv file using 600 permission not 644

### DIFF
--- a/docs/resources/identity_access_key.md
+++ b/docs/resources/identity_access_key.md
@@ -10,7 +10,8 @@ description: |-
 
 Manages a permanent Access Key resource within HuaweiCloud IAM service.
 
--> **NOTE:** You *must* have admin privileges in your HuaweiCloud cloud to use this resource.
+-> You **must** have IAM admin privileges in your HuaweiCloud cloud to use this resource.<br>
+   The generated CSV file has the permission of `600` (`-rw-------`).
 
 ## Example Usage
 

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_access_key_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_access_key_test.go
@@ -2,7 +2,10 @@ package iam
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -100,6 +103,27 @@ resource "huaweicloud_identity_access_key" "test" {
   user_id     = huaweicloud_identity_user.test.id
   description = "Created by terraform script"
   secret_file = abspath("./credentials.csv")
+
+  # Check the mode of the credential file (created by huaweicloud_identity_access_key resource and with a default name)
+  # after the resource is created, want 600 access mode.
+  provisioner "local-exec" {
+    when    = create
+    command = <<-EOT
+      f="${abspath("./credentials.csv")}"
+      perms=$(stat -c '%%a' "$f")
+      if [ "$perms" != "600" ]; then
+        echo "ERROR: $f has mode $perms, expected 600" >&2
+        exit 1
+      fi
+    EOT
+  }
+
+  # Clean up the credential file (created by huaweicloud_identity_access_key resource and with a default name) after the
+  # test is completed.
+  provisioner "local-exec" {
+    command = format("rm -f %%s", abspath("./credentials.csv"))
+    when    = destroy
+  }
 }
 `, testAccV3AccessKey_basic_base(name))
 }
@@ -113,13 +137,73 @@ resource "huaweicloud_identity_access_key" "test" {
   secret_file = abspath("./credentials.csv")
   status      = "inactive"
 
-  # Clean up the credentials.csv file (created by huaweicloud_identity_access_key resource) after the test is completed.
+  # Check the mode of the credential file (created by huaweicloud_identity_access_key resource and with a default name)
+  # after the resource is created, want 600 access mode.
   provisioner "local-exec" {
-    command = "rm credentials.csv"
+    when    = create
+    command = <<-EOT
+      f="${abspath("./credentials.csv")}"
+      perms=$(stat -c '%%a' "$f")
+      if [ "$perms" != "600" ]; then
+        echo "ERROR: $f has mode $perms, expected 600" >&2
+        exit 1
+      fi
+    EOT
+  }
+
+  # Clean up the credential file (created by huaweicloud_identity_access_key resource and with a default name) after the
+  # test is completed.
+  provisioner "local-exec" {
+    command = format("rm -f %%s", abspath("./credentials.csv"))
     when    = destroy
   }
 }
 `, testAccV3AccessKey_basic_base(name))
+}
+
+// defaultV3AccessKeyCredentialFilePath returns the default credentials CSV path or the path specified by secret_file.
+func defaultV3AccessKeyCredentialFilePath(suffix ...string) (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("unable to get the workspace directory: %w", err)
+	}
+
+	fileName := "credentials.csv"
+	if len(suffix) > 0 {
+		fileName = fmt.Sprintf("credentials-%s.csv", strings.Join(suffix, "-"))
+	}
+	return filepath.Join(wd, fileName), nil
+}
+
+func testAccCheckV3AccessKeyDefaultCredentialFileMode600(suffix ...string) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		path, err := defaultV3AccessKeyCredentialFilePath(suffix...)
+		if err != nil {
+			return err
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("credential file not found at %s: %w", path, err)
+		}
+		if info.Mode().Perm() != 0600 {
+			return fmt.Errorf("credential file %s has mode %o, expected 0600", path, info.Mode().Perm())
+		}
+		return nil
+	}
+}
+
+func testAccCleanupV3AccessKeyDefaultCredentialFile(suffix ...string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		path, err := defaultV3AccessKeyCredentialFilePath(suffix...)
+		if err != nil {
+			return err
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("unable to remove credential file %s: %w", path, err)
+		}
+		return nil
+	}
 }
 
 func TestAccV3AccessKey_withoutSecretFileInput(t *testing.T) {
@@ -145,7 +229,10 @@ func TestAccV3AccessKey_withoutSecretFileInput(t *testing.T) {
 				VersionConstraint: "3.3.0",
 			},
 		},
-		CheckDestroy: rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rc.CheckResourceDestroy(),
+			testAccCleanupV3AccessKeyDefaultCredentialFile(name),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccV3AccessKey_withoutSecretFileInput_step1(name),
@@ -156,6 +243,7 @@ func TestAccV3AccessKey_withoutSecretFileInput(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "create_time",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|(\.\d{6}Z))$`)),
 					resource.TestCheckNoResourceAttr(resourceName, "secret"),
+					testAccCheckV3AccessKeyDefaultCredentialFileMode600(name),
 				),
 			},
 		},

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_access_key.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_access_key.go
@@ -99,7 +99,7 @@ func storeV3AccessKeyToCsvFile(path string, cred *credentials.Credential) error 
 		}
 	)
 
-	csvFile, err := os.Create(path)
+	csvFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Currently, the permission of generated CSV file (includes AKSK) by resource `huaweicloud_identity_access_key` is `644`.
It's not safety if we are using `600` permission to replace it.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

<img width="487" height="185" alt="image" src="https://github.com/user-attachments/assets/d7dd23e9-5bb5-4f24-8bad-fc07c1bfc750" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. change the permission of csv file from 644 to 600.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o iam -f TestAccV3AccessKey_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/iam" -v -coverprofile="./huaweicloud/services/acceptance/iam/iam_coverage.cov" -coverpkg="./huaweicloud/services/iam" -run TestAccV3AccessKey_ -timeout 360m -parallel 10
=== RUN   TestAccV3AccessKey_basic
=== PAUSE TestAccV3AccessKey_basic
=== RUN   TestAccV3AccessKey_withoutSecretFileInput
=== PAUSE TestAccV3AccessKey_withoutSecretFileInput
=== RUN   TestAccV3AccessKey_withIncorrectSecretFileInput
=== PAUSE TestAccV3AccessKey_withIncorrectSecretFileInput
=== CONT  TestAccV3AccessKey_basic
=== CONT  TestAccV3AccessKey_withIncorrectSecretFileInput
=== CONT  TestAccV3AccessKey_withoutSecretFileInput
--- PASS: TestAccV3AccessKey_withoutSecretFileInput (24.78s)
--- PASS: TestAccV3AccessKey_withIncorrectSecretFileInput (25.08s)
--- PASS: TestAccV3AccessKey_basic (38.14s)
PASS
coverage: 3.5% of statements in ./huaweicloud/services/iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       38.311s coverage: 3.5% of statements in ./huaweicloud/services/iam
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
