### PR TITLE
feat(gaussdb): add alarm history records data source for huaweicloud gaussdb.

### DIFF
--- a/docs/data-sources/gaussdb_alarms.md
+++ b/docs/data-sources/gaussdb_alarms.md
@@ -1,0 +1,67 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_alarms"
+description: |-
+  Use this data source to query GaussDB alarms within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_alarms
+
+Use this data source to query GaussDB alarms within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "start_time" {}
+
+data "huaweicloud_gaussdb_alarms" "test" {
+  start_time = var.start_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource. If omitted, the provider-level
+  region will be used.
+
+* `start_time` - (Required, String) Specifies the start time for querying alarms. The value is in the
+  **yyyy-mm-ddThh:mm:ssZ** format.
+
+* `level` - (Optional, Int) Specifies the alarm level. The valid values are as follows:
+ + **1**: CRITICAL.
+ + **2**: MAJOR.
+ + **3**: MINOR.
+ + **4**: WARNING.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `history_records` - The list of alarm history records.
+  The [history_records](#history_records_struct) structure is documented below.
+
+<a name="history_records_struct"></a>
+The `history_records` block supports:
+
+* `alarm_id` - The alarm ID.
+
+* `name` - The alarm name.
+
+* `status` - The alarm status.
+
+* `alarm_type` - The alarm type.
+
+* `level` - The alarm level.
+
+* `instance_id` - The ID of the GaussDB instance that triggered the alarm.
+
+* `instance_name` - The name of the GaussDB instance that triggered the alarm.
+
+* `begin_time` - The time when the alarm was triggered.
+
+* `update_time` - The time when the alarm was updated.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1519,6 +1519,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_table_restored_databases":      geminidb.DataSourceGeminiDBTableRestoredDatabases(),
 			"huaweicloud_geminidb_table_restored_tables":         geminidb.DataSourceGeminiDBTableRestoredTables(),
 
+			"huaweicloud_gaussdb_alarms":                          gaussdb.DataSourceAlarms(),
 			"huaweicloud_gaussdb_storage_types":                   gaussdb.DataSourceGaussDbStorageTypes(),
 			"huaweicloud_gaussdb_datastores":                      gaussdb.DataSourceGaussDbDatastores(),
 			"huaweicloud_gaussdb_flavors":                         gaussdb.DataSourceGaussDbFlavors(),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_alarms_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_alarms_test.go
@@ -1,0 +1,66 @@
+package gaussdb
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAlarms_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_gaussdb_alarms.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(
+		t, resource.TestCase{
+			PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+			ProviderFactories: acceptance.TestAccProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: testDataSourceAlarms_basic(),
+					Check: resource.ComposeTestCheckFunc(
+						dc.CheckResourceExists(),
+						resource.TestMatchResourceAttr(all, "history_records.#", regexp.MustCompile(`^[0-9]+$`)),
+						resource.TestCheckResourceAttrSet(all, "history_records.0.alarm_id"),
+						resource.TestCheckResourceAttrSet(all, "history_records.0.name"),
+						resource.TestCheckResourceAttrSet(all, "history_records.0.status"),
+						resource.TestCheckResourceAttrSet(all, "history_records.0.alarm_type"),
+						resource.TestCheckResourceAttrSet(all, "history_records.0.level"),
+						resource.TestCheckResourceAttrSet(all, "history_records.0.instance_id"),
+						resource.TestCheckResourceAttrSet(all, "history_records.0.instance_name"),
+						resource.TestCheckResourceAttrSet(all, "history_records.0.begin_time"),
+						resource.TestCheckResourceAttrSet(all, "history_records.0.update_time"),
+						resource.TestCheckOutput("level_filter_is_useful", "true"),
+					),
+				},
+			},
+		},
+	)
+}
+
+func testDataSourceAlarms_basic() string {
+	startTime := time.Now().UTC().Add(-30 * 24 * time.Hour).Format("2006-01-02T15:04:05+0000")
+
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_alarms" "all" {
+  start_time = "%[1]s"
+}
+
+# Filter by 'level' parameter
+data "huaweicloud_gaussdb_alarms" "level_filter" {
+  start_time = "%[1]s"
+  level      = 1
+}
+
+output "level_filter_is_useful" {
+ value = length(data.huaweicloud_gaussdb_alarms.level_filter.history_records) >= 0
+}
+`, startTime,
+	)
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_alarms.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_alarms.go
@@ -1,0 +1,200 @@
+package gaussdb
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB GET /v3/{project_id}/alarm-history-record
+func DataSourceAlarms() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAlarmsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"level": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"history_records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     gaussDbAlarmsSchema(),
+			},
+		},
+	}
+}
+
+func gaussDbAlarmsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"alarm_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"alarm_type": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"level": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"begin_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildAlarmsParams(d *schema.ResourceData) string {
+	startTime := strings.ReplaceAll(d.Get("start_time").(string), "+", "%2B")
+	queryParams := fmt.Sprintf("&start_time=%s", startTime)
+
+	if v, ok := d.GetOk("level"); ok {
+		queryParams = fmt.Sprintf("%s&level=%v", queryParams, v)
+	}
+
+	return queryParams
+}
+
+func listAlarms(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+
+	var (
+		httpUrl = "v3/{project_id}/alarm-history-record?limit={limit}"
+		result  = make([]interface{}, 0)
+		limit   = 100
+		offset  = 0
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listPath += buildAlarmsParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		alarms := utils.PathSearch("history_records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, alarms...)
+		if len(alarms) < limit {
+			break
+		}
+
+		offset += len(alarms)
+	}
+
+	return result, nil
+}
+
+func dataSourceAlarmsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("opengauss", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	alarms, err := listAlarms(client, d)
+	if err != nil {
+		return diag.Errorf("error querying alarms: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("history_records", flattenAlarms(alarms)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAlarms(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("history_records", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	res := make([]interface{}, 0, len(curArray))
+
+	for _, v := range curArray {
+		res = append(
+			res, map[string]interface{}{
+				"alarm_id":      utils.PathSearch("alarm_id", v, nil),
+				"name":          utils.PathSearch("name", v, nil),
+				"status":        utils.PathSearch("status", v, nil),
+				"alarm_type":    utils.PathSearch("alarm_type", v, nil),
+				"level":         utils.PathSearch("level", v, nil),
+				"instance_id":   utils.PathSearch("instance_id", v, nil),
+				"instance_name": utils.PathSearch("instance_name", v, nil),
+				"begin_time":    utils.PathSearch("begin_time", v, nil),
+				"update_time":   utils.PathSearch("update_time", v, nil),
+			},
+		)
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source `(huaweicloud_gaussdb_alarm_history_records) ` to query alarm history records list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```release-note
1.  add a new data source  `(huaweicloud_gaussdb_alarm_history_records) ` for GaussDB.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
```
./scripts/coverage.sh -o gaussdb -f TestAccDataSourceAlarms_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/gaussdb" -v -coverprofile="./huaweicloud/services/acceptance/gaussdb/gaussdb_coverage.cov" -coverpkg="./huaweicloud/services/gaussdb" -run TestAccDataSourceAlarms_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceAlarms_basic
=== PAUSE TestAccDataSourceAlarms_basic
=== CONT  TestAccDataSourceAlarms_basic
--- PASS: TestAccDataSourceAlarms_basic (15.45s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/gaussdb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   15.539s coverage: 3.4% of statements in ./huaweicloud/services/gaussdb
```

<img width="1022" height="30" alt="image" src="https://github.com/user-attachments/assets/dfefd2ab-67ba-42a9-b2ae-4dd89b0d2139" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
