### PR TITLE
feat(geminidb): add resource geminidb Load Balancer IP Addresses access control

### DIFF
--- a/docs/resources/geminidb_instance.md
+++ b/docs/resources/geminidb_instance.md
@@ -157,6 +157,9 @@ The following arguments are supported:
   -> This parameter is valid and available for **GeminiDB Influx** and **GeminiDB Redis** instances.
     The instances across subnets are not supported.
 
+* `access_control` - (Optional, List) Specifies the access control for Load Balancer.
+  The [access_control](#access_control_struct) structure is documented below.
+
 * `delete_node_list` - (Optional, List) Specifies the ID of the nodes to be deleted. Make sure that the node
   can be deleted. This parameter can not be specified when add nodes. When delete nodes, if this parameter is specified,
   then the nodes specified by this parameter will be deleted, and id this parameter is not transferred, the nodes will be
@@ -276,6 +279,27 @@ The `policy` block supports:
   + For GeminiDB Redis instances, the storage upper limit ≥ Current storage + 1 GB. The storage upper limit cannot
   exceed the maximum storage supported by the current specifications. Learn more details , refer to
   [GeminiDB Redis Instance Specifications](https://support.huaweicloud.com/intl/en-us/redisug-nosql/nosql_05_0059.html).
+
+<a name="access_control_struct"></a>
+The `access_control` block supports:
+
+* `enabled` - (Required, String) Specifies whether to enable load balancer IP access control. Value options:
+  + **true**: Enable load balancer IP access control.
+  + **false**: Disable load balancer IP access control.
+
+* `type` - (Required, String) Specifies the type of IP access control. Value options:
+  + **whiteList**: Whitelist, only allow specified IPs or network segments to access.
+  + **blackList**: Blacklist, deny specified IPs or network segments from accessing.
+
+* `ip_groups` - (Optional, List) Specifies the list of IP addresses or network segments.
+  The [ip_groups](#ip_groups_struct) structure is documented below.
+
+<a name="ip_groups_struct"></a>
+The `ip_groups` block supports:
+
+* `ip` - (Required, String) Specifies the IP address or network segment.
+
+* `description` - (Optional, String) Specifies the description of the IP address or network segment.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
@@ -396,6 +396,11 @@ func TestAccGeminiDbInstance_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "config_ips.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "lb_ip_address", "192.168.0.153"),
 
+					resource.TestCheckResourceAttr(resourceName, "access_control.0.type", "blackList"),
+					resource.TestCheckResourceAttr(resourceName, "access_control.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "access_control.0.ip_groups.0.ip", "123.123.123.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "access_control.0.ip_groups.0.description", "test"),
+
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
 					resource.TestCheckResourceAttrSet(resourceName, "policy.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "policy.0.threshold"),
@@ -414,6 +419,11 @@ func TestAccGeminiDbInstance_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "second_level_monitoring_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "config_ips.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "lb_ip_address", "192.168.0.118"),
+
+					resource.TestCheckResourceAttr(resourceName, "access_control.0.type", "blackList"),
+					resource.TestCheckResourceAttr(resourceName, "access_control.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "access_control.0.ip_groups.0.ip", "192.168.0.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "access_control.0.ip_groups.0.description", "test update"),
 				),
 			},
 			{
@@ -422,6 +432,9 @@ func TestAccGeminiDbInstance_configuration(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "switch_option", "off"),
 					resource.TestCheckResourceAttr(resourceName, "config_ips.#", "0"),
+
+					resource.TestCheckResourceAttr(resourceName, "access_control.0.type", "blackList"),
+					resource.TestCheckResourceAttr(resourceName, "access_control.0.enabled", "false"),
 				),
 			},
 			{
@@ -847,6 +860,16 @@ resource "huaweicloud_geminidb_instance" "test" {
 
   # update loadbalancer IP address
   lb_ip_address = "192.168.0.153"
+
+  # Configuring the Blacklist or Whitelist of Load Balancer IP Addresses
+  access_control {
+    type    = "blackList"
+    enabled = "true"
+    ip_groups { 
+      ip          = "123.123.123.0/24"
+      description = "test" 
+    }
+  }
 }
 `, common.TestBaseNetwork(name), name)
 }
@@ -896,6 +919,15 @@ resource "huaweicloud_geminidb_instance" "test" {
   second_level_monitoring_enabled = "false"
   config_ips                      = ["192.168.1.15","192.168.1.23/24","192.168.1.38"]
   lb_ip_address                   = "192.168.0.118"
+
+  access_control {
+    type    = "blackList"
+    enabled = "true"
+    ip_groups { 
+      ip          = "192.168.0.0/24"
+      description = "test update" 
+    }
+  }
 }
 `, common.TestBaseNetwork(name), name)
 }
