### PR TITLE
feat(geminidb): add resource geminidb parameter template copy

### DIFF
--- a/docs/resources/geminidb_parameter_template_copy.md
+++ b/docs/resources/geminidb_parameter_template_copy.md
@@ -1,0 +1,100 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_parameter_template_copy"
+description: |-
+  Manages a GeminiDB parameter template copy resource within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_parameter_template_copy
+
+Manages a GeminiDB parameter template copy resource within HuaweiCloud.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+variable "config_id" {}
+
+resource "huaweicloud_geminidb_parameter_template_copy" "test" {
+  config_id = var.config_id
+  name      = "my-configuration-copy"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the configuration copy.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `config_id` - (Required, String, NonUpdatable) Specifies the ID of the source parameter template.
+
+* `name` - (Required, String) Specifies the name of the copied parameter template.
+
+* `description` - (Optional, String) Specifies the description of the copied parameter template.
+
+* `values` - (Optional, Map) Specifies the parameter values.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `datastore_version_name` - The database version name.
+
+* `datastore_name` - The database name.
+
+* `mode` - The database instance mode.
+
+* `created` - The creation time. The format is **yyyy-MM-ddTHH:mm:ssZ**.
+
+* `updated` - The update time. The format is **yyyy-MM-ddTHH:mm:ssZ**.
+
+* `configuration_parameters` - The list of parameter configurations.
+  The [configuration_parameters](#geminidb_configuration_parameters) structure is documented below.
+
+<a name="geminidb_configuration_parameters"></a>
+The `configuration_parameters` block supports:
+
+* `name` - The parameter name.
+
+* `value` - The parameter value.
+
+* `restart_required` - The parameter whether a restart is required after modifying.
+
+* `readonly` - The parameter whether is read-only.
+
+* `value_range` - The parameter value range.
+
+* `type` - The parameter type. Valid values: **string**, **integer**, **boolean**, **list**, **float**.
+
+* `description` - The parameter description.
+
+## Import
+
+The GeminiDB parameter template can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_geminidb_parameter_template_copy.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `config_id` and `values`.
+It is generally recommended running `terraform plan` after importing a parameter template.
+You can then decide if changes should be applied to the parameter template, or the resource definition should be
+updated to align with the parameter template. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_geminidb_parameter_template_copy" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      config_id, values,
+    ]
+  }
+}

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3763,6 +3763,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_node_session_kill":          geminidb.ResourceNodeSessionKill(),
 			"huaweicloud_geminidb_parameter_template":         geminidb.ResourceGeminiDBParameterTemplate(),
 			"huaweicloud_geminidb_parameter_template_compare": geminidb.ResourceGeminiDBParameterTemplateCompare(),
