### PR TITLE
feat(hss): new datasource to query custom rules

### DIFF
--- a/docs/data-sources/hss_custom_rules.md
+++ b/docs/data-sources/hss_custom_rules.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_custom_rules"
+description: |-
+  Use this data source to get the custom rules list of HSS within HuaweiCloud.
+---
+
+# huaweicloud_hss_custom_rules
+
+Use this data source to get the custom rules list of HSS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_custom_rules" "test" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `rule_id` - (Optional, String) Specifies the rule ID.
+
+* `rule_name` - (Optional, String) Specifies the rule name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data_list` - The custom rules list.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `rule_id` - The rule ID.
+
+* `host_num` - The number of protected hosts.
+
+* `rule_name` - The rule name.
+
+* `rule_status` - The rule status.  
+  The valid values are as follows:
+  + `0`: Disabled.
+  + `1`: Enabled.
+
+* `rule_type` - The rule type.  
+  The valid values are as follows:
+  + **black_hash**: Black hash.
+
+* `auto_block` - Whether to automatically block alerts.  
+  The valid values are as follows:
+  + `0`: Do not automatically block alerts.
+  + `1`: Automatically block alerts.
+
+* `hash_type` - The hash type.  
+  Valid values are: **sha256**, **md5**, and **sha1**.
+
+* `is_all_host` - Whether to select all hosts.
+
+* `create_time` - The creation time in milliseconds.
+
+* `update_time` - The update time in milliseconds.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1643,6 +1643,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_container_kubernetes_template":              hss.DataSourceHssContainerKubernetesTemplate(),
 			"huaweicloud_hss_container_kubernetes_clusters_daemonsets":   hss.DataSourceContainerKubernetesClustersDaemonsets(),
 			"huaweicloud_hss_container_nodes":                            hss.DataSourceContainerNodes(),
+			"huaweicloud_hss_custom_rules":                               hss.DataSourceCustomRules(),
 			"huaweicloud_hss_container_node_statistics":                  hss.DataSourceContainerNodeStatistics(),
 			"huaweicloud_hss_container_cluster_risks":                    hss.DataSourceContainerClusterRisks(),
 			"huaweicloud_hss_container_cluster_risk_affected_resources":  hss.DataSourceContainerClusterRiskAffectedResources(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_custom_rules_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_custom_rules_test.go
@@ -1,0 +1,115 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCustomRules_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_custom_rules.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCustomRules_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.rule_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.host_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.rule_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.rule_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.rule_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.auto_block"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.hash_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.is_all_host"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.0.update_time"),
+
+					resource.TestCheckOutput("is_rule_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_rule_name_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCustomRules_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_custom_rule" "test" {
+  rule_name   = "%[1]s"
+  is_all_host = true
+  agent_ids   = ["af08124fd77581dcd2a5f7cdaa208c285af0a1480f7ca9b5258193c021ca2637"] // mock data
+  rule_status = 0
+
+  custom_rule_value_info {
+    auto_block  = 1
+    hash_type   = "sha1"
+    rule_type   = "black_hash"
+    rule_values = ["08a7baa28dd268f8a12bc1f6fd95869321fe51144c5bf3321a6f6305edcd5245"] // mock data
+  }
+}
+`, name)
+}
+
+func testAccDataSourceCustomRules_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_hss_custom_rules" "test" {
+  depends_on = [huaweicloud_hss_custom_rule.test]
+}
+
+# Filter using rule_id.
+locals {
+  rule_id = data.huaweicloud_hss_custom_rules.test.data_list[0].rule_id
+}
+
+data "huaweicloud_hss_custom_rules" "rule_id_filter" {
+  rule_id = local.rule_id
+}
+
+output "is_rule_id_filter_useful" {
+  value = length(data.huaweicloud_hss_custom_rules.rule_id_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_custom_rules.rule_id_filter.data_list[*].rule_id : v == local.rule_id]
+  )
+}
+
+# Filter using rule_name.
+locals {
+  rule_name = data.huaweicloud_hss_custom_rules.test.data_list[0].rule_name
+}
+
+data "huaweicloud_hss_custom_rules" "rule_name_filter" {
+  rule_name = local.rule_name
+}
+
+output "is_rule_name_filter_useful" {
+  value = length(data.huaweicloud_hss_custom_rules.rule_name_filter.data_list) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_custom_rules.rule_name_filter.data_list[*].rule_name : v == local.rule_name]
+  )
+}
+
+# Filter using non existent rule_name.
+data "huaweicloud_hss_custom_rules" "not_found" {
+  rule_name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_hss_custom_rules.not_found.data_list) == 0
+}
+`, testAccDataSourceCustomRules_base(name))
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_custom_rules.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_custom_rules.go
@@ -1,0 +1,187 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/custom/rule/config
+func DataSourceCustomRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCustomRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"rule_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rule_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     customRulesDataListSchema(),
+			},
+		},
+	}
+}
+
+func customRulesDataListSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"rule_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"rule_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rule_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"rule_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auto_block": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"hash_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_all_host": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCustomRulesQueryParams(d *schema.ResourceData) string {
+	queryParams := "?limit=200"
+
+	if v, ok := d.GetOk("rule_id"); ok {
+		queryParams = fmt.Sprintf("%s&rule_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("rule_name"); ok {
+		queryParams = fmt.Sprintf("%s&rule_name=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceCustomRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		result  = make([]interface{}, 0)
+		offset  = 0
+		httpUrl = "v5/{project_id}/custom/rule/config"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildCustomRulesQueryParams(d)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%d", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS custom rules: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenCustomRulesDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCustomRulesDataList(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"rule_id":     utils.PathSearch("rule_id", v, nil),
+			"host_num":    utils.PathSearch("host_num", v, nil),
+			"rule_name":   utils.PathSearch("rule_name", v, nil),
+			"rule_status": utils.PathSearch("rule_status", v, nil),
+			"rule_type":   utils.PathSearch("rule_type", v, nil),
+			"auto_block":  utils.PathSearch("auto_block", v, nil),
+			"hash_type":   utils.PathSearch("hash_type", v, nil),
+			"is_all_host": utils.PathSearch("is_all_host", v, nil),
+			"create_time": utils.PathSearch("create_time", v, nil),
+			"update_time": utils.PathSearch("update_time", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query custom rules

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccDataSourceCustomRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceCustomRules_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCustomRules_basic
=== PAUSE TestAccDataSourceCustomRules_basic
=== CONT  TestAccDataSourceCustomRules_basic
--- PASS: TestAccDataSourceCustomRules_basic (16.69s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       16.863s coverage: 3.4% of statements in ./huaweicloud/services/hss
```
<img width="1386" height="74" alt="image" src="https://github.com/user-attachments/assets/ec5f4966-f38f-4ef9-86c9-384b73cfe8fe" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
