### PR TITLE
feat(modelarts): add new data source to query the list of workflow executions

### DIFF
--- a/docs/data-sources/modelartsv2_workflow_executions.md
+++ b/docs/data-sources/modelartsv2_workflow_executions.md
@@ -1,0 +1,328 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelartsv2_workflow_executions"
+description: |-
+  Use this data source to get the list of ModelArts workflow executions within HuaweiCloud.
+---
+
+# huaweicloud_modelartsv2_workflow_executions
+
+Use this data source to get the list of ModelArts workflow executions within HuaweiCloud.
+
+## Example Usage
+
+### Query all workflow executions by workflow ID
+
+```hcl
+variable "workflow_id" {}
+
+data "huaweicloud_modelartsv2_workflow_executions" "test" {
+  workflow_id = var.workflow_id
+}
+```
+
+### Query workflow executions using labels filter
+
+```hcl
+variable "workflow_id" {}
+variable "workflow_execution_labels" {}
+
+data "huaweicloud_modelartsv2_workflow_executions" "test" {
+  workflow_id = var.workflow_id
+  labels      = var.workflow_execution_labels
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the workflow executions are located.  
+  If omitted, the provider-level region will be used.
+
+* `workflow_id` - (Required, String) Specifies the workflow ID of the execution records to be queried.
+
+* `workspace_id` - (Optional, String) Specifies the workspace ID of the execution records to be queried.
+
+* `labels` - (Optional, String) Specifies the labels of the execution records to be queried.
+
+* `status` - (Optional, String) Specifies the status of the execution records to be queried.  
+  The valid values are as follows:
+  + **init**: Initialization.
+  + **wait_inputs**: Waiting for input.
+  + **pending**: Pending.
+  + **creating**: Creating.
+  + **created**: Created.
+  + **create_failed**: Create failed.
+  + **running**: Running.
+  + **stopping**: Stopping.
+  + **stopped**: Stopped.
+  + **timeout**: Timeout.
+  + **completed**: Completed.
+  + **failed**: Failed.
+  + **hold**: Hold.
+  + **skipped**: Skipped.
+
+* `scene_id` - (Optional, String) Specifies the scene ID of the execution records to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `executions` - The list of the workflow executions that matched filter parameters.  
+  The [executions](#modelartsv2_workflow_executions) structure is documented below.
+
+<a name="modelartsv2_workflow_executions"></a>
+The `executions` block supports:
+
+* `id` - The ID of the workflow execution.
+
+* `name` - The name of the workflow execution.
+
+* `description` - The description of the workflow execution.
+
+* `status` - The status of the workflow execution.
+
+* `workspace_id` - The workspace ID to which the workflow execution belongs.
+
+* `workflow_id` - The workflow ID.
+
+* `workflow_name` - The workflow name.
+
+* `scene_id` - The custom scene ID.
+
+* `scene_name` - The custom scene name.
+
+* `labels` - The labels of the workflow execution.
+
+* `data_requirements` - The data requirements used by the workflow execution steps.  
+  The [data_requirements](#modelartsv2_workflow_executions_data_requirements) structure is documented below.
+
+* `parameters` - The parameters used by the workflow execution steps.  
+  The [parameters](#modelartsv2_workflow_executions_parameters) structure is documented below.
+
+* `policies` - The execution policies used by the workflow execution.  
+  The [policies](#modelartsv2_workflow_executions_policies) structure is documented below.
+
+* `steps_execution` - The step execution information of the workflow execution.  
+  The [steps_execution](#modelartsv2_workflow_executions_steps_execution) structure is documented below.
+
+* `sub_graphs` - The subgraph information of the workflow execution.  
+  The [sub_graphs](#modelartsv2_workflow_executions_sub_graphs) structure is documented below.
+
+* `events` - The events of the workflow execution.
+
+* `duration` - The duration of the workflow execution.
+
+* `created_at` - The creation time of the workflow execution, in RFC3339 format.
+
+<a name="modelartsv2_workflow_executions_data_requirements"></a>
+The `data_requirements` block supports:
+
+* `name` - The name of the training data.
+
+* `type` - The type of the data source.
+
+* `conditions` - The data constraint conditions.  
+  The [conditions](#modelartsv2_workflow_executions_data_requirements_conditions) structure is documented below.
+
+* `value` - The value of the data, in JSON format.
+
+* `used_steps` - The workflow steps that use this data.
+
+* `delay` - Whether the data is delayed.
+
+<a name="modelartsv2_workflow_executions_data_requirements_conditions"></a>
+The `conditions` block supports:
+
+* `attribute` - The condition attribute.
+
+* `operator` - The operator of the condition.
+
+* `value` - The value of the condition, in JSON format.
+
+<a name="modelartsv2_workflow_executions_parameters"></a>
+The `parameters` block supports:
+
+* `name` - The name of the parameter.
+
+* `type` - The type of the parameter.
+
+* `description` - The description of the parameter.
+
+* `example` - The example of the parameter, in JSON format.
+
+* `delay` - Whether the parameter is delayed.
+
+* `default` - The default value of the parameter, in JSON format.
+
+* `value` - The value of the parameter, in JSON format.
+
+* `enum` - The enumeration values of the parameter, in JSON format.
+
+* `used_steps` - The workflow steps that use this parameter.
+
+* `format` - The data format of the parameter.
+
+* `constraint` - The constraint of the parameter, in JSON format.
+
+<a name="modelartsv2_workflow_executions_policies"></a>
+The `policies` block supports:
+
+* `use_cache` - Whether to use cache.
+
+<a name="modelartsv2_workflow_executions_steps_execution"></a>
+The `steps_execution` block supports:
+
+* `step_name` - The name of the step.
+
+* `execution_name` - The name of the execution record.
+
+* `name` - The name of the step in this execution.
+
+* `uuid` - The UUID of the step in the execution instance.
+
+* `execution_uuid` - The UUID of the execution instance.
+
+* `created_at` - The creation time of the step execution, in RFC3339 format.
+
+* `updated_at` - The update time of the step execution, in RFC3339 format.
+
+* `duration` - The execution duration of the step, in seconds.
+
+* `type` - The type of the step.
+  + **job**: Training.
+  + **labeling**: Labeling.
+  + **release_dataset**: Dataset release.
+  + **model**: Model release.
+  + **service**: Service deployment.
+  + **mrs_job**: MRS job.
+  + **dataset_import**: Dataset import.
+  + **create_dataset**: Create dataset.
+
+* `instance_id` - The instance ID of the step execution.
+
+* `status` - The status of the step execution.
+  + **init**: Initialization.
+  + **wait_inputs**: Waiting for input.
+  + **pending**: Pending.
+  + **creating**: Creating.
+  + **created**: Created.
+  + **create_failed**: Create failed.
+  + **running**: Running.
+  + **stopping**: Stopping.
+  + **stopped**: Stopped.
+  + **timeout**: Timeout.
+  + **completed**: Completed.
+  + **failed**: Failed.
+  + **hold**: Hold.
+  + **skipped**: Skipped.
+
+* `inputs` - The inputs of the step.  
+  The [inputs](#modelartsv2_workflow_executions_steps_execution_inputs) structure is documented below.
+
+* `outputs` - The outputs of the step.  
+  The [outputs](#modelartsv2_workflow_executions_steps_execution_outputs) structure is documented below.
+
+* `step_uuid` - The UUID of the step.
+
+* `properties` - The properties of the step, in JSON format.
+
+* `events` - The events of the step.
+
+* `error_info` - The error information of the step execution.  
+  The [error_info](#modelartsv2_workflow_executions_steps_execution_error_info) structure is documented below.
+
+* `policy` - The execution policy of the step.  
+  The [policy](#modelartsv2_workflow_executions_steps_execution_policy) structure is documented below.
+
+* `conditions_execution` - The condition execution of the step.  
+  The [conditions_execution](#modelartsv2_workflow_executions_steps_execution_conditions_execution) structure is
+  documented below.
+
+* `step_title` - The title of the step.
+
+* `conditions` - The conditions of the step.  
+  The [conditions](#modelartsv2_workflow_executions_steps_execution_conditions) structure is documented below.
+
+<a name="modelartsv2_workflow_executions_steps_execution_inputs"></a>
+The `inputs` block supports:
+
+* `name` - The name of the input data.
+
+* `type` - The type of the input.
+  + **dataset**: Dataset.
+  + **obs**: OBS.
+  + **data_selector**: Data selector.
+
+* `data` - The input data, in JSON format.
+
+* `value` - The value of the input, in JSON format.
+
+<a name="modelartsv2_workflow_executions_steps_execution_outputs"></a>
+The `outputs` block supports:
+
+* `name` - The name of the output data.
+
+* `type` - The type of the output.
+  + **obs**: OBS.
+  + **model**: AI application meta model.
+
+* `config` - The output configuration, in JSON format.
+
+<a name="modelartsv2_workflow_executions_steps_execution_error_info"></a>
+The `error_info` block supports:
+
+* `error_code` - The error code.
+
+* `error_message` - The error message.
+
+<a name="modelartsv2_workflow_executions_steps_execution_policy"></a>
+The `policy` block supports:
+
+* `execution_policy` - The execution policy.
+
+* `use_cache` - Whether to use cache.
+
+<a name="modelartsv2_workflow_executions_steps_execution_conditions_execution"></a>
+The `conditions_execution` block supports:
+
+* `result` - The execution result, in JSON format.
+
+* `metric_list` - The list of workflow metric information.  
+  The [metric_list](#modelartsv2_workflow_executions_steps_execution_conditions_execution_metric_list) structure is
+  documented below.
+
+<a name="modelartsv2_workflow_executions_steps_execution_conditions_execution_metric_list"></a>
+The `metric_list` block supports:
+
+* `key` - The key of the metric.
+
+* `value` - The value of the metric, in JSON format.
+
+<a name="modelartsv2_workflow_executions_steps_execution_conditions"></a>
+The `conditions` block supports:
+
+* `type` - The condition type.
+  + **==**
+  + **!=**
+  + **>**
+  + **>=**
+  + **<**
+  + **<=**
+  + **in**
+  + **or**
+
+* `left` - The left branch when the condition is true, in JSON format.
+
+* `right` - The right branch when the condition is false, in JSON format.
+
+<a name="modelartsv2_workflow_executions_sub_graphs"></a>
+The `sub_graphs` block supports:
+
+* `name` - The name of the subgraph.
+
+* `steps` - The step members of the subgraph.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2045,6 +2045,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelartsv2_resource_pool_workloads": modelarts.DataSourceResourcePoolWorkloads(),
 			"huaweicloud_modelartsv2_resource_pools":          modelarts.DataSourceV2ResourcePools(),
 			"huaweicloud_modelartsv2_workflows":               modelarts.DataSourceV2Workflows(),
+			"huaweicloud_modelartsv2_workflow_executions":     modelarts.DataSourceV2WorkflowExecutions(),
 			"huaweicloud_modelartsv2_workflow_schedules":      modelarts.DataSourceV2WorkflowSchedules(),
 
 			"huaweicloud_mapreduce_availability_zones":               mrs.DataSourceAvailabilityZones(),

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelartsv2_workflow_executions_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelartsv2_workflow_executions_test.go
@@ -1,0 +1,361 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataV2WorkflowExecutions_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_modelartsv2_workflow_executions.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byStatus   = "data.huaweicloud_modelartsv2_workflow_executions.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byLabels   = "data.huaweicloud_modelartsv2_workflow_executions.filter_by_labels"
+		dcByLabels = acceptance.InitDataSourceCheck(byLabels)
+
+		bySceneId   = "data.huaweicloud_modelartsv2_workflow_executions.filter_by_scene_id"
+		dcBySceneId = acceptance.InitDataSourceCheck(bySceneId)
+
+		byWorkspaceId   = "data.huaweicloud_modelartsv2_workflow_executions.filter_by_workspace_id"
+		dcByWorkspaceId = acceptance.InitDataSourceCheck(byWorkspaceId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataV2WorkflowExecutions_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "executions.#", regexp.MustCompile(`^[1-9]([0-9]+)?$`)),
+					resource.TestCheckResourceAttrSet(all, "executions.0.id"),
+					resource.TestCheckResourceAttrSet(all, "executions.0.name"),
+					resource.TestCheckResourceAttrSet(all, "executions.0.status"),
+					resource.TestCheckResourceAttrSet(all, "executions.0.workflow_id"),
+					resource.TestCheckResourceAttrSet(all, "executions.0.workflow_name"),
+					resource.TestCheckResourceAttrSet(all, "executions.0.created_at"),
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					dcByLabels.CheckResourceExists(),
+					resource.TestCheckOutput("is_labels_filter_useful", "true"),
+					dcBySceneId.CheckResourceExists(),
+					resource.TestCheckOutput("is_scene_id_filter_useful", "true"),
+					dcByWorkspaceId.CheckResourceExists(),
+					resource.TestCheckOutput("is_workspace_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataV2WorkflowExecution_base(name string) string {
+	return fmt.Sprintf(`
+variable "workflow_data_requirements" {
+  type    = list(object({
+    name       = string
+    type       = string
+    delay      = optional(bool, false)
+    used_steps = list(string)
+  }))
+  default = [
+    {
+      name       = "input_dataset"
+      type       = "dataset"
+      delay      = false
+      used_steps = ["dataset_step"]
+    },
+  ]
+}
+
+variable "workflow_parameters" {
+  type    = list(object({
+    name       = string
+    type       = string
+    default    = optional(string)
+    used_steps = list(string)
+  }))
+  default = [
+    {
+      name       = "can_execute"
+      type       = "bool"
+      default    = "true"
+      used_steps = ["condition_step"]
+    },
+    {
+      name       = "placeholder_name"
+      type       = "str"
+      default    = "\"0.8\""
+      used_steps = ["dataset_step"]
+    },
+  ]
+}
+
+variable "workflow_policy_scenes" {
+  type    = list(object({
+    id    = optional(string)
+    name  = string
+    steps = list(string)
+  }))
+  default = [
+    {
+      name  = "scene_a"
+      steps = ["condition_step", "dataset_step"]
+    },
+    {
+      name  = "scene_b"
+      steps = ["condition_step"]
+    },
+  ]
+}
+
+resource "huaweicloud_modelartsv2_workflow" "test" {
+  name        = "%[1]s"
+  description = "created by terraform for execution test"
+  labels      = ["terraform"]
+
+  steps {
+    name  = "condition_step"
+    type  = "condition"
+    title = "condition_step"
+
+    conditions {
+      type  = "=="
+      left  = jsonencode("$ref/parameters/can_execute")
+      right = jsonencode(true)
+    }
+
+    depend_steps    = []
+    if_then_steps   = ["dataset_step"]
+    else_then_steps = []
+  }
+  steps {
+    name  = "dataset_step"
+    type  = "release_dataset"
+    title = "dataset release"
+
+    inputs {
+      name = "input_name"
+      data = jsonencode("$ref/data_requirements/input_dataset")
+      type = "dataset"
+    }
+    outputs {
+      name = "output_name"
+      type = "dataset"
+    }
+    properties = jsonencode({
+      version_format              = "Default"
+      train_evaluate_sample_ratio = "$ref/parameters/placeholder_name"
+      clear_hard_property         = true
+      remove_sample_usage         = true
+      label_task_type             = 0
+    })
+
+    depend_steps = []
+  }
+
+  dynamic "data_requirements" {
+    for_each = var.workflow_data_requirements
+
+    content {
+      name       = data_requirements.value.name
+      type       = data_requirements.value.type
+      delay      = data_requirements.value.delay
+      used_steps = data_requirements.value.used_steps
+    }
+  }
+
+  dynamic "parameters" {
+    for_each = var.workflow_parameters
+
+    content {
+      name       = parameters.value.name
+      type       = parameters.value.type
+      default    = parameters.value.default
+      used_steps = parameters.value.used_steps
+    }
+  }
+
+  policy {
+    dynamic "scenes" {
+      for_each = var.workflow_policy_scenes
+
+      content {
+        id    = scenes.value.id
+        name  = scenes.value.name
+        steps = scenes.value.steps
+      }
+    }
+  }
+}
+
+variable "workflow_executions" {
+  type    = list(object({
+    name        = string
+    description = string
+    scene_name  = string
+    labels      = list(string)
+  }))
+  default = [
+    {
+      name        = "terraform-test-execution-scene-a"
+      description = "created by terraform with scene_a"
+      scene_name  = "scene_a"
+      labels      = ["scene-a", "test"]
+    },
+    {
+      name        = "terraform-test-execution-scene-b"
+      description = "created by terraform with scene_b"
+      scene_name  = "scene_b"
+      labels      = ["scene-b", "test"]
+    },
+  ]
+}
+
+resource "huaweicloud_modelartsv2_workflow_execution" "test_scene_a" {
+  name        = var.workflow_executions[0].name
+  description = var.workflow_executions[0].description
+  workflow_id = huaweicloud_modelartsv2_workflow.test.id
+  scene_name  = var.workflow_executions[0].scene_name
+  labels      = var.workflow_executions[0].labels
+
+  depends_on = [huaweicloud_modelartsv2_workflow.test]
+
+  lifecycle {
+    ignore_changes = [
+      data_requirements,
+      parameters,
+    ]
+  }
+}
+
+resource "huaweicloud_modelartsv2_workflow_execution" "test_scene_b" {
+  name        = var.workflow_executions[1].name
+  description = var.workflow_executions[1].description
+  workflow_id = huaweicloud_modelartsv2_workflow.test.id
+  scene_name  = var.workflow_executions[1].scene_name
+  labels      = var.workflow_executions[1].labels
+
+  depends_on = [huaweicloud_modelartsv2_workflow_execution.test_scene_a]
+
+  lifecycle {
+    ignore_changes = [
+      data_requirements,
+      parameters,
+    ]
+  }
+}
+`, name)
+}
+
+func testAccDataV2WorkflowExecutions_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Query all workflow executions without any filter.
+data "huaweicloud_modelartsv2_workflow_executions" "all" {
+  workflow_id = huaweicloud_modelartsv2_workflow.test.id
+
+  depends_on = [
+    huaweicloud_modelartsv2_workflow_execution.test_scene_a,
+    huaweicloud_modelartsv2_workflow_execution.test_scene_b,
+  ]
+}
+
+# Filter workflow executions by status.
+locals {
+  status = try(data.huaweicloud_modelartsv2_workflow_executions.all.executions[0].status, "NOT_FOUND")
+}
+
+data "huaweicloud_modelartsv2_workflow_executions" "filter_by_status" {
+  workflow_id = huaweicloud_modelartsv2_workflow.test.id
+  status      = local.status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_modelartsv2_workflow_executions.filter_by_status.executions : v.status == local.status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 || alltrue(local.status_filter_result)
+}
+
+# Filter workflow executions by labels.
+locals {
+  labels_list = try(data.huaweicloud_modelartsv2_workflow_executions.all.executions[0].labels, [])
+  labels      = join(",", local.labels_list)
+}
+
+data "huaweicloud_modelartsv2_workflow_executions" "filter_by_labels" {
+  workflow_id = huaweicloud_modelartsv2_workflow.test.id
+  labels      = local.labels
+}
+
+locals {
+  labels_filter_result = [
+    for v in data.huaweicloud_modelartsv2_workflow_executions.filter_by_labels.executions :
+    length(setintersection(v.labels, local.labels_list)) > 0
+  ]
+}
+
+output "is_labels_filter_useful" {
+  value = length(local.labels_filter_result) > 0 || alltrue(local.labels_filter_result)
+}
+
+# Filter workflow executions by scene_id.
+locals {
+  scene_id = try(data.huaweicloud_modelartsv2_workflow_executions.all.executions[0].scene_id, "NOT_FOUND")
+}
+
+data "huaweicloud_modelartsv2_workflow_executions" "filter_by_scene_id" {
+  workflow_id = huaweicloud_modelartsv2_workflow.test.id
+  scene_id    = local.scene_id
+}
+
+locals {
+  scene_id_filter_result = [
+    for v in data.huaweicloud_modelartsv2_workflow_executions.filter_by_scene_id.executions :
+    v.scene_id == local.scene_id
+  ]
+}
+
+output "is_scene_id_filter_useful" {
+  value = length(local.scene_id_filter_result) > 0 || alltrue(local.scene_id_filter_result)
+}
+
+# Filter workflow executions by workspace_id.
+locals {
+  workspace_id = try(data.huaweicloud_modelartsv2_workflow_executions.all.executions[0].workspace_id, "NOT_FOUND")
+}
+
+data "huaweicloud_modelartsv2_workflow_executions" "filter_by_workspace_id" {
+  workflow_id  = huaweicloud_modelartsv2_workflow.test.id
+  workspace_id = local.workspace_id
+}
+
+locals {
+  workspace_id_filter_result = [
+    for v in data.huaweicloud_modelartsv2_workflow_executions.filter_by_workspace_id.executions :
+    v.workspace_id == local.workspace_id
+  ]
+}
+
+output "is_workspace_id_filter_useful" {
+  value = length(local.workspace_id_filter_result) > 0 || alltrue(local.workspace_id_filter_result)
+}
+`, testAccDataV2WorkflowExecution_base(name))
+}

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_workflow_executions.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelartsv2_workflow_executions.go
@@ -1,0 +1,959 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ModelArts GET /v2/{project_id}/workflows/{workflow_id}/executions
+func DataSourceV2WorkflowExecutions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV2WorkflowExecutionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the workflow executions are located.`,
+			},
+
+			// Required parameters.
+			"workflow_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The workflow ID of the execution records to be queried.`,
+			},
+
+			// Optional parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The workspace ID of the execution records to be queried.`,
+			},
+			"labels": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The labels of the execution records to be queried.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The status of the execution records to be queried.`,
+			},
+			"scene_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The scene ID of the execution records to be queried.`,
+			},
+
+			// Attributes.
+			"executions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionsElemSchema(),
+				Description: `The list of the workflow executions that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionsElemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the workflow execution.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the workflow execution.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the workflow execution.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the workflow execution.`,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The workspace ID to which the workflow execution belongs.`,
+			},
+			"workflow_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The workflow ID.`,
+			},
+			"workflow_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The workflow name.`,
+			},
+			"scene_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The custom scene ID.`,
+			},
+			"scene_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The custom scene name.`,
+			},
+			"labels": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The labels of the workflow execution.`,
+			},
+			"data_requirements": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionDataRequirementSchema(),
+				Description: `The data requirements used by the workflow execution steps.`,
+			},
+			"parameters": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionParameterSchema(),
+				Description: `The parameters used by the workflow execution steps.`,
+			},
+			"policies": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionPolicySchema(),
+				Description: `The execution policies used by the workflow execution.`,
+			},
+			"steps_execution": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionStepExecutionSchema(),
+				Description: `The step execution information of the workflow execution.`,
+			},
+			"sub_graphs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionSubGraphSchema(),
+				Description: `The subgraph information of the workflow execution.`,
+			},
+			"events": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The events of the workflow execution.`,
+			},
+			"duration": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The duration of the workflow execution.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the workflow execution, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionDataRequirementConditionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"attribute": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The condition attribute.`,
+			},
+			"operator": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The operator of the condition.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the condition, in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionDataRequirementSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the training data.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the data source.`,
+			},
+			"conditions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionDataRequirementConditionSchema(),
+				Description: `The data constraint conditions.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the data, in JSON format.`,
+			},
+			"used_steps": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The workflow steps that use this data.`,
+			},
+			"delay": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the data is delayed.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionParameterSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the parameter.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the parameter.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the parameter.`,
+			},
+			"example": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The example of the parameter, in JSON format.`,
+			},
+			"delay": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the parameter is delayed.`,
+			},
+			"default": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The default value of the parameter, in JSON format.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the parameter, in JSON format.`,
+			},
+			"enum": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The enumeration values of the parameter, in JSON format.`,
+			},
+			"used_steps": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The workflow steps that use this parameter.`,
+			},
+			"format": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The data format of the parameter.`,
+			},
+			"constraint": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The constraint of the parameter, in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionPolicySchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"use_cache": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to use cache.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionStepInputSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the input data.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the input.`,
+			},
+			"data": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The input data, in JSON format.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the input, in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionStepOutputSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the output data.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the output.`,
+			},
+			"config": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The output configuration, in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionStepErrorInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"error_code": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The error code.`,
+			},
+			"error_message": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The error message.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionStepPolicySchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"execution_policy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The execution policy.`,
+			},
+			"use_cache": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to use cache.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionMetricPairSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The key of the metric.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the metric, in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionConditionExecutionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"result": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The execution result, in JSON format.`,
+			},
+			"metric_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionMetricPairSchema(),
+				Description: `The list of workflow metric information.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionStepConditionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The condition type.`,
+			},
+			"left": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The left branch when the condition is true, in JSON format.`,
+			},
+			"right": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The right branch when the condition is false, in JSON format.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionStepExecutionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"step_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the step.`,
+			},
+			"execution_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the execution record.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the step in this execution.`,
+			},
+			"uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The UUID of the step in the execution instance.`,
+			},
+			"execution_uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The UUID of the execution instance.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the step execution, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the step execution, in RFC3339 format.`,
+			},
+			"duration": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The execution duration of the step, in seconds.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the step.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The instance ID of the step execution.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the step execution.`,
+			},
+			"inputs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionStepInputSchema(),
+				Description: `The inputs of the step.`,
+			},
+			"outputs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionStepOutputSchema(),
+				Description: `The outputs of the step.`,
+			},
+			"step_uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The UUID of the step.`,
+			},
+			"properties": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The properties of the step, in JSON format.`,
+			},
+			"events": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The events of the step.`,
+			},
+			"error_info": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionStepErrorInfoSchema(),
+				Description: `The error information of the step execution.`,
+			},
+			"policy": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionStepPolicySchema(),
+				Description: `The execution policy of the step.`,
+			},
+			"conditions_execution": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionConditionExecutionSchema(),
+				Description: `The condition execution of the step.`,
+			},
+			"step_title": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The title of the step.`,
+			},
+			"conditions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataV2WorkflowExecutionStepConditionSchema(),
+				Description: `The conditions of the step.`,
+			},
+		},
+	}
+}
+
+func dataV2WorkflowExecutionSubGraphSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the subgraph.`,
+			},
+			"steps": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The step members of the subgraph.`,
+			},
+		},
+	}
+}
+
+func buildListV2WorkflowExecutionsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("workspace_id"); ok {
+		res = fmt.Sprintf("%s&workspace_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("labels"); ok {
+		res = fmt.Sprintf("%s&labels=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("scene_id"); ok {
+		res = fmt.Sprintf("%s&scene_id=%v", res, v)
+	}
+
+	return res
+}
+
+func listV2WorkflowExecutions(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl    = "v2/{project_id}/workflows/{workflow_id}/executions?limit={limit}"
+		workflowID = d.Get("workflow_id").(string)
+		limit      = 100
+		offset     = 0
+		result     = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{workflow_id}", workflowID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+	listPathWithLimit += buildListV2WorkflowExecutionsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPathWithLimit, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		items := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, items...)
+
+		if len(items) < limit {
+			break
+		}
+		offset += len(items)
+	}
+	return result, nil
+}
+
+func flattenDataV2WorkflowExecutionDataRequirementConditions(conditions []interface{}) []interface{} {
+	if len(conditions) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(conditions))
+	for _, condition := range conditions {
+		result = append(result, map[string]interface{}{
+			"attribute": utils.PathSearch("attribute", condition, nil),
+			"operator":  utils.PathSearch("operator", condition, nil),
+			"value":     utils.JsonToString(utils.PathSearch("value", condition, nil)),
+		})
+	}
+	return result
+}
+
+func flattenDataV2WorkflowExecutionDataRequirements(dataRequirements []interface{}) []interface{} {
+	if len(dataRequirements) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(dataRequirements))
+	for _, req := range dataRequirements {
+		result = append(result, map[string]interface{}{
+			"name": utils.PathSearch("name", req, nil),
+			"type": utils.PathSearch("type", req, nil),
+			"conditions": flattenDataV2WorkflowExecutionDataRequirementConditions(
+				utils.PathSearch("conditions", req, make([]interface{}, 0)).([]interface{})),
+			"value":      utils.JsonToString(utils.PathSearch("value", req, nil)),
+			"used_steps": utils.ExpandToStringList(utils.PathSearch("used_steps", req, make([]interface{}, 0)).([]interface{})),
+			"delay":      utils.PathSearch("delay", req, nil),
+		})
+	}
+	return result
+}
+
+func flattenDataV2WorkflowExecutionParametersEnum(enumList []interface{}) []string {
+	if len(enumList) < 1 {
+		return nil
+	}
+
+	result := make([]string, 0, len(enumList))
+	for _, enum := range enumList {
+		result = append(result, utils.JsonToString(enum))
+	}
+	return result
+}
+
+func flattenDataV2WorkflowExecutionParameters(parameters []interface{}) []interface{} {
+	if len(parameters) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(parameters))
+	for _, param := range parameters {
+		result = append(result, map[string]interface{}{
+			"name":        utils.PathSearch("name", param, nil),
+			"type":        utils.PathSearch("type", param, nil),
+			"description": utils.PathSearch("description", param, nil),
+			"example":     utils.JsonToString(utils.PathSearch("example", param, nil)),
+			"delay":       utils.PathSearch("delay", param, nil),
+			"default":     utils.JsonToString(utils.PathSearch("default", param, nil)),
+			"value":       utils.JsonToString(utils.PathSearch("value", param, nil)),
+			"enum": flattenDataV2WorkflowExecutionParametersEnum(
+				utils.PathSearch("enum", param, make([]interface{}, 0)).([]interface{})),
+			"used_steps": utils.ExpandToStringList(utils.PathSearch("used_steps", param, make([]interface{}, 0)).([]interface{})),
+			"format":     utils.PathSearch("format", param, nil),
+			"constraint": utils.JsonToString(utils.PathSearch("constraint", param, nil)),
+		})
+	}
+	return result
+}
+
+func flattenDataV2WorkflowExecutionPolicies(policies interface{}) []interface{} {
+	if policies == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"use_cache": utils.PathSearch("use_cache", policies, nil),
+		},
+	}
+}
+
+func flattenDataV2WorkflowExecutionStepInputs(inputs []interface{}) []interface{} {
+	if len(inputs) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(inputs))
+	for _, input := range inputs {
+		result = append(result, map[string]interface{}{
+			"name":  utils.PathSearch("name", input, nil),
+			"type":  utils.PathSearch("type", input, nil),
+			"data":  utils.JsonToString(utils.PathSearch("data", input, nil)),
+			"value": utils.JsonToString(utils.PathSearch("value", input, nil)),
+		})
+	}
+	return result
+}
+
+func flattenDataV2WorkflowExecutionStepOutputs(outputs []interface{}) []interface{} {
+	if len(outputs) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(outputs))
+	for _, output := range outputs {
+		result = append(result, map[string]interface{}{
+			"name":   utils.PathSearch("name", output, nil),
+			"type":   utils.PathSearch("type", output, nil),
+			"config": utils.JsonToString(utils.PathSearch("config", output, nil)),
+		})
+	}
+	return result
+}
+
+func flattenDataV2WorkflowExecutionStepErrorInfo(errorInfo interface{}) []interface{} {
+	if errorInfo == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"error_code":    utils.PathSearch("error_code", errorInfo, nil),
+			"error_message": utils.PathSearch("error_message", errorInfo, nil),
+		},
+	}
+}
+
+func flattenDataV2WorkflowExecutionStepPolicy(policy interface{}) []interface{} {
+	if policy == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"execution_policy": utils.PathSearch("execution_policy", policy, nil),
+			"use_cache":        utils.PathSearch("use_cache", policy, nil),
+		},
+	}
+}
+
+func flattenDataV2WorkflowExecutionMetricPairs(metricList []interface{}) []interface{} {
+	if len(metricList) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(metricList))
+	for _, metric := range metricList {
+		result = append(result, map[string]interface{}{
+			"key":   utils.PathSearch("key", metric, nil),
+			"value": utils.JsonToString(utils.PathSearch("value", metric, nil)),
+		})
+	}
+	return result
+}
+
+func flattenDataV2WorkflowExecutionConditionExecution(conditionExecution interface{}) []interface{} {
+	if conditionExecution == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"result": utils.JsonToString(utils.PathSearch("result", conditionExecution, nil)),
+			"metric_list": flattenDataV2WorkflowExecutionMetricPairs(
+				utils.PathSearch("metric_list", conditionExecution, make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}
+
+func flattenDataV2WorkflowExecutionStepConditions(conditions []interface{}) []interface{} {
+	if len(conditions) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(conditions))
+	for _, condition := range conditions {
+		result = append(result, map[string]interface{}{
+			"type":  utils.PathSearch("type", condition, nil),
+			"left":  utils.JsonToString(utils.PathSearch("left", condition, nil)),
+			"right": utils.JsonToString(utils.PathSearch("right", condition, nil)),
+		})
+	}
+	return result
+}
+
+func flattenDataV2WorkflowExecutionStepExecutions(stepExecutions []interface{}) []interface{} {
+	if len(stepExecutions) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(stepExecutions))
+	for _, stepExec := range stepExecutions {
+		result = append(result, map[string]interface{}{
+			"step_name":      utils.PathSearch("step_name", stepExec, nil),
+			"execution_name": utils.PathSearch("execution_name", stepExec, nil),
+			"name":           utils.PathSearch("name", stepExec, nil),
+			"uuid":           utils.PathSearch("uuid", stepExec, nil),
+			"execution_uuid": utils.PathSearch("execution_uuid", stepExec, nil),
+			"duration":       utils.PathSearch("duration", stepExec, nil),
+			"type":           utils.PathSearch("type", stepExec, nil),
+			"instance_id":    utils.PathSearch("instance_id", stepExec, nil),
+			"status":         utils.PathSearch("status", stepExec, nil),
+			"inputs": flattenDataV2WorkflowExecutionStepInputs(
+				utils.PathSearch("inputs", stepExec, make([]interface{}, 0)).([]interface{})),
+			"outputs": flattenDataV2WorkflowExecutionStepOutputs(
+				utils.PathSearch("outputs", stepExec, make([]interface{}, 0)).([]interface{})),
+			"step_uuid":            utils.PathSearch("step_uuid", stepExec, nil),
+			"properties":           utils.JsonToString(utils.PathSearch("properties", stepExec, nil)),
+			"events":               utils.ExpandToStringList(utils.PathSearch("events", stepExec, make([]interface{}, 0)).([]interface{})),
+			"error_info":           flattenDataV2WorkflowExecutionStepErrorInfo(utils.PathSearch("error_info", stepExec, nil)),
+			"policy":               flattenDataV2WorkflowExecutionStepPolicy(utils.PathSearch("policy", stepExec, nil)),
+			"conditions_execution": flattenDataV2WorkflowExecutionConditionExecution(utils.PathSearch("conditions_execution", stepExec, nil)),
+			"step_title":           utils.PathSearch("step_title", stepExec, nil),
+			"conditions": flattenDataV2WorkflowExecutionStepConditions(
+				utils.PathSearch("conditions", stepExec, make([]interface{}, 0)).([]interface{})),
+			"created_at": utils.FormatTimeStampRFC3339(
+				utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("created_at", stepExec, "").(string))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(
+				utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("updated_at", stepExec, "").(string))/1000, false),
+		})
+	}
+	return result
+}
+
+func flattenDataV2WorkflowExecutionSubGraphs(subGraphs []interface{}) []interface{} {
+	if len(subGraphs) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(subGraphs))
+	for _, subGraph := range subGraphs {
+		result = append(result, map[string]interface{}{
+			"name":  utils.PathSearch("name", subGraph, nil),
+			"steps": utils.ExpandToStringList(utils.PathSearch("steps", subGraph, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result
+}
+
+func flattenDataV2WorkflowExecutions(executions []interface{}) []interface{} {
+	if len(executions) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(executions))
+	for _, item := range executions {
+		result = append(result, map[string]interface{}{
+			"id":            utils.PathSearch("execution_id", item, nil),
+			"name":          utils.PathSearch("name", item, nil),
+			"description":   utils.PathSearch("description", item, nil),
+			"status":        utils.PathSearch("status", item, nil),
+			"workspace_id":  utils.PathSearch("workspace_id", item, nil),
+			"workflow_id":   utils.PathSearch("workflow_id", item, nil),
+			"workflow_name": utils.PathSearch("workflow_name", item, nil),
+			"scene_id":      utils.PathSearch("scene_id", item, nil),
+			"scene_name":    utils.PathSearch("scene_name", item, nil),
+			"labels":        utils.ExpandToStringList(utils.PathSearch("labels", item, make([]interface{}, 0)).([]interface{})),
+			"data_requirements": flattenDataV2WorkflowExecutionDataRequirements(
+				utils.PathSearch("data_requirements", item, make([]interface{}, 0)).([]interface{})),
+			"parameters": flattenDataV2WorkflowExecutionParameters(
+				utils.PathSearch("parameters", item, make([]interface{}, 0)).([]interface{})),
+			"policies": flattenDataV2WorkflowExecutionPolicies(utils.PathSearch("policies", item, nil)),
+			"steps_execution": flattenDataV2WorkflowExecutionStepExecutions(
+				utils.PathSearch("steps_execution", item, make([]interface{}, 0)).([]interface{})),
+			"sub_graphs": flattenDataV2WorkflowExecutionSubGraphs(
+				utils.PathSearch("sub_graphs", item, make([]interface{}, 0)).([]interface{})),
+			"events":   utils.ExpandToStringList(utils.PathSearch("events", item, make([]interface{}, 0)).([]interface{})),
+			"duration": fmt.Sprintf("%v", utils.PathSearch("duration", item, nil)),
+			"created_at": utils.FormatTimeStampRFC3339(
+				utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("created_at", item, "").(string))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceV2WorkflowExecutionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	executions, err := listV2WorkflowExecutions(client, d)
+	if err != nil {
+		return diag.Errorf("error querying workflow executions: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("executions", flattenDataV2WorkflowExecutions(executions)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data source to query the list of workflow executions.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
Since attributes such as `mertic_pairs` and `error_info` are server-generated, it is currently not possible to achieve coverage for the parsing logic.

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.go`
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataV2WorkflowExecutions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV2WorkflowExecutions_basic
=== PAUSE TestAccDataV2WorkflowExecutions_basic
=== CONT  TestAccDataV2WorkflowExecutions_basic
--- PASS: TestAccDataV2WorkflowExecutions_basic (26.19s)
PASS
coverage: 10.5% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 26.312s coverage: 10.5% of statements in ./huaweicloud/services/modelarts
```
<img width="1639" height="1294" alt="image" src="https://github.com/user-attachments/assets/4ff6a977-4f10-4620-a433-444fa6161718" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.
