### PR TITLE
feat(das): add new data source for shared connections

### DIFF
--- a/docs/data-sources/das_shared_connections.md
+++ b/docs/data-sources/das_shared_connections.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Data Admin Service (DAS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_das_shared_connections"
+description: |-
+  Use this data source to query DAS shared connections within HuaweiCloud.
+---
+
+# huaweicloud_das_shared_connections
+
+Use this data source to query DAS shared connections within HuaweiCloud.
+
+## Example Usage
+
+### Query all shared connections under a specified connection
+
+```hcl
+variable "connection_id" {}
+
+data "huaweicloud_das_shared_connections" "test" {
+  connection_id = var.connection_id
+}
+```
+
+### Query shared connections by keyword
+
+```hcl
+# Fuzzy search for shared connections where the target fields (e.g., `user_id`, `user_name`) contain this keyword.
+variable "connection_id" {}
+variable "fuzzy_search_keyword" {}
+
+data "huaweicloud_das_shared_connections" "by_keyword" {
+  connection_id = var.connection_id
+  keywords      = var.fuzzy_search_keyword 
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the shared connections are located.  
+  If omitted, the provider-level region will be used.
+
+* `connection_id` - (Required, String) Specifies the ID of the connection to which the shared connection belongs.
+
+* `keywords` - (Optional, String) Specifies keywords to search for shared connections.  
+  The fuzzy search is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, in UUID format.
+
+* `shared_connections` - The list of shared connections that matched filter parameters.  
+  The [shared_connections](#das_shared_connections) structure is documented below.
+
+<a name="das_shared_connections"></a>
+The `shared_connections` block supports:
+
+* `user_id` - The user ID of the shared connection.
+
+* `user_name` - The user name of the shared connection.
+
+* `expired_at` - The expiration time of the shared connection, in RFC3339 format.
+
+* `shared_at` - The creation time of the shared connection, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1021,6 +1021,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_das_inspection_reports":                 das.DataSourceInspectionReports(),
 			"huaweicloud_das_instance_groups":                    das.DataSourceInstanceGroups(),
 			"huaweicloud_das_instance_metadata_locks":            das.DataSourceInstanceMetadataLocks(),
+			"huaweicloud_das_shared_connections":                 das.DataSourceSharedConnections(),
 
 			"huaweicloud_cdm_clusters":              cdm.DataSourceCdmClusters(),
 			"huaweicloud_cdm_flavors":               cdm.DataSourceCdmFlavors(),

--- a/huaweicloud/services/acceptance/das/data_source_huaweicloud_das_shared_connections_test.go
+++ b/huaweicloud/services/acceptance/das/data_source_huaweicloud_das_shared_connections_test.go
@@ -1,0 +1,191 @@
+package das
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSharedConnections_basic(t *testing.T) {
+	var (
+		name        = acceptance.RandomAccResourceName()
+		password    = acceptance.RandomPassword()
+		currentTime = time.Now().Local().Format(time.RFC3339)
+
+		all = "data.huaweicloud_das_shared_connections.all"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		filterByUserId   = "data.huaweicloud_das_shared_connections.filter_by_user_id"
+		dcFilterByUserId = acceptance.InitDataSourceCheck(filterByUserId)
+
+		filterByUserNameFuzzy   = "data.huaweicloud_das_shared_connections.filter_by_user_name_fuzzy"
+		dcFilterByUserNameFuzzy = acceptance.InitDataSourceCheck(filterByUserNameFuzzy)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { acceptance.TestAccPreCheck(t) },
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source:            "hashicorp/time",
+				VersionConstraint: "0.12.1",
+			},
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSharedConnections_nonExistentSharedConnections(),
+				ExpectError: regexp.MustCompile("error querying DAS shared connections"),
+			},
+			{
+				Config: testAccDataSharedConnections_basic(name, password, currentTime),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "shared_connections.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+
+					// filter by user ID
+					dcFilterByUserId.CheckResourceExists(),
+					resource.TestCheckOutput("is_user_id_filter_useful", "true"),
+					resource.TestCheckResourceAttrPair(filterByUserId, "shared_connections.0.user_id",
+						"huaweicloud_das_shared_connection.test", "user_id"),
+					resource.TestCheckResourceAttrPair(filterByUserId, "shared_connections.0.user_name",
+						"huaweicloud_das_shared_connection.test", "user_name"),
+					resource.TestCheckResourceAttrPair(filterByUserId, "shared_connections.0.expired_at",
+						"huaweicloud_das_shared_connection.test", "expired_at"),
+					resource.TestCheckResourceAttrPair(filterByUserId, "shared_connections.0.shared_at",
+						"huaweicloud_das_shared_connection.test", "shared_at"),
+
+					// filter by user name fuzzy
+					dcFilterByUserNameFuzzy.CheckResourceExists(),
+					resource.TestCheckOutput("is_user_name_fuzzy_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSharedConnections_nonExistentSharedConnections() string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_das_shared_connections" "non_existent_shared_connections" {
+  connection_id = "%[1]s"
+}
+`, randUUID)
+}
+
+func testAccDataSharedConnections_basic_base(name, password, currentTime string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_rds_mysql_account" "test" {
+  instance_id = "%[1]s"
+  name        = "%[2]s"
+  password    = "%[3]s"
+
+  hosts = [
+    "%%"
+  ]
+}
+
+resource "huaweicloud_das_database_instance_connection" "test" {
+  depends_on = [
+    huaweicloud_rds_mysql_account.test,
+  ]
+
+  instance_id      = "%[1]s"
+  engine_type      = "mysql"
+  network_type     = "rds"
+  username         = "%[2]s"
+  password         = "%[3]s"
+  is_save_password = true
+  node_ids         = ["%[1]s"]
+  description      = "Created by terraform script"
+  database_name    = "%[2]s"
+  sql_record_flag  = true
+}
+
+data "huaweicloud_identity_users" "test" {
+  depends_on = [
+    huaweicloud_das_database_instance_connection.test,
+  ]
+}
+
+resource "huaweicloud_das_shared_connection" "test" {
+  depends_on = [
+    data.huaweicloud_identity_users.test,
+  ]
+
+  connection_id = huaweicloud_das_database_instance_connection.test.id
+  user_id       = data.huaweicloud_identity_users.test.users[0].id
+  user_name     = data.huaweicloud_identity_users.test.users[0].name
+  expired_at    = format("%%s+08:00", split("+", timeadd("%[4]s", "1h"))[0])
+}
+`, acceptance.HW_RDS_INSTANCE_ID, name, password, currentTime)
+}
+
+func testAccDataSharedConnections_basic(name, password, currentTime string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_das_shared_connections" "all" {
+  depends_on = [
+    huaweicloud_das_shared_connection.test,
+  ]
+
+  connection_id = huaweicloud_das_database_instance_connection.test.id
+}
+
+# Filter by user ID
+locals {
+  user_id = huaweicloud_das_shared_connection.test.user_id
+}
+
+data "huaweicloud_das_shared_connections" "filter_by_user_id" {
+  depends_on = [
+    data.huaweicloud_das_shared_connections.all,
+  ]
+
+  connection_id = huaweicloud_das_database_instance_connection.test.id
+  keywords      = local.user_id
+}
+
+locals {
+  user_id_filter_result = [
+    for v in data.huaweicloud_das_shared_connections.filter_by_user_id.shared_connections : v.user_id == local.user_id
+  ]
+}
+
+output "is_user_id_filter_useful" {
+  value = length(local.user_id_filter_result) > 0 && alltrue(local.user_id_filter_result)
+}
+
+# Filter by user name fuzzy
+locals {
+  user_name        = data.huaweicloud_identity_users.test.users[0].name
+  user_name_prefix = substr(local.user_name, 1, 2)
+}
+
+data "huaweicloud_das_shared_connections" "filter_by_user_name_fuzzy" {
+  depends_on = [
+    data.huaweicloud_das_shared_connections.all,
+  ]
+
+  connection_id = huaweicloud_das_database_instance_connection.test.id
+  keywords      = local.user_name_prefix
+}
+
+locals {
+	user_name_fuzzy_filter_result = [
+    for v in data.huaweicloud_das_shared_connections.filter_by_user_name_fuzzy.shared_connections : strcontains(v.user_name, local.user_name_prefix)
+  ]
+}
+
+output "is_user_name_fuzzy_filter_useful" {
+  value = length(local.user_name_fuzzy_filter_result) > 0 && alltrue(local.user_name_fuzzy_filter_result)
+}
+`, testAccDataSharedConnections_basic_base(name, password, currentTime))
+}

