### PR TITLE
feat(GeminiDB): add new data source to query IP addresses number

### DIFF
--- a/docs/data-sources/geminidb_ip_num_requirement.md
+++ b/docs/data-sources/geminidb_ip_num_requirement.md
@@ -1,0 +1,84 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_ip_num_requirement"
+description: |-
+  Use this data source to query the IP addresses number for creating an instance or adding nodes to an instance.
+---
+
+# huaweicloud_geminidb_ip_num_requirement
+
+Use this data source to query the IP addresses number for creating an instance or adding nodes to an instance.
+
+-> This data source supports the following instances: GeminiDB Cassandra, GeminiDB Mongo, GeminiDB Influx and
+  GeminiDB Redis.
+
+## Example Usage
+
+### Query IP addresses number by instance type
+
+```hcl
+variable "node_num" {}
+variable "engine_name" {}
+variable "instance_mode" {}
+
+data "huaweicloud_geminidb_ip_num_requirement" "test" {
+  node_num      = var.node_num
+  engine_name   = var.engine_name
+  instance_mode = var.instance_mode
+}
+```
+
+### Query IP addresses number by instance ID
+
+```hcl
+variable "node_num" {}
+variable "instance_id" {}
+
+data "huaweicloud_geminidb_ip_num_requirement" "test" {
+  node_num    = var.node_num
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `node_num` - (Required, Int) Specifies the nodes number for creating or scaling out an instance.
+  The valid value ranges from `1` to `200`.
+
+* `engine_name` - (Optional, String) Specifies the database type.
+  The valid values are as follows:
+  + **cassandra**: Indicates GeminiDB Cassandra.
+  + **mongodb**: Indicates GeminiDB Mongo.
+  + **influxdb**: Indicates GeminiDB Influx.
+  + **redis**: Indicates GeminiDB Redis.
+
+  -> This parameter is mandatory when `instance_id` is not transferred.
+
+* `instance_mode` - (Optional, String) Specifies the instance type.
+  The valid values are as follows:
+  + **Cluster**: Indicates proxy cluster GeminiDB Redis instance, cluster GeminiDB Cassandra or Influx instance
+  with classic storage.
+  + **CloudNativeCluster**: Indicates cluster GeminiDB Cassandra, Influx, or Redis instance with cloud native storage.
+  + **RedisCluster**: Indicates Redis Cluster GeminiDB Redis instance with classic storage.
+  + **Replication**: Indicates primary/standby GeminiDB Redis instance with classic storage.
+  + **InfluxdbSingle**: Indicates single-node GeminiDB Influx instance with classic storage.
+  + **EnhancedCluster**: Indicates GeminiDB Influx cluster (performance-enhanced) instance with classic storage.
+  + **ReplicaSet**: Indicates GeminiDB Mongo instance in a replica set.
+
+  -> This parameter is mandatory when `instance_id` is not transferred.
+
+* `instance_id` - (Optional, String) Specifies the instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `ip_address_count` - The number of IP addresses.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1502,6 +1502,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_flavors":                       geminidb.DataSourceGeminiDBFlavors(),
 			"huaweicloud_geminidb_instance_parameters_histories": geminidb.DataSourceGeminiDBInstanceParametersHistories(),
 			"huaweicloud_geminidb_instance_sessions":             geminidb.DataSourceInstanceSessions(),
+			"huaweicloud_geminidb_ip_num_requirement":            geminidb.DataSourceIpNumRequirement(),
 			"huaweicloud_geminidb_memory_mappings":               geminidb.DataSourceMemoryMappings(),
 			"huaweicloud_geminidb_memory_rules":                  geminidb.DataSourceMemoryRules(),
 			"huaweicloud_geminidb_node_sessions":                 geminidb.DataSourceNodeSessions(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_ip_num_requirement_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_ip_num_requirement_test.go
@@ -1,0 +1,101 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataSourceIpNumRequirement_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_geminidb_ip_num_requirement.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceIpNumRequirement_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "ip_address_count"),
+
+					resource.TestCheckOutput("ip_address_number", "true"),
+					resource.TestCheckOutput("instance_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceIpNumRequirement_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_geminidb_flavors" "test" {
+  engine_name  = "redis"
+  mode         = "CloudNativeCluster"
+  product_type = "Capacity"
+}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[1]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "test_1234"
+  mode              = "CloudNativeCluster"
+  product_type      = "Capacity"
+
+  datastore {
+    type           = "redis"
+    version        = "5.0"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "3"
+    size      = "16"
+    storage   = "ULTRAHIGH"
+    spec_code = data.huaweicloud_geminidb_flavors.test.flavors[1].spec_code
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccDataSourceIpNumRequirement_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_geminidb_ip_num_requirement" "test" {
+  node_num      = 2
+  engine_name   = "redis"
+  instance_mode = "Cluster"
+}
+
+data "huaweicloud_geminidb_ip_num_requirement" "instance_id_filter" {
+  node_num    = 4
+  instance_id = huaweicloud_geminidb_instance.test.id
+}
+
+output "ip_address_number" {
+  value = data.huaweicloud_geminidb_ip_num_requirement.test.ip_address_count > 0
+}
+
+output "instance_id_filter_useful" {
+  value = data.huaweicloud_geminidb_ip_num_requirement.instance_id_filter.ip_address_count > 0
+}
+`, testAccDataSourceIpNumRequirement_base(name))
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_ip_num_requirement.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_ip_num_requirement.go
@@ -1,0 +1,117 @@
+package geminidb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GeminiDB GET /v3/{project_id}/ip-num-requirement
+func DataSourceIpNumRequirement() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIpNumRequirementRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"node_num": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"engine_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip_address_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildIpNumRequirementQueryParams(d *schema.ResourceData) string {
+	queryParams := fmt.Sprintf("?node_num=%v", d.Get("node_num"))
+
+	if v, ok := d.GetOk("engine_name"); ok {
+		queryParams = fmt.Sprintf("%s&engine_name=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("instance_mode"); ok {
+		queryParams = fmt.Sprintf("%s&instance_mode=%v", queryParams, v)
+	}
+
+	if v, ok := d.GetOk("instance_id"); ok {
+		queryParams = fmt.Sprintf("%s&instance_id=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func dataSourceIpNumRequirementRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/ip-num-requirement"
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildIpNumRequirementQueryParams(d)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the number of IP addresses: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("ip_address_count", utils.PathSearch("count", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to query IP addresses number.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to  query IP addresses number.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o geminidb -f TestAccDataSourceIpNumRequirement_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/geminidb" -v -coverprofile="./huaweicloud/services/acceptance/geminidb/geminidb_coverage.cov" -coverpkg="./huaweicloud/services/geminidb" -run TestAccDataSourceIpNumRequirement_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceIpNumRequirement_basic
=== PAUSE TestAccDataSourceIpNumRequirement_basic
=== CONT  TestAccDataSourceIpNumRequirement_basic
--- PASS: TestAccDataSourceIpNumRequirement_basic (1315.11s)
PASS
coverage: 9.8% of statements in ./huaweicloud/services/geminidb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1315.266s 
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
