### PR TITLE
feat(modelarts): add new data source to get public flavors for training job

### DIFF
--- a/docs/data-sources/modelarts_training_job_flavors.md
+++ b/docs/data-sources/modelarts_training_job_flavors.md
@@ -1,0 +1,135 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_training_job_flavors"
+description: |-
+  Use this data source to get public resource pool flavor list supported by ModelArts training job within HuaweiCloud.
+---
+
+# huaweicloud_modelarts_training_job_flavors
+
+Use this data source to get public resource pool flavor list supported by ModelArts training job within HuaweiCloud.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+data "huaweicloud_modelarts_training_job_flavors" "test" {}
+```
+
+### Filter by flavor type
+
+```hcl
+data "huaweicloud_modelarts_training_job_flavors" "test" {
+  flavor_type = "CPU"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the training job flavors are located.  
+  If omitted, the provider-level region will be used.
+
+* `flavor_type` - (Optional, String) Specifies the type of the flavor.  
+  The valid values are as follows:
+  + **CPU**
+  + **GPU**
+  + **Ascend**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `flavors` - The list of training job flavors that match the filter parameters.  
+  The [flavors](#modelarts_training_job_flavors_attr) structure is documented below.
+
+<a name="modelarts_training_job_flavors_attr"></a>
+The `flavors` block supports:
+
+* `flavor_id` - The ID of the flavor.
+
+* `flavor_name` - The name of the flavor.
+
+* `flavor_type` - The type of the flavor.
+
+* `billing` - The billing information of the flavor.  
+  The [billing](#modelarts_training_job_flavors_billing) structure is documented below.
+
+* `flavor_info` - The detailed information of the flavor.  
+  The [flavor_info](#modelarts_training_job_flavors_flavor_info) structure is documented below.
+
+* `attributes` - The other attributes of the flavor.
+
+* `support_engines` - The engines supported by the flavor.
+
+<a name="modelarts_training_job_flavors_billing"></a>
+The `billing` block supports:
+
+* `code` - The billing code.
+
+* `unit_num` - The billing unit.
+
+<a name="modelarts_training_job_flavors_flavor_info"></a>
+The `flavor_info` block supports:
+
+* `max_num` - The maximum number of nodes that can be selected.  
+  `1` means that the flavor does not support distributed.
+
+* `cpu` - The CPU information of the flavor.  
+  The [cpu](#modelarts_training_job_flavors_cpu) structure is documented below.
+
+* `gpu` - The GPU information of the flavor.  
+  The [gpu](#modelarts_training_job_flavors_gpu) structure is documented below.
+
+* `npu` - The Ascend information of the flavor.  
+  The [npu](#modelarts_training_job_flavors_npu) structure is documented below.
+
+* `memory` - The memory information of the flavor.  
+  The [memory](#modelarts_training_job_flavors_memory) structure is documented below.
+
+* `disk` - The disk information of the flavor.  
+  The [disk](#modelarts_training_job_flavors_disk) structure is documented below.
+
+<a name="modelarts_training_job_flavors_cpu"></a>
+The `cpu` block supports:
+
+* `arch` - The CPU architecture.
+
+* `core_num` - The number of CPU cores.
+
+<a name="modelarts_training_job_flavors_gpu"></a>
+The `gpu` block supports:
+
+* `unit_num` - The number of GPUs.
+
+* `product_name` - The GPU product name.
+
+* `memory` - The GPU memory.
+
+<a name="modelarts_training_job_flavors_npu"></a>
+The `npu` block supports:
+
+* `unit_num` - The number of NPUs.
+
+* `product_name` - The NPU product name.
+
+* `memory` - The NPU memory.
+
+<a name="modelarts_training_job_flavors_memory"></a>
+The `memory` block supports:
+
+* `size` - The memory size.
+
+* `unit` - The memory unit.
+
+<a name="modelarts_training_job_flavors_disk"></a>
+The `disk` block supports:
+
+* `size` - The disk size.
+
+* `unit` - The disk unit.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2047,6 +2047,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_services":             modelarts.DataSourceServices(),
 			"huaweicloud_modelarts_training_experiments": modelarts.DataSourceTrainingExperiments(),
 			"huaweicloud_modelarts_training_job_engines": modelarts.DataSourceTrainingJobEngines(),
+			"huaweicloud_modelarts_training_job_flavors": modelarts.DataSourceTrainingJobFlavors(),
 			"huaweicloud_modelarts_workspace_quotas":     modelarts.DataSourceWorkspaceQuotas(),
 			"huaweicloud_modelarts_workspaces":           modelarts.DataSourceWorkspaces(),
 			// Resource management via V2 APIs.

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_training_job_flavors_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_training_job_flavors_test.go
@@ -1,0 +1,77 @@
+package modelarts
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataTrainingJobFlavors_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_modelarts_training_job_flavors.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byFlavorType   = "data.huaweicloud_modelarts_training_job_flavors.filter_by_flavor_type"
+		dcByFlavorType = acceptance.InitDataSourceCheck(byFlavorType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataTrainingJobFlavors_basic,
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "flavors.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.flavor_name"),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.flavor_type"),
+					resource.TestCheckResourceAttr(all, "flavors.0.billing.#", "1"),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.billing.0.code"),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.billing.0.unit_num"),
+					resource.TestCheckResourceAttr(all, "flavors.0.flavor_info.#", "1"),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.flavor_info.0.max_num"),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.flavor_info.0.cpu.0.arch"),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.flavor_info.0.cpu.0.core_num"),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.flavor_info.0.memory.0.size"),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.flavor_info.0.memory.0.unit"),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.flavor_info.0.disk.0.size"),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.flavor_info.0.disk.0.unit"),
+					resource.TestCheckResourceAttrSet(all, "flavors.0.support_engines"),
+					// Filter by 'flavor_type' parameter.
+					dcByFlavorType.CheckResourceExists(),
+					resource.TestCheckOutput("is_flavor_type_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataTrainingJobFlavors_basic = `
+# Without any filter parameters.
+data "huaweicloud_modelarts_training_job_flavors" "test" {}
+
+# Filter by 'flavor_type' parameter.
+locals {
+  flavor_type = try(data.huaweicloud_modelarts_training_job_flavors.test.flavors[0].flavor_type, "")
+}
+
+data "huaweicloud_modelarts_training_job_flavors" "filter_by_flavor_type" {
+  flavor_type = local.flavor_type
+}
+
+locals {
+  flavor_type_filter_result = [for v in data.huaweicloud_modelarts_training_job_flavors.filter_by_flavor_type.flavors[*].flavor_type :
+    v == local.flavor_type
+  ]
+}
+
+output "is_flavor_type_filter_useful" {
+  value = length(local.flavor_type_filter_result) > 0 && alltrue(local.flavor_type_filter_result)
+}
+`

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_training_job_flavors.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_training_job_flavors.go
@@ -1,0 +1,397 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ModelArts GET /v2/{project_id}/training-job-flavors
+func DataSourceTrainingJobFlavors() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTrainingJobFlavorsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the training job flavors are located.`,
+			},
+			"flavor_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of the flavor.`,
+			},
+			"flavors": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"flavor_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the flavor.`,
+						},
+						"flavor_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the flavor.`,
+						},
+						"flavor_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the flavor. The valid values are **CPU**, **GPU**, and **Ascend**.`,
+						},
+						"billing": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"code": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The billing code.`,
+									},
+									"unit_num": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The billing unit.`,
+									},
+								},
+							},
+							Description: `The billing information of the flavor.`,
+						},
+						"flavor_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"max_num": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The maximum number of nodes that can be selected.`,
+									},
+									"cpu": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"arch": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: `The CPU architecture.`,
+												},
+												"core_num": {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: `The number of CPU cores.`,
+												},
+											},
+										},
+										Description: `The CPU information of the flavor.`,
+									},
+									"gpu": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"unit_num": {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: `The number of GPUs.`,
+												},
+												"product_name": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: `The GPU product name.`,
+												},
+												"memory": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: `The GPU memory.`,
+												},
+											},
+										},
+										Description: `The GPU information of the flavor.`,
+									},
+									"npu": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"unit_num": {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: `The number of NPUs.`,
+												},
+												"product_name": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: `The NPU product name.`,
+												},
+												"memory": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: `The NPU memory.`,
+												},
+											},
+										},
+										Description: `The Ascend information of the flavor.`,
+									},
+									"memory": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"size": {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: `The memory size.`,
+												},
+												"unit": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: `The memory unit.`,
+												},
+											},
+										},
+										Description: `The memory information of the flavor.`,
+									},
+									"disk": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"size": {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: `The disk size.`,
+												},
+												"unit": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: `The disk unit.`,
+												},
+											},
+										},
+										Description: `The disk information of the flavor.`,
+									},
+								},
+							},
+							Description: `The detailed information of the flavor.`,
+						},
+						"attributes": {
+							Type:        schema.TypeMap,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Computed:    true,
+							Description: `The other attributes of the flavor.`,
+						},
+						"support_engines": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The engines supported by the flavor.`,
+						},
+					},
+				},
+				Description: `The list of training job flavors that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func buildTrainingJobFlavorsQueryParams(d *schema.ResourceData) string {
+	if v, ok := d.GetOk("flavor_type"); ok {
+		return fmt.Sprintf("?flavor_type=%v", v)
+	}
+
+	return ""
+}
+
+func listTrainingJobFlavors(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	httpUrl := "v2/{project_id}/training-job-flavors"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildTrainingJobFlavorsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("flavors", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func dataSourceTrainingJobFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	flavors, err := listTrainingJobFlavors(client, d)
+	if err != nil {
+		return diag.Errorf("error querying training job flavors: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("flavors", flattenTrainingJobFlavors(flavors)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTrainingJobFlavors(flavors []interface{}) []map[string]interface{} {
+	if len(flavors) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(flavors))
+	for _, flavor := range flavors {
+		result = append(result, map[string]interface{}{
+			"flavor_id":   utils.PathSearch("flavor_id", flavor, nil),
+			"flavor_name": utils.PathSearch("flavor_name", flavor, nil),
+			"flavor_type": utils.PathSearch("flavor_type", flavor, nil),
+			"billing": flattenTrainingJobFlavorsBilling(utils.PathSearch("billing", flavor,
+				make(map[string]interface{})).(map[string]interface{})),
+			"flavor_info": flattenTrainingJobFlavorsInfo(utils.PathSearch("flavor_info", flavor,
+				make(map[string]interface{})).(map[string]interface{})),
+			"attributes":      utils.PathSearch("attributes", flavor, nil),
+			"support_engines": utils.PathSearch("support_engines", flavor, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenTrainingJobFlavorsBilling(billing map[string]interface{}) []map[string]interface{} {
+	if len(billing) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"code":     utils.PathSearch("code", billing, nil),
+			"unit_num": utils.PathSearch("unit_num", billing, nil),
+		},
+	}
+}
+
+func flattenTrainingJobFlavorsInfo(flavorInfo map[string]interface{}) []map[string]interface{} {
+	if len(flavorInfo) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"max_num": utils.PathSearch("max_num", flavorInfo, nil),
+			"cpu": flattenTrainingJobFlavorsInfoCpu(utils.PathSearch("cpu", flavorInfo,
+				make(map[string]interface{})).(map[string]interface{})),
+			"gpu": flattenTrainingJobFlavorsInfoGpu(utils.PathSearch("gpu", flavorInfo,
+				make(map[string]interface{})).(map[string]interface{})),
+			"npu": flattenTrainingJobFlavorsInfoNpu(utils.PathSearch("npu", flavorInfo,
+				make(map[string]interface{})).(map[string]interface{})),
+			"memory": flattenTrainingJobFlavorsInfoMemory(utils.PathSearch("memory", flavorInfo,
+				make(map[string]interface{})).(map[string]interface{})),
+			"disk": flattenTrainingJobFlavorsInfoDisk(utils.PathSearch("disk", flavorInfo,
+				make(map[string]interface{})).(map[string]interface{})),
+		},
+	}
+}
+
+func flattenTrainingJobFlavorsInfoCpu(cpu map[string]interface{}) []map[string]interface{} {
+	if len(cpu) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"arch":     utils.PathSearch("arch", cpu, nil),
+			"core_num": utils.PathSearch("core_num", cpu, nil),
+		},
+	}
+}
+
+func flattenTrainingJobFlavorsInfoGpu(gpu map[string]interface{}) []map[string]interface{} {
+	if len(gpu) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"unit_num":     utils.PathSearch("unit_num", gpu, nil),
+			"product_name": utils.PathSearch("product_name", gpu, nil),
+			"memory":       utils.PathSearch("memory", gpu, nil),
+		},
+	}
+}
+
+func flattenTrainingJobFlavorsInfoNpu(npu map[string]interface{}) []map[string]interface{} {
+	if len(npu) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"unit_num":     utils.PathSearch("unit_num", npu, nil),
+			"product_name": utils.PathSearch("product_name", npu, nil),
+			"memory":       utils.PathSearch("memory", npu, nil),
+		},
+	}
+}
+
+func flattenTrainingJobFlavorsInfoMemory(memory map[string]interface{}) []map[string]interface{} {
+	if len(memory) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"size": utils.PathSearch("size", memory, nil),
+			"unit": utils.PathSearch("unit", memory, nil),
+		},
+	}
+}
+
+func flattenTrainingJobFlavorsInfoDisk(disk map[string]interface{}) []map[string]interface{} {
+	if len(disk) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"size": utils.PathSearch("size", disk, nil),
+			"unit": utils.PathSearch("unit", disk, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_modelarts_training_job_flavors`) to query public resource pool flavor list for training job.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The `support_engines` field has been confirmed to be missing in the API documentation via a support ticket. The documentation will be optimized in the future.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source for Modelarts.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDataTrainingJobFlavors_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataTrainingJobFlavors_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTrainingJobFlavors_basic
=== PAUSE TestAccDataTrainingJobFlavors_basic
=== CONT  TestAccDataTrainingJobFlavors_basic
--- PASS: TestAccDataTrainingJobFlavors_basic (18.15s)
PASS
coverage: 5.2% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 18.266s coverage: 5.2% of statements in ./huaweicloud/services/modelarts
```

<img width="1165" height="30" alt="image" src="https://github.com/user-attachments/assets/0896bec7-5a5e-4f53-a713-4a40d2af5b2d" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
