### PR TITLE
docs: fix contradictory code_type guidance for SWR images in fgs_function

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -413,7 +413,7 @@ The following arguments are supported:
 
 * `handler` - (Required, String) Specifies the entry point of the function.
 
--> If the function is created by an SWR image, keep `code_type` empty and use hyphen character (-) to set the handler.
+-> If the function is created by an SWR image, set `code_type` to **Custom-Image-Swr** and use the hyphen character (-) to set the handler.
 
 * `description` - (Optional, String) Specifies the description of the function.
 


### PR DESCRIPTION
## Summary

Fixes a self-contradictory note in the `huaweicloud_fgs_function` docs: the SWR-image guidance told users to "keep `code_type` empty", which contradicted both the working SWR example and the `code_type` argument reference (both of which require `code_type = "Custom-Image-Swr"`). The schema's `ConflictsWith` between `code_type` and `custom_image` was already removed in master, so the note is now updated to match the correct, internally consistent behavior.

Fixes #6182

AI was used for assistance.
