### PR TITLE
feat(apig): supports NLB and more edition types

### DIFF
--- a/docs/resources/apig_instance.md
+++ b/docs/resources/apig_instance.md
@@ -65,6 +65,9 @@ The following arguments are supported:
   + **ENTERPRISE_IPV6**: IPv6 instance of the Enterprise Edition.
   + **PLATINUM_IPV6**: IPv6 instance of the Platinum Edition.
 
+  For more editions, please following values of the `spec_id` parameters in the
+  [documentation](https://support.huaweicloud.com/intl/en-us/api-apig/CreateInstanceV2.html#section4).
+
 * `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC used to create the dedicated instance.  
   Changing this will create a new resource.
 

--- a/docs/resources/apig_instance.md
+++ b/docs/resources/apig_instance.md
@@ -64,6 +64,14 @@ The following arguments are supported:
   + **PROFESSIONAL_IPV6**: IPv6 instance of the Professional Edition.
   + **ENTERPRISE_IPV6**: IPv6 instance of the Enterprise Edition.
   + **PLATINUM_IPV6**: IPv6 instance of the Platinum Edition.
+  + **NLB_BASIC**: without built-in ELBs.
+  + **NLB_PROFESSIONAL**: without built-in ELBs.
+  + **NLB_ENTERPRISE**: without built-in ELBs.
+  + **NLB_PLATINUM**: without built-in ELBs.
+  + **NLB_BASIC_IPV6**: without built-in ELBs.
+  + **NLB_PROFESSIONAL_IPV6**: without built-in ELBs.
+  + **NLB_ENTERPRISE_IPV6**: without built-in ELBs.
+  + **NLB_PLATINUM_IPV6**: without built-in ELBs.
 
   For more editions, please following values of the `spec_id` parameters in the
   [documentation](https://support.huaweicloud.com/intl/en-us/api-apig/CreateInstanceV2.html#section4).
@@ -73,6 +81,8 @@ The following arguments are supported:
 
 * `subnet_id` - (Required, String, ForceNew) Specifies the ID of the VPC subnet used to create the dedicated instance.  
   Changing this will create a new resource.
+
+  -> If the value of `edition` parameter is NLB series edition, the network must be same as the ELB's network.
 
 * `security_group_id` - (Required, String) Specifies the ID of the security group to which the dedicated instance
   belongs to.
@@ -95,6 +105,12 @@ The following arguments are supported:
   The format is **xx:00:00**, the value of **xx** can be `02`, `06`, `10`, `14`, `18` or `22`.
 
 * `ipv6_enable` - (Optional, Bool, ForceNew) Specifies whether public access with an IPv6 address is supported.  
+  Changing this will create a new resource.
+
+* `elb_ids` - (Optional, List, ForceNew) Specifies the list of the dedicated network load balancer IDs associated with
+  the dedicated instance.  
+  This parameter is required when the instance edition is NLB series edition. The ELB must be dedicated and include
+  network load balancing type.  
   Changing this will create a new resource.
 
 * `vpcep_service_name` - (Optional, String) Specifies the name of the VPC endpoint service.

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
@@ -272,3 +272,161 @@ resource "huaweicloud_apig_instance" "test" {
 }
 `, common.TestBaseNetwork(rName), rName, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
 }
