### PR TITLE
feat(hss): add resource to batch configure host management

### DIFF
--- a/docs/resources/hss_host_batch_config.md
+++ b/docs/resources/hss_host_batch_config.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_host_batch_config"
+description: |-
+  Manages a resource to batch configure host management settings within HuaweiCloud.
+---
+
+# huaweicloud_hss_host_batch_config
+
+Manages a resource to batch configure host management settings within HuaweiCloud.
+
+-> This resource is a one-time action resource used to batch configure host management Agent resource limits.
+  Deleting this resource will not undo the configuration, but will only remove the resource information
+  from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "operate_all" {}
+variable "host_ids" {
+  type = list(string)
+}
+variable "enterprise_project_id" {}
+variable "mode" {}
+variable "cpu_limit" {}
+variable "mem_limit" {}
+
+resource "huaweicloud_hss_host_batch_config" "test" {
+  operate_all           = var.operate_all
+  enterprise_project_id = var.enterprise_project_id
+  host_ids              = var.host_ids
+  mode                  = var.mode
+  cpu_limit             = var.cpu_limit
+  mem_limit             = var.mem_limit
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `operate_all` - (Required, Bool, NonUpdatable) Specifies whether to process all host Agents.
+  + **true**: Process all hosts.
+  + **false**: Process only the specified hosts (need to set `host_ids`).
+
+* `host_ids` - (Optional, List, NonUpdatable) Specifies the list of host IDs to batch configure.
+  Required when `operate_all` is set to **false**. The maximum number of host IDs is `200`.
+
+* `mode` - (Required, String, NonUpdatable) Specifies the resource limit type.
+  The valid values are as follows:
+  + **default**: Default rule.
+  + **customized**: User-defined rule.
+  + **adaptive**: Adaptive rule.
+
+* `cpu_limit` - (Required, String, NonUpdatable) Specifies the maximum CPU limit.
+  The length is `0` to `32` characters.
+
+* `mem_limit` - (Required, String, NonUpdatable) Specifies the maximum memory limit.
+  The length is `0` to `32` characters.
+
+* `enterprise_project_id` - (Optional, String, NonUpdatable) Specifies the enterprise project ID.
+  This parameter is required only when the enterprise project feature is enabled.
+  If you want to query assets under all enterprise projects, set this parameter to **all_granted_eps**.
+  Defaults to **0** (the default enterprise project).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3898,6 +3898,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_hss_antivirus_create_pay_per_scan_task":             hss.ResourceAntivirusCreatePayPerScanTask(),
 			"huaweicloud_hss_app_whitelist_policy_process":                   hss.ResourceAppWhitelistPolicyProcess(),
 			"huaweicloud_hss_associated_asset_importance":                    hss.ResourceAssociatedAssetImportance(),
+			"huaweicloud_hss_host_batch_config":                              hss.ResourceHostBatchConfig(),
 
 			"huaweicloud_identity_access_key":                   iam.ResourceV3AccessKey(),
 			"huaweicloud_identity_acl":                          iam.ResourceV3Acl(),

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_batch_config_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_batch_config_test.go
@@ -1,0 +1,39 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccHostBatchConfig_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare a valid HSS host protection host id and config it to the environment variable.
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testHostBatchConfig_basic(),
+			},
+		},
+	})
+}
+
+func testHostBatchConfig_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_hss_host_batch_config" "test" {
+  operate_all = false
+  host_ids    = ["%s"]
+  mode        = "default"
+  cpu_limit   = "0.2"
+  mem_limit   = "800"
+}
+`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_host_batch_config.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_host_batch_config.go
@@ -1,0 +1,157 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var hostBatchConfigNonUpdatableParams = []string{
+	"operate_all",
+	"host_ids",
+	"mode",
+	"cpu_limit",
+	"mem_limit",
+	"enterprise_project_id",
+}
+
+// @API HSS POST /v5/{project_id}/host-management/batch-config
+func ResourceHostBatchConfig() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHostBatchConfigCreate,
+		ReadContext:   resourceHostBatchConfigRead,
+		UpdateContext: resourceHostBatchConfigUpdate,
+		DeleteContext: resourceHostBatchConfigDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(hostBatchConfigNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"mode": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cpu_limit": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mem_limit": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"operate_all": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"host_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildHostBatchConfigQueryParams(epsId string) string {
+	if epsId != "" {
+		return fmt.Sprintf("?enterprise_project_id=%s", epsId)
+	}
+
+	return ""
+}
+
+func buildHostBatchConfigBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"operate_all": d.Get("operate_all"),
+		"host_ids":    utils.ValueIgnoreEmpty(utils.ExpandToStringList(d.Get("host_ids").([]interface{}))),
+		"mode":        d.Get("mode"),
+		"cpu_limit":   d.Get("cpu_limit"),
+		"mem_limit":   d.Get("mem_limit"),
+	}
+
+	return bodyParams
+}
+
+func resourceHostBatchConfigCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "hss"
+		epsId   = cfg.GetEnterpriseProjectID(d)
+		httpUrl = "v5/{project_id}/host-management/batch-config"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating HSS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildHostBatchConfigQueryParams(epsId)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildHostBatchConfigBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch configuring HSS host management: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	return nil
+}
+
+func resourceHostBatchConfigRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceHostBatchConfigUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceHostBatchConfigDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource using to batch configure HSS host management. Deleting
+    this resource will not clear the corresponding request record, but will only remove the resource information from
+    the tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a new resource `huaweicloud_hss_host_batch_config` for HuaweiCloud Host Security Service (HSS). This resource supports batch configuration of resource limit policies for host agents, including CPU limit, memory limit, limit mode and batch operation objects. It helps users quickly configure resource restrictions for multiple hosts in batches through Terraform.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add resource huaweicloud_hss_host_batch_config for batch configuring HSS host resource limits
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run=TestAccHostBatchConfig_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run=TestAccHostBatchConfig_basic -timeout 360m -parallel 4
=== RUN   TestAccHostBatchConfig_basic
=== PAUSE TestAccHostBatchConfig_basic
=== CONT  TestAccHostBatchConfig_basic
--- PASS: TestAccHostBatchConfig_basic (29.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       30.087s
```
<img width="461" height="18" alt="Snipaste_2026-06-03_15-51-34" src="https://github.com/user-attachments/assets/71895547-b645-450e-8c2b-daae4ca89f7c" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
