### PR TITLE
feat(drs): support `drs_batch_rpos_and_rtos` data source

### DIFF
--- a/docs/data-sources/drs_batch_rpos_and_rtos.md
+++ b/docs/data-sources/drs_batch_rpos_and_rtos.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_batch_rpos_and_rtos"
+description: |-
+  Use this data source to batch query RPO and RTO of specified DRS jobs within HuaweiCloud.
+---
+
+# huaweicloud_drs_batch_rpos_and_rtos
+
+Use this data source to batch query RPO and RTO of specified DRS jobs within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "jobs" {
+  type = list(string)
+}
+
+data "huaweicloud_drs_batch_rpos_and_rtos" "test" {
+  jobs = var.jobs
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `jobs` - (Required, List) Specifies the list of DRS job detail IDs to query.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `results` - The batch query RPO and RTO result list.
+
+  The [results](#results_struct) structure is documented below.
+
+<a name="results_struct"></a>
+The `results` block supports:
+
+* `job_id` - The job ID.
+
+* `rpo_info` - The RPO information.
+
+  The [rpo_info](#rpo_rto_info_struct) structure is documented below.
+
+* `rto_info` - The RTO information.
+
+  The [rto_info](#rpo_rto_info_struct) structure is documented below.
+
+* `error_code` - The error code.
+
+* `error_msg` - The error message.
+
+<a name="rpo_rto_info_struct"></a>
+The `rpo_info` and `rto_info` blocks support:
+
+* `check_point` - The check point.
+
+* `delay` - The delay in milliseconds.
+
+* `gtid_set` - The GTID set.
+
+* `time` - The current time in the format **yyyy-MM-dd HH:mm:ss**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1346,6 +1346,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_availability_zones":       drs.DataSourceAvailabilityZones(),
 			"huaweicloud_drs_batch_get_params":         drs.DataSourceDrsBatchGetParams(),
 			"huaweicloud_drs_batch_progresses":         drs.DataSourceDrsBatchProgresses(),
+			"huaweicloud_drs_batch_rpos_and_rtos":      drs.DataSourceDrsBatchRposAndRtos(),
 			"huaweicloud_drs_batch_struct_process":     drs.DataSourceDrsBatchStructProcess(),
 			"huaweicloud_drs_compare_content_detail":   drs.DataSourceDrsCompareContentDetail(),
 			"huaweicloud_drs_compare_content_overview": drs.DataSourceDrsCompareContentOverview(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_batch_rpos_and_rtos_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_batch_rpos_and_rtos_test.go
@@ -1,0 +1,50 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsBatchRposAndRtos_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_batch_rpos_and_rtos.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobIds(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDrsBatchRposAndRtos_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.job_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.rpo_info.0.check_point"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.rpo_info.0.delay"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.rpo_info.0.gtid_set"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.rpo_info.0.time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.rto_info.0.check_point"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.rto_info.0.delay"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.rto_info.0.gtid_set"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.rto_info.0.time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDrsBatchRposAndRtos_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_batch_rpos_and_rtos" "test" {
+  jobs = split(",", "%s")
+}
+`, acceptance.HW_DRS_JOB_IDS)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_batch_rpos_and_rtos.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_batch_rpos_and_rtos.go
@@ -1,0 +1,177 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS POST /v3/{project_id}/jobs/batch-rpo-and-rto
+func DataSourceDrsBatchRposAndRtos() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsBatchRposAndRtosRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"jobs": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"job_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"rpo_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     rpoRtoInfoSchema(),
+						},
+						"rto_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     rpoRtoInfoSchema(),
+						},
+						"error_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_msg": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func rpoRtoInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"check_point": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"delay": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"gtid_set": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildBatchRposAndRtosBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"jobs": utils.ExpandToStringList(d.Get("jobs").([]interface{})),
+	}
+}
+
+func dataSourceDrsBatchRposAndRtosRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v3/{project_id}/jobs/batch-rpo-and-rto"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildBatchRposAndRtosBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DRS batch RPOs and RTOs: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("results", flattenBatchRposAndRtosResults(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenBatchRposAndRtosResults(respBody interface{}) []interface{} {
+	resultsRaw := utils.PathSearch("results", respBody, make([]interface{}, 0)).([]interface{})
+	if len(resultsRaw) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resultsRaw))
+	for _, item := range resultsRaw {
+		result = append(result, map[string]interface{}{
+			"job_id":     utils.PathSearch("job_id", item, nil),
+			"rpo_info":   flattenRpoRtoInfo(utils.PathSearch("rpo_info", item, nil)),
+			"rto_info":   flattenRpoRtoInfo(utils.PathSearch("rto_info", item, nil)),
+			"error_code": utils.PathSearch("error_code", item, nil),
+			"error_msg":  utils.PathSearch("error_msg", item, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenRpoRtoInfo(info interface{}) []interface{} {
+	if info == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"check_point": utils.PathSearch("check_point", info, nil),
+			"delay":       utils.PathSearch("delay", info, nil),
+			"gtid_set":    utils.PathSearch("gtid_set", info, nil),
+			"time":        utils.PathSearch("time", info, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_batch_rpos_and_rtos` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `drs_batch_rpos_and_rtos` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o drs -f TestAccDataSourceDrsBatchRposAndRtos_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccDataSourceDrsBatchRposAndRtos_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDrsBatchRposAndRtos_basic
=== PAUSE TestAccDataSourceDrsBatchRposAndRtos_basic
=== CONT  TestAccDataSourceDrsBatchRposAndRtos_basic
--- PASS: TestAccDataSourceDrsBatchRposAndRtos_basic (12.22s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs  coverage: 4.8% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       12.319s coverage: 4.8% of statements in ./huaweicloud/services/drs
```
<img width="907" height="40" alt="image" src="https://github.com/user-attachments/assets/2edb5dd3-1d4e-467e-932a-7fa98eab3a79" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