+			"huaweicloud_geminidb_parameter_template_copy":    geminidb.ResourceGeminiDBParameterTemplateCopy(),
 			"huaweicloud_geminidb_parameter_template_reset":   geminidb.ResourceGeminiDBParameterTemplateReset(),
 			"huaweicloud_geminidb_primary_standby_switch":     geminidb.ResourcePrimaryStandbySwitch(),
 			"huaweicloud_geminidb_recycling_policy":           geminidb.ResourceGeminiDBRecyclingPolicy(),

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_parameter_template_copy_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_parameter_template_copy_test.go
@@ -1,0 +1,85 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGeminiDBParameterTemplateCopy_basic(t *testing.T) {
+	var obj interface{}
+	resourceName := "huaweicloud_geminidb_parameter_template_copy.test"
+	rName := acceptance.RandomAccResourceName()
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getParameterTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDBParameterTemplateCopy_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_copy"),
+					resource.TestCheckResourceAttr(resourceName, "description", "This is a test parameter template copy"),
+				),
+			},
+			{
+				Config: testAccGeminiDBParameterTemplateCopy_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_copy_update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test parameter template update"),
+					resource.TestCheckResourceAttr(resourceName, "values.request_timeout_in_ms", "10000"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config_id", "values"},
+			},
+		},
+	})
+}
+
+func testAccGeminiDBParameterTemplateCopy_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_geminidb_parameter_template_copy" "test" {
+  config_id   = huaweicloud_geminidb_parameter_template.test.id
+  name        = "%[2]s_copy"
+  description = "This is a test parameter template copy"
+
+  values = {
+    request_timeout_in_ms = "20000"
+  }
+}
+`, testAccGeminiDBParameterTemplate_basic(rName), rName)
+}
+
+func testAccGeminiDBParameterTemplateCopy_update(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_geminidb_parameter_template_copy" "test" {
+  config_id   = huaweicloud_geminidb_parameter_template.test.id
+  name        = "%[2]s_copy_update"
+  description = "test parameter template update"
+
+  values = {
+    request_timeout_in_ms = "10000"
+  }
+}
+`, testAccGeminiDBParameterTemplate_basic(rName), rName)
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_parameter_template.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_parameter_template.go
@@ -2,6 +2,7 @@ package geminidb
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -287,32 +288,35 @@ func resourceGeminiDBParameterTemplateUpdate(ctx context.Context, d *schema.Reso
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
-	var (
-		httpUrl = "v3/{project_id}/configurations/{config_id}"
-		product = "geminidb"
-	)
-
-	client, err := cfg.NewServiceClient(product, region)
+	client, err := cfg.NewServiceClient("geminidb", region)
 	if err != nil {
 		return diag.Errorf("error creating GeminiDB client: %s", err)
 	}
 
+	if err := updateGeminiDBParameterTemplate(client, d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceGeminiDBParameterTemplateRead(ctx, d, meta)
+}
+
+func updateGeminiDBParameterTemplate(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v3/{project_id}/configurations/{config_id}"
 	updatePath := client.Endpoint + httpUrl
 	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
 	updatePath = strings.ReplaceAll(updatePath, "{config_id}", d.Id())
-
 	updateOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 		JSONBody:         buildUpdateGeminiDBParameterTemplateBodyParams(d),
 	}
 
-	_, err = client.Request("PUT", updatePath, &updateOpt)
+	_, err := client.Request("PUT", updatePath, &updateOpt)
 	if err != nil {
-		return diag.Errorf("error updating GeminiDB parameter template: %s", err)
+		return fmt.Errorf("error updating GeminiDB parameter template: %s", err)
 	}
 
-	return resourceGeminiDBParameterTemplateRead(ctx, d, meta)
+	return nil
 }
 
 func buildUpdateGeminiDBParameterTemplateBodyParams(d *schema.ResourceData) map[string]interface{} {

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_parameter_template_copy.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_parameter_template_copy.go
@@ -1,0 +1,150 @@
+package geminidb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var geminiDBParameterTemplateCopyNonUpdatableParams = []string{
+	"config_id",
+}
+
+// @API GeminiDB POST /v3/{project_id}/configurations/{config_id}/copy
+// @API GeminiDB DELETE /v3/{project_id}/configurations/{config_id}
+// @API GeminiDB GET /v3/{project_id}/configurations/{config_id}
+// @API GeminiDB PUT /v3/{project_id}/configurations/{config_id}
+func ResourceGeminiDBParameterTemplateCopy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGeminiDBParameterTemplateCopyCreate,
+		UpdateContext: resourceGeminiDBParameterTemplateUpdate,
+		ReadContext:   resourceGeminiDBParameterTemplateRead,
+		DeleteContext: resourceGeminiDBParameterTemplateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(geminiDBParameterTemplateCopyNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"config_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"values": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"datastore_version_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"datastore_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"configuration_parameters": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     geminiDBParameterTemplateParameterSchema(),
+			},
+		},
+	}
+}
+
+func resourceGeminiDBParameterTemplateCopyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	httpUrl := "v3/{project_id}/configurations/{config_id}/copy"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{config_id}", d.Get("config_id").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildGeminiDBParameterTemplateCopyBody(d)),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error copying GeminiDB configuration: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	configID := utils.PathSearch("config_id", respBody, "").(string)
+	if configID == "" {
+		return diag.Errorf("unable to find configuration ID from API response")
+	}
+
+	d.SetId(configID)
+
+	if _, ok := d.GetOk("values"); ok {
+		if err := updateGeminiDBParameterTemplate(client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceGeminiDBParameterTemplateRead(ctx, d, meta)
+}
+
+func buildGeminiDBParameterTemplateCopyBody(d *schema.ResourceData) map[string]interface{} {
+	body := map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+
+	return body
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource geminidb parameter template copy
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add resource geminidb parameter template copy
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDBParameterTemplateCopy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDBParameterTemplateCopy_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBParameterTemplateCopy_basic
=== PAUSE TestAccGeminiDBParameterTemplateCopy_basic
=== CONT  TestAccGeminiDBParameterTemplateCopy_basic
--- PASS: TestAccGeminiDBParameterTemplateCopy_basic (30.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  30.713s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