+
+func TestAccInstance_nlb(t *testing.T) {
+	var (
+		instance instances.Instance
+
+		resourceName = "huaweicloud_apig_instance.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &instance, getInstanceFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil, // The detection of the APIG instance deletion will be performed in the steps.
+		Steps: []resource.TestStep{
+			// Initially, two ELBs are bound, one through the creation API and the other through the bulk binding API.
+			{
+				Config: testAccInstance_nlb_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "edition", "NLB_BASIC"),
+					resource.TestCheckResourceAttr(resourceName, "elb_ids.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			// Change the binding relationship of one of the ELBs.
+			// The logical operation steps are: unbind an ELB -> bind an ELB
+			{
+				Config: testAccInstance_nlb_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "elb_ids.#", "2"),
+				),
+			},
+			// Remove all ELB bindings and add a new ELB binding.
+			// The logical operation steps are: unbind an ELB -> bind an ELB -> unbind an ELB
+			{
+				Config: testAccInstance_nlb_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "elb_ids.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// The APIG instance must be deleted first before ELB's deletion protection can be removed via update
+			// (otherwise it will be automatically restored).
+			{
+				Config: testAccInstance_nlb_step4(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceDestroy(),
+				),
+			},
+		},
+	})
+}
+
+func testAccInstance_nlb_base(name string, deleteProtectionEnable bool) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+%[2]s
+
+data "huaweicloud_elb_flavors" "test" {
+  type = "L4_elastic_max"
+}
+
+resource "huaweicloud_elb_loadbalancer" "test" {
+  count = 3
+
+  name                       = format("%[3]s_%%d", count.index)
+  vpc_id                     = huaweicloud_vpc.test.id
+  ipv4_subnet_id             = huaweicloud_vpc_subnet.test.ipv4_subnet_id
+  l4_flavor_id               = data.huaweicloud_elb_flavors.test.flavors[0].id
+  availability_zone          = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  enterprise_project_id      = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+  deletion_protection_enable = %[4]v
+
+  tags = {
+    managed_by = "APIG"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST,
+		common.TestBaseNetwork(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), name, deleteProtectionEnable)
+}
+
+func testAccInstance_nlb_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_instance" "test" {
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  elb_ids               = slice(huaweicloud_elb_loadbalancer.test[*].id, 0, 2)
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
+  edition = "NLB_BASIC"
+  name    = "%[2]s"
+}
+`, testAccInstance_nlb_base(name, true), name)
+}
+
+func testAccInstance_nlb_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_instance" "test" {
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  elb_ids               = slice(huaweicloud_elb_loadbalancer.test[*].id, 1, 3)
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
+  edition = "NLB_BASIC"
+  name    = "%[2]s"
+}
+`, testAccInstance_nlb_base(name, true), name)
+}
+
+func testAccInstance_nlb_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_instance" "test" {
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  elb_ids               = slice(huaweicloud_elb_loadbalancer.test[*].id, 0, 1)
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
+  edition = "NLB_BASIC"
+  name    = "%[2]s"
+}
+`, testAccInstance_nlb_base(name, true), name)
+}
+
+// Delete the APIG instance and update the ELB's delete protection status (from enabled to disabled; currently, this
+// function can only be disabled via an update operation and will be automatically restored by existing APIG instances).
+func testAccInstance_nlb_step4(name string) string {
+	return testAccInstance_nlb_base(name, false)
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -24,6 +24,9 @@ import (
 
 // @API APIG POST /v2/{project_id}/apigw/instances
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/extra-elbs
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/extra-elbs
+// @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/extra-elbs
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/postpaid-resize
 // @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}
@@ -122,6 +125,13 @@ func ResourceApigInstanceV2() *schema.Resource {
 				Computed:    true,
 				ForceNew:    true,
 				Description: `Whether public access with an IPv6 address is supported.`,
+			},
+			"elb_ids": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of the dedicated network load balancer IDs associated with the dedicated instance.`,
 			},
 			"maintain_begin": {
 				Type:     schema.TypeString,
@@ -294,6 +304,16 @@ func buildInstanceAvailabilityZones(d *schema.ResourceData) interface{} {
 }
 
 func buildCreateInstanceBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
+	var (
+		initialElbId         = ""
+		elbIds               = d.Get("elb_ids").(*schema.Set).List()
+		loadbalancerProvider = d.Get("loadbalancer_provider").(string)
+	)
+	if loadbalancerProvider == "" && len(elbIds) > 0 {
+		loadbalancerProvider = "elb"
+		initialElbId = elbIds[0].(string)
+	}
+
 	result := map[string]interface{}{
 		"instance_name":                   d.Get("name"),
 		"spec_id":                         d.Get("edition"),
@@ -302,11 +322,11 @@ func buildCreateInstanceBodyParams(d *schema.ResourceData, cfg *config.Config) m
 		"security_group_id":               d.Get("security_group_id"),
 		"available_zone_ids":              utils.ValueIgnoreEmpty(buildInstanceAvailabilityZones(d)),
 		"description":                     utils.ValueIgnoreEmpty(d.Get("description")),
-		"bandwidth_size":                  d.Get("bandwidth_size"), // Bandwidth 0 means turn off the egress access.
 		"enterprise_project_id":           cfg.GetEnterpriseProjectID(d),
 		"eip_id":                          utils.ValueIgnoreEmpty(d.Get("eip_id")),
 		"ipv6_enable":                     utils.ValueIgnoreEmpty(d.Get("ipv6_enable")),
-		"loadbalancer_provider":           utils.ValueIgnoreEmpty(d.Get("loadbalancer_provider")),
+		"elb_id":                          utils.ValueIgnoreEmpty(initialElbId),
+		"loadbalancer_provider":           utils.ValueIgnoreEmpty(loadbalancerProvider),
 		"tags":                            utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
 		"vpcep_service_name":              utils.ValueIgnoreEmpty(d.Get("vpcep_service_name")),
 		"ingress_bandwidth_size":          utils.ValueIgnoreEmpty(d.Get("ingress_bandwidth_size")), // BandWidth must be greater than or equal to 5.
@@ -314,6 +334,12 @@ func buildCreateInstanceBodyParams(d *schema.ResourceData, cfg *config.Config) m
 		"maintain_begin":                  utils.ValueIgnoreEmpty(d.Get("maintain_begin")),
 		"maintain_end":                    utils.ValueIgnoreEmpty(buildMaintainEndTime(d.Get("maintain_begin").(string))),
 	}
+
+	if len(elbIds) == 0 {
+		// NLB series edition does not support bandwidth size.
+		result["bandwidth_size"] = d.Get("bandwidth_size") // Bandwidth 0 means turn off the egress access.
+	}
+
 	log.Printf("[DEBUG] The request body of the create method for the dedicated instance is: %#v", result)
 	return result
 }
