### PR TITLE
feat(hss): new resource to manage custom rule

### DIFF
--- a/docs/resources/hss_custom_rule.md
+++ b/docs/resources/hss_custom_rule.md
@@ -1,0 +1,110 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_custom_rule"
+description: |-
+  Manages a custom rule resource within HuaweiCloud HSS.
+---
+
+# huaweicloud_hss_custom_rule
+
+Manages a custom rule resource within HuaweiCloud HSS.
+
+## Example Usage
+
+```hcl
+variable "agent_ids" {
+  type = list(string)
+}
+
+variable "rule_values" {
+  type = list(string)
+}
+
+resource "huaweicloud_hss_custom_rule" "test" {
+  rule_name   = "test-name"
+  is_all_host = true
+  agent_ids   = var.agent_ids
+
+  custom_rule_value_info {
+    auto_block  = 1
+    hash_type   = "sha1"
+    rule_type   = "black_hash"
+    rule_values = var.rule_values
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `rule_name` - (Required, String) Specifies the custom rule name. The name does not support editing at the moment.
+
+* `custom_rule_value_info` - (Required, List) Specifies the custom rule value information.  
+  The [custom_rule_value_info](#custom_rule_value_info_struct) structure is documented below.
+
+* `is_all_host` - (Optional, Bool) Specifies whether to apply the rule to all hosts.  
+  Defaults to **false**.
+
+* `agent_ids` - (Optional, List) Specifies the list of agent IDs to which the rule applies.  
+
+* `rule_status` - (Optional, Int) Specifies the rule status.  
+  Defaults to `1`. Valid values are:
+  + `0`: disabled
+  + `1`: enabled
+
+<a name="custom_rule_value_info_struct"></a>
+The `custom_rule_value_info` block supports:
+
+* `rule_type` - (Required, String) Specifies the rule type. Valid value is **black_hash**.
+
+* `hash_type` - (Required, String) Specifies the hash type. Valid values are: **sha256**, **md5**, and **sha1**.
+
+* `auto_block` - (Required, Int) Specifies whether to automatically block.  
+  Valid values are `0` (no auto block) and `1` (auto block).
+
+* `rule_values` - (Required, List) Specifies the list of rule values.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (same as the custom rule ID).
+
+* `create_time` - The creation time of the custom rule.
+
+* `update_time` - The last update time of the custom rule.
+
+* `host_num` - The number of hosts associated with the custom rule.
+
+* `agent_ids_attr` - The list of agent IDs that are associated with the custom rule.
+
+## Import
+
+Custom rule can be imported using the custom rule ID, e.g.
+
+```bash
+$ terraform import huaweicloud_hss_custom_rule.test <rule_id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `agent_ids`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition
+should be updated to align with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_hss_custom_rule" "test" { 
+  # ...
+
+  lifecycle {
+    ignore_changes = [
+      agent_ids,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3824,6 +3824,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_close_honeypot_port_policy":                     hss.ResourceCloseHoneypotPortPolicy(),
 			"huaweicloud_hss_container_export_task":                          hss.ResourceContainerExportTask(),
 			"huaweicloud_hss_container_sync_cluster_information":             hss.ResourceContainerSyncClusterInformation(),
+			"huaweicloud_hss_custom_rule":                                    hss.ResourceCustomRule(),
 			"huaweicloud_hss_container_kubernetes_sync_mccs":                 hss.ResourceContainerKubernetesSyncMccs(),
 			"huaweicloud_hss_container_kubernetes_cluster_daemonset":         hss.ResourceContainerKubernetesClusterDaemonset(),
 			"huaweicloud_hss_container_kubernetes_cluster_protection_enable": hss.ResourceContainerKubernetesClusterProtectionEnable(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_custom_rule_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_custom_rule_test.go
@@ -1,0 +1,121 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/hss"
+)
+
+func getCustomRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("hss", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HSS client: %s", err)
+	}
+
+	return hss.GetCustomRuleByList(client, state.Primary.ID)
+}
+
+func TestAccCustomRule_basic(t *testing.T) {
+	var (
+		host       interface{}
+		rName      = "huaweicloud_hss_custom_rule.test"
+		name       = acceptance.RandomAccResourceName()
+		agentId1   = "af08124fd77581dcd2a5f7cdaa208c285af0a1480f7ca9b5258193c021ca2637" // mock data
+		agentId2   = "af08124fd77581dcd2a5f7cdaa208c285af0a1480f7ca9b5258193c021ca2638" // mock data
+		ruleValue1 = "08a7baa28dd268f8a12bc1f6fd95869321fe51144c5bf3321a6f6305edcd5245" // mock data
+		ruleValue2 = "08a7baa28dd268f8a12bc1f6fd95869321fe51144c5bf3321a6f6305edcd5246" // mock data
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&host,
+		getCustomRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomRule_basic(name, agentId1, ruleValue1),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "rule_name", name),
+					resource.TestCheckResourceAttr(rName, "is_all_host", "true"),
+					resource.TestCheckResourceAttr(rName, "custom_rule_value_info.0.auto_block", "1"),
+					resource.TestCheckResourceAttr(rName, "custom_rule_value_info.0.hash_type", "sha1"),
+					resource.TestCheckResourceAttr(rName, "custom_rule_value_info.0.rule_type", "black_hash"),
+					resource.TestCheckResourceAttr(rName, "custom_rule_value_info.0.rule_values.0", ruleValue1),
+					resource.TestCheckResourceAttr(rName, "rule_status", "0"),
+					resource.TestCheckResourceAttrSet(rName, "create_time"),
+					resource.TestCheckResourceAttrSet(rName, "update_time"),
+					resource.TestCheckResourceAttrSet(rName, "host_num"),
+				),
+			},
+			{
+				Config: testAccCustomRule_basic_update(name, agentId2, ruleValue2),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "rule_name", name),
+					resource.TestCheckResourceAttr(rName, "is_all_host", "false"),
+					resource.TestCheckResourceAttr(rName, "custom_rule_value_info.0.auto_block", "0"),
+					resource.TestCheckResourceAttr(rName, "custom_rule_value_info.0.hash_type", "md5"),
+					resource.TestCheckResourceAttr(rName, "custom_rule_value_info.0.rule_type", "black_hash"),
+					resource.TestCheckResourceAttr(rName, "custom_rule_value_info.0.rule_values.0", ruleValue2),
+					resource.TestCheckResourceAttr(rName, "rule_status", "1"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"agent_ids"},
+			},
+		},
+	})
+}
+
+func testAccCustomRule_basic(name, agentId, ruleValue string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_custom_rule" "test" {
+  rule_name   = "%[1]s"
+  is_all_host = true
+  agent_ids   = ["%[2]s"]
+  rule_status = 0
+
+  custom_rule_value_info {
+    auto_block  = 1
+    hash_type   = "sha1"
+    rule_type   = "black_hash"
+    rule_values = ["%[3]s"]
+  }
+}
+`, name, agentId, ruleValue)
+}
+
+func testAccCustomRule_basic_update(name, agentId, ruleValue string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_custom_rule" "test" {
+  rule_name   = "%[1]s"
+  is_all_host = false
+  agent_ids   = ["%[2]s"]
+  rule_status = 1
+
+  custom_rule_value_info {
+    auto_block  = 0
+    hash_type   = "md5"
+    rule_type   = "black_hash"
+    rule_values = ["%[3]s"]
+  }
+}
+`, name, agentId, ruleValue)
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_custom_rule.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_custom_rule.go
@@ -1,0 +1,386 @@
+package hss
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/custom/rule/config/detail
+// @API HSS POST /v5/{project_id}/custom/rule/config/operate
+// @API HSS POST /v5/{project_id}/custom/rule/config
+// @API HSS GET /v5/{project_id}/custom/rule/config
+// @API HSS PUT /v5/{project_id}/custom/rule/config
+// @API HSS DELETE /v5/{project_id}/custom/rule/config
+func ResourceCustomRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCustomRuleCreate,
+		ReadContext:   resourceCustomRuleRead,
+		UpdateContext: resourceCustomRuleUpdate,
+		DeleteContext: resourceCustomRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			// The API works fine when the rule name is changed, but the changes don't take effect.
+			// A special note has been added to the documentation that the provider will not restrict the API's behavior.
+			"rule_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"custom_rule_value_info": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem:     customRuleValueInfoSchema(),
+			},
+			// This fields defaults to false in API definition.
+			"is_all_host": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			// The value of the `agent_ids` field does not always meet expectations.
+			// For example, a response timeout, a change in value, etc.
+			// Therefore, an additional attribute field is provided to record its value.
+			"agent_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// Defaults to `1`, means enabled. `0` means disabled.
+			"rule_status": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1,
+				ValidateFunc: validation.IntInSlice([]int{0, 1}),
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"host_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"agent_ids_attr": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func customRuleValueInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"rule_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"hash_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"auto_block": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"rule_values": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func buildCustomRuleValueInfoParams(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"rule_type":   rawMap["rule_type"],
+		"hash_type":   rawMap["hash_type"],
+		"auto_block":  rawMap["auto_block"],
+		"rule_values": rawMap["rule_values"],
+	}
+}
+
+func buildAgentIdsParam(rawArray []interface{}) interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	return utils.ExpandToStringList(rawArray)
+}
+
+func buildCreateCustomRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"rule_name":              d.Get("rule_name"),
+		"custom_rule_value_info": buildCustomRuleValueInfoParams(d.Get("custom_rule_value_info").([]interface{})),
+		"is_all_host":            d.Get("is_all_host"),
+		"agent_ids":              buildAgentIdsParam(d.Get("agent_ids").([]interface{})),
+	}
+}
+
+func updateCustomRuleRunStatus(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v5/{project_id}/custom/rule/config/operate"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		JSONBody: map[string]interface{}{
+			"enable": d.Get("rule_status"),
+			"rule_id_list": []string{
+				d.Id(),
+			},
+		},
+	}
+
+	_, err := client.Request("POST", requestPath, &requestOpt)
+	return err
+}
+
+func resourceCustomRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/custom/rule/config"
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateCustomRuleBodyParams(d)),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating HSS custom rule: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("rule_id", respBody, "").(string)
+	if id == "" {
+		return diag.FromErr(errors.New("error creating HSS custom rule: empty rule_id in response"))
+	}
+	d.SetId(id)
+
+	if d.Get("rule_status").(int) == 0 {
+		// close the custom rule
+		if err := updateCustomRuleRunStatus(client, d); err != nil {
+			return diag.Errorf("error updating HSS custom rule status in creation operation: %s", err)
+		}
+	}
+
+	return resourceCustomRuleRead(ctx, d, meta)
+}
+
+// We need to use both `GetCustomRuleByDetail` and `GetCustomRuleByList` to get the complete information of a custom rule.
+func GetCustomRuleByList(client *golangsdk.ServiceClient, ruleId string) (interface{}, error) {
+	requestPath := client.Endpoint + "v5/{project_id}/custom/rule/config"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?rule_id=%s", ruleId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	target := utils.PathSearch("data_list|[0]", respBody, nil)
+	if target == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return target, nil
+}
+
+func GetCustomRuleByDetail(client *golangsdk.ServiceClient, ruleId string) (interface{}, error) {
+	requestPath := client.Endpoint + "v5/{project_id}/custom/rule/config/detail"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += fmt.Sprintf("?rule_id=%s", ruleId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceCustomRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	targetFromList, err := GetCustomRuleByList(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving custom rule from list API")
+	}
+
+	targetFromDetail, err := GetCustomRuleByDetail(client, d.Id())
+	if err != nil {
+		return diag.Errorf("error retrieving custom rule from detail API: %s", err)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("rule_name", utils.PathSearch("rule_name", targetFromList, nil)),
+		d.Set("is_all_host", utils.PathSearch("is_all_host", targetFromList, nil)),
+		d.Set("rule_status", utils.PathSearch("rule_status", targetFromList, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", targetFromList, nil)),
+		d.Set("update_time", utils.PathSearch("update_time", targetFromList, nil)),
+		d.Set("host_num", utils.PathSearch("host_num", targetFromList, nil)),
+		d.Set("custom_rule_value_info", flattenCustomRuleValueInfo(targetFromDetail)),
+		d.Set("agent_ids_attr", utils.PathSearch("agent_ids", targetFromDetail, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCustomRuleValueInfo(respBody interface{}) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"rule_type":   utils.PathSearch("rule_type", respBody, nil),
+			"hash_type":   utils.PathSearch("hash_type", respBody, nil),
+			"auto_block":  utils.PathSearch("auto_block", respBody, nil),
+			"rule_values": utils.PathSearch("rule_values", respBody, nil),
+		},
+	}
+}
+
+func buildUpdateCustomRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return utils.RemoveNil(map[string]interface{}{
+		"rule_id":                d.Id(),
+		"rule_name":              d.Get("rule_name"),
+		"custom_rule_value_info": buildCustomRuleValueInfoParams(d.Get("custom_rule_value_info").([]interface{})),
+		"is_all_host":            d.Get("is_all_host"),
+		"agent_ids":              buildAgentIdsParam(d.Get("agent_ids").([]interface{})),
+	})
+}
+
+func resourceCustomRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	if d.HasChanges("rule_name", "custom_rule_value_info", "is_all_host", "agent_ids") {
+		requestPath := client.Endpoint + "v5/{project_id}/custom/rule/config"
+		requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+		requestOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         utils.RemoveNil(buildUpdateCustomRuleBodyParams(d)),
+		}
+
+		_, err := client.Request("PUT", requestPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error updating HSS custom rule: %s", err)
+		}
+	}
+
+	if d.HasChange("rule_status") {
+		if err := updateCustomRuleRunStatus(client, d); err != nil {
+			return diag.Errorf("error updating HSS custom rule status in update operation: %s", err)
+		}
+	}
+
+	return resourceCustomRuleRead(ctx, d, meta)
+}
+
+func resourceCustomRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v5/{project_id}/custom/rule/config"
+	)
+
+	client, err := cfg.NewServiceClient("hss", region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"rule_id_list": []string{d.Id()},
+		},
+	}
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error deleting HSS custom rule: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage custom rule

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [XX] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccCustomRule_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccCustomRule_basic -timeout 360m -parallel 10
=== RUN   TestAccCustomRule_basic
=== PAUSE TestAccCustomRule_basic
=== CONT  TestAccCustomRule_basic
--- PASS: TestAccCustomRule_basic (26.34s)
PASS
coverage: 3.2% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       26.491s coverage: 3.2% of statements in ./huaweicloud/services/hss
```
<img width="1417" height="83" alt="image" src="https://github.com/user-attachments/assets/07202547-7014-4b83-ad57-80b9b161c3c3" />


* [X] Documentation updated.
* [X] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="700" height="185" alt="image" src="https://github.com/user-attachments/assets/417facd4-95db-45e1-9787-2612834fe5bf" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
