### PR TITLE
feat(hss): new datasource to query common hosts

### DIFF
--- a/docs/data-sources/hss_common_hosts.md
+++ b/docs/data-sources/hss_common_hosts.md
@@ -1,0 +1,142 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_common_hosts"
+description: |-
+  Use this data source to get the common hosts list of HSS within HuaweiCloud.
+---
+
+# huaweicloud_hss_common_hosts
+
+Use this data source to get the common hosts list of HSS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_hss_common_hosts" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  For querying assets under all enterprise projects, pass **all_granted_eps**.
+  If omitted, the default enterprise project **0** will be used.
+
+* `host_id` - (Optional, String) Specifies the server ID.
+
+* `host_name` - (Optional, String) Specifies the server name.
+
+* `private_ip` - (Optional, String) Specifies the server private IP address.
+
+* `public_ip` - (Optional, String) Specifies the server elastic IP address.
+
+* `feature_name` - (Optional, String) Specifies the policy name.
+  The valid values are as follows:
+  + **av_detect_feature**: AV policy.
+
+* `group_id` - (Optional, String) Specifies the unique identifier ID of the server group.
+
+* `asset_value` - (Optional, String) Specifies the asset importance.
+  The valid values are as follows:
+  + **important**: Important asset.
+  + **common**: Common asset.
+  + **test**: Test asset.
+
+* `agent_status` - (Optional, String) Specifies the Agent status.
+  The valid values are as follows:
+  + **installed**: Installed.
+  + **not_installed**: Not installed.
+  + **online**: Online.
+  + **offline**: Offline.
+  + **install_failed**: Installation failed.
+  + **installing**: Installing.
+
+* `cluster_id` - (Optional, String) Specifies the cluster ID.
+
+* `cluster_name` - (Optional, String) Specifies the cluster name.
+
+* `version_name_upper` - (Optional, String) Specifies the host version higher than this version.
+  The valid values are as follows:
+  + **hss.version.basic**: Basic version.
+  + **hss.version.advanced**: Advanced version.
+  + **hss.version.enterprise**: Enterprise version.
+  + **hss.version.premium**: Premium version.
+  + **hss.version.wtp**: Web page tamper protection version.
+  + **hss.version.container.enterprise**: Container version.
+
+* `version_name_lower` - (Optional, String) Specifies the host version lower than this version.
+  The valid values are as follows:
+  + **hss.version.basic**: Basic version.
+  + **hss.version.advanced**: Advanced version.
+  + **hss.version.enterprise**: Enterprise version.
+  + **hss.version.premium**: Premium version.
+  + **hss.version.wtp**: Web page tamper protection version.
+  + **hss.version.container.enterprise**: Container version.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `data_list` - The common hosts list.
+
+  The [data_list](#data_list_struct) structure is documented below.
+
+<a name="data_list_struct"></a>
+The `data_list` block supports:
+
+* `host_id` - The unique identifier ID of the server.
+
+* `host_name` - The server name.
+
+* `public_ip` - The server elastic IP address.
+
+* `private_ip` - The server private IP address.
+
+* `agent_id` - The unique identifier ID of the antivirus Agent installed on the host,
+  used to associate the host with the antivirus service.
+
+* `os_type` - The operating system type.
+  The valid values are as follows:
+  + **Linux**: Linux.
+  + **Windows**: Windows.
+
+* `host_status` - The server status.
+  The valid values are as follows:
+  + **ACTIVE**: Running.
+  + **SHUTOFF**: Shut down.
+  + **BUILDING**: Creating.
+  + **ERROR**: Error.
+
+* `agent_status` - The Agent status.
+  The valid values are as follows:
+  + **installed**: Installed.
+  + **not_installed**: Not installed.
+  + **online**: Online.
+  + **offline**: Offline.
+  + **install_failed**: Installation failed.
+  + **installing**: Installing.
+
+* `os_name` - The operating system name.
+
+* `os_version` - The operating system version.
+
+* `asset_value` - The asset importance.
+  The valid values are as follows:
+  + **important**: Important asset.
+  + **common**: Common asset.
+  + **test**: Test asset.
+
+* `cluster_id` - The cluster ID.
+
+* `cluster_name` - The cluster name.
+
+* `group_id` - The server group ID.
+
+* `group_name` - The server group name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1615,6 +1615,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_cluster_protect_overview":                   hss.DataSourceClusterProtectOverview(),
 			"huaweicloud_hss_cluster_protect_default_policies":           hss.DataSourceClusterProtectDefaultPolicies(),
 			"huaweicloud_hss_cluster_protect_protection_items":           hss.DataSourceClusterProtectProtectionItems(),
+			"huaweicloud_hss_common_hosts":                               hss.DataSourceCommonHosts(),
 			"huaweicloud_hss_cluster_protect_alarm_events":               hss.DataSourceClusterProtectAlarmEvents(),
 			"huaweicloud_hss_image_local_repositories":                   hss.DataSourceImageLocalRepositories(),
 			"huaweicloud_hss_image_local_hosts":                          hss.DataSourceImageLocalHosts(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_common_hosts_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_common_hosts_test.go
@@ -1,0 +1,39 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCommonHosts_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_common_hosts.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCommonHosts_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data_list.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCommonHosts_basic() string {
+	return `
+data "huaweicloud_hss_common_hosts" "test" {
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_common_hosts.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_common_hosts.go
@@ -1,0 +1,289 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/common/hosts
+func DataSourceCommonHosts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCommonHostsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"feature_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"asset_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"agent_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"version_name_upper": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"version_name_lower": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     commonHostsDataListSchema(),
+			},
+		},
+	}
+}
+
+func commonHostsDataListSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"host_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"agent_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"os_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"agent_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"os_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"os_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"asset_value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCommonHostsQueryParams(d *schema.ResourceData) string {
+	queryParams := "?limit=200"
+
+	if v, ok := d.GetOk("enterprise_project_id"); ok {
+		queryParams = fmt.Sprintf("%s&enterprise_project_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("host_id"); ok {
+		queryParams = fmt.Sprintf("%s&host_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("host_name"); ok {
+		queryParams = fmt.Sprintf("%s&host_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("private_ip"); ok {
+		queryParams = fmt.Sprintf("%s&private_ip=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("public_ip"); ok {
+		queryParams = fmt.Sprintf("%s&public_ip=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("feature_name"); ok {
+		queryParams = fmt.Sprintf("%s&feature_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("group_id"); ok {
+		queryParams = fmt.Sprintf("%s&group_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("asset_value"); ok {
+		queryParams = fmt.Sprintf("%s&asset_value=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("agent_status"); ok {
+		queryParams = fmt.Sprintf("%s&agent_status=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("cluster_id"); ok {
+		queryParams = fmt.Sprintf("%s&cluster_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("cluster_name"); ok {
+		queryParams = fmt.Sprintf("%s&cluster_name=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("version_name_upper"); ok {
+		queryParams = fmt.Sprintf("%s&version_name_upper=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("version_name_lower"); ok {
+		queryParams = fmt.Sprintf("%s&version_name_lower=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceCommonHostsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		result  = make([]interface{}, 0)
+		offset  = 0
+		httpUrl = "v5/{project_id}/common/hosts"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildCommonHostsQueryParams(d)
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestPathWithOffset := fmt.Sprintf("%s&offset=%v", requestPath, offset)
+		resp, err := client.Request("GET", requestPathWithOffset, &requestOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving HSS common hosts: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		dataList := utils.PathSearch("data_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(dataList) == 0 {
+			break
+		}
+
+		result = append(result, dataList...)
+		offset += len(dataList)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data_list", flattenCommonHostsDataList(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCommonHostsDataList(respArray []interface{}) []interface{} {
+	if len(respArray) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(respArray))
+	for _, v := range respArray {
+		rst = append(rst, map[string]interface{}{
+			"host_id":      utils.PathSearch("host_id", v, nil),
+			"host_name":    utils.PathSearch("host_name", v, nil),
+			"public_ip":    utils.PathSearch("public_ip", v, nil),
+			"private_ip":   utils.PathSearch("private_ip", v, nil),
+			"agent_id":     utils.PathSearch("agent_id", v, nil),
+			"os_type":      utils.PathSearch("os_type", v, nil),
+			"host_status":  utils.PathSearch("host_status", v, nil),
+			"agent_status": utils.PathSearch("agent_status", v, nil),
+			"os_name":      utils.PathSearch("os_name", v, nil),
+			"os_version":   utils.PathSearch("os_version", v, nil),
+			"asset_value":  utils.PathSearch("asset_value", v, nil),
+			"cluster_id":   utils.PathSearch("cluster_id", v, nil),
+			"cluster_name": utils.PathSearch("cluster_name", v, nil),
+			"group_id":     utils.PathSearch("group_id", v, nil),
+			"group_name":   utils.PathSearch("group_name", v, nil),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query common hosts

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o hss -f TestAccDataSourceCommonHosts_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/hss" -v -coverprofile="./huaweicloud/services/acceptance/hss/hss_coverage.cov" -coverpkg="./huaweicloud/services/hss" -run TestAccDataSourceCommonHosts_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCommonHosts_basic
=== PAUSE TestAccDataSourceCommonHosts_basic
=== CONT  TestAccDataSourceCommonHosts_basic
--- PASS: TestAccDataSourceCommonHosts_basic (13.83s)
PASS
coverage: 2.9% of statements in ./huaweicloud/services/hss
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       13.978s coverage: 2.9% of statements in ./huaweicloud/services/hss
```
<img width="1385" height="80" alt="image" src="https://github.com/user-attachments/assets/4fa122d1-c840-4c65-a41a-c50823708c63" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
