### PR TITLE
feat(modelarts): add new data source to get engines for training job

### DIFF
--- a/docs/data-sources/modelarts_training_job_engines.md
+++ b/docs/data-sources/modelarts_training_job_engines.md
@@ -1,0 +1,59 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_training_job_engines"
+description: |-
+  Use this data source to get AI preset framework engine list supported by the ModelArts training job
+  within HuaweiCloud.
+---
+
+# huaweicloud_modelarts_training_job_engines
+
+Use this data source to get AI preset framework engine list supported by the ModelArts training job within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_modelarts_training_job_engines" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the training job engines are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `engines` - The list of training job engines.  
+  The [engines](#modelarts_training_job_engines_attr) structure is documented below.
+
+<a name="modelarts_training_job_engines_attr"></a>
+The `engines` block supports:
+
+* `engine_id` - The ID of the engine.
+
+* `engine_name` - The name of the engine.
+
+* `engine_version` - The version of the engine.
+
+* `v1_compatible` - Whether the engine is v1 compatible.
+
+* `run_user` - The default startup user UID of the engine.
+
+* `image_info` - The image information of the engine.  
+  The [image_info](#modelarts_training_job_engines_image_info) structure is documented below.
+
+<a name="modelarts_training_job_engines_image_info"></a>
+The `image_info` block supports:
+
+* `cpu_image_url` - The CPU image URL of the engine.
+
+* `gpu_image_url` - The GPU or Ascend image URL of the engine.
+
+* `image_version` - The image version of the engine.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2043,6 +2043,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_service_flavors":      modelarts.DataSourceServiceFlavors(),
 			"huaweicloud_modelarts_services":             modelarts.DataSourceServices(),
 			"huaweicloud_modelarts_training_experiments": modelarts.DataSourceTrainingExperiments(),
+			"huaweicloud_modelarts_training_job_engines": modelarts.DataSourceTrainingJobEngines(),
 			"huaweicloud_modelarts_workspace_quotas":     modelarts.DataSourceWorkspaceQuotas(),
 			"huaweicloud_modelarts_workspaces":           modelarts.DataSourceWorkspaces(),
 			// Resource management via V2 APIs.

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_training_job_engines_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_training_job_engines_test.go
@@ -1,0 +1,53 @@
+package modelarts
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataTrainingJobEngines_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_modelarts_training_job_engines.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataTrainingJobEngines_basic,
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "engines.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(all, "engines.0.image_info.#", "1"),
+					resource.TestCheckResourceAttrSet(all, "engines.0.engine_id"),
+					resource.TestCheckResourceAttrSet(all, "engines.0.engine_name"),
+					resource.TestCheckResourceAttrSet(all, "engines.0.engine_version"),
+					resource.TestCheckResourceAttrSet(all, "engines.0.v1_compatible"),
+					resource.TestCheckResourceAttrSet(all, "engines.0.image_info.0.image_version"),
+					resource.TestCheckOutput("is_image_url_set_and_valid", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataTrainingJobEngines_basic = `
+# Without any filter parameters.
+data "huaweicloud_modelarts_training_job_engines" "test" {}
+
+locals {
+  engine = try(data.huaweicloud_modelarts_training_job_engines.test.engines[0], {})
+}
+
+# At least one of gpu_image_url and cpu_image_url is not empty.
+output "is_image_url_set_and_valid" {
+  value = try(local.engine.image_info[0].cpu_image_url != "" || local.engine.image_info[0].gpu_image_url != "", false)
+}
+`

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_training_job_engines.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_training_job_engines.go
@@ -1,0 +1,177 @@
+package modelarts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ModelArts GET /v2/{project_id}/training-job-engines
+func DataSourceTrainingJobEngines() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTrainingJobEnginesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the training job engines are located.`,
+			},
+			"engines": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"engine_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the engine.`,
+						},
+						"engine_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the engine.`,
+						},
+						"engine_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version of the engine.`,
+						},
+						"v1_compatible": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the engine is v1 compatible.`,
+						},
+						"run_user": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The default startup user UID of the engine.`,
+						},
+						"image_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cpu_image_url": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The CPU image URL of the engine.`,
+									},
+									"gpu_image_url": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The GPU or Ascend image URL of the engine.`,
+									},
+									"image_version": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The image version of the engine.`,
+									},
+								},
+							},
+							Description: `The image information of the engine.`,
+						},
+					},
+				},
+				Description: `The list of training job engines.`,
+			},
+		},
+	}
+}
+
+func listTrainingJobEngines(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	httpUrl := "v2/{project_id}/training-job-engines"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func dataSourceTrainingJobEnginesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	engines, err := listTrainingJobEngines(client)
+	if err != nil {
+		return diag.Errorf("error querying training job engines: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("engines", flattenTrainingJobEngines(engines)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTrainingJobEngines(engines []interface{}) []map[string]interface{} {
+	if len(engines) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(engines))
+	for _, engine := range engines {
+		result = append(result, map[string]interface{}{
+			"engine_id":      utils.PathSearch("engine_id", engine, nil),
+			"engine_name":    utils.PathSearch("engine_name", engine, nil),
+			"engine_version": utils.PathSearch("engine_version", engine, nil),
+			"v1_compatible":  utils.PathSearch("v1_compatible", engine, nil),
+			"run_user":       utils.PathSearch("run_user", engine, nil),
+			"image_info": flattenTrainingJobEngineImageInfo(utils.PathSearch("image_info",
+				engine, make(map[string]interface{})).(map[string]interface{})),
+		})
+	}
+
+	return result
+}
+
+func flattenTrainingJobEngineImageInfo(imageInfo map[string]interface{}) []map[string]interface{} {
+	if len(imageInfo) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"cpu_image_url": utils.PathSearch("cpu_image_url", imageInfo, nil),
+			"gpu_image_url": utils.PathSearch("gpu_image_url", imageInfo, nil),
+			"image_version": utils.PathSearch("image_version", imageInfo, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_modelarts_training_job_engines`) to query AI preset frameworks engine list supported by the training job.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source for Modelarts.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDataTrainingJobEngines_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataTrainingJobEngines_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTrainingJobEngines_basic
=== PAUSE TestAccDataTrainingJobEngines_basic
=== CONT  TestAccDataTrainingJobEngines_basic
--- PASS: TestAccDataTrainingJobEngines_basic (14.75s)
PASS
coverage: 4.9% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 15.422s coverage: 4.9% of statements in ./huaweicloud/services/modelarts

```
<img width="1480" height="58" alt="image" src="https://github.com/user-attachments/assets/afee29ea-c7e5-44e5-a581-eecdfc6ce220" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
