### PR TITLE
feat(CSS): add data-source to query volume usage of a cluster

### DIFF
--- a/docs/data-sources/css_cluster_volume_usage.md
+++ b/docs/data-sources/css_cluster_volume_usage.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_css_cluster_volume_usage"
+description: |-
+  Use this data source to query the disk usage of a CSS cluster within HuaweiCloud.
+---
+
+# huaweicloud_css_cluster_volume_usage
+
+Use this data source to query the disk usage of a CSS cluster within HuaweiCloud.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_css_cluster_volume_usage" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the cluster volume usage.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the ID of the CSS cluster.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `disk_info_list` - The disk usage of each node in the cluster.
+  The [disk_info_list](#disk_info_list_struct) structure is documented below.
+
+<a name="disk_info_list_struct"></a>
+The `disk_info_list` block supports:
+
+* `id` - The node ID.
+
+* `name` - The node name.
+
+* `group` - The node group.
+
+* `role` - The node role.
+
+* `disk_type` - The node disk type.
+
+* `disk_capacity` - The total node storage capacity, in GB.
+
+* `disk_used` - The used node storage capacity, in GB.
+
+* `percentage` - The node storage usage, in percentage.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1087,6 +1087,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_css_smn_topics":                css.DataSourceCssSmnTopics(),
 			"huaweicloud_css_snapshots":                 css.DataSourceCssSnapshots(),
 			"huaweicloud_css_vpcep_connections":         css.DataSourceVpcepserviceConnections(),
+			"huaweicloud_css_cluster_volume_usage":      css.DataSourceCssClusterVolumeUsage(),
 
 			// DataArts Studio Management Center
 			"huaweicloud_dataarts_studio_data_connections":     dataarts.DataSourceStudioDataConnections(),

--- a/huaweicloud/services/acceptance/css/data_source_huaweicloud_css_cluster_volume_usage_test.go
+++ b/huaweicloud/services/acceptance/css/data_source_huaweicloud_css_cluster_volume_usage_test.go
@@ -1,0 +1,47 @@
+package css
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceClusterVolumeUsage_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_css_cluster_volume_usage.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCSSClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceClusterVolumeUsage_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "disk_info_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "disk_info_list.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "disk_info_list.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "disk_info_list.0.group"),
+					resource.TestCheckResourceAttrSet(dataSource, "disk_info_list.0.role"),
+					resource.TestCheckResourceAttrSet(dataSource, "disk_info_list.0.disk_capacity"),
+					resource.TestCheckResourceAttrSet(dataSource, "disk_info_list.0.disk_used"),
+					resource.TestCheckResourceAttrSet(dataSource, "disk_info_list.0.percentage"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceClusterVolumeUsage_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_css_cluster_volume_usage" "test" {
+  cluster_id = "%s"
+}
+`, acceptance.HW_CSS_CLUSTER_ID)
+}

--- a/huaweicloud/services/css/data_source_huaweicloud_css_cluster_volume_usage.go
+++ b/huaweicloud/services/css/data_source_huaweicloud_css_cluster_volume_usage.go
@@ -1,0 +1,146 @@
+package css
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSS GET /v1.0/{project_id}/clusters/{cluster_id}/volume
+func DataSourceCssClusterVolumeUsage() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterVolumeUsageRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"disk_info_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     clusterVolumeUsageDiskInfoSchema(),
+			},
+		},
+	}
+}
+
+func clusterVolumeUsageDiskInfoSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"group": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disk_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disk_capacity": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disk_used": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"percentage": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceClusterVolumeUsageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		httpUrl   = "v1.0/{project_id}/clusters/{cluster_id}/volume"
+		clusterId = d.Get("cluster_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("css", region)
+	if err != nil {
+		return diag.Errorf("error creating CSS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CSS cluster(%s) volume usage: %s", clusterId, err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("disk_info_list", flattenGetClusterVolumeUsageDiskInfoBody(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGetClusterVolumeUsageDiskInfoBody(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("diskInfoList", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	res := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		res = append(res, map[string]interface{}{
+			"id":            utils.PathSearch("id", v, nil),
+			"name":          utils.PathSearch("name", v, nil),
+			"group":         utils.PathSearch("group", v, nil),
+			"role":          utils.PathSearch("role", v, nil),
+			"disk_type":     utils.PathSearch("diskType", v, nil),
+			"disk_capacity": utils.PathSearch("diskCapacity", v, nil),
+			"disk_used":     utils.PathSearch("diskUsed", v, nil),
+			"percentage":    utils.PathSearch("percentage", v, nil),
+		})
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data-source to query volume usage of a cluster
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data-source to query volume usage of a cluster
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run=TestAccDataSourceClusterVolumeUsage'
=== RUN   TestAccDataSourceClusterVolumeUsage_basic
=== PAUSE TestAccDataSourceClusterVolumeUsage_basic
=== CONT  TestAccDataSourceClusterVolumeUsage_basic
--- PASS: TestAccDataSourceClusterVolumeUsage_basic (16.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css 16.215s
```

<img width="791" height="191" alt="image" src="https://github.com/user-attachments/assets/63fcc404-ef1b-46e9-b2d9-98c2dfe0bb29" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