@@ -938,6 +970,11 @@ resource "huaweicloud_geminidb_instance" "test" {
   second_level_monitoring_enabled = false
   config_ips                      = []
   lb_ip_address                   = "192.168.0.118"
+
+  access_control {
+    type    = "blackList"
+    enabled = "false"
+  }
 }
 `, common.TestBaseNetwork(name), name)
 }

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
@@ -54,6 +54,8 @@ var geminiDbInstanceNonUpdatableParams = []string{"datastore", "datastore.*.type
 // @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/passwordless-config
 // @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/passwordless-config
 // @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/lb
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/lb/access-control
+// @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/lb/access-control
 // @API BSS GET /v2/orders/customer-orders/details/{order_id}
 // @API BSS POST /v2/orders/subscriptions/resources/autorenew/{instance_id}
 // @API BSS DELETE /v2/orders/subscriptions/resources/autorenew/{instance_id}
@@ -207,6 +209,13 @@ func ResourceGeminiDbInstance() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"access_control": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem:     geminiDbAccessControlSchema(),
+			},
 			// charge info: charging_mode, period_unit, period, auto_renew
 			// make ForceNew false here but do nothing in update method!
 			"charging_mode": {
@@ -278,6 +287,40 @@ func ResourceGeminiDbInstance() *schema.Resource {
 			},
 		},
 	}
+}
+
+func geminiDbAccessControlSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"enabled": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ip_groups": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	return &sc
 }
 
 func geminiDbInstanceDatastoreSchema() *schema.Resource {
@@ -601,6 +644,14 @@ func resourceGeminiDbInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
+	// Configuring the Blacklist or Whitelist of Load Balancer IP Addresses
+	if v, ok := d.GetOk("access_control.0.enabled"); ok && v.(string) == "true" {
+		err = updateLBAccessControl(ctx, d, client)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceGeminiDbInstanceRead(ctx, d, meta)
 }
 
@@ -909,7 +960,68 @@ func resourceGeminiDbInstanceRead(_ context.Context, d *schema.ResourceData, met
 	// Set password-free configuration
 	mErr = multierror.Append(mErr, getPasswordFreeConfigurationInfo(d, client))
 
+	// Querying the Blacklist or Whitelist of Load Balancer IP Addresses
+	accessControlRespBody, err := getLBAccessControlInfo(client, d.Id())
+	if err != nil {
+		log.Printf("[Warn] error get the GeminiDB Load Balancer access control: %s", err)
+	} else {
+		mErr = multierror.Append(mErr,
+			d.Set("access_control", flattenAccessControl(accessControlRespBody)),
+		)
+	}
+
 	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getLBAccessControlInfo(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	getRespBody, err := getInstanceField(client, getInstanceFieldParams{
+		httpUrl:    "v3/{project_id}/instances/{instance_id}/lb/access-control",
+		httpMethod: "GET",
+		pathParams: map[string]string{"instance_id": instanceId},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return getRespBody, err
+}
+
+func flattenAccessControl(accessControlRespBody interface{}) []map[string]interface{} {
+	if accessControlRespBody == nil {
+		return nil
+	}
+	ipGroupsRaw := utils.PathSearch("ip_groups", accessControlRespBody, make([]interface{}, 0))
+	ipGroups := flattenLbAccessControlIpGroups(ipGroupsRaw)
+	enabledBool := utils.PathSearch("enabled", accessControlRespBody, false).(bool)
+
+	result := map[string]interface{}{
+		"enabled":   strconv.FormatBool(enabledBool),
+		"type":      utils.PathSearch("type", accessControlRespBody, nil),
+		"ip_groups": ipGroups,
+	}
+
+	return []map[string]interface{}{result}
+}
+
+func flattenLbAccessControlIpGroups(ipGroupsRaw interface{}) []map[string]interface{} {
+	if ipGroupsRaw == nil {
+		return nil
+	}
+
+	ipGroupsSlice, ok := ipGroupsRaw.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(ipGroupsSlice))
+	for _, ipGroupRaw := range ipGroupsSlice {
+		result = append(result, map[string]interface{}{
+			"ip":          utils.PathSearch("ip", ipGroupRaw, nil),
+			"description": utils.PathSearch("description", ipGroupRaw, nil),
+		})
+	}
+	return result
 }
 
 func getAutoEnlargePolicyInfo(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
@@ -1237,10 +1349,18 @@ func resourceGeminiDbInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	// Update loadbalancer IP address
+	// Update load balancer IP address
 	err = updateLoadbalancerIpAddress(ctx, d, client)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	// Configuring the Blacklist or Whitelist of Load Balancer IP Addresses
+	if d.HasChange("access_control") {
+		err = updateLBAccessControl(ctx, d, client)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return resourceGeminiDbInstanceRead(ctx, d, meta)
@@ -1639,6 +1759,54 @@ func updateLoadbalancerIpAddress(ctx context.Context, d *schema.ResourceData, cl
 func buildUpdateLoadbalancerIpAddressBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"ip": d.Get("lb_ip_address"),
+	}
+
+	return bodyParams
+}
+
+func updateLBAccessControl(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	_, err := updateGeminiDbInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:          "v3/{project_id}/instances/{instance_id}/lb/access-control",
+		httpMethod:       "PUT",
+		pathParams:       map[string]string{"instance_id": d.Id()},
+		updateBodyParams: buildUpdateLBAccessControlBodyParams(d),
+		isRetry:          true,
+		timeout:          schema.TimeoutUpdate,
+	})
+	if err != nil {
+		return fmt.Errorf("error setting GeminiDB load balancer access control: %s", err)
+	}
+	return nil
+}
+
+func buildUpdateLBAccessControlBodyParams(d *schema.ResourceData) map[string]interface{} {
+	accessControlRaw := d.Get("access_control").([]interface{})
+	if len(accessControlRaw) == 0 {
+		return nil
+	}
+	accessControl, ok := accessControlRaw[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	ipGroups := make([]map[string]interface{}, 0)
+	ipGroupsRaw := accessControl["ip_groups"].(*schema.Set).List()
+
+	for _, ipGroupRaw := range ipGroupsRaw {
+		ipGroup := ipGroupRaw.(map[string]interface{})
+		ipGroupMap := map[string]interface{}{
+			"ip": ipGroup["ip"],
+		}
+		if description, ok := ipGroup["description"]; ok && description != "" {
+			ipGroupMap["description"] = description
+		}
+		ipGroups = append(ipGroups, ipGroupMap)
+	}
+
+	bodyParams := map[string]interface{}{
+		"enabled":   accessControl["enabled"],
+		"type":      accessControl["type"],
+		"ip_groups": ipGroups,
 	}
 
 	return bodyParams


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource geminidb Load Balancer IP Addresses access control
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add resource geminidb Load Balancer IP Addresses access control
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDbInstance_configuration"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDbInstance_configuration -timeout 360m -parallel 4
=== RUN   TestAccGeminiDbInstance_configuration
=== PAUSE TestAccGeminiDbInstance_configuration
=== CONT  TestAccGeminiDbInstance_configuration
--- PASS: TestAccGeminiDbInstance_configuration (1468.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1469.324s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