--- a/huaweicloud/services/das/data_source_huaweicloud_das_shared_connections.go
+++ b/huaweicloud/services/das/data_source_huaweicloud_das_shared_connections.go
@@ -1,0 +1,138 @@
+package das
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DAS GET /v3/{project_id}/connections/{connection_id}/get-shared-list
+func DataSourceSharedConnections() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSharedConnectionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the shared connections are located.`,
+			},
+
+			// Required parameters.
+			"connection_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the connection to which the shared connection belongs.`,
+			},
+
+			// Optional parameters.
+			"keywords": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Keywords to search for shared connections.",
+			},
+
+			// Attributes.
+			"shared_connections": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        sharedConnectionsElem(),
+				Description: `The list of shared connections that matched filter parameters.`,
+			},
+		},
+	}
+}
+
+func sharedConnectionsElem() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user ID of the shared connection.`,
+			},
+			"user_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The user name of the shared connection.",
+			},
+			"expired_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The expiration time of the shared connection, in RFC3339 format.",
+			},
+			"shared_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the shared connection, in RFC3339 format.",
+			},
+		},
+	}
+	return &sc
+}
+
+func buildSharedConnectionsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("keywords"); ok {
+		res = fmt.Sprintf("%s&keywords=%v", res, v)
+	}
+
+	return res
+}
+
+func flattenSharedConnections(sharedConnections []interface{}) []map[string]interface{} {
+	if len(sharedConnections) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(sharedConnections))
+	for _, sharedConnection := range sharedConnections {
+		result = append(result, map[string]interface{}{
+			"user_id":   utils.PathSearch("user_id", sharedConnection, nil),
+			"user_name": utils.PathSearch("user_name", sharedConnection, nil),
+			"shared_at": utils.FormatTimeStampRFC3339(
+				int64(utils.PathSearch("shared_time", sharedConnection, float64(0)).(float64))/1000, false),
+			"expired_at": utils.FormatTimeStampRFC3339(
+				int64(utils.PathSearch("expired_time", sharedConnection, float64(0)).(float64))/1000, false),
+		})
+	}
+	return result
+}
+
+func dataSourceSharedConnectionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("das", region)
+	if err != nil {
+		return diag.Errorf("error creating DAS client: %s", err)
+	}
+
+	sharedConnections, err := listSharedConnections(client, d.Get("connection_id").(string), buildSharedConnectionsQueryParams(d))
+	if err != nil {
+		return diag.Errorf("error querying DAS shared connections: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("shared_connections", flattenSharedConnections(sharedConnections)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/das/resource_huaweicloud_das_shared_connection.go
+++ b/huaweicloud/services/das/resource_huaweicloud_das_shared_connection.go
@@ -175,7 +175,7 @@ func resourceSharedConnectionCreate(ctx context.Context, d *schema.ResourceData,
 
 func listSharedConnections(client *golangsdk.ServiceClient, connectionId, queryParams string) ([]interface{}, error) {
 	var (
-		httpUrl = "v3/{project_id}/connections/{connection_id}/get-shared-list?perPage"
+		httpUrl = "v3/{project_id}/connections/{connection_id}/get-shared-list?per_page={per_page}"
 		perPage = 100
 		curPage = 1
 		result  = make([]interface{}, 0)
@@ -184,7 +184,7 @@ func listSharedConnections(client *golangsdk.ServiceClient, connectionId, queryP
 	listPath := client.Endpoint + httpUrl
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 	listPath = strings.ReplaceAll(listPath, "{connection_id}", connectionId)
-	listPath = strings.ReplaceAll(listPath, "{perPage}", strconv.Itoa(perPage))
+	listPath = strings.ReplaceAll(listPath, "{per_page}", strconv.Itoa(perPage))
 	if queryParams != "" {
 		listPath += queryParams
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add new data source for shared connections
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
  add new data source for shared connections.
  the listSharedConnections function was previously passing an incorrect value for the per_page parameter. This has been fixed to ensure accurate pagination when listing shared connections.
  <img width="1262" height="502" alt="image" src="https://github.com/user-attachments/assets/e3e165f0-1449-4cf0-b282-d9a2750202d0" />


**Unit Test Result:**
  <img width="1381" height="193" alt="image" src="https://github.com/user-attachments/assets/c7b08a89-a5a2-41b4-8a81-46eb3cbfccb8" />
  <img width="1315" height="485" alt="image" src="https://github.com/user-attachments/assets/8ccc52c6-94e7-4d48-b1e2-1fe4695dbf88" />



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NEW: data.huaweicloud_das_shared_connections: Support querying shared connections by connection ID or keywords.
BUG FIXES: data.huaweicloud_das_shared_connections: Fixed an issue where the per_page parameter was passed incorrectly in the list operation.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccDataSharedConnections_basic'
...
=== RUN   TestAccDataSharedConnections_basic
--- PASS: TestAccDataSharedConnections_basic (27.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/das       27.394s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