@@ -359,6 +385,150 @@ func instanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceId string
 	}
 }
 
+func associatedElbStateRefreshFunc(client *golangsdk.ServiceClient, instanceId string, elbIds []interface{},
+	isDelete bool) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := getInstanceExtraElbs(client, instanceId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		extraELbIds := utils.PathSearch("[*].elb_id", respBody, make([]interface{}, 0)).([]interface{})
+		extraElbsContainsInputElbs := utils.SliceContainsAnother(extraELbIds, elbIds)
+		if (isDelete && !extraElbsContainsInputElbs) || (!isDelete && extraElbsContainsInputElbs) {
+			return respBody, "COMPLETED", nil
+		}
+
+		return "continue", "PENDING", nil
+	}
+}
+
+func batchDeleteExtraElbs(ctx context.Context, client *golangsdk.ServiceClient, instanceId string, elbIds []interface{},
+	timeout time.Duration) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/extra-elbs"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: map[string]interface{}{
+			"elb_ids": elbIds,
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &opt)
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      associatedElbStateRefreshFunc(client, instanceId, elbIds, true),
+		Timeout:      timeout,
+		Delay:        15 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func deleteInstanceExtraElb(ctx context.Context, client *golangsdk.ServiceClient, instanceId, elbId string, timeout time.Duration) error {
+	return batchDeleteExtraElbs(ctx, client, instanceId, []interface{}{elbId}, timeout)
+}
+
+func buildBatchCreateExtraElbsBodyParams(elbIds []interface{}) map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(elbIds))
+	for _, elbId := range elbIds {
+		result = append(result, map[string]interface{}{
+			"id":                      elbId,
+			"force_overwrite_enabled": true,
+		})
+	}
+
+	return map[string]interface{}{
+		"elb_details": result,
+	}
+}
+
+func batchCreateExtraElbs(ctx context.Context, client *golangsdk.ServiceClient, instanceId string, elbIds []interface{},
+	timeout time.Duration) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/extra-elbs"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		JSONBody: buildBatchCreateExtraElbsBodyParams(elbIds),
+	}
+
+	_, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      associatedElbStateRefreshFunc(client, instanceId, elbIds, false),
+		Timeout:      timeout,
+		Delay:        15 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func createInstanceExtraElb(ctx context.Context, client *golangsdk.ServiceClient, instanceId, elbId string, timeout time.Duration) error {
+	return batchCreateExtraElbs(ctx, client, instanceId, []interface{}{elbId}, timeout)
+}
+
+func updateInstanceExtraElbs(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData, timeout time.Duration) error {
+	var (
+		oldRaw, newRaw      = d.GetChange("elb_ids")
+		oldSet              = oldRaw.(*schema.Set)
+		newSet              = newRaw.(*schema.Set)
+		removeList          = oldSet.Difference(newSet).List()
+		addList             = newSet.Difference(oldSet).List()
+		deleteExtraElbFirst = oldSet.Len() > 1
+		instanceId          = d.Id()
+	)
+
+	// To ensure the effective execution of the ELB operation (the maximum number of ELBs that can be associated with
+	// different instances is different).
+	// When the number of bound ELBs is greater than 1, it is necessary to delete the extra ELBs first, then add new
+	// ELBs, and each group of ELBs to be deleted and added should be operated sequentially.
+	// When the number of bound ELBs is less than or equal to 1, it is necessary to add new ELBs first, then delete
+	// extra ELBs, and each group of ELBs to be deleted and added should be operated sequentially.
+	for len(removeList) > 0 || len(addList) > 0 {
+		if deleteExtraElbFirst && len(removeList) > 0 {
+			if err := deleteInstanceExtraElb(ctx, client, instanceId, removeList[0].(string), timeout); err != nil {
+				return err
+			}
+			removeList = removeList[1:]
+		}
+
+		if len(addList) > 0 {
+			if err := createInstanceExtraElb(ctx, client, instanceId, addList[0].(string), timeout); err != nil {
+				return err
+			}
+			addList = addList[1:]
+		}
+
+		deleteExtraElbFirst = true
+	}
+
+	return nil
+}
+
 func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
