### PR TITLE
feat(drs): add drs batch_struct_detail datasource

### DIFF
--- a/docs/data-sources/drs_batch_struct_detail.md
+++ b/docs/data-sources/drs_batch_struct_detail.md
@@ -1,0 +1,98 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_batch_struct_detail"
+description: |-
+  Use this data source to get the details of DR initialization objects within HuaweiCloud.
+---
+
+# huaweicloud_drs_batch_struct_detail
+
+Use this data source to get the details of DR initialization objects within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "type" {}
+variable "jobs" {
+  type = list(string)
+}
+
+data "huaweicloud_drs_batch_struct_detail" "test" {
+  type = var.type
+  jobs = var.jobs
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Required, String) Specifies the database migration object type.
+  The valid values are as follows:
+  + **database**
+  + **schema**
+  + **table**
+  + **view**
+  + **procedure**
+  + **trigger**
+  + **index**
+  + **table_indexs**
+  + **table_structure**
+
+* `jobs` - (Required, List) Specifies the list of DRS job detail IDs to query.
+
+* `cur_page` - (Optional, Int) Specifies the current page number.
+
+* `per_page` - (Optional, Int) Specifies the number of items per page.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `results` - The list of batch struct details.
+
+  The [results](#results_struct) structure is documented below.
+
+<a name="results_struct"></a>
+The `results` block supports:
+
+* `job_id` - The task ID.
+
+* `error_code` - The error code.
+
+* `error_message` - The error message.
+
+* `struct_detail` - The details of the DR initialization object.
+
+  The [struct_detail](#struct_detail_struct) structure is documented below.
+
+<a name="struct_detail_struct"></a>
+The `struct_detail` block supports:
+
+* `total_record` - The total number of tasks.
+
+* `create_time` - The time when the data was generated.
+
+* `list` - The list of comparison results.
+
+  The [list](#list_struct) structure is documented below.
+
+<a name="list_struct"></a>
+The `list` block supports:
+
+* `progress` - The progress of the task.
+
+* `src_db` - The name of the source database.
+   If the source database has a three-level structure, the format is: **database.schema**.
+
+* `src_tb` - The name of the source object.
+
+* `dst_db` - The name of the target database.
+
+* `dst_tb` - The name of the target object.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1348,6 +1348,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_batch_get_params":         drs.DataSourceDrsBatchGetParams(),
 			"huaweicloud_drs_batch_progresses":         drs.DataSourceDrsBatchProgresses(),
 			"huaweicloud_drs_batch_rpos_and_rtos":      drs.DataSourceDrsBatchRposAndRtos(),
+			"huaweicloud_drs_batch_struct_detail":      drs.DataSourceDrsBatchStructDetail(),
 			"huaweicloud_drs_batch_struct_process":     drs.DataSourceDrsBatchStructProcess(),
 			"huaweicloud_drs_compare_content_detail":   drs.DataSourceDrsCompareContentDetail(),
 			"huaweicloud_drs_compare_content_overview": drs.DataSourceDrsCompareContentOverview(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_batch_struct_detail_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_batch_struct_detail_test.go
@@ -1,0 +1,47 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDrsBatchStructDetail_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_drs_batch_struct_detail.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobIds(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDrsBatchStructDetail_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.job_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.struct_detail.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.struct_detail.0.total_record"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.struct_detail.0.list.0.progress"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDrsBatchStructDetail_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_drs_batch_struct_detail" "test" {
+  type = "database"
+  jobs = split(",", "%s")
+}
+`, acceptance.HW_DRS_JOB_IDS)
+}

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_batch_struct_detail.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_batch_struct_detail.go
@@ -1,0 +1,242 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS POST /v3/{project_id}/jobs/{type}/batch-struct-detail
+func DataSourceDrsBatchStructDetail() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDrsBatchStructDetailRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"jobs": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"cur_page": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"per_page": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     resultsStructSchema(),
+			},
+		},
+	}
+}
+
+func resultsStructSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"job_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error_message": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"struct_detail": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     structDetailSchema(),
+			},
+		},
+	}
+}
+
+func structDetailSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"total_record": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     listItemSchema(),
+			},
+		},
+	}
+}
+
+func listItemSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"progress": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"src_db": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"src_tb": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_db": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dst_tb": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildBatchStructDetailBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"jobs": d.Get("jobs").([]interface{}),
+	}
+
+	if v, ok := d.GetOk("cur_page"); ok {
+		bodyParams["cur_page"] = v.(int)
+	}
+	if v, ok := d.GetOk("per_page"); ok {
+		bodyParams["per_page"] = v.(int)
+	}
+
+	return bodyParams
+}
+
+func dataSourceDrsBatchStructDetailRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "drs"
+		httpUrl = "v3/{project_id}/jobs/{type}/batch-struct-detail"
+		jobType = d.Get("type").(string)
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{type}", jobType)
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildBatchStructDetailBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &reqOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving DRS batch struct detail: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	results := utils.PathSearch("results", respBody, make([]interface{}, 0)).([]interface{})
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("results", flattenResults(results)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenResults(results []interface{}) []interface{} {
+	if len(results) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(results))
+	for _, v := range results {
+		rst = append(rst, map[string]interface{}{
+			"job_id":        utils.PathSearch("job_id", v, nil),
+			"error_code":    utils.PathSearch("error_code", v, nil),
+			"error_message": utils.PathSearch("error_message", v, nil),
+			"struct_detail": flattenStructDetail(utils.PathSearch("struct_detail", v, nil)),
+		})
+	}
+	return rst
+}
+
+func flattenStructDetail(detail interface{}) []interface{} {
+	if detail == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"total_record": utils.PathSearch("total_record", detail, nil),
+			"create_time":  utils.PathSearch("create_time", detail, nil),
+			"list":         flattenListItem(utils.PathSearch("list", detail, make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}
+
+func flattenListItem(items []interface{}) []interface{} {
+	if len(items) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		rst = append(rst, map[string]interface{}{
+			"progress": utils.PathSearch("progress", item, nil),
+			"src_db":   utils.PathSearch("src_db", item, nil),
+			"src_tb":   utils.PathSearch("src_tb", item, nil),
+			"dst_db":   utils.PathSearch("dst_db", item, nil),
+			"dst_tb":   utils.PathSearch("dst_tb", item, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a new data source `huaweicloud_drs_batch_struct_detail` for HuaweiCloud Data Replication Service (DRS). This data source is used to batch query the details of DR initialization objects, supports filtering by object type and job ID list, and provides pagination query parameters. It helps users obtain the structure details of multiple DRS jobs in batches through Terraform.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add data source huaweicloud_drs_batch_struct_detail for batch querying DRS structure details
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/drs' TESTARGS='-run=TestAccDataSourceDrsBatchStructDetail_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run=TestAccDataSourceDrsBatchStructDetail_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDrsBatchStructDetail_basic
=== PAUSE TestAccDataSourceDrsBatchStructDetail_basic
=== CONT  TestAccDataSourceDrsBatchStructDetail_basic
--- PASS: TestAccDataSourceDrsBatchStructDetail_basic (26.27s)
PASS
```
<img width="474" height="15" alt="Snipaste_2026-06-02_16-20-57" src="https://github.com/user-attachments/assets/4ca20867-86cc-4935-8ed4-ed303a6e434a" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
