### PR TITLE
feat(modelarts): add new data source to query algorithms

### DIFF
--- a/docs/data-sources/modelarts_algorithms.md
+++ b/docs/data-sources/modelarts_algorithms.md
@@ -1,0 +1,245 @@
+﻿---
+subcategory: "ModelArts"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_algorithms"
+description: |-
+  Use this data source to query the ModelArts algorithm list within HuaweiCloud.
+---
+
+# huaweicloud_modelarts_algorithms
+
+Use this data source to query the ModelArts algorithm list within HuaweiCloud.
+
+## Example Usage
+
+### Query all algorithms
+
+```hcl
+data "huaweicloud_modelarts_algorithms" "test" {}
+```
+
+### Filter by name fuzzy matching
+
+```hcl
+variable "algorithm_name" {}
+
+data "huaweicloud_modelarts_algorithms" "test" {
+  searches = "name:${var.algorithm_name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the algorithms are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Optional, String) Specifies the ID of the workspace to which the algorithms belong.  
+  If omitted, all algorithms in the current region will be queried.
+
+* `searches` - (Optional, String) Specifies the filter condition for searching algorithms.
+  The format is: `key:value`.
+  For example, `name:${name}` means fuzzy matching by algorithm name.
+
+* `sort_by` - (Optional, String) Specifies the field by which the algorithms are sorted.  
+  The valid values are as follows:
+  + **name**
+  + **create_time**
+
+  Defaults to `create_time`.
+
+* `order` - (Optional, String) Specifies the sort order of the algorithms.  
+  The valid values are as follows:
+  + **asc**
+  + **desc**
+
+  Defaults to `desc`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `algorithms` - The list of algorithms that matched filter parameters.  
+  The [algorithms](#modelarts_algorithms) structure is documented below.
+
+<a name="modelarts_algorithms"></a>
+The `algorithms` block supports:
+
+* `metadata` - The metadata of the algorithm.  
+  The [metadata](#modelarts_algorithms_metadata) structure is documented below.
+
+* `job_config` - The configuration of the algorithm.  
+  The [job_config](#modelarts_algorithms_job_config) structure is documented below.
+
+* `resource_requirements` - The resource constraint list of the algorithm.  
+  The [resource_requirements](#modelarts_algorithms_resource_requirements) structure is documented below.
+
+* `advanced_config` - The advanced configuration of the algorithm.  
+  The [advanced_config](#modelarts_algorithms_advanced_config) structure is documented below.
+
+<a name="modelarts_algorithms_metadata"></a>
+The `metadata` block supports:
+
+* `id` - The ID of the algorithm.
+
+* `name` - The name of the algorithm.
+
+* `description` - The description of the algorithm.
+
+* `workspace_id` - The ID of the workspace to which the algorithm belongs.
+
+* `user_name` - The user name of the algorithm.
+
+* `source` - The source type of the algorithm.
+
+* `is_valid` - The availability of the algorithm.
+
+* `state` - The state of the algorithm.
+
+* `tags` - The tags of the algorithm.  
+  The [tags](#modelarts_algorithms_metadata_tags) structure is documented below.
+
+* `attr_list` - The attribute list of the algorithm.
+
+* `version_num` - The version number of the algorithm.
+
+* `size` - The size of the algorithm.
+
+* `create_time` - The creation time of the algorithm, in RFC3339 format.
+
+* `update_time` - The update time of the algorithm, in RFC3339 format.
+
+<a name="modelarts_algorithms_metadata_tags"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+<a name="modelarts_algorithms_job_config"></a>
+The `job_config` block supports:
+
+* `code_dir` - The code directory of the algorithm.
+
+* `boot_file` - The boot file of the algorithm.
+
+* `command` - The container start command for custom image algorithm.
+
+* `parameters_customization` - Whether the hyperparameter can be customized.
+
+* `parameters` - The running parameters of the algorithm.  
+  The [parameters](#modelarts_algorithms_job_config_parameters) structure is documented below.
+
+* `inputs` - The data input list of the algorithm.  
+  The [inputs](#modelarts_algorithms_job_config_inputs) structure is documented below.
+
+* `outputs` - The data output list of the algorithm.  
+  The [outputs](#modelarts_algorithms_job_config_outputs) structure is documented below.
+
+* `engine` - The engine of the algorithm.  
+  The [engine](#modelarts_algorithms_job_config_engine) structure is documented below.
+
+<a name="modelarts_algorithms_job_config_parameters"></a>
+The `parameters` block supports:
+
+* `name` - The name of the parameter.
+
+* `value` - The value of the parameter.
+
+* `description` - The description of the parameter.
+
+<a name="modelarts_algorithms_job_config_inputs"></a>
+The `inputs` block supports:
+
+* `name` - The name of the data input channel.
+
+* `description` - The description of the data input channel.
+
+<a name="modelarts_algorithms_job_config_outputs"></a>
+The `outputs` block supports:
+
+* `name` - The name of the data output channel.
+
+* `description` - The description of the data output channel.
+
+<a name="modelarts_algorithms_job_config_engine"></a>
+The `engine` block supports:
+
+* `engine_id` - The ID of the engine.
+
+* `engine_name` - The name of the engine.
+
+* `engine_version` - The version of the engine.
+
+* `image_url` - The custom image URL of the algorithm.
+
+<a name="modelarts_algorithms_resource_requirements"></a>
+The `resource_requirements` block supports:
+
+* `key` - The key of the resource constraint.
+
+* `values` - The values corresponding to the key.
+
+* `operator` - The relationship between the key and values.
+
+<a name="modelarts_algorithms_advanced_config"></a>
+The `advanced_config` block supports:
+
+* `auto_search` - The hyperparameter search strategy.  
+  The [auto_search](#modelarts_algorithms_advanced_config_auto_search) structure is documented below.
+
+<a name="modelarts_algorithms_advanced_config_auto_search"></a>
+The `auto_search` block supports:
+
+* `skip_search_params` - The hyperparameter combinations to be excluded from search.
+
+* `reward_attrs` - The metric list of search.  
+  The [reward_attrs](#modelarts_algorithms_advanced_config_auto_search_reward_attrs) structure is documented below.
+
+* `search_params` - The search parameters.  
+  The [search_params](#modelarts_algorithms_advanced_config_auto_search_search_params) structure is documented below.
+
+* `algo_configs` - The search algorithm configurations.  
+  The [algo_configs](#modelarts_algorithms_advanced_config_auto_search_algo_configs) structure is documented below.
+
+<a name="modelarts_algorithms_advanced_config_auto_search_reward_attrs"></a>
+The `reward_attrs` block supports:
+
+* `name` - The metric name.
+
+* `mode` - The search direction.
+
+* `regex` - The metric regular expression.
+
+<a name="modelarts_algorithms_advanced_config_auto_search_search_params"></a>
+The `search_params` block supports:
+
+* `name` - The hyperparameter name.
+
+* `param_type` - The parameter type.
+
+* `lower_bound` - The lower bound of the hyperparameter.
+
+* `upper_bound` - The upper bound of the hyperparameter.
+
+* `discrete_points_num` - The number of discrete samples for continuous hyperparameters.
+
+* `discrete_values` - The discrete values for discrete hyperparameters.
+
+<a name="modelarts_algorithms_advanced_config_auto_search_algo_configs"></a>
+The `algo_configs` block supports:
+
+* `name` - The search algorithm name.
+
+* `params` - The search algorithm parameters.  
+  The [params](#modelarts_algorithms_advanced_config_auto_search_algo_configs_params) structure is documented below.
+
+<a name="modelarts_algorithms_advanced_config_auto_search_algo_configs_params"></a>
+The `params` block supports:
+
+* `key` - The key of the parameter.
+
+* `value` - The value of the parameter.
+
+* `type` - The type of the parameter.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2031,6 +2031,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_networking_secgroup_rules":    vpc.DataSourceNetworkingSecGroupRules(),
 			"huaweicloud_networking_secgroup_tags":     vpc.DataSourceVpcNetworkingSecgroupTags(),
 
+			"huaweicloud_modelarts_algorithms":           modelarts.DataSourceAlgorithms(),
 			"huaweicloud_modelarts_dataset_versions":     modelarts.DataSourceDatasetVerions(),
 			"huaweicloud_modelarts_datasets":             modelarts.DataSourceDatasets(),
 			"huaweicloud_modelarts_devserver_flavors":    modelarts.DataSourceDevServerFlavors(),

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_algorithms_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_algorithms_test.go
@@ -1,0 +1,311 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataAlgorithms_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceNameWithDash()
+
+		all   = "data.huaweicloud_modelarts_algorithms.all"
+		dcAll = acceptance.InitDataSourceCheck(all)
+
+		byWorkspaceId   = "data.huaweicloud_modelarts_algorithms.filter_by_workspace_id"
+		dcByWorkspaceId = acceptance.InitDataSourceCheck(byWorkspaceId)
+
+		bySearches   = "data.huaweicloud_modelarts_algorithms.filter_by_searches"
+		dcBySearches = acceptance.InitDataSourceCheck(bySearches)
+
+		bySortByAndOrderDesc   = "data.huaweicloud_modelarts_algorithms.filter_by_sort_by_and_order_desc"
+		dcBySortByAndOrderDesc = acceptance.InitDataSourceCheck(bySortByAndOrderDesc)
+
+		bySortByAndOrderAsc   = "data.huaweicloud_modelarts_algorithms.filter_by_sort_by_and_order_asc"
+		dcBySortByAndOrderAsc = acceptance.InitDataSourceCheck(bySortByAndOrderAsc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckModelArtsAlgorithm(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataAlgorithms_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dcAll.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "algorithms.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'workspace_id' parameter.
+					dcByWorkspaceId.CheckResourceExists(),
+					resource.TestCheckOutput("is_workspace_id_filter_useful", "true"),
+					// Filter by 'searches' (fuzzy name matching) parameter.
+					dcBySearches.CheckResourceExists(),
+					resource.TestCheckOutput("is_searches_filter_useful", "true"),
+					// Filter by 'sort_by' and 'order' parameters.
+					dcBySortByAndOrderDesc.CheckResourceExists(),
+					dcBySortByAndOrderAsc.CheckResourceExists(),
+					resource.TestCheckOutput("is_sort_by_and_order_useful", "true"),
+					// Check attributes.
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.metadata.0.id"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.metadata.0.name"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.metadata.0.description"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.metadata.0.workspace_id"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.metadata.0.create_time"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.metadata.0.source"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.metadata.0.is_valid"),
+					resource.TestMatchResourceAttr(bySearches, "algorithms.0.job_config.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.job_config.0.code_dir"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.job_config.0.boot_file"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.job_config.0.parameters_customization"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.job_config.0.engine.0.engine_id"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.job_config.0.engine.0.engine_name"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.job_config.0.engine.0.engine_version"),
+					resource.TestMatchResourceAttr(bySearches, "algorithms.0.job_config.0.inputs.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.job_config.0.inputs.0.name"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.job_config.0.inputs.0.description"),
+					resource.TestMatchResourceAttr(bySearches, "algorithms.0.job_config.0.outputs.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.job_config.0.outputs.0.name"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.job_config.0.outputs.0.description"),
+					resource.TestMatchResourceAttr(bySearches, "algorithms.0.job_config.0.parameters.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.job_config.0.parameters.0.name"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.job_config.0.parameters.0.description"),
+					resource.TestMatchResourceAttr(bySearches, "algorithms.0.resource_requirements.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.resource_requirements.0.key"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.resource_requirements.0.operator"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.resource_requirements.0.values.#"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.resource_requirements.1.key"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.resource_requirements.1.values.#"),
+					resource.TestMatchResourceAttr(bySearches, "algorithms.0.advanced_config.0.auto_search.0.reward_attrs.#",
+						regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.advanced_config.0.auto_search.0.reward_attrs.0.name"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.advanced_config.0.auto_search.0.reward_attrs.0.mode"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.advanced_config.0.auto_search.0.reward_attrs.0.regex"),
+					resource.TestMatchResourceAttr(bySearches, "algorithms.0.advanced_config.0.auto_search.0.search_params.#",
+						regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.advanced_config.0.auto_search.0.search_params.0.name"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.advanced_config.0.auto_search.0.search_params.0.lower_bound"),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.advanced_config.0.auto_search.0.search_params.0.upper_bound"),
+					resource.TestMatchResourceAttr(bySearches, "algorithms.0.advanced_config.0.auto_search.0.algo_configs.#",
+						regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(bySearches, "algorithms.0.advanced_config.0.auto_search.0.algo_configs.0.name"),
+					resource.TestMatchResourceAttr(bySearches, "algorithms.0.advanced_config.0.auto_search.0.algo_configs.0.params.#",
+						regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataAlgorithms_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[1]s"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "%[1]s/bootfile.py"
+  content      = <<EOF
+#!/usr/bin/env python
+import os
+print(os.getcwd())
+EOF
+  content_type = "text/py"
+}
+
+resource "huaweicloud_modelarts_workspace" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_modelarts_algorithm" "test" {
+  metadata {
+    name         = "%[1]s"
+    description  = "Created by terraform script"
+    workspace_id = huaweicloud_modelarts_workspace.test.id
+
+    tags {
+      key = "auto_search"
+    }
+  }
+
+  job_config {
+    code_dir  = "/${huaweicloud_obs_bucket.test.bucket}/%[1]s/"
+    boot_file = "/${huaweicloud_obs_bucket.test.bucket}/${huaweicloud_obs_bucket_object.test.key}"
+
+    engine {
+      engine_id      = "%[2]s"
+      engine_version = "%[2]s"
+      engine_name    = "%[3]s"
+    }
+
+    parameters_customization = true
+
+    inputs {
+      name          = "%[1]s"
+      description   = "Input parameter1"
+      access_method = "parameter"
+      remote_constraints {
+        data_type = "obs"
+      }
+
+      remote_constraints {
+        data_type = "modelarts_dataset"
+        attributes = jsonencode({
+          data_format       = ["CarbonData"]
+          data_segmentation = ["false"]
+          dataset_type      = ["0"]
+        })
+      }
+    }
+
+    outputs {
+      name          = "%[1]s"
+      description   = "Output parameter1"
+      access_method = "env"
+    }
+
+    parameters {
+      name        = "%[1]s"
+      description = "parameter1"
+
+      constraint {
+        type        = "Float"
+        editable    = true
+        required    = true
+        valid_range = ["10", "50"]
+      }
+    }
+  }
+
+  resource_requirements {
+    key      = "flavor_type"
+    values   = ["Ascend", "CPU"]
+    operator = "in"
+  }
+  resource_requirements {
+    key      = "device_distributed_mode"
+    values   = ["singular"]
+    operator = "in"
+  }
+  resource_requirements {
+    key      = "host_distributed_mode"
+    values   = ["multiple"]
+    operator = "in"
+  }
+
+  advanced_config {
+    auto_search {
+      reward_attrs {
+        name  = "search"
+        mode  = "max"
+        regex = "10.0"
+      }
+
+      search_params {
+        name        = "%[1]s"
+        lower_bound = "20"
+        upper_bound = "30"
+      }
+
+      algo_configs {
+        name = "bayes_opt_search"
+
+        params {
+          key   = "num_samples"
+          value = "20"
+          type  = "Integer"
+        }
+        params {
+          key   = "kind"
+          value = "ucb"
+          type  = "String"
+        }
+      }
+    }
+  }
+}
+`, name, acceptance.HW_MODELARTS_ALGORITHM_ENGINE_ID, acceptance.HW_MODELARTS_ALGORITHM_ENGINE_NAME)
+}
+
+func testAccDataAlgorithms_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_modelarts_algorithms" "all" {
+  depends_on = [huaweicloud_modelarts_algorithm.test]
+}
+
+# Filter by 'workspace_id' parameter.
+locals {
+  workspace_id = huaweicloud_modelarts_workspace.test.id
+}
+data "huaweicloud_modelarts_algorithms" "filter_by_workspace_id" {
+  workspace_id = local.workspace_id
+
+  depends_on = [huaweicloud_modelarts_algorithm.test]
+}
+
+locals {
+  workspace_id_filter_result = [for v in data.huaweicloud_modelarts_algorithms.filter_by_workspace_id.algorithms :
+  v.metadata[0].workspace_id == local.workspace_id]
+}
+
+output "is_workspace_id_filter_useful" {
+  value = length(local.workspace_id_filter_result) > 0 && alltrue(local.workspace_id_filter_result)
+}
+
+# Filter by 'searches' (fuzzy name matching) parameter.
+locals {
+  name = huaweicloud_modelarts_algorithm.test.metadata[0].name
+}
+
+data "huaweicloud_modelarts_algorithms" "filter_by_searches" {
+  searches = "name:${local.name}"
+
+  depends_on = [huaweicloud_modelarts_algorithm.test]
+}
+
+locals {
+  searches_filter_result = [for v in data.huaweicloud_modelarts_algorithms.filter_by_searches.algorithms :
+  v.metadata[0].name == local.name]
+}
+
+output "is_searches_filter_useful" {
+  value = length(local.searches_filter_result) > 0 && alltrue(local.searches_filter_result)
+}
+
+# Filter by 'sort_by' and 'order' parameters.
+data "huaweicloud_modelarts_algorithms" "filter_by_sort_by_and_order_desc" {
+  sort_by = "name"
+
+  depends_on = [huaweicloud_modelarts_algorithm.test]
+}
+
+data "huaweicloud_modelarts_algorithms" "filter_by_sort_by_and_order_asc" {
+  sort_by = "name"
+  order   = "asc"
+
+  depends_on = [huaweicloud_modelarts_algorithm.test]
+}
+
+locals {
+  sort_by_and_order_desc_result = data.huaweicloud_modelarts_algorithms.filter_by_sort_by_and_order_desc.algorithms[*].metadata[0].name
+  sort_by_and_order_asc_result  = data.huaweicloud_modelarts_algorithms.filter_by_sort_by_and_order_asc.algorithms[*].metadata[0].name
+}
+
+output "is_sort_by_and_order_useful" {
+  value = local.sort_by_and_order_desc_result == reverse(local.sort_by_and_order_asc_result)
+}
+`, testAccDataAlgorithms_base(name))
+}

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_algorithms.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_algorithms.go
@@ -1,0 +1,839 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ModelArts GET /v2/{project_id}/algorithms
+func DataSourceAlgorithms() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAlgorithmsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region where the algorithms are located.",
+			},
+
+			// Optional parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the workspace to which the algorithms belong.",
+			},
+			"searches": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The filter condition for searching algorithms.",
+			},
+			"sort_by": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The field by which the algorithms are sorted.",
+			},
+			"order": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The sort order of the algorithms.",
+			},
+
+			// Attributes.
+			"algorithms": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        algorithmsSchema(),
+				Description: "The list of algorithms that matched filter parameters.",
+			},
+		},
+	}
+}
+
+func algorithmsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"metadata": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        algorithmsMetadataSchema(),
+				Description: "The metadata configuration of the algorithm.",
+			},
+			"job_config": {
+				Type:        schema.TypeList,
+				Elem:        algorithmsJobConfigSchema(),
+				Computed:    true,
+				Description: "The configuration of the algorithm.",
+			},
+			"resource_requirements": {
+				Type:        schema.TypeList,
+				Elem:        algorithmsResourceRequirementsSchema(),
+				Computed:    true,
+				Description: "The resource constraint list of the algorithm.",
+			},
+			"advanced_config": {
+				Type:        schema.TypeList,
+				Elem:        algorithmsAdvancedConfigSchema(),
+				Computed:    true,
+				Description: "The advanced configuration of the algorithm.",
+			},
+		},
+	}
+}
+
+func algorithmsMetadataSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the algorithm.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the algorithm.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the algorithm.",
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the workspace to which the algorithm belongs.",
+			},
+			"user_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The user name of the algorithm.",
+			},
+			"source": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The source type of the algorithm.",
+			},
+			"is_valid": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "The availability of the algorithm.",
+			},
+			"state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The state of the algorithm.",
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The key of the tag.`,
+						},
+					},
+				},
+				Description: "The tags of the algorithm.",
+			},
+			"attr_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The attribute list of the algorithm.",
+			},
+			"version_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The version number of the algorithm.",
+			},
+			"size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The size of the algorithm.",
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the algorithm, in RFC3339 format.",
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The update time of the algorithm, in RFC3339 format.",
+			},
+		},
+	}
+}
+
+func algorithmsJobConfigSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"code_dir": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The code directory of the algorithm.",
+			},
+			"boot_file": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The boot file of the algorithm.",
+			},
+			"command": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The container start command for custom image algorithm.",
+			},
+			"parameters_customization": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the hyperparameter can be customized.",
+			},
+			"parameters": {
+				Type:        schema.TypeList,
+				Elem:        algorithmsJobConfigParametersSchema(),
+				Computed:    true,
+				Description: "The running parameters of the algorithm.",
+			},
+			"inputs": {
+				Type:        schema.TypeList,
+				Elem:        algorithmsJobConfigInputsSchema(),
+				Computed:    true,
+				Description: "The data input list of the algorithm.",
+			},
+			"outputs": {
+				Type:        schema.TypeList,
+				Elem:        algorithmsJobConfigOutputsSchema(),
+				Computed:    true,
+				Description: "The data output list of the algorithm.",
+			},
+			"engine": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        algorithmsJobConfigEngineSchema(),
+				Description: "The engine of the algorithm.",
+			},
+		},
+	}
+}
+
+func algorithmsJobConfigParametersSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the parameter.",
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The value of the parameter.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the parameter.",
+			},
+		},
+	}
+}
+
+func algorithmsJobConfigInputsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the data input channel.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the data input channel.",
+			},
+		},
+	}
+}
+
+func algorithmsJobConfigOutputsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the data output channel.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the data output channel.",
+			},
+		},
+	}
+}
+
+func algorithmsJobConfigEngineSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"engine_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the engine.",
+			},
+			"engine_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the engine.",
+			},
+			"engine_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The version of the engine.",
+			},
+			"image_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The custom image URL of the algorithm.",
+			},
+		},
+	}
+}
+
+func algorithmsResourceRequirementsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The key of the resource constraint.",
+			},
+			"values": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The values corresponding to the key.",
+			},
+			"operator": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The relationship between the key and values.",
+			},
+		},
+	}
+}
+
+func algorithmsAdvancedConfigSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"auto_search": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        algorithmsAdvancedConfigAutoSearchSchema(),
+				Description: "The hyperparameter search strategy.",
+			},
+		},
+	}
+}
+
+func algorithmsAdvancedConfigAutoSearchSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"skip_search_params": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The hyperparameter combinations to be excluded from search.",
+			},
+			"reward_attrs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        algorithmsAdvancedConfigAutoSearchRewardAttrsSchema(),
+				Description: "The metric list of search.",
+			},
+			"search_params": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        algorithmsAdvancedConfigAutoSearchSearchParamsSchema(),
+				Description: "The search parameters.",
+			},
+			"algo_configs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        algorithmsAdvancedConfigAutoSearchAlgoConfigsSchema(),
+				Description: "The search algorithm configurations.",
+			},
+		},
+	}
+}
+
+func algorithmsAdvancedConfigAutoSearchRewardAttrsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The metric name.",
+			},
+			"mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The search direction.",
+			},
+			"regex": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The metric regular expression.",
+			},
+		},
+	}
+}
+
+func algorithmsAdvancedConfigAutoSearchSearchParamsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The hyperparameter name.",
+			},
+			"param_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The parameter type.",
+			},
+			"lower_bound": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The lower bound of the hyperparameter.",
+			},
+			"upper_bound": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The upper bound of the hyperparameter.",
+			},
+			"discrete_points_num": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The number of discrete samples for continuous hyperparameters.",
+			},
+			"discrete_values": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The discrete values for discrete hyperparameters.",
+			},
+		},
+	}
+}
+
+func algorithmsAdvancedConfigAutoSearchAlgoConfigsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The search algorithm name.",
+			},
+			"params": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        algorithmsAdvancedConfigAutoSearchAlgoConfigsParamsSchema(),
+				Description: "The search algorithm parameters.",
+			},
+		},
+	}
+}
+
+func algorithmsAdvancedConfigAutoSearchAlgoConfigsParamsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The key of the parameter.",
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The value of the parameter.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the parameter.",
+			},
+		},
+	}
+}
+
+func buildAlgorithmsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("workspace_id"); ok {
+		res = fmt.Sprintf("%s&workspace_id=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("searches"); ok {
+		res = fmt.Sprintf("%s&searches=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("sort_by"); ok {
+		res = fmt.Sprintf("%s&sort_by=%v", res, v)
+	}
+
+	if v, ok := d.GetOk("order"); ok {
+		res = fmt.Sprintf("%s&order=%v", res, v)
+	}
+
+	return res
+}
+
+func listAlgorithms(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/algorithms"
+		// Maximum is 50.
+		limit    = 50
+		pageSize = 0
+		result   = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += fmt.Sprintf("?limit=%d%s", limit, buildAlgorithmsQueryParams(d))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithPageSize := listPath + fmt.Sprintf("&offset=%d", pageSize)
+		requestResp, err := client.Request("GET", listPathWithPageSize, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		items := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(items) < 1 {
+			break
+		}
+
+		result = append(result, items...)
+		if len(items) < limit {
+			break
+		}
+
+		pageSize++
+	}
+
+	return result, nil
+}
+
+func flattenAlgorithms(algorithms []interface{}) []interface{} {
+	if len(algorithms) < 1 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(algorithms))
+	for _, v := range algorithms {
+		rst = append(rst, map[string]interface{}{
+			"metadata":   flattenAlgorithmsMetadata(utils.PathSearch("metadata", v, nil)),
+			"job_config": flattenAlgorithmsJobConfig(utils.PathSearch("job_config", v, nil)),
+			"resource_requirements": flattenAlgorithmsResourceRequirements(utils.PathSearch("resource_requirements",
+				v, make([]interface{}, 0)).([]interface{})),
+			"advanced_config": flattenAlgorithmsAdvancedConfig(utils.PathSearch("advanced_config", v, nil)),
+		})
+	}
+	return rst
+}
+
+func flattenAlgorithmsMetadata(metadata interface{}) []interface{} {
+	if metadata == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"id":           utils.PathSearch("id", metadata, nil),
+			"name":         utils.PathSearch("name", metadata, nil),
+			"description":  utils.PathSearch("description", metadata, nil),
+			"workspace_id": utils.PathSearch("workspace_id", metadata, nil),
+			"user_name":    utils.PathSearch("user_name", metadata, nil),
+			"source":       utils.PathSearch("source", metadata, nil),
+			"is_valid":     utils.PathSearch("is_valid", metadata, nil),
+			"state":        utils.PathSearch("state", metadata, nil),
+			"tags": flattenAlgorithmsMetadataTags(utils.PathSearch("tags",
+				metadata, make([]interface{}, 0)).([]interface{})),
+			"attr_list":   utils.PathSearch("attr_list", metadata, nil),
+			"version_num": utils.PathSearch("version_num", metadata, nil),
+			"size":        utils.PathSearch("size", metadata, nil),
+			"create_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time",
+				metadata, float64(0)).(float64))/1000, false),
+			"update_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time",
+				metadata, float64(0)).(float64))/1000, false),
+		},
+	}
+}
+
+func flattenAlgorithmsMetadataTags(tags []interface{}) []map[string]interface{} {
+	if len(tags) < 1 {
+		return make([]map[string]interface{}, 0)
+	}
+
+	result := make([]map[string]interface{}, 0, len(tags))
+	for _, v := range tags {
+		result = append(result, map[string]interface{}{
+			"key": utils.PathSearch("key", v, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenAlgorithmsJobConfig(jobConfig interface{}) []interface{} {
+	if jobConfig == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"code_dir":                 utils.PathSearch("code_dir", jobConfig, nil),
+			"boot_file":                utils.PathSearch("boot_file", jobConfig, nil),
+			"command":                  utils.PathSearch("command", jobConfig, nil),
+			"parameters_customization": utils.PathSearch("parameters_customization", jobConfig, nil),
+			"parameters": flattenAlgorithmsJobConfigParameters(
+				utils.PathSearch("parameters", jobConfig, make([]interface{}, 0)).([]interface{})),
+			"inputs": flattenAlgorithmsJobConfigInputs(
+				utils.PathSearch("inputs", jobConfig, make([]interface{}, 0)).([]interface{})),
+			"outputs": flattenAlgorithmsJobConfigOutputs(
+				utils.PathSearch("outputs", jobConfig, make([]interface{}, 0)).([]interface{})),
+			"engine": flattenAlgorithmsJobConfigEngine(
+				utils.PathSearch("engine", jobConfig, nil)),
+		},
+	}
+}
+
+func flattenAlgorithmsJobConfigParameters(parameters []interface{}) []interface{} {
+	if len(parameters) < 1 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(parameters))
+	for _, v := range parameters {
+		rst = append(rst, map[string]interface{}{
+			"name":        utils.PathSearch("name", v, nil),
+			"value":       utils.PathSearch("value", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenAlgorithmsJobConfigInputs(inputs []interface{}) []interface{} {
+	if len(inputs) < 1 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(inputs))
+	for _, v := range inputs {
+		rst = append(rst, map[string]interface{}{
+			"name":        utils.PathSearch("name", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenAlgorithmsJobConfigOutputs(outputs []interface{}) []interface{} {
+	if len(outputs) < 1 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(outputs))
+	for _, v := range outputs {
+		rst = append(rst, map[string]interface{}{
+			"name":        utils.PathSearch("name", v, nil),
+			"description": utils.PathSearch("description", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenAlgorithmsJobConfigEngine(engine interface{}) []interface{} {
+	if engine == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"engine_id":      utils.PathSearch("engine_id", engine, nil),
+			"engine_name":    utils.PathSearch("engine_name", engine, nil),
+			"engine_version": utils.PathSearch("engine_version", engine, nil),
+			"image_url":      utils.PathSearch("image_url", engine, nil),
+		},
+	}
+}
+
+func flattenAlgorithmsResourceRequirements(requirements []interface{}) []interface{} {
+	if len(requirements) < 1 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(requirements))
+	for _, v := range requirements {
+		rst = append(rst, map[string]interface{}{
+			"key":      utils.PathSearch("key", v, nil),
+			"values":   utils.PathSearch("values", v, nil),
+			"operator": utils.PathSearch("operator", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenAlgorithmsAdvancedConfig(advancedConfig interface{}) []interface{} {
+	if advancedConfig == nil {
+		return nil
+	}
+
+	autoSearch := utils.PathSearch("auto_search", advancedConfig, nil)
+	if autoSearch == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"auto_search": flattenAlgorithmsAdvancedConfigAutoSearch(autoSearch),
+		},
+	}
+}
+
+func flattenAlgorithmsAdvancedConfigAutoSearch(autoSearch interface{}) []interface{} {
+	if autoSearch == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"skip_search_params": utils.PathSearch("skip_search_params", autoSearch, nil),
+			"reward_attrs": flattenAlgorithmsAdvancedConfigAutoSearchRewardAttrs(
+				utils.PathSearch("reward_attrs", autoSearch, make([]interface{}, 0)).([]interface{})),
+			"search_params": flattenAlgorithmsAdvancedConfigAutoSearchSearchParams(
+				utils.PathSearch("search_params", autoSearch, make([]interface{}, 0)).([]interface{})),
+			"algo_configs": flattenAlgorithmsAdvancedConfigAutoSearchAlgoConfigs(
+				utils.PathSearch("algo_configs", autoSearch, make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}
+
+func flattenAlgorithmsAdvancedConfigAutoSearchRewardAttrs(rewardAttrs []interface{}) []interface{} {
+	if len(rewardAttrs) < 1 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(rewardAttrs))
+	for _, v := range rewardAttrs {
+		rst = append(rst, map[string]interface{}{
+			"name":  utils.PathSearch("name", v, nil),
+			"mode":  utils.PathSearch("mode", v, nil),
+			"regex": utils.PathSearch("regex", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenAlgorithmsAdvancedConfigAutoSearchSearchParams(searchParams []interface{}) []interface{} {
+	if len(searchParams) < 1 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(searchParams))
+	for _, v := range searchParams {
+		rst = append(rst, map[string]interface{}{
+			"name":                utils.PathSearch("name", v, nil),
+			"param_type":          utils.PathSearch("param_type", v, nil),
+			"lower_bound":         utils.PathSearch("lower_bound", v, nil),
+			"upper_bound":         utils.PathSearch("upper_bound", v, nil),
+			"discrete_points_num": utils.PathSearch("discrete_points_num", v, nil),
+			"discrete_values":     utils.PathSearch("discrete_values", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenAlgorithmsAdvancedConfigAutoSearchAlgoConfigs(algoConfigs []interface{}) []interface{} {
+	if len(algoConfigs) < 1 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(algoConfigs))
+	for _, v := range algoConfigs {
+		rst = append(rst, map[string]interface{}{
+			"name": utils.PathSearch("name", v, nil),
+			"params": flattenAlgorithmsAdvancedConfigAutoSearchAlgoConfigsParams(
+				utils.PathSearch("params", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return rst
+}
+
+func flattenAlgorithmsAdvancedConfigAutoSearchAlgoConfigsParams(params []interface{}) []interface{} {
+	if len(params) < 1 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(params))
+	for _, v := range params {
+		rst = append(rst, map[string]interface{}{
+			"key":   utils.PathSearch("key", v, nil),
+			"value": utils.PathSearch("value", v, nil),
+			"type":  utils.PathSearch("type", v, nil),
+		})
+	}
+	return rst
+}
+
+func dataSourceAlgorithmsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	algorithms, err := listAlgorithms(client, d)
+	if err != nil {
+		return diag.Errorf("error querying ModelArts algorithms: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("algorithms", flattenAlgorithms(algorithms)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_modelarts_algorithms`) to query algorithm list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

1. In the API, pagination is defined as limit + offset, but the actual logic is limit + pageSize. This logic has been confirmed with the development team and will not be changed in the future.
2.  It has also been confirmed with the developers that the `group_by` filtering parameter is invalid.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source for Modelarts.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDataAlgorithms_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataAlgorithms_basic -timeout 360m -parallel 10
=== RUN   TestAccDataAlgorithms_basic
=== PAUSE TestAccDataAlgorithms_basic
=== CONT  TestAccDataAlgorithms_basic
--- PASS: TestAccDataAlgorithms_basic (44.22s)
PASS
coverage: 11.0% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 44.328s coverage: 11.0% of statements in ./huaweicloud/services/modelarts
```
<img width="1042" height="48" alt="image" src="https://github.com/user-attachments/assets/c9cd8722-68d7-425c-a8f1-1609264b7cce" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
