### PR TITLE
feat(drs): support `drs_update_data_progress_rules` resource

### DIFF
--- a/docs/resources/drs_update_data_progress_rules.md
+++ b/docs/resources/drs_update_data_progress_rules.md
@@ -1,0 +1,245 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_update_data_progress_rules"
+description: |-
+  Manages a resource to update DRS data processing rules within HuaweiCloud.
+---
+
+# huaweicloud_drs_update_data_progress_rules
+
+Manages a resource to update DRS data processing rules within HuaweiCloud.
+
+-> This resource is a one-time action resource used to update DRS data processing rules. Deleting this resource will not
+  clear the corresponding request record, but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+resource "huaweicloud_drs_update_data_progress_rules" "test" {
+  job_id = var.job_id
+
+  data_process_info {
+    filter_conditions {
+      filtering_type = "contentConditionalFilter"
+      value          = "id>1"
+    }
+
+    db_object {
+      object_scope = "table"
+
+      object_info = <<EOT
+      {
+        "dyh4" : {
+          "name" : "dyh4",
+          "all" : false,
+          "tables" : {
+            "test1_table1" : {
+              "name" : "test1_table1",
+              "type" : "table",
+              "all" : true
+            }
+          }
+        }
+      }
+      EOT
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `job_id` - (Required, String, NonUpdatable) Specifies the job ID.
+
+* `data_process_info` - (Optional, List, NonUpdatable) Specifies the data processing rules to update.
+  The [data_process_info](#data_process_info_struct) structure is documented below.
+
+<a name="data_process_info_struct"></a>
+The `data_process_info` block supports:
+
+* `filter_conditions` - (Optional, List, NonUpdatable) Specifies the filter conditions.
+  Required when updating data filtering rules.
+  The [filter_conditions](#filter_conditions_struct) structure is documented below.
+
+* `is_batch_process` - (Optional, Bool, NonUpdatable) Specifies whether it is a batch process.
+  **true**: Database-level or batch table-level processing.
+  **false**: Single table operation.
+
+* `add_columns` - (Optional, List, NonUpdatable) Specifies the additional columns.
+  Required when selecting additional columns. Used to avoid data conflicts in many-to-one operations.
+  The [add_columns](#add_columns_struct) structure is documented below.
+
+* `ddl_operation` - (Optional, Map, NonUpdatable) Specifies the DDL operation support for incremental migration or
+  synchronization. If left empty, no DDL operations will be migrated or synchronized.
+  Example: "table": "CREATE TABLE, ALTER TABLE, DROP TABLE, RENAME TABLE".
+
+* `dml_operation` - (Optional, String, NonUpdatable) Specifies the DML operation support.
+  If left empty, no DML operations will be incrementally migrated or synchronized.  
+  The valid values are as follows:
+  + **i**: INSERT.
+  + **u**: UPDATE.
+  + **d**: DELETE.
+
+* `db_object_column_info` - (Optional, List, NonUpdatable) Specifies the database object column information for column
+  mapping and filtering. Required when performing column mapping or filtering.
+  The [db_object_column_info](#db_object_column_info_struct) structure is documented below.
+
+* `db_or_table_rename_rule` - (Optional, List, NonUpdatable) Specifies the database or table rename rule.
+  The [db_or_table_rename_rule](#db_or_table_rename_rule_struct) structure is documented below.
+
+* `db_object` - (Optional, List, NonUpdatable) Specifies the database object information.
+  Required when performing mapping or data filtering condition validation.
+  The [db_object](#db_object_struct) structure is documented below.
+
+* `is_synchronized` - (Optional, Bool, NonUpdatable) Specifies whether the rule has been synchronized to the target
+  database.
+
+* `source` - (Optional, String, NonUpdatable) Specifies the comparison source.  
+  The valid values are as follows:
+  + **job**: Data synchronization filtering.
+  + **compare**: Data comparison filtering.
+
+* `process_rule_level` - (Optional, String, NonUpdatable) Specifies the data processing rule level.
+  Required when updating data processing rules.  
+  The valid values are as follows:
+  + **table**: Data synchronization filtering.
+  + **combinations**: Combination set, operations on multiple tables.
+
+<a name="filter_conditions_struct"></a>
+The `filter_conditions` block supports:
+
+* `value` - (Optional, String, NonUpdatable) Specifies the filter condition value.
+  When `filtering_type` is **configConditionalFilter**, the value defaults to **config**.
+  When `filtering_type` is **contentConditionalFilter**, the value should be the filter condition.
+  Only one validation rule can be added per table.
+  Data filtering supports up to 500 tables at a time.
+  The filter expression must use standard SQL syntax and cannot use database-specific packages, functions, variables,
+  or constants. Enter only the part after WHERE in the SQL
+  statement (excluding WHERE and semicolons, e.g., `sid > 3 and sname like "G %"`).
+  Maximum length: `512` characters.
+
+* `filtering_type` - (Optional, String, NonUpdatable) Specifies the filter condition type.  
+  The valid values are as follows:
+  + **contentConditionalFilter**: Simple condition filtering.
+  + **configConditionalFilter**: Related table filtering.
+
+<a name="add_columns_struct"></a>
+The `add_columns` block supports:
+
+* `column_type` - (Optional, String, NonUpdatable) Specifies the column type.  
+  The valid values are as follows:
+  + **default_value**: Default value.
+  + **create_time**: Create time.
+  + **update_time**: Update time.
+  + **expression**: Expression.
+  + **server_database_table**: Server name, database, and table.
+
+* `column_name` - (Optional, String, NonUpdatable) Specifies the column name.
+
+* `column_value` - (Optional, String, NonUpdatable) Specifies the column filling value.
+
+* `data_type` - (Optional, String, NonUpdatable) Specifies the data type of the filled column.  
+  The valid values are as follows:
+  + **int**: Integer.
+  + **long**: Long integer.
+  + **varchar(256)**: Variable character string with maximum length `256`.
+  + **varchar(191)**: Variable character string with maximum length `191`.
+  + **datetime**: Date and time.
+  + **timestamp**: Timestamp.
+
+<a name="db_object_column_info_struct"></a>
+The `db_object_column_info` block supports:
+
+* `db_name` - (Optional, String, NonUpdatable) Specifies the database name.
+
+* `schema_name` - (Optional, String, NonUpdatable) Specifies the database schema name.
+
+* `table_name` - (Optional, String, NonUpdatable) Specifies the database table name.
+
+* `column_infos` - (Optional, List, NonUpdatable) Specifies the column information.  
+  The [column_infos](#column_infos_struct) structure is documented below.
+
+* `total_count` - (Optional, Int, NonUpdatable) Specifies the total count of column information.
+  This is only a return parameter and is unrelated to pagination.
+
+<a name="column_infos_struct"></a>
+The `column_infos` block supports:
+
+* `column_name` - (Optional, String, NonUpdatable) Specifies the column name.
+
+* `column_type` - (Optional, String, NonUpdatable) Specifies the column type.
+
+* `primary_key_or_unique_index` - (Optional, String, NonUpdatable) Specifies the primary key or unique index.
+
+* `column_mapped_name` - (Optional, String, NonUpdatable) Specifies the column name after mapping.
+
+* `is_filtered` - (Optional, Bool, NonUpdatable) Specifies whether the column is filtered.
+
+* `is_partition_key` - (Optional, Bool, NonUpdatable) Specifies whether the column is a partition key.
+
+<a name="db_or_table_rename_rule_struct"></a>
+The `db_or_table_rename_rule` block supports:
+
+* `prefix_name` - (Optional, String, NonUpdatable) Specifies the prefix name.
+  When `type` is **prefixAndSuffix**, fill in `prefix_name` to add a prefix to the database or table name.
+  If `suffix_name` is also filled in, both prefix and suffix will be added.
+
+* `suffix_name` - (Optional, String, NonUpdatable) Specifies the suffix name.
+  When `type` is **prefixAndSuffix**, fill in `suffix_name` to add a suffix to the database or table name.
+  If `prefix_name` is also filled in, both prefix and suffix will be added.
+
+* `type` - (Optional, String, NonUpdatable) Specifies the rename rule type.  
+  The valid values are as follows:
+  + **prefixAndSuffix**: Prefix, suffix, or both prefix and suffix.
+  + **manyToOne**: Many-to-one mapping.
+
+<a name="db_object_struct"></a>
+The `db_object` block supports:
+
+* `object_scope` - (Required, String, NonUpdatable) Specifies the database object migration or synchronization scope.  
+  The valid values are as follows:
+  + **all**: Full migration.
+  + **database**: Database-level migration or synchronization.
+  + **table**: Table-level migration or synchronization.
+
+* `target_root_db` - (Optional, List, NonUpdatable) Specifies the target database for database object migration or
+  synchronization. Required for two-to-three layer database synchronization.
+  The [target_root_db](#target_root_db_struct) structure is documented below.
+
+* `object_info` - (Optional, String, NonUpdatable) Specifies the database object migration or synchronization
+  information in JSON format. Required when `object_scope` is **database** or **table**.
+  Do not fill when `object_scope` is **all**.
+
+<a name="target_root_db_struct"></a>
+The `target_root_db` block supports:
+
+* `db_name` - (Optional, String, NonUpdatable) Specifies the database name.
+
+* `db_encoding` - (Optional, String, NonUpdatable) Specifies the database encoding.
+  The default encoding format is **utf8**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The query result ID.
+
+* `status` - The update status.  
+  The valid values are as follows:
+  + **pending**: Processing.
+  + **failed**: Failed.
+  + **success**: Successful.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3631,6 +3631,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_batch_pause_task":               drs.ResourceBatchPauseTask(),
 			"huaweicloud_drs_batch_retry_task":               drs.ResourceBatchRetryTask(),
 			"huaweicloud_drs_check_data_filter":              drs.ResourceDrsCheckDataFilter(),
+			"huaweicloud_drs_update_data_progress_rules":     drs.ResourceDrsUpdateDataProgressRules(),
 			"huaweicloud_drs_compare_job_cancel":             drs.ResourceCancelCompareJob(),
 			"huaweicloud_drs_compare_policy":                 drs.ResourceDrsComparePolicy(),
 			"huaweicloud_drs_download_batch_create_template": drs.ResourceDownloadBatchCreateTemplate(),

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_update_data_progress_rules_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_update_data_progress_rules_test.go
@@ -1,0 +1,41 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccUpdateDataProgressRules_basic(t *testing.T) {
+	resourceName := "huaweicloud_drs_update_data_progress_rules.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testUpdateDataProgressRules_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+// Currently, the update API only succeeds when the boyd parameter is not passed.
+// Otherwise, the query API will report an error instead of a task failure
+func testUpdateDataProgressRules_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_drs_update_data_progress_rules" "test" {
+  job_id = "%s"
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_update_data_progress_rules.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_update_data_progress_rules.go
@@ -1,0 +1,628 @@
+package drs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var updateDataProgressRulesNonUpdatableParams = []string{
+	"job_id",
+	"data_process_info",
+	"data_process_info.*.filter_conditions",
+	"data_process_info.*.filter_conditions.*.value",
+	"data_process_info.*.filter_conditions.*.filtering_type",
+	"data_process_info.*.is_batch_process",
+	"data_process_info.*.add_columns",
+	"data_process_info.*.add_columns.*.column_type",
+	"data_process_info.*.add_columns.*.column_name",
+	"data_process_info.*.add_columns.*.column_value",
+	"data_process_info.*.add_columns.*.data_type",
+	"data_process_info.*.ddl_operation",
+	"data_process_info.*.dml_operation",
+	"data_process_info.*.db_object_column_info",
+	"data_process_info.*.db_object_column_info.*.db_name",
+	"data_process_info.*.db_object_column_info.*.schema_name",
+	"data_process_info.*.db_object_column_info.*.table_name",
+	"data_process_info.*.db_object_column_info.*.column_infos",
+	"data_process_info.*.db_object_column_info.*.column_infos.*.column_name",
+	"data_process_info.*.db_object_column_info.*.column_infos.*.column_type",
+	"data_process_info.*.db_object_column_info.*.column_infos.*.primary_key_or_unique_index",
+	"data_process_info.*.db_object_column_info.*.column_infos.*.column_mapped_name",
+	"data_process_info.*.db_object_column_info.*.column_infos.*.is_filtered",
+	"data_process_info.*.db_object_column_info.*.column_infos.*.is_partition_key",
+	"data_process_info.*.db_object_column_info.*.total_count",
+	"data_process_info.*.db_or_table_rename_rule",
+	"data_process_info.*.db_or_table_rename_rule.*.prefix_name",
+	"data_process_info.*.db_or_table_rename_rule.*.suffix_name",
+	"data_process_info.*.db_or_table_rename_rule.*.type",
+	"data_process_info.*.db_object",
+	"data_process_info.*.db_object.*.object_scope",
+	"data_process_info.*.db_object.*.target_root_db",
+	"data_process_info.*.db_object.*.target_root_db.*.db_name",
+	"data_process_info.*.db_object.*.target_root_db.*.db_encoding",
+	"data_process_info.*.db_object.*.object_info",
+	"data_process_info.*.is_synchronized",
+	"data_process_info.*.source",
+	"data_process_info.*.process_rule_level",
+}
+
+// @API DRS PUT /v5/{project_id}/jobs/{job_id}/data-processing-rules
+// @API DRS GET /v5/{project_id}/jobs/{job_id}/data-processing-rules/result
+func ResourceDrsUpdateDataProgressRules() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceUpdateDataProgressRulesCreate,
+		ReadContext:   resourceUpdateDataProgressRulesRead,
+		UpdateContext: resourceUpdateDataProgressRulesUpdate,
+		DeleteContext: resourceUpdateDataProgressRulesDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(updateDataProgressRulesNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"data_process_info": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     updateDataProgressRulesDataProcessInfoSchema(),
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func updateDataProgressRulesDataProcessInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"filter_conditions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     updateDataProgressRulesFilterConditionsSchema(),
+			},
+			"is_batch_process": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"add_columns": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     updateDataProgressRulesAddColumnsSchema(),
+			},
+			"ddl_operation": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"dml_operation": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"db_object_column_info": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     updateDataProgressRulesDbObjectColumnInfoSchema(),
+			},
+			"db_or_table_rename_rule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     updateDataProgressRulesDbOrTableRenameRuleSchema(),
+			},
+			"db_object": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     updateDataProgressRulesDbObjectSchema(),
+			},
+			"is_synchronized": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"source": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"process_rule_level": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func updateDataProgressRulesFilterConditionsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filtering_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func updateDataProgressRulesAddColumnsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"column_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"column_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"column_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func updateDataProgressRulesDbObjectColumnInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"db_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"schema_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"table_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"column_infos": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     updateDataProgressRulesColumnInfosSchema(),
+			},
+			"total_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func updateDataProgressRulesColumnInfosSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"column_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"column_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"primary_key_or_unique_index": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"column_mapped_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"is_filtered": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"is_partition_key": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func updateDataProgressRulesDbOrTableRenameRuleSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"prefix_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"suffix_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func updateDataProgressRulesDbObjectSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"object_scope": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"target_root_db": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     updateDataProgressRulesTargetRootDbSchema(),
+			},
+			// Convert this field from struct to JSON string value.
+			"object_info": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func updateDataProgressRulesTargetRootDbSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"db_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"db_encoding": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func buildUpdateDataProgressRulesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return utils.RemoveNil(map[string]interface{}{
+		"data_process_info": buildUpdateDataProgressRulesDataProcessInfoParams(
+			d.Get("data_process_info").([]interface{})),
+	})
+}
+
+func buildUpdateDataProgressRulesDataProcessInfoParams(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"filter_conditions": buildUpdateDataProgressRulesFilterConditionsParams(
+				rawMap["filter_conditions"].([]interface{})),
+			"is_batch_process": utils.ValueIgnoreEmpty(rawMap["is_batch_process"]),
+			"add_columns": buildUpdateDataProgressRulesAddColumnsParams(
+				rawMap["add_columns"].([]interface{})),
+			"ddl_operation": buildUpdateDataProgressRulesMapValues(rawMap["ddl_operation"]),
+			"dml_operation": utils.ValueIgnoreEmpty(rawMap["dml_operation"]),
+			"db_object_column_info": buildUpdateDataProgressRulesDbObjectColumnInfoParams(
+				rawMap["db_object_column_info"].([]interface{})),
+			"db_or_table_rename_rule": buildUpdateDataProgressRulesDbOrTableRenameRuleParams(
+				rawMap["db_or_table_rename_rule"].([]interface{})),
+			"db_object": buildUpdateDataProgressRulesDbObjectParams(
+				rawMap["db_object"].([]interface{})),
+			"is_synchronized":    utils.ValueIgnoreEmpty(rawMap["is_synchronized"]),
+			"source":             utils.ValueIgnoreEmpty(rawMap["source"]),
+			"process_rule_level": utils.ValueIgnoreEmpty(rawMap["process_rule_level"]),
+		})
+	}
+
+	return rst
+}
+
+func buildUpdateDataProgressRulesMapValues(rawMap interface{}) map[string]string {
+	mapRaw, ok := rawMap.(map[string]interface{})
+	if !ok || len(mapRaw) == 0 {
+		return nil
+	}
+
+	return utils.ExpandToStringMap(mapRaw)
+}
+
+func buildUpdateDataProgressRulesFilterConditionsParams(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"value":          utils.ValueIgnoreEmpty(rawMap["value"]),
+			"filtering_type": utils.ValueIgnoreEmpty(rawMap["filtering_type"]),
+		})
+	}
+
+	return rst
+}
+
+func buildUpdateDataProgressRulesAddColumnsParams(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"column_type":  utils.ValueIgnoreEmpty(rawMap["column_type"]),
+			"column_name":  utils.ValueIgnoreEmpty(rawMap["column_name"]),
+			"column_value": utils.ValueIgnoreEmpty(rawMap["column_value"]),
+			"data_type":    utils.ValueIgnoreEmpty(rawMap["data_type"]),
+		})
+	}
+
+	return rst
+}
+
+func buildUpdateDataProgressRulesDbObjectColumnInfoParams(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"db_name":      utils.ValueIgnoreEmpty(rawMap["db_name"]),
+		"schema_name":  utils.ValueIgnoreEmpty(rawMap["schema_name"]),
+		"table_name":   utils.ValueIgnoreEmpty(rawMap["table_name"]),
+		"column_infos": buildUpdateDataProgressRulesColumnInfosParams(rawMap["column_infos"].([]interface{})),
+		"total_count":  utils.ValueIgnoreEmpty(rawMap["total_count"]),
+	}
+}
+
+func buildUpdateDataProgressRulesColumnInfosParams(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(rawArray))
+	for _, v := range rawArray {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"column_name":                 utils.ValueIgnoreEmpty(rawMap["column_name"]),
+			"column_type":                 utils.ValueIgnoreEmpty(rawMap["column_type"]),
+			"primary_key_or_unique_index": utils.ValueIgnoreEmpty(rawMap["primary_key_or_unique_index"]),
+			"column_mapped_name":          utils.ValueIgnoreEmpty(rawMap["column_mapped_name"]),
+			"is_filtered":                 utils.ValueIgnoreEmpty(rawMap["is_filtered"]),
+			"is_partition_key":            utils.ValueIgnoreEmpty(rawMap["is_partition_key"]),
+		})
+	}
+
+	return rst
+}
+
+func buildUpdateDataProgressRulesDbOrTableRenameRuleParams(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"prefix_name": utils.ValueIgnoreEmpty(rawMap["prefix_name"]),
+		"suffix_name": utils.ValueIgnoreEmpty(rawMap["suffix_name"]),
+		"type":        utils.ValueIgnoreEmpty(rawMap["type"]),
+	}
+}
+
+func buildUpdateDataProgressRulesDbObjectParams(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"object_scope": utils.ValueIgnoreEmpty(rawMap["object_scope"]),
+		"target_root_db": buildUpdateDataProgressRulesTargetRootDbParams(
+			rawMap["target_root_db"].([]interface{})),
+		"object_info": utils.StringToJson(rawMap["object_info"].(string)),
+	}
+}
+
+func buildUpdateDataProgressRulesTargetRootDbParams(rawArray []interface{}) map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rawMap, ok := rawArray[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"db_name":     utils.ValueIgnoreEmpty(rawMap["db_name"]),
+		"db_encoding": utils.ValueIgnoreEmpty(rawMap["db_encoding"]),
+	}
+}
+
+func resourceUpdateDataProgressRulesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		jobId   = d.Get("job_id").(string)
+		httpUrl = "v5/{project_id}/jobs/{job_id}/data-processing-rules"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildUpdateDataProgressRulesBodyParams(d)),
+	}
+
+	resp, err := client.Request("PUT", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error updating DRS data processing rules: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	queryId := utils.PathSearch("id", respBody, "").(string)
+	if queryId == "" {
+		return diag.Errorf("unable to find the ID from the API response")
+	}
+	d.SetId(queryId)
+
+	if err := waitForUpdateDataProcessingRulesCompleted(ctx, client, jobId, queryId, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func waitForUpdateDataProcessingRulesCompleted(ctx context.Context, client *golangsdk.ServiceClient,
+	jobId, queryId string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"pending"},
+		Target:  []string{"success"},
+		Refresh: func() (interface{}, string, error) {
+			respBody, err := getUpdateDataProcessingRulesResult(client, jobId, queryId)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			status := utils.PathSearch("status", respBody, "").(string)
+			if status == "failed" {
+				return respBody, "failed", errors.New("the data processing rules update task failed")
+			}
+
+			return respBody, status, nil
+		},
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for DRS data processing rules update (%s) to complete: %s",
+			queryId, err)
+	}
+
+	return nil
+}
+
+func getUpdateDataProcessingRulesResult(client *golangsdk.ServiceClient, jobId, queryId string) (interface{}, error) {
+	httpUrl := "v5/{project_id}/jobs/{job_id}/data-processing-rules/result"
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{job_id}", jobId)
+	requestPath += fmt.Sprintf("?query_id=%s", queryId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes:          []int{200, 202},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DRS update data processing rules result: %s", err)
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceUpdateDataProgressRulesRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceUpdateDataProgressRulesUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceUpdateDataProgressRulesDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to update DRS data processing rules. Deleting this
+    resource will not clear the corresponding request record, but will only remove the resource information
+    from the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_update_data_progress_rules` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `drs_update_data_progress_rules` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o drs -f TestAccUpdateDataProgressRules_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccUpdateDataProgressRules_basic -timeout 360m -parallel 10
=== RUN   TestAccUpdateDataProgressRules_basic
=== PAUSE TestAccUpdateDataProgressRules_basic
=== CONT  TestAccUpdateDataProgressRules_basic
--- PASS: TestAccUpdateDataProgressRules_basic (18.84s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs  coverage: 5.5% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       18.960s coverage: 5.5% of statements in ./huaweicloud/services/drs
```
<img width="917" height="31" alt="image" src="https://github.com/user-attachments/assets/2f75c50c-0d54-47fc-b261-0f0d96d33443" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