@@ -401,6 +571,13 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("error waiting for the status of dedicated instance (%s) to become running: %s", instanceId, err)
 	}
 
+	extraElbIds := d.Get("elb_ids").(*schema.Set).List()[1:]
+	if len(extraElbIds) > 0 {
+		if err := batchCreateExtraElbs(ctx, client, instanceId, extraElbIds, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	if v, ok := d.GetOk("custom_ingress_ports"); ok {
 		if err := addCustomIngressPorts(client, instanceId, v.(*schema.Set).List()); err != nil {
 			return diag.FromErr(err)
@@ -431,6 +608,28 @@ func parseVpcepServiceName(serviceName string) string {
 	// For the result of the regex matching, the first element (result[0]) is the full
 	// address ({region}.{vpcep_service_name}.{service_id}), the others (result[1:]) are match objects.
 	return result[1]
+}
+
+func getInstanceExtraElbs(client *golangsdk.ServiceClient, instanceId string) ([]interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/extra-elbs"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("elbs", respBody, make([]interface{}, 0)).([]interface{}), nil
 }
 
 func queryInstanceTags(client *golangsdk.ServiceClient, instanceId string) interface{} {
@@ -472,6 +671,11 @@ func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interf
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error qeurying dedicated instance (%s) detail", instanceId))
 	}
 
+	extraElbs, err := getInstanceExtraElbs(client, instanceId)
+	if err != nil {
+		log.Printf("[WARN] error querying extra ELBs of the dedicated instance (%s): %s", instanceId, err)
+	}
+
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
 		d.Set("name", utils.PathSearch("instance_name", respBody, nil)),
@@ -484,6 +688,7 @@ func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("bandwidth_size", utils.PathSearch("bandwidth_size", respBody, nil)),
 		d.Set("ipv6_enable", utils.PathSearch("!!eip_ipv6_address", respBody, nil)),
 		d.Set("loadbalancer_provider", utils.PathSearch("loadbalancer_provider", respBody, nil)),
+		d.Set("elb_ids", utils.PathSearch("[*].elb_id", extraElbs, make([]interface{}, 0))),
 		d.Set("availability_zones", parseInstanceAvailabilityZones(utils.PathSearch("available_zone_ids", respBody, "").(string))),
 		d.Set("maintain_begin", utils.PathSearch("maintain_begin", respBody, nil)),
 		d.Set("vpcep_service_name", parseVpcepServiceName(utils.PathSearch("endpoint_services[0].service_name", respBody, "").(string))),
@@ -904,6 +1109,12 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		oldRaws, newRaws := d.GetChange("custom_ingress_ports")
 		err = updateCustomIngressPorts(client, oldRaws, newRaws, instanceId)
 		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("elb_ids") {
+		if err = updateInstanceExtraElbs(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return diag.FromErr(err)
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Currently, there are only a few edition types are supported, do not have NLB and other types.
- supports `elb_id` parameter to support NLB instance creation
- supports a reference link to support more edition types

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports NLB and more edition types
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccInstance_nlb
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccInstance_nlb -timeout 360m -parallel 10
=== RUN   TestAccInstance_nlb
=== PAUSE TestAccInstance_nlb
=== CONT  TestAccInstance_nlb
--- PASS: TestAccInstance_nlb (810.09s)
PASS
coverage: 4.2% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      810.194s        coverage: 4.2% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
