### PR TITLE
feat(modelarts): add new data source to query training jobs

### DIFF
--- a/docs/data-sources/modelarts_training_jobs.md
+++ b/docs/data-sources/modelarts_training_jobs.md
@@ -1,0 +1,651 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_training_jobs"
+description: |-
+  Use this data source to get the list of ModelArts training jobs within HuaweiCloud.
+---
+
+# huaweicloud_modelarts_training_jobs
+
+Use this data source to get the list of ModelArts training jobs within HuaweiCloud.
+
+## Example Usage
+
+### Query all training jobs
+
+```hcl
+data "huaweicloud_modelarts_training_jobs" "test" {}
+```
+
+### Filter training jobs by its id
+
+```hcl
+variable "training_job_id" {}
+
+data "huaweicloud_modelarts_training_jobs" "test" {
+  filters {
+    key      = "id"
+    operator = "in"
+    value    = [var.training_job_id]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the training jobs are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Optional, String) Specifies the workspace ID of the training jobs to be queried.  
+  If omitted, all training jobs in the default workspace will be queried.
+
+* `sort_by` - (Optional, String) Specifies the metric used to sort the training jobs.  
+  The valid values are as follows:
+  + **create_time**
+
+  Defaults to **create_time**.
+
+* `order` - (Optional, String) Specifies the sort order of the training jobs.  
+  The valid values are as follows:
+  + **asc**
+  + **desc**
+
+  Defaults to **desc**.
+
+* `unified_jobs` - (Optional, Bool) Specifies whether to query custom jobs and fine-tuning jobs together.  
+  Defaults to **false**.
+
+* `train_type` - (Optional, String) Specifies the training job type to be queried.  
+  The valid values are as follows:
+  + **job**
+  + **ftjob**
+
+* `filters` - (Optional, List) Specifies the filter conditions used to query training jobs.  
+  The [filters](#modelarts_training_jobs_filters_arg) structure is documented below.
+
+<a name="modelarts_training_jobs_filters_arg"></a>
+The `filters` block supports:
+
+* `key` - (Required, String) Specifies the filter key.  
+  The valid values are as follows:
+  + **id**
+  + **name**
+  + **kind**
+  + **phase**
+  + **algorithm_id**
+  + **algorithm_name**
+  + **create_time**
+  + **user_id**
+  + **pool_id**
+  + **training_experiment_id**
+  + **runtime_type**
+  + **priority**
+
+* `operator` - (Optional, String) Specifies the filter operator.  
+  The valid values are as follows:
+  + **between**
+  + **like**
+  + **in**
+  + **not**
+
+* `value` - (Optional, List) Specifies the filter values.  
+  The maximum length of the list is `10`.  
+  When `key` is set to **create_time**, the value is a list of two elements, representing the start and end times
+  of the creation time range, in RFC3339 format. The maximum value range of the creation time is `31` days.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `jobs` - The list of training jobs that match the filter parameters.  
+  The [jobs](#modelarts_training_jobs) structure is documented below.
+
+<a name="modelarts_training_jobs"></a>
+The `jobs` block supports:
+
+* `kind` - The type of the training job.
+  + **job**
+  + **federated_pool_job**
+  + **edge_job**
+  + **hetero_job**
+  + **mrs_job**
+  + **autosearch_job**
+  + **diag_job**
+  + **visualization_job**
+
+* `metadata` - The metadata of the training job.  
+  The [metadata](#modelarts_training_jobs_metadata) structure is documented below.
+
+* `status` - The status of the training job.  
+  The [status](#modelarts_training_jobs_status) structure is documented below.
+
+* `algorithm` - The algorithm configuration of the training job.  
+  The [algorithm](#modelarts_training_jobs_algorithm) structure is documented below.
+
+* `spec` - The specification of the training job.  
+  The [spec](#modelarts_training_jobs_spec) structure is documented below.
+
+* `endpoints` - The remote access endpoints of the training job.  
+  The [endpoints](#modelarts_training_jobs_endpoints) structure is documented below.
+
+* `create_time` - The creation time of the training job, in RFC3339 format.
+
+<a name="modelarts_training_jobs_metadata"></a>
+The `metadata` block supports:
+
+* `id` - The ID of the training job.
+
+* `name` - The name of the training job.
+
+* `workspace_id` - The workspace ID to which the training job belongs.
+
+* `description` - The description of the training job.
+
+* `user_name` - The user name that created the training job.
+
+* `annotations` - The advanced feature configuration of the training job.
+
+<a name="modelarts_training_jobs_status"></a>
+The `status` block supports:
+
+* `phase` - The primary status of the training job.
+  + **Running**
+  + **Failed**
+  + **Completed**
+  + **Terminated**
+  + **Abnormal**
+
+* `secondary_phase` - The secondary status of the training job.
+  + **Running**
+  + **Failed**
+  + **Completed**
+  + **Terminated**
+  + **CreateFailed**
+  + **TerminatedFailed**
+  + **Unknown**
+  + **Lost**: Abnormal.
+
+* `duration` - The running duration of the training job, in milliseconds.
+
+* `start_time` - The start time of the training job, in RFC3339 format.
+
+* `tasks` - The subtask names of the training job.
+
+* `node_count_metrics` - The node count metrics of the training job, in JSON format.
+
+* `task_statuses` - The status of the first failed subtask.  
+  The [task_statuses](#modelarts_training_jobs_status_task_statuses) structure is documented below.
+
+* `running_records` - The running and fault recovery records of the training job.  
+  The [running_records](#modelarts_training_jobs_status_running_records) structure is documented below.
+
+<a name="modelarts_training_jobs_status_task_statuses"></a>
+The `task_statuses` block supports:
+
+* `task` - The subtask name.
+
+* `exit_code` - The exit code of the subtask.
+
+* `message` - The error message of the subtask.
+
+<a name="modelarts_training_jobs_status_running_records"></a>
+The `running_records` block supports:
+
+* `start_at` - The start time of the run, in RFC3339 format.
+
+* `end_at` - The end time of the run, in RFC3339 format.
+
+* `xpu_start_at` - The accelerator start time of the run, in RFC3339 format.
+
+* `start_type` - The start type of the run.
+
+* `end_reason` - The end reason of the run.
+
+* `end_related_task` - The task worker ID that caused the run to end.
+
+* `end_recover` - The final fault tolerance strategy when the run ended abnormally.
+  + **npu_proc_restart**
+  + **proc_restart**
+  + **npu_step_retry**
+  + **pod_reschedule**
+  + **job_reschedule**
+  + **job_reschedule_with_taint**
+
+* `end_recover_before_downgrade` - The fault tolerance strategy before downgrade when the run ended abnormally.
+
+* `recover_records` - The fault tolerance strategy details when the run ended abnormally.  
+  The [recover_records](#modelarts_training_jobs_status_running_records_recover_records) structure is documented below.
+
+<a name="modelarts_training_jobs_status_running_records_recover_records"></a>
+The `recover_records` block supports:
+
+* `recover_start_at` - The start time of the fault tolerance strategy, in RFC3339 format.
+
+* `recover_end_at` - The end time of the fault tolerance strategy, in RFC3339 format.
+
+* `recover` - The fault tolerance strategy.
+  + **npu_step_retry**
+  + **npu_proc_restart**
+  + **proc_restart**
+  + **pod_reschedule**
+  + **job_reschedule**
+  + **job_reschedule_with_taint**
+
+* `fault_scenario` - The fault scenario.
+  + **chip_fault**
+  + **node_fault**
+  + **job_failed**
+  + **job_hanged**
+  + **job_subhealth**
+  + **error_in_log**
+
+* `reason` - The fault reason.
+
+* `related_task` - The task worker ID that triggered the fault.
+
+* `recover_result` - The execution result of the fault tolerance strategy.
+  + **recovering**
+  + **success**
+  + **failed**
+  + **downgrade**: Strategy downgrade.
+  + **terminated**: Strategy terminated.
+  + **quotaExceeded**: Strategy execution times exceeded.
+
+<a name="modelarts_training_jobs_algorithm"></a>
+The `algorithm` block supports:
+
+* `id` - The algorithm ID of the training job.
+
+* `name` - The algorithm name of the training job.
+
+* `subscription_id` - The subscription ID of the subscribed algorithm.
+
+* `item_version_id` - The version ID of the subscribed algorithm.
+
+* `code_dir` - The code directory of the training job.
+
+* `boot_file` - The boot file of the training job.
+
+* `autosearch_config_path` - The YAML configuration path of the auto search job.
+
+* `autosearch_framework_path` - The framework code directory of the auto search job.
+
+* `command` - The startup command of the custom image training job.
+
+* `local_code_dir` - The local code directory in the training container.
+
+* `working_dir` - The working directory when running the algorithm.
+
+* `parameters` - The runtime parameters of the training job.  
+  The [parameters](#modelarts_training_jobs_algorithm_parameters) structure is documented below.
+
+* `inputs` - The input channels of the training job.  
+  The [inputs](#modelarts_training_jobs_algorithm_inputs) structure is documented below.
+
+* `outputs` - The output channels of the training job.  
+  The [outputs](#modelarts_training_jobs_algorithm_outputs) structure is documented below.
+
+* `engine` - The engine configuration of the training job.  
+  The [engine](#modelarts_training_jobs_algorithm_engine) structure is documented below.
+
+* `environments` - The environment variables of the training job.
+
+<a name="modelarts_training_jobs_algorithm_parameters"></a>
+The `parameters` block supports:
+
+* `name` - The parameter name.
+
+* `value` - The parameter value.
+
+* `description` - The parameter description.
+
+* `constraint` - The parameter constraint.  
+  The [constraint](#modelarts_training_jobs_algorithm_parameters_constraint) structure is documented below.
+
+<a name="modelarts_training_jobs_algorithm_parameters_constraint"></a>
+The `constraint` block supports:
+
+* `type` - The parameter constraint type.
+  + **Integer**
+  + **Float**
+  + **String**
+  + **Boolean**
+
+* `editable` - Whether the parameter is editable.
+
+* `required` - Whether the parameter is required.
+
+* `valid_type` - The parameter valid type.
+  + **Choice**
+  + **Range**
+  + **None**
+
+* `valid_range` - The parameter valid values.
+
+<a name="modelarts_training_jobs_algorithm_engine"></a>
+The `engine` block supports:
+
+* `engine_id` - The engine specification ID of the training job.
+
+* `engine_name` - The engine specification name of the training job.
+
+* `engine_version` - The engine specification version of the training job.
+
+* `image_url` - The custom image URL of the training job.
+
+* `install_sys_packages` - Whether to install the moxing version specified by the training platform.
+
+<a name="modelarts_training_jobs_algorithm_inputs"></a>
+The `inputs` block supports:
+
+* `name` - The name of the input channel.
+
+* `description` - The description of the input channel.
+
+* `local_dir` - The local directory mapped by the input channel.
+
+* `access_method` - The delivery method of the input channel path.
+  + **parameter**
+  + **env**
+
+* `remote` - The remote input information.  
+  The [remote](#modelarts_training_jobs_algorithm_inputs_remote) structure is documented below.
+
+* `remote_constraint` - The data input constraint.  
+  The [remote_constraint](#modelarts_training_jobs_algorithm_inputs_remote_constraint) structure is documented below.
+
+<a name="modelarts_training_jobs_algorithm_inputs_remote"></a>
+The `remote` block supports:
+
+* `dataset` - The dataset input information.  
+  The [dataset](#modelarts_training_jobs_algorithm_inputs_remote_dataset) structure is documented below.
+
+* `obs` - The OBS input information.  
+  The [obs](#modelarts_training_jobs_algorithm_inputs_remote_obs) structure is documented below.
+
+<a name="modelarts_training_jobs_algorithm_inputs_remote_dataset"></a>
+The `dataset` block supports:
+
+* `id` - The dataset ID.
+
+* `version_id` - The dataset version ID.
+
+* `obs_url` - The OBS URL of the dataset.
+
+* `service_type` - The dataset service type.
+
+* `name` - The dataset name.
+
+<a name="modelarts_training_jobs_algorithm_inputs_remote_obs"></a>
+The `obs` block supports:
+
+* `obs_url` - The OBS URL of the input data.
+
+<a name="modelarts_training_jobs_algorithm_inputs_remote_constraint"></a>
+The `remote_constraint` block supports:
+
+* `data_type` - The data type of the remote constraint.
+
+* `attributes` - The attributes of the remote constraint.
+  + **data_format**
+  + **data_segmentation**
+  + **dataset_type**
+
+<a name="modelarts_training_jobs_algorithm_outputs"></a>
+The `outputs` block supports:
+
+* `name` - The name of the output channel.
+
+* `description` - The description of the output channel.
+
+* `local_dir` - The local directory mapped by the output channel.
+
+* `access_method` - The delivery method of the output channel path.
+  + **parameter**
+  + **env**
+
+* `remote` - The remote output information.  
+  The [remote](#modelarts_training_jobs_algorithm_outputs_remote) structure is documented below.
+
+<a name="modelarts_training_jobs_algorithm_outputs_remote"></a>
+The `remote` block supports:
+
+* `obs` - The OBS output information.  
+  The [obs](#modelarts_training_jobs_algorithm_outputs_remote_obs) structure is documented below.
+
+<a name="modelarts_training_jobs_algorithm_outputs_remote_obs"></a>
+The `obs` block supports:
+
+* `obs_url` - The OBS URL of the output data.
+
+<a name="modelarts_training_jobs_spec"></a>
+The `spec` block supports:
+
+* `resource` - The resource specification of the training job.  
+  The [resource](#modelarts_training_jobs_spec_resource) structure is documented below.
+
+* `runtime_type` - The runtime type of the training job.
+
+* `volumes` - The mounted volumes of the training job.  
+  The [volumes](#modelarts_training_jobs_spec_volumes) structure is documented below.
+
+* `log_export_path` - The log export path of the training job.  
+  The [log_export_path](#modelarts_training_jobs_spec_log_export_path) structure is documented below.
+
+* `schedule_policy` - The scheduling policy of the training job.  
+  The [schedule_policy](#modelarts_training_jobs_spec_schedule_policy) structure is documented below.
+
+* `custom_metrics` - The custom metrics configuration of the training job.  
+  The [custom_metrics](#modelarts_training_jobs_spec_custom_metrics) structure is documented below.
+
+<a name="modelarts_training_jobs_spec_resource"></a>
+The `resource` block supports:
+
+* `policy` - The resource specification mode of the training job.
+
+* `flavor_id` - The flavor ID of the training job.
+
+* `flavor_name` - The flavor name of the training job.
+
+* `node_count` - The number of resource replicas selected by the training job.
+
+* `pool_id` - The resource pool ID selected by the training job.
+
+* `pool_group_id` - The federated resource pool ID selected by the training job.
+
+* `main_container_allocated_resources` - The allocated resources of the main container.  
+  The [main_container_allocated_resources](#modelarts_training_jobs_spec_resource_main_container_allocated_resources)
+  structure is documented below.
+
+* `main_container_customized_flavor` - The customized flavor of the main container.  
+  The [main_container_customized_flavor](#modelarts_training_jobs_spec_resource_main_container_customized_flavor)
+  structure is documented below.
+
+<a name="modelarts_training_jobs_spec_resource_main_container_allocated_resources"></a>
+The `main_container_allocated_resources` block supports:
+
+* `cpu_arch` - The CPU architecture.
+
+* `cpu_core_num` - The number of CPU cores.
+
+* `mem_size` - The memory size.
+
+* `accelerator_num` - The number of accelerator cards.
+
+* `accelerator_type` - The accelerator type.
+
+<a name="modelarts_training_jobs_spec_resource_main_container_customized_flavor"></a>
+The `main_container_customized_flavor` block supports:
+
+* `cpu_core_num` - The number of CPU cores.
+
+* `mem_size` - The memory size.
+
+* `accelerator_num` - The number of accelerator cards.
+
+<a name="modelarts_training_jobs_spec_volumes"></a>
+The `volumes` block supports:
+
+* `nfs` - The NFS volume configuration.  
+  The [nfs](#modelarts_training_jobs_spec_volumes_nfs) structure is documented below.
+
+<a name="modelarts_training_jobs_spec_volumes_nfs"></a>
+The `nfs` block supports:
+
+* `nfs_server_path` - The NFS server path.
+
+* `local_path` - The path for attaching volumes to the training container.
+
+* `read_only` - Whether the disks attached in NFS mode are read-only.
+
+<a name="modelarts_training_jobs_spec_log_export_path"></a>
+The `log_export_path` block supports:
+
+* `obs_url` - The OBS path where the training job logs are exported.
+
+<a name="modelarts_training_jobs_spec_schedule_policy"></a>
+The `schedule_policy` block supports:
+
+* `priority` - The scheduling priority of the training job.
+
+* `preemptible` - Whether the training job can be preempted.
+
+* `required_affinity` - The required affinity policy of the training job.  
+  The [required_affinity](#modelarts_training_jobs_spec_schedule_policy_required_affinity) structure is
+  documented below.
+
+* `preferred_affinity` - The preferred affinity configuration of the training job.  
+  The [preferred_affinity](#modelarts_training_jobs_spec_schedule_policy_preferred_affinity) structure is
+  documented below.
+
+<a name="modelarts_training_jobs_spec_schedule_policy_required_affinity"></a>
+The `required_affinity` block supports:
+
+* `affinity_type` - The affinity scheduling policy.
+  + **cabinet**: Strong cabinet scheduling.
+  + **hyperinstance**: Hypernode affinity scheduling.
+
+* `affinity_group_size` - The affinity group size.
+
+* `node_affinity` - The node affinity configuration of the training job.  
+  The [node_affinity](#modelarts_training_jobs_spec_schedule_policy_required_affinity_node_affinity) structure is
+  documented below.
+
+<a name="modelarts_training_jobs_spec_schedule_policy_required_affinity_node_affinity"></a>
+The `node_affinity` block supports:
+
+* `node_selector_terms` - The required node selector terms.  
+  The [node_selector_terms](#modelarts_training_jobs_spec_schedule_policy_node_selector_terms) structure is
+  documented below.
+
+<a name="modelarts_training_jobs_spec_schedule_policy_preferred_affinity"></a>
+The `preferred_affinity` block supports:
+
+* `node_affinity` - The preferred node affinity terms.  
+  The [node_affinity](#modelarts_training_jobs_spec_schedule_policy_preferred_affinity_node_affinity) structure
+  is documented below.
+
+<a name="modelarts_training_jobs_spec_schedule_policy_preferred_affinity_node_affinity"></a>
+The `node_affinity` block supports:
+
+* `weight` - The weight associated with the preferred node selector term.
+
+* `preference` - The preferred node selector term.  
+  The [preference](#modelarts_training_jobs_spec_schedule_policy_node_selector_terms) structure is documented below.
+
+<a name="modelarts_training_jobs_spec_schedule_policy_node_selector_terms"></a>
+The `node_selector_terms` and `preference` block supports:
+
+* `match_expressions` - The node selector requirements based on node labels.  
+  The [match_expressions](#modelarts_training_jobs_spec_schedule_policy_node_selector_requirement) structure is
+  documented below.
+
+* `match_fields` - The node selector requirements based on node fields.  
+  The [match_fields](#modelarts_training_jobs_spec_schedule_policy_node_selector_requirement) structure is
+  documented below.
+
+<a name="modelarts_training_jobs_spec_schedule_policy_node_selector_requirement"></a>
+The `match_expressions` and `match_fields` block supports:
+
+* `key` - The label key used by the node selector requirement.
+
+* `operator` - The operator used by the node selector requirement.
+
+* `values` - The label values used by the node selector requirement.
+
+<a name="modelarts_training_jobs_spec_custom_metrics"></a>
+The `custom_metrics` block supports:
+
+* `exec` - The command-based metrics collection configuration.  
+  The [exec](#modelarts_training_jobs_spec_custom_metrics_exec) structure is documented below.
+
+* `http_get` - The HTTP-based metrics collection configuration.  
+  The [http_get](#modelarts_training_jobs_spec_custom_metrics_http_get) structure is documented below.
+
+<a name="modelarts_training_jobs_spec_custom_metrics_exec"></a>
+The `exec` block supports:
+
+* `command` - The command for metrics collection.
+
+<a name="modelarts_training_jobs_spec_custom_metrics_http_get"></a>
+The `http_get` block supports:
+
+* `path` - The URL path for HTTP metrics collection.
+
+* `port` - The port for HTTP metrics collection.
+
+<a name="modelarts_training_jobs_endpoints"></a>
+The `endpoints` block supports:
+
+* `ssh` - The SSH connection information.  
+  The [ssh](#modelarts_training_jobs_endpoints_ssh) structure is documented below.
+
+* `jupyter_lab` - The JupyterLab connection information.  
+  The [jupyter_lab](#modelarts_training_jobs_endpoints_jupyter_lab) structure is documented below.
+
+* `tensorboard` - The Tensorboard connection information.  
+  The [tensorboard](#modelarts_training_jobs_endpoints_tensorboard) structure is documented below.
+
+* `mindstudio_insight` - The MindStudio Insight connection information.  
+  The [mindstudio_insight](#modelarts_training_jobs_endpoints_mindstudio_insight) structure is documented below.
+
+<a name="modelarts_training_jobs_endpoints_ssh"></a>
+The `ssh` block supports:
+
+* `key_pair_names` - The SSH key pair names.
+
+* `task_urls` - The SSH connection URLs.  
+  The [task_urls](#modelarts_training_jobs_endpoints_ssh_task_urls) structure is documented below.
+
+<a name="modelarts_training_jobs_endpoints_ssh_task_urls"></a>
+The `task_urls` block supports:
+
+* `task` - The task ID.
+
+* `url` - The SSH connection URL.
+
+<a name="modelarts_training_jobs_endpoints_jupyter_lab"></a>
+The `jupyter_lab` block supports:
+
+* `url` - The JupyterLab URL.
+
+* `token` - The JupyterLab token.
+
+<a name="modelarts_training_jobs_endpoints_tensorboard"></a>
+The `tensorboard` block supports:
+
+* `url` - The Tensorboard URL.
+
+* `token` - The Tensorboard token.
+
+<a name="modelarts_training_jobs_endpoints_mindstudio_insight"></a>
+The `mindstudio_insight` block supports:
+
+* `url` - The MindStudio Insight URL.
+
+* `token` - The MindStudio Insight token.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2063,6 +2063,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_service_flavors":      modelarts.DataSourceServiceFlavors(),
 			"huaweicloud_modelarts_services":             modelarts.DataSourceServices(),
 			"huaweicloud_modelarts_training_experiments": modelarts.DataSourceTrainingExperiments(),
+			"huaweicloud_modelarts_training_jobs":        modelarts.DataSourceTrainingJobs(),
 			"huaweicloud_modelarts_training_job_engines": modelarts.DataSourceTrainingJobEngines(),
 			"huaweicloud_modelarts_training_job_flavors": modelarts.DataSourceTrainingJobFlavors(),
 			"huaweicloud_modelarts_workspace_quotas":     modelarts.DataSourceWorkspaceQuotas(),

--- a/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_training_jobs_test.go
+++ b/huaweicloud/services/acceptance/modelarts/data_source_huaweicloud_modelarts_training_jobs_test.go
@@ -1,0 +1,533 @@
+package modelarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataTrainingJobs_basic(t *testing.T) {
+	var (
+		name                 = acceptance.RandomAccResourceNameWithDash()
+		rName                = "huaweicloud_modelarts_training_job.test"
+		rNameWithCustomImage = "huaweicloud_modelarts_training_job.with_custom_image"
+
+		all = "data.huaweicloud_modelarts_training_jobs.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byWorkspaceId   = "data.huaweicloud_modelarts_training_jobs.filter_by_workspace_id"
+		dcByWorkspaceId = acceptance.InitDataSourceCheck(byWorkspaceId)
+
+		byTrainType   = "data.huaweicloud_modelarts_training_jobs.filter_by_train_type"
+		dcByTrainType = acceptance.InitDataSourceCheck(byTrainType)
+
+		byFilters   = "data.huaweicloud_modelarts_training_jobs.filter_by_filters"
+		dcByFilters = acceptance.InitDataSourceCheck(byFilters)
+
+		bySortByAndOrderDesc   = "data.huaweicloud_modelarts_training_jobs.filter_by_sort_by_and_order_desc"
+		dcBySortByAndOrderDesc = acceptance.InitDataSourceCheck(bySortByAndOrderDesc)
+		bySortByAndOrderAsc    = "data.huaweicloud_modelarts_training_jobs.filter_by_sort_by_and_order_asc"
+		dcBySortByAndOrderAsc  = acceptance.InitDataSourceCheck(bySortByAndOrderAsc)
+
+		byIdWithCustomImage   = "data.huaweicloud_modelarts_training_jobs.filter_by_id_with_custom_image"
+		dcByIdWithCustomImage = acceptance.InitDataSourceCheck(byIdWithCustomImage)
+		byIdWithAlgorithm     = "data.huaweicloud_modelarts_training_jobs.filter_by_id_with_algorithm"
+		dcByIdWithAlgorithm   = acceptance.InitDataSourceCheck(byIdWithAlgorithm)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckModelArtsAlgorithm(t)
+			acceptance.TestAccPreCheckModelArtsTrainingJobPublicResourcePoolFlavorID(t)
+			acceptance.TestAccPreCheckModelArtsResourcePoolIds(t, 1)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataTrainingJobs_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Without any filter parameters.
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "jobs.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Filter by 'workspace_id' parameter.
+					dcByWorkspaceId.CheckResourceExists(),
+					resource.TestCheckOutput("is_workspace_id_filter_useful", "true"),
+					// Filter by 'train_type' parameter.
+					dcByTrainType.CheckResourceExists(),
+					resource.TestCheckOutput("is_train_type_filter_useful", "true"),
+					// Filter by 'filters' parameter.
+					dcByFilters.CheckResourceExists(),
+					resource.TestCheckOutput("is_filters_filter_useful", "true"),
+					// Filter by 'sort_by' and 'order' parameters.
+					dcBySortByAndOrderDesc.CheckResourceExists(),
+					dcBySortByAndOrderAsc.CheckResourceExists(),
+					resource.TestCheckOutput("is_sort_by_and_order_useful", "true"),
+					// Check Attributes.
+					resource.TestCheckResourceAttr(byFilters, "jobs.#", "1"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.metadata.0.id", rName, "id"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.kind", "job"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.metadata.0.name", rName, "metadata.0.name"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.metadata.0.description", "Created by Terraform script"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.metadata.0.workspace_id", rName, "metadata.0.workspace_id"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.metadata.0.annotations", rName, "metadata.0.annotations"),
+					resource.TestCheckResourceAttrSet(byFilters, "jobs.0.metadata.0.user_name"),
+					resource.TestCheckResourceAttrSet(byFilters, "jobs.0.status.0.phase"),
+					resource.TestMatchResourceAttr(byFilters, "jobs.0.create_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.code_dir", rName, "algorithm.0.code_dir"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.boot_file", rName, "algorithm.0.boot_file"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.autosearch_config_path", rName,
+						"algorithm.0.autosearch_config_path"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.autosearch_framework_path", rName,
+						"algorithm.0.autosearch_framework_path"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.local_code_dir", rName, "algorithm.0.local_code_dir"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.working_dir", rName, "algorithm.0.working_dir"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.engine.0.engine_id", rName,
+						"algorithm.0.engine.0.engine_id"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.engine.0.engine_name", rName,
+						"algorithm.0.engine.0.engine_name"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.engine.0.engine_version", rName,
+						"algorithm.0.engine.0.engine_version"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.inputs.#", "1"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.inputs.0.name", "data_url"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.inputs.0.description", "Training data input"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.inputs.0.local_dir", rName,
+						"algorithm.0.inputs.0.local_dir"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.inputs.0.access_method", "parameter"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.inputs.0.remote.0.obs.0.obs_url", rName,
+						"algorithm.0.inputs.0.remote.0.obs.0.obs_url"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.outputs.#", "1"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.outputs.0.name", "train_url"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.outputs.0.description", "Model output"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.outputs.0.local_dir", rName,
+						"algorithm.0.outputs.0.local_dir"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.outputs.0.access_method", "parameter"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.algorithm.0.outputs.0.remote.0.obs.0.obs_url", rName,
+						"algorithm.0.outputs.0.remote.0.obs.0.obs_url"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.parameters.#", "1"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.parameters.0.name", "workers"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.parameters.0.value", "4"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.parameters.0.constraint.0.type", "Float"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.parameters.0.constraint.0.valid_type", "None"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.algorithm.0.environments.RUN_TYPE", "custom_job"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.spec.0.resource.0.flavor_id", rName,
+						"spec.0.resource.0.flavor_id"),
+					resource.TestCheckResourceAttrPair(byFilters, "jobs.0.spec.0.resource.0.node_count", rName,
+						"spec.0.resource.0.node_count"),
+					resource.TestCheckResourceAttrSet(byFilters, "jobs.0.spec.0.log_export_path.0.obs_url"),
+					resource.TestCheckResourceAttr(byFilters, "jobs.0.spec.0.custom_metrics.#", "1"),
+					resource.TestCheckResourceAttrSet(byFilters, "jobs.0.spec.0.custom_metrics.0.http_get.0.path"),
+					resource.TestCheckResourceAttrSet(byFilters, "jobs.0.spec.0.custom_metrics.0.http_get.0.port"),
+					dcByIdWithCustomImage.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(byIdWithCustomImage, "jobs.0.algorithm.0.command",
+						rNameWithCustomImage, "algorithm.0.command"),
+					resource.TestCheckResourceAttrPair(byIdWithCustomImage, "jobs.0.algorithm.0.engine.0.image_url",
+						rNameWithCustomImage, "algorithm.0.engine.0.image_url"),
+					resource.TestCheckResourceAttrPair(byIdWithCustomImage, "jobs.0.spec.0.resource.0.pool_id",
+						rNameWithCustomImage, "spec.0.resource.0.pool_id"),
+					resource.TestCheckResourceAttrPair(byIdWithCustomImage,
+						"jobs.0.spec.0.resource.0.main_container_customized_flavor.0.cpu_core_num",
+						rNameWithCustomImage, "spec.0.resource.0.main_container_customized_flavor.0.cpu_core_num"),
+					resource.TestCheckResourceAttrPair(byIdWithCustomImage, "jobs.0.spec.0.resource.0.main_container_customized_flavor.0.mem_size",
+						rNameWithCustomImage, "spec.0.resource.0.main_container_customized_flavor.0.mem_size"),
+					resource.TestCheckResourceAttr(byIdWithCustomImage, "jobs.0.spec.0.runtime_type", "debug"),
+					resource.TestCheckResourceAttrPair(byIdWithCustomImage, "jobs.0.spec.0.volumes.0.nfs.0.nfs_server_path",
+						rNameWithCustomImage, "spec.0.volumes.0.nfs.0.nfs_server_path"),
+					resource.TestCheckResourceAttrPair(byIdWithCustomImage, "jobs.0.spec.0.volumes.0.nfs.0.local_path",
+						rNameWithCustomImage, "spec.0.volumes.0.nfs.0.local_path"),
+					resource.TestCheckResourceAttrPair(byIdWithCustomImage, "jobs.0.spec.0.volumes.0.nfs.0.read_only",
+						rNameWithCustomImage, "spec.0.volumes.0.nfs.0.read_only"),
+					resource.TestCheckResourceAttr(byIdWithCustomImage, "jobs.0.spec.0.schedule_policy.0.priority", "1"),
+					resource.TestCheckResourceAttr(byIdWithCustomImage, "jobs.0.spec.0.schedule_policy.0.preemptible", "true"),
+					resource.TestCheckResourceAttr(byIdWithCustomImage,
+						"jobs.0.spec.0.schedule_policy.0.required_affinity.0.node_affinity.0.node_selector_terms.0.match_expressions.0.key",
+						"kubernetes.io/hostname"),
+					resource.TestCheckResourceAttr(byIdWithCustomImage,
+						"jobs.0.spec.0.schedule_policy.0.required_affinity.0.node_affinity.0.node_selector_terms.0.match_expressions.0.operator",
+						"In"),
+					resource.TestCheckResourceAttrPair(byIdWithCustomImage, "jobs.0.endpoints.0.ssh.0.key_pair_names.0",
+						"huaweicloud_kps_keypair.test", "id"),
+					dcByIdWithAlgorithm.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(byIdWithAlgorithm, "jobs.0.metadata.0.id",
+						"huaweicloud_modelarts_training_job.with_algorithm", "id"),
+					resource.TestCheckResourceAttrPair(byIdWithAlgorithm, "jobs.0.algorithm.0.id",
+						"huaweicloud_modelarts_algorithm.test", "id"),
+					resource.TestCheckResourceAttrPair(byIdWithAlgorithm, "jobs.0.algorithm.0.name",
+						"huaweicloud_modelarts_algorithm.test", "metadata.0.name"),
+					resource.TestCheckResourceAttr(byIdWithAlgorithm,
+						"jobs.0.spec.0.schedule_policy.0.preferred_affinity.0.node_affinity.0.weight", "100"),
+					resource.TestCheckResourceAttr(byIdWithAlgorithm, "jobs.0.spec.0.schedule_policy.0.preferred_affinity.0.node_affinity.#", "1"),
+					resource.TestCheckResourceAttr(byIdWithAlgorithm,
+						"jobs.0.spec.0.schedule_policy.0.preferred_affinity.0.node_affinity.0.preference.0.match_expressions.0.key",
+						"kubernetes.io/hostname"),
+					resource.TestCheckResourceAttr(byIdWithAlgorithm,
+						"jobs.0.spec.0.schedule_policy.0.preferred_affinity.0.node_affinity.0.preference.0.match_expressions.0.operator", "In"),
+					resource.TestCheckResourceAttrSet(byIdWithAlgorithm,
+						"jobs.0.spec.0.schedule_policy.0.preferred_affinity.0.node_affinity.0.preference.0.match_expressions.0.values.0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataTrainingJobs_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[1]s"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "%[1]s/bootfile.py"
+  content      = <<EOF
+#!/usr/bin/env python
+import os
+print(os.getcwd())
+EOF
+  content_type = "text/py"
+}
+
+# Preset image algorithm job with public resource pool.
+resource "huaweicloud_modelarts_training_job" "test" {
+  kind = "job"
+
+  metadata {
+    name         = "%[1]s"
+    description  = "Created by Terraform script"
+    workspace_id = "0"
+
+    annotations = {
+      "performance_diagnosis_enabled" = "true"
+    }
+  }
+
+  algorithm {
+    code_dir                  = "/${huaweicloud_obs_bucket.test.bucket}/%[1]s/"
+    boot_file                 = "/${huaweicloud_obs_bucket.test.bucket}/${huaweicloud_obs_bucket_object.test.key}"
+    autosearch_config_path    = "/config/autosearch.yaml"
+    autosearch_framework_path = "/config/framework/"
+    local_code_dir            = "/home/ma-user/modelarts/user-job-dir"
+    working_dir               = "/home/ma-user/modelarts/user-job-dir"
+
+    engine {
+      engine_id      = "%[2]s"
+      engine_version = "%[2]s"
+      engine_name    = "%[3]s"
+    }
+
+    inputs {
+      name          = "data_url"
+      description   = "Training data input"
+      local_dir     = "/home/ma-user/modelarts/user-job-dir/data_url_0"
+      access_method = "parameter"
+
+      remote {
+        obs {
+          obs_url = "/${huaweicloud_obs_bucket.test.bucket}/%[1]s/"
+        }
+      }
+    }
+
+    outputs {
+      name          = "train_url"
+      description   = "Model output"
+      local_dir     = "/home/ma-user/modelarts/user-job-dir/train_url_0"
+      access_method = "parameter"
+
+      remote {
+        obs {
+          obs_url = "/${huaweicloud_obs_bucket.test.bucket}/%[1]s/"
+        }
+      }
+    }
+
+    parameters {
+      name  = "workers"
+      value = "4"
+
+      constraint {
+        type       = "Float"
+        valid_type = "None"
+      }
+    }
+
+    environments = {
+      RUN_TYPE = "custom_job"
+    }
+  }
+
+  spec {
+    resource {
+      flavor_id  = "%[4]s"
+      node_count = 1
+    }
+
+    log_export_path {
+      obs_url = "/${huaweicloud_obs_bucket.test.bucket}/logs/"
+    }
+    
+    custom_metrics {
+      http_get {
+        path = "/raw_text"
+        port = 10001
+      }
+    }
+  }
+
+  depends_on = [huaweicloud_obs_bucket_object.test]
+}
+
+resource "huaweicloud_kps_keypair" "test" {
+  name = "%[1]s"
+}
+
+data "huaweicloud_modelartsv2_resource_pools" "test" {}
+
+locals {
+  resource_pool_id = try(split(",", "%[5]s")[0], "")
+}
+
+data "huaweicloud_modelartsv2_resource_pool_nodes" "test" {
+  resource_pool_name = local.resource_pool_id
+}
+
+locals {
+  private_ip = try(data.huaweicloud_modelartsv2_resource_pool_nodes.test.nodes[0].status[0].private_ip, "")
+}
+
+# Custom image algorithm job with dedicated resource pool.
+resource "huaweicloud_modelarts_training_job" "with_custom_image" {
+  kind = "job"
+
+  metadata {
+    name        = "%[1]s_debug_job"
+    annotations = {
+      "jupyter-lab/enable" = "true"
+    }
+  }
+
+  algorithm {
+    code_dir = "/${huaweicloud_obs_bucket.test.bucket}/%[1]s/"
+    command  = "python bootfile.py --epochs 10"
+
+    engine {
+      image_url = "%[6]s"
+    }
+  }
+
+  spec {
+    resource {
+      pool_id    = local.resource_pool_id
+      node_count = 1
+
+      main_container_customized_flavor {
+        cpu_core_num = 2
+        mem_size     = 10
+      }
+    }
+
+    runtime_type = "debug"
+
+    volumes {
+      nfs {
+        nfs_server_path = "nas.local:/share/work"
+        local_path      = "/mnt/nfs/"
+        read_only       = false
+      }
+    }
+
+    schedule_policy {
+      priority    = 1
+      preemptible = true
+
+      required_affinity {
+        node_affinity {
+          node_selector_terms {
+            match_expressions {
+              key      = "kubernetes.io/hostname"
+              operator = "In"
+              values   = try(local.private_ip, "") != "" ? [local.private_ip] : []
+            }
+          }
+        }
+      }
+    }
+  }
+
+  endpoints {
+    ssh {
+      key_pair_names = [huaweicloud_kps_keypair.test.id]
+    }
+  }
+}
+
+resource "huaweicloud_modelarts_algorithm" "test" {
+  metadata {
+    name = "%[1]s"
+  }
+
+  job_config {
+    code_dir = "/${huaweicloud_obs_bucket.test.bucket}/%[1]s/"
+    command  = "python bootfile.py --epochs 10"
+
+    engine {
+      image_url = "%[6]s"
+    }
+  }
+
+  depends_on = [huaweicloud_obs_bucket_object.test]
+}
+
+# Existing algorithm job with dedicated resource pool.
+resource "huaweicloud_modelarts_training_job" "with_algorithm" {
+  kind = "job"
+
+  metadata {
+    name = "%[1]s_with_dedicated_resource_pool"
+  }
+
+  algorithm {
+    id = huaweicloud_modelarts_algorithm.test.id
+  }
+
+  spec {
+    resource {
+      pool_id    = local.resource_pool_id
+      node_count = 1
+    }
+
+    schedule_policy {
+      priority    = 1
+      preemptible = true
+
+      preferred_affinity {
+        node_affinity {
+          weight = 100
+          preference {
+            match_expressions {
+              key      = "kubernetes.io/hostname"
+              operator = "In"
+              values   = local.private_ip != "" ? [local.private_ip] : []
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, name,
+		acceptance.HW_MODELARTS_ALGORITHM_ENGINE_ID,
+		acceptance.HW_MODELARTS_ALGORITHM_ENGINE_NAME,
+		acceptance.HW_MODELARTS_TRAINING_JOB_PUBLIC_RESOURCE_POOL_FLAVOR_ID,
+		acceptance.HW_MODELARTS_RESOURCE_POOL_IDS,
+		acceptance.HW_MODELARTS_ALGORITHM_IMAGE_URL,
+	)
+}
+
+func testAccDataTrainingJobs_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Without any filter parameters.
+data "huaweicloud_modelarts_training_jobs" "test" {
+  depends_on = [huaweicloud_modelarts_training_job.test]
+}
+
+# Filter by 'workspace_id' parameter.
+locals {
+  workspace_id = huaweicloud_modelarts_training_job.test.metadata[0].workspace_id
+}
+
+data "huaweicloud_modelarts_training_jobs" "filter_by_workspace_id" {
+  workspace_id = local.workspace_id
+
+  depends_on = [huaweicloud_modelarts_training_job.test]
+}
+
+locals {
+  workspace_id_filter_result = [for v in data.huaweicloud_modelarts_training_jobs.filter_by_workspace_id.jobs[*].metadata[0] :
+  v.workspace_id == local.workspace_id]
+}
+
+output "is_workspace_id_filter_useful" {
+  value = length(local.workspace_id_filter_result) > 0 && alltrue(local.workspace_id_filter_result)
+}
+
+# Filter by 'train_type' parameter.
+data "huaweicloud_modelarts_training_jobs" "filter_by_train_type" {
+  train_type = "job"
+
+  depends_on = [huaweicloud_modelarts_training_job.test]
+}
+
+output "is_train_type_filter_useful" {
+  value = length(data.huaweicloud_modelarts_training_jobs.filter_by_train_type.jobs) > 0
+}
+
+# Filter by 'filters' parameter.
+locals {
+  job_id = huaweicloud_modelarts_training_job.test.id
+}
+
+data "huaweicloud_modelarts_training_jobs" "filter_by_filters" {
+  filters {
+    key      = "id"
+    operator = "in"
+    value    = [local.job_id]
+  }
+}
+
+locals {
+  filters_filter_result = [for v in data.huaweicloud_modelarts_training_jobs.filter_by_filters.jobs[*].metadata[0].id :
+  v == local.job_id]
+}
+
+output "is_filters_filter_useful" {
+  value = length(local.filters_filter_result) > 0 && alltrue(local.filters_filter_result)
+}
+
+# Filter by 'sort_by' and 'order' parameters.
+data "huaweicloud_modelarts_training_jobs" "filter_by_sort_by_and_order_desc" {
+  depends_on = [huaweicloud_modelarts_training_job.test]
+}
+
+data "huaweicloud_modelarts_training_jobs" "filter_by_sort_by_and_order_asc" {
+  sort_by = "create_time"
+  order   = "asc"
+
+  depends_on = [huaweicloud_modelarts_training_job.test]
+}
+
+locals {
+  sort_by_and_order_desc_result = data.huaweicloud_modelarts_training_jobs.filter_by_sort_by_and_order_desc.jobs[*].create_time
+  sort_by_and_order_asc_result  = data.huaweicloud_modelarts_training_jobs.filter_by_sort_by_and_order_asc.jobs[*].create_time
+}
+
+output "is_sort_by_and_order_useful" {
+  value = local.sort_by_and_order_desc_result == reverse(local.sort_by_and_order_asc_result)
+}
+
+data "huaweicloud_modelarts_training_jobs" "filter_by_id_with_custom_image" {
+  filters {
+    key      = "id"
+    operator = "in"
+    value    = [huaweicloud_modelarts_training_job.with_custom_image.id]
+  }
+}
+
+data "huaweicloud_modelarts_training_jobs" "filter_by_id_with_algorithm" {
+  filters {
+    key      = "id"
+    operator = "in"
+    value    = [huaweicloud_modelarts_training_job.with_algorithm.id]
+  }
+}
+`, testAccDataTrainingJobs_base(name))
+}

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_training_jobs.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_training_jobs.go
@@ -1,0 +1,1884 @@
+package modelarts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ModelArts POST /v2/{project_id}/training-job-searches
+func DataSourceTrainingJobs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTrainingJobsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the training jobs are located.`,
+			},
+
+			// Optional parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The workspace ID of the training jobs to be queried.`,
+			},
+			"sort_by": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The metric used to sort the training jobs.`,
+			},
+			"order": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The sort order of the training jobs.`,
+			},
+			"unified_jobs": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to query custom jobs and fine-tuning jobs together.`,
+			},
+			"train_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The training job type to be queried when unified_jobs is enabled.`,
+			},
+			"filters": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 20,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The filter key.`,
+						},
+						"operator": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The filter operator.`,
+						},
+						"value": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							MaxItems:    10,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The filter values.`,
+						},
+					},
+				},
+				Description: `The filter conditions used to query training jobs.`,
+			},
+
+			// Attributes.
+			"jobs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSchema(),
+				Description: `The list of training jobs that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"kind": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the training job.`,
+			},
+			"metadata": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the training job.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the training job.`,
+						},
+						"workspace_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The workspace ID to which the training job belongs.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the training job.`,
+						},
+						"user_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The user name that created the training job.`,
+						},
+						"annotations": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The advanced feature configuration of the training job.`,
+						},
+					},
+				},
+				Description: `The metadata of the training job.`,
+			},
+			"status": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"phase": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The primary status of the training job.`,
+						},
+						"secondary_phase": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The secondary status of the training job.`,
+						},
+						"duration": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The running duration of the training job, in milliseconds.`,
+						},
+						"start_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The start time of the training job, in RFC3339 format.`,
+						},
+						"tasks": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The subtask names of the training job.`,
+						},
+						"node_count_metrics": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The node count metrics of the training job, in JSON format.`,
+						},
+						"task_statuses": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"task": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The subtask name.`,
+									},
+									"exit_code": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The exit code of the subtask.`,
+									},
+									"message": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The error message of the subtask.`,
+									},
+								},
+							},
+							Description: `The status of the first failed subtask.`,
+						},
+						"running_records": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        trainingJobsRunningRecordSchema(),
+							Description: `The running and fault recovery records of the training job.`,
+						},
+					},
+				},
+				Description: `The status of the training job.`,
+			},
+			"algorithm": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsAlgorithmSchema(),
+				Description: `The algorithm configuration of the training job.`,
+			},
+			"spec": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSpecSchema(),
+				Description: `The specification of the training job.`,
+			},
+			"endpoints": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsEndpointsSchema(),
+				Description: `The remote access endpoints of the training job.`,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the training job, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func trainingJobsAlgorithmSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The algorithm ID of the training job.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The algorithm name of the training job.`,
+			},
+			"subscription_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subscription ID of the subscribed algorithm.`,
+			},
+			"item_version_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The version ID of the subscribed algorithm.`,
+			},
+			"code_dir": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The code directory of the training job.`,
+			},
+			"boot_file": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The boot file of the training job.`,
+			},
+			"autosearch_config_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The YAML configuration path of the auto search job.`,
+			},
+			"autosearch_framework_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The framework code directory of the auto search job.`,
+			},
+			"command": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The startup command of the custom image training job.`,
+			},
+			"local_code_dir": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The local code directory in the training container.`,
+			},
+			"working_dir": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The working directory when running the algorithm.`,
+			},
+			"parameters": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The parameter name.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The parameter value.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The parameter description.`,
+						},
+						"constraint": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The parameter constraint type.`,
+									},
+									"editable": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: `Whether the parameter is editable.`,
+									},
+									"required": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: `Whether the parameter is required.`,
+									},
+									"valid_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The parameter valid type.`,
+									},
+									"valid_range": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `The parameter valid values.`,
+									},
+								},
+							},
+							Description: `The parameter constraint.`,
+						},
+					},
+				},
+				Description: `The runtime parameters of the training job.`,
+			},
+			"inputs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsAlgorithmInputSchema(),
+				Description: `The input channels of the training job.`,
+			},
+			"outputs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsAlgorithmOutputSchema(),
+				Description: `The output channels of the training job.`,
+			},
+			"engine": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsAlgorithmEngineSchema(),
+				Description: `The engine configuration of the training job.`,
+			},
+			"environments": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The environment variables of the training job.`,
+			},
+		},
+	}
+}
+
+func trainingJobsAlgorithmInputSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the input channel.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the input channel.`,
+			},
+			"local_dir": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The local directory mapped by the input channel.`,
+			},
+			"access_method": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The delivery method of the input channel path.`,
+			},
+			"remote": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"dataset": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The dataset ID.`,
+									},
+									"version_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The dataset version ID.`,
+									},
+									"obs_url": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The OBS URL of the dataset.`,
+									},
+									"service_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The dataset service type.`,
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The dataset name.`,
+									},
+								},
+							},
+							Description: `The dataset input information.`,
+						},
+						"obs": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"obs_url": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The OBS URL of the input data.`,
+									},
+								},
+							},
+							Description: `The OBS input information.`,
+						},
+					},
+				},
+				Description: `The actual input information.`,
+			},
+			"remote_constraint": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"data_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The data type of the remote constraint.`,
+						},
+						"attributes": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The attributes of the remote constraint.`,
+						},
+					},
+				},
+				Description: `The data input constraint.`,
+			},
+		},
+	}
+}
+
+func trainingJobsAlgorithmOutputSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the output channel.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the output channel.`,
+			},
+			"local_dir": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The local directory mapped by the output channel.`,
+			},
+			"access_method": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The delivery method of the output channel path.`,
+			},
+			"remote": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"obs": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"obs_url": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The OBS URL of the output data.`,
+									},
+								},
+							},
+							Description: `The OBS output information.`,
+						},
+					},
+				},
+				Description: `The remote output information.`,
+			},
+		},
+	}
+}
+
+func trainingJobsAlgorithmEngineSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"engine_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The engine specification ID of the training job.`,
+			},
+			"engine_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The engine specification name of the training job.`,
+			},
+			"engine_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The engine specification version of the training job.`,
+			},
+			"image_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The custom image URL of the training job.`,
+			},
+			"install_sys_packages": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to install the moxing version specified by the training platform.`,
+			},
+		},
+	}
+}
+
+func trainingJobsRecoverRecordSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"recover_start_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The start time of the fault tolerance strategy, in RFC3339 format.`,
+			},
+			"recover_end_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The end time of the fault tolerance strategy, in RFC3339 format.`,
+			},
+			"recover": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The fault tolerance strategy.`,
+			},
+			"fault_scenario": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The fault scenario.`,
+			},
+			"reason": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The fault reason.`,
+			},
+			"related_task": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The task worker ID that triggered the fault.`,
+			},
+			"recover_result": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The execution result of the fault tolerance strategy.`,
+			},
+		},
+	}
+}
+
+func trainingJobsRunningRecordSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"start_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The start time of the run, in RFC3339 format.`,
+			},
+			"end_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The end time of the run, in RFC3339 format.`,
+			},
+			"xpu_start_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The accelerator start time of the run, in RFC3339 format.`,
+			},
+			"start_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The start type of the run.`,
+			},
+			"end_reason": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The end reason of the run.`,
+			},
+			"end_related_task": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The task worker ID that caused the run to end.`,
+			},
+			"end_recover": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The final fault tolerance strategy when the run ended abnormally.`,
+			},
+			"end_recover_before_downgrade": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The fault tolerance strategy before downgrade when the run ended abnormally.`,
+			},
+			"recover_records": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsRecoverRecordSchema(),
+				Description: `The fault tolerance strategy details when the run ended abnormally.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSpecSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"resource": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSpecResourceSchema(),
+				Description: `The resource specification of the training job.`,
+			},
+			"runtime_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The runtime type of the training job.`,
+			},
+			"volumes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nfs": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        trainingJobsSpecVolumeNfsSchema(),
+							Description: `The NFS volume configuration.`,
+						},
+					},
+				},
+				Description: `The mounted volumes of the training job.`,
+			},
+			"log_export_path": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"obs_url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The OBS path where the training job logs are exported.`,
+						},
+					},
+				},
+				Description: `The log export path of the training job.`,
+			},
+			"schedule_policy": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSpecSchedulePolicySchema(),
+				Description: `The scheduling policy of the training job.`,
+			},
+			"custom_metrics": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSpecCustomMetricsSchema(),
+				Description: `The custom metrics configuration of the training job.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSpecResourceSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"policy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resource specification mode of the training job.`,
+			},
+			"flavor_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor ID of the training job.`,
+			},
+			"flavor_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The flavor name of the training job.`,
+			},
+			"node_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of resource replicas selected by the training job.`,
+			},
+			"pool_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resource pool ID selected by the training job.`,
+			},
+			"pool_group_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The federated resource pool ID selected by the training job.`,
+			},
+			"main_container_allocated_resources": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSpecResourceMainContainerAllocatedResourcesSchema(),
+				Description: `The allocated resources of the main container.`,
+			},
+			"main_container_customized_flavor": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSpecResourceMainContainerCustomizedFlavorSchema(),
+				Description: `The customized flavor of the main container.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSpecResourceMainContainerAllocatedResourcesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cpu_arch": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The CPU architecture.`,
+			},
+			"cpu_core_num": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The number of CPU cores.`,
+			},
+			"mem_size": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The memory size.`,
+			},
+			"accelerator_num": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The number of accelerator cards.`,
+			},
+			"accelerator_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The accelerator type.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSpecResourceMainContainerCustomizedFlavorSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cpu_core_num": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The number of CPU cores.`,
+			},
+			"mem_size": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The memory size.`,
+			},
+			"accelerator_num": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `The number of accelerator cards.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSpecVolumeNfsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"nfs_server_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The NFS server path.`,
+			},
+			"local_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The path for attaching volumes to the training container.`,
+			},
+			"read_only": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the disks attached in NFS mode are read-only.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSpecSchedulePolicySchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"priority": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The scheduling priority of the training job.`,
+			},
+			"preemptible": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the training job can be preempted.`,
+			},
+			"required_affinity": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSpecSchedulePolicyRequiredAffinitySchema(),
+				Description: `The required affinity policy of the training job.`,
+			},
+			"preferred_affinity": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSpecSchedulePolicyPreferredAffinitySchema(),
+				Description: `The preferred affinity configuration of the training job.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSpecSchedulePolicyRequiredAffinitySchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"affinity_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The affinity scheduling policy type.`,
+			},
+			"affinity_group_size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The affinity group size.`,
+			},
+			"node_affinity": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSpecSchedulePolicyRequiredAffinityNodeAffinitySchema(),
+				Description: `The node affinity configuration.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSpecSchedulePolicyRequiredAffinityNodeAffinitySchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"node_selector_terms": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSpecSchedulePolicyNodeSelectorTermsSchema(),
+				Description: `The node selector term list.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSpecSchedulePolicyPreferredAffinitySchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"node_affinity": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSpecSchedulePolicyPreferredAffinityNodeAffinitySchema(),
+				Description: `The preferred node affinity terms.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSpecSchedulePolicyPreferredAffinityNodeAffinitySchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"weight": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The weight associated with the preferred node selector term.`,
+			},
+			"preference": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsSpecSchedulePolicyNodeSelectorTermsSchema(),
+				Description: `The preferred node selector term.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSpecSchedulePolicyNodeSelectorTermsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"match_expressions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsNodeSelectorRequirementSchema(),
+				Description: `The node selector requirements based on node labels.`,
+			},
+			"match_fields": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        trainingJobsNodeSelectorRequirementSchema(),
+				Description: `The node selector requirements based on node fields.`,
+			},
+		},
+	}
+}
+
+func trainingJobsNodeSelectorRequirementSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The label key used by the node selector requirement.`,
+			},
+			"operator": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The operator used by the node selector requirement.`,
+			},
+			"values": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The label values used by the node selector requirement.`,
+			},
+		},
+	}
+}
+
+func trainingJobsSpecCustomMetricsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"exec": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"command": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The command for metrics collection.`,
+						},
+					},
+				},
+				Description: `The command-based metrics collection configuration.`,
+			},
+			"http_get": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"path": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The URL path for HTTP metrics collection.`,
+						},
+						"port": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The port for HTTP metrics collection.`,
+						},
+					},
+				},
+				Description: `The HTTP-based metrics collection configuration.`,
+			},
+		},
+	}
+}
+
+func trainingJobsEndpointsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"ssh": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key_pair_names": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The SSH key pair names.`,
+						},
+						"task_urls": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"task": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The task ID.`,
+									},
+									"url": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The SSH connection URL.`,
+									},
+								},
+							},
+							Description: `The SSH connection URLs.`,
+						},
+					},
+				},
+				Description: `The SSH connection information.`,
+			},
+			"jupyter_lab": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The JupyterLab URL.`,
+						},
+						"token": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The JupyterLab token.`,
+						},
+					},
+				},
+				Description: `The JupyterLab connection information.`,
+			},
+			"tensorboard": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The Tensorboard URL.`,
+						},
+						"token": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The Tensorboard token.`,
+						},
+					},
+				},
+				Description: `The Tensorboard connection information.`,
+			},
+			"mindstudio_insight": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The MindStudio Insight URL.`,
+						},
+						"token": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The MindStudio Insight token.`,
+						},
+					},
+				},
+				Description: `The MindStudio Insight connection information.`,
+			},
+		},
+	}
+}
+
+func buildTrainingJobsRequestBody(d *schema.ResourceData, offset, limit int) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"offset":       offset,
+		"limit":        limit,
+		"workspace_id": utils.ValueIgnoreEmpty(d.Get("workspace_id")),
+		"sort_by":      utils.ValueIgnoreEmpty(d.Get("sort_by")),
+		"order":        utils.ValueIgnoreEmpty(d.Get("order")),
+		"unified_jobs": utils.ValueIgnoreEmpty(d.Get("unified_jobs")),
+		"train_type":   utils.ValueIgnoreEmpty(d.Get("train_type")),
+		"filters":      buildTrainingJobsFiltersBodyParams(d.Get("filters").([]interface{})),
+	}
+
+	return bodyParams
+}
+
+func buildTrainingJobsFiltersBodyParams(filtersInput []interface{}) []map[string]interface{} {
+	if len(filtersInput) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(filtersInput))
+	for _, item := range filtersInput {
+		result = append(result, map[string]interface{}{
+			"key":      utils.ValueIgnoreEmpty(utils.PathSearch("key", item, nil)),
+			"operator": utils.ValueIgnoreEmpty(utils.PathSearch("operator", item, nil)),
+			"value":    utils.ValueIgnoreEmpty(utils.PathSearch("value", item, nil)),
+		})
+	}
+
+	return result
+}
+
+func listTrainingJobs(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/training-job-searches"
+		// Maximum is 50.
+		limit    = 50
+		pageSize = 0
+		result   = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildTrainingJobsRequestBody(d, pageSize, limit)),
+	}
+
+	for {
+		listOpt.JSONBody.(map[string]interface{})["offset"] = pageSize
+		requestResp, err := client.Request("POST", listPath, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		jobs := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, jobs...)
+
+		if len(jobs) < limit {
+			break
+		}
+
+		pageSize++
+	}
+
+	return result, nil
+}
+
+func dataSourceTrainingJobsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	jobs, err := listTrainingJobs(client, d)
+	if err != nil {
+		return diag.Errorf("error querying training jobs: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("jobs", flattenTrainingJobs(jobs)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTrainingJobs(jobs []interface{}) []map[string]interface{} {
+	if len(jobs) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(jobs))
+	for _, job := range jobs {
+		result = append(result, map[string]interface{}{
+			"kind":      utils.PathSearch("kind", job, nil),
+			"metadata":  flattenTrainingJobsMetadata(utils.PathSearch("metadata", job, nil)),
+			"status":    flattenTrainingJobsStatus(utils.PathSearch("status", job, nil)),
+			"algorithm": flattenTrainingJobsAlgorithm(utils.PathSearch("algorithm", job, nil)),
+			"spec":      flattenTrainingJobsSpec(utils.PathSearch("spec", job, nil)),
+			"endpoints": flattenTrainingJobsEndpoints(utils.PathSearch("endpoints", job, nil)),
+			"create_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("metadata.create_time",
+				job, float64(0)).(float64))/1000, false),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsMetadata(metadata interface{}) []map[string]interface{} {
+	if metadata == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"id":           utils.PathSearch("id", metadata, nil),
+			"name":         utils.PathSearch("name", metadata, nil),
+			"workspace_id": utils.PathSearch("workspace_id", metadata, nil),
+			"description":  utils.PathSearch("description", metadata, nil),
+			"user_name":    utils.PathSearch("user_name", metadata, nil),
+			"annotations":  utils.PathSearch("annotations", metadata, nil),
+		},
+	}
+}
+
+func flattenTrainingJobsStatus(status interface{}) []map[string]interface{} {
+	if status == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"phase":           utils.PathSearch("phase", status, nil),
+			"secondary_phase": utils.PathSearch("secondary_phase", status, nil),
+			"duration":        utils.PathSearch("duration", status, nil),
+			"start_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("start_time",
+				status, float64(0)).(float64))/1000, false),
+			"tasks":              utils.PathSearch("tasks", status, make([]interface{}, 0)).([]interface{}),
+			"node_count_metrics": utils.JsonToString(utils.PathSearch("node_count_metrics", status, nil)),
+			"task_statuses": flattenTrainingJobsTaskStatuses(utils.PathSearch("task_statuses", status,
+				make([]interface{}, 0)).([]interface{})),
+			"running_records": flattenTrainingJobsRunningRecords(utils.PathSearch("running_records", status,
+				make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}
+
+func flattenTrainingJobsTaskStatuses(taskStatuses []interface{}) []map[string]interface{} {
+	if len(taskStatuses) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(taskStatuses))
+	for _, taskStatus := range taskStatuses {
+		result = append(result, map[string]interface{}{
+			"task":      utils.PathSearch("task", taskStatus, nil),
+			"exit_code": utils.PathSearch("exit_code", taskStatus, nil),
+			"message":   utils.PathSearch("message", taskStatus, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenTrainingJobsRunningRecords(runningRecords []interface{}) []map[string]interface{} {
+	if len(runningRecords) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(runningRecords))
+	for _, runningRecord := range runningRecords {
+		result = append(result, map[string]interface{}{
+			"start_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("start_at",
+				runningRecord, float64(0)).(float64)), false),
+			"end_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("end_at",
+				runningRecord, float64(0)).(float64)), false),
+			"xpu_start_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("xpu_start_at",
+				runningRecord, float64(0)).(float64)), false),
+			"start_type":                   utils.PathSearch("start_type", runningRecord, nil),
+			"end_reason":                   utils.PathSearch("end_reason", runningRecord, nil),
+			"end_related_task":             utils.PathSearch("end_related_task", runningRecord, nil),
+			"end_recover":                  utils.PathSearch("end_recover", runningRecord, nil),
+			"end_recover_before_downgrade": utils.PathSearch("end_recover_before_downgrade", runningRecord, nil),
+			"recover_records": flattenTrainingJobsRecoverRecords(utils.PathSearch("recover_records", runningRecord,
+				make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsRecoverRecords(records []interface{}) []map[string]interface{} {
+	if len(records) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(records))
+	for _, record := range records {
+		result = append(result, map[string]interface{}{
+			"recover_start_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("recover_start_at",
+				record, float64(0)).(float64)), false),
+			"recover_end_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("recover_end_at",
+				record, float64(0)).(float64)), false),
+			"recover":        utils.PathSearch("recover", record, nil),
+			"fault_scenario": utils.PathSearch("fault_scenario", record, nil),
+			"reason":         utils.PathSearch("reason", record, nil),
+			"related_task":   utils.PathSearch("related_task", record, nil),
+			"recover_result": utils.PathSearch("recover_result", record, nil),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsAlgorithm(algorithm interface{}) []map[string]interface{} {
+	if algorithm == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"id":                        utils.PathSearch("id", algorithm, nil),
+			"name":                      utils.PathSearch("name", algorithm, nil),
+			"subscription_id":           utils.PathSearch("subscription_id", algorithm, nil),
+			"item_version_id":           utils.PathSearch("item_version_id", algorithm, nil),
+			"code_dir":                  utils.PathSearch("code_dir", algorithm, nil),
+			"boot_file":                 utils.PathSearch("boot_file", algorithm, nil),
+			"autosearch_config_path":    utils.PathSearch("autosearch_config_path", algorithm, nil),
+			"autosearch_framework_path": utils.PathSearch("autosearch_framework_path", algorithm, nil),
+			"command":                   utils.PathSearch("command", algorithm, nil),
+			"local_code_dir":            utils.PathSearch("local_code_dir", algorithm, nil),
+			"working_dir":               utils.PathSearch("working_dir", algorithm, nil),
+			"parameters": flattenTrainingJobsAlgorithmParameters(utils.PathSearch("parameters", algorithm,
+				make([]interface{}, 0)).([]interface{})),
+			"inputs": flattenTrainingJobsAlgorithmInputs(utils.PathSearch("inputs", algorithm,
+				make([]interface{}, 0)).([]interface{})),
+			"outputs": flattenTrainingJobsAlgorithmOutputs(utils.PathSearch("outputs", algorithm,
+				make([]interface{}, 0)).([]interface{})),
+			"engine":       flattenTrainingJobsAlgorithmEngine(utils.PathSearch("engine", algorithm, nil)),
+			"environments": utils.PathSearch("environments", algorithm, nil),
+		},
+	}
+}
+
+func flattenTrainingJobsAlgorithmParameters(parameters []interface{}) []map[string]interface{} {
+	if len(parameters) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(parameters))
+	for _, parameter := range parameters {
+		result = append(result, map[string]interface{}{
+			"name":        utils.PathSearch("name", parameter, nil),
+			"value":       utils.PathSearch("value", parameter, nil),
+			"description": utils.PathSearch("description", parameter, nil),
+			"constraint": flattenTrainingJobsAlgorithmParameterConstraint(utils.PathSearch("constraint",
+				parameter, nil)),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsAlgorithmParameterConstraint(constraint interface{}) []map[string]interface{} {
+	if constraint == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"type":        utils.PathSearch("type", constraint, nil),
+			"editable":    utils.PathSearch("editable", constraint, nil),
+			"required":    utils.PathSearch("required", constraint, nil),
+			"valid_type":  utils.PathSearch("valid_type", constraint, nil),
+			"valid_range": utils.PathSearch("valid_range", constraint, make([]interface{}, 0)),
+		},
+	}
+}
+
+func flattenTrainingJobsAlgorithmInputs(inputs []interface{}) []map[string]interface{} {
+	if len(inputs) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(inputs))
+	for _, input := range inputs {
+		result = append(result, map[string]interface{}{
+			"name":          utils.PathSearch("name", input, nil),
+			"description":   utils.PathSearch("description", input, nil),
+			"local_dir":     utils.PathSearch("local_dir", input, nil),
+			"access_method": utils.PathSearch("access_method", input, nil),
+			"remote":        flattenTrainingJobsAlgorithmInputRemote(utils.PathSearch("remote", input, nil)),
+			"remote_constraint": flattenTrainingJobsAlgorithmInputRemoteConstraints(utils.PathSearch("remote_constraint",
+				input, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsAlgorithmInputRemote(remote interface{}) []map[string]interface{} {
+	if remote == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"dataset": flattenTrainingJobsAlgorithmInputRemoteDataset(utils.PathSearch("dataset", remote, nil)),
+			"obs":     flattenTrainingJobsAlgorithmInputRemoteObs(utils.PathSearch("obs", remote, nil)),
+		},
+	}
+}
+
+func flattenTrainingJobsAlgorithmInputRemoteDataset(dataset interface{}) []map[string]interface{} {
+	if dataset == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"id":           utils.PathSearch("id", dataset, nil),
+			"version_id":   utils.PathSearch("version_id", dataset, nil),
+			"obs_url":      utils.PathSearch("obs_url", dataset, nil),
+			"service_type": utils.PathSearch("service_type", dataset, nil),
+			"name":         utils.PathSearch("name", dataset, nil),
+		},
+	}
+}
+
+func flattenTrainingJobsAlgorithmInputRemoteObs(obs interface{}) []map[string]interface{} {
+	if obs == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"obs_url": utils.PathSearch("obs_url", obs, nil),
+		},
+	}
+}
+
+func flattenTrainingJobsAlgorithmInputRemoteConstraints(constraints []interface{}) []map[string]interface{} {
+	if len(constraints) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(constraints))
+	for _, constraint := range constraints {
+		result = append(result, map[string]interface{}{
+			"data_type":  utils.PathSearch("data_type", constraint, nil),
+			"attributes": utils.PathSearch("attributes", constraint, nil),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsAlgorithmOutputs(outputs []interface{}) []map[string]interface{} {
+	if len(outputs) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(outputs))
+	for _, output := range outputs {
+		result = append(result, map[string]interface{}{
+			"name":          utils.PathSearch("name", output, nil),
+			"description":   utils.PathSearch("description", output, nil),
+			"local_dir":     utils.PathSearch("local_dir", output, nil),
+			"access_method": utils.PathSearch("access_method", output, nil),
+			"remote":        flattenTrainingJobsAlgorithmOutputRemote(utils.PathSearch("remote", output, nil)),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsAlgorithmOutputRemote(remote interface{}) []map[string]interface{} {
+	if remote == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"obs": flattenTrainingJobsAlgorithmOutputRemoteObs(utils.PathSearch("obs", remote, nil)),
+		},
+	}
+}
+
+func flattenTrainingJobsAlgorithmOutputRemoteObs(obs interface{}) []map[string]interface{} {
+	if obs == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"obs_url": utils.PathSearch("obs_url", obs, nil),
+		},
+	}
+}
+
+func flattenTrainingJobsAlgorithmEngine(engine interface{}) []map[string]interface{} {
+	if engine == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"engine_id":            utils.PathSearch("engine_id", engine, nil),
+			"engine_name":          utils.PathSearch("engine_name", engine, nil),
+			"engine_version":       utils.PathSearch("engine_version", engine, nil),
+			"image_url":            utils.PathSearch("image_url", engine, nil),
+			"install_sys_packages": utils.PathSearch("install_sys_packages", engine, nil),
+		},
+	}
+}
+
+func flattenTrainingJobsSpec(spec interface{}) []map[string]interface{} {
+	if spec == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"resource":     flattenTrainingJobsSpecResource(utils.PathSearch("resource", spec, nil)),
+			"runtime_type": utils.PathSearch("runtime_type", spec, nil),
+			"volumes": flattenTrainingJobsSpecVolumes(utils.PathSearch("volumes", spec,
+				make([]interface{}, 0)).([]interface{})),
+			"log_export_path": flattenTrainingJobsLogExportPath(utils.PathSearch("log_export_path",
+				spec, make(map[string]interface{})).(map[string]interface{})),
+			"schedule_policy": flattenTrainingJobsSchedulePolicy(utils.PathSearch("schedule_policy", spec, nil)),
+			"custom_metrics": flattenTrainingJobsSpecCustomMetrics(utils.PathSearch("custom_metrics", spec,
+				make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}
+
+func flattenTrainingJobsSpecResource(resource interface{}) []map[string]interface{} {
+	if resource == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"policy":        utils.PathSearch("policy", resource, nil),
+			"flavor_id":     utils.PathSearch("flavor_id", resource, nil),
+			"flavor_name":   utils.PathSearch("flavor_name", resource, nil),
+			"node_count":    utils.PathSearch("node_count", resource, nil),
+			"pool_id":       utils.PathSearch("pool_id", resource, nil),
+			"pool_group_id": utils.PathSearch("pool_group_id", resource, nil),
+			"main_container_allocated_resources": flattenTrainingJobsSpecResourceMainContainerAllocatedResources(
+				utils.PathSearch("main_container_allocated_resources", resource, nil)),
+			"main_container_customized_flavor": flattenTrainingJobsSpecResourceMainContainerCustomizedFlavor(
+				utils.PathSearch("main_container_customized_flavor", resource, nil)),
+		},
+	}
+}
+
+func flattenTrainingJobsSpecResourceMainContainerAllocatedResources(allocatedResources interface{}) []map[string]interface{} {
+	if allocatedResources == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"cpu_arch":         utils.PathSearch("cpu_arch", allocatedResources, nil),
+			"cpu_core_num":     utils.PathSearch("cpu_core_num", allocatedResources, nil),
+			"mem_size":         utils.PathSearch("mem_size", allocatedResources, nil),
+			"accelerator_num":  utils.PathSearch("accelerator_num", allocatedResources, nil),
+			"accelerator_type": utils.PathSearch("accelerator_type", allocatedResources, nil),
+		},
+	}
+}
+
+func flattenTrainingJobsSpecResourceMainContainerCustomizedFlavor(customizedFlavor interface{}) []map[string]interface{} {
+	if customizedFlavor == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"cpu_core_num":    utils.PathSearch("cpu_core_num", customizedFlavor, nil),
+			"mem_size":        utils.PathSearch("mem_size", customizedFlavor, nil),
+			"accelerator_num": utils.PathSearch("accelerator_num", customizedFlavor, nil),
+		},
+	}
+}
+
+func flattenTrainingJobsSpecVolumes(volumes []interface{}) []map[string]interface{} {
+	if len(volumes) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(volumes))
+	for _, volume := range volumes {
+		result = append(result, map[string]interface{}{
+			"nfs": flattenTrainingJobsSpecVolumeNfs(utils.PathSearch("nfs", volume, nil)),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsSpecVolumeNfs(nfs interface{}) []map[string]interface{} {
+	if nfs == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"nfs_server_path": utils.PathSearch("nfs_server_path", nfs, nil),
+			"local_path":      utils.PathSearch("local_path", nfs, nil),
+			"read_only":       utils.PathSearch("read_only", nfs, nil),
+		},
+	}
+}
+
+func flattenTrainingJobsLogExportPath(logExportPath map[string]interface{}) []map[string]interface{} {
+	if len(logExportPath) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"obs_url": utils.PathSearch("obs_url", logExportPath, nil),
+		},
+	}
+}
+
+func flattenTrainingJobsSchedulePolicy(schedulePolicy interface{}) []map[string]interface{} {
+	if schedulePolicy == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"priority":    utils.PathSearch("priority", schedulePolicy, nil),
+			"preemptible": utils.PathSearch("preemptible", schedulePolicy, nil),
+			"required_affinity": flattenTrainingJobsSpecSchedulePolicyRequiredAffinity(utils.PathSearch("required_affinity",
+				schedulePolicy, nil)),
+			"preferred_affinity": flattenTrainingJobsSpecSchedulePolicyPreferredAffinity(utils.PathSearch("preferred_affinity",
+				schedulePolicy, nil)),
+		},
+	}
+}
+
+func flattenTrainingJobsSpecSchedulePolicyRequiredAffinity(requiredAffinity interface{}) []map[string]interface{} {
+	if requiredAffinity == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"affinity_type":       utils.PathSearch("affinity_type", requiredAffinity, nil),
+			"affinity_group_size": utils.PathSearch("affinity_group_size", requiredAffinity, nil),
+			"node_affinity": flattenTrainingJobsSpecSchedulePolicyRequiredAffinityNodeAffinity(utils.PathSearch("node_affinity",
+				requiredAffinity, nil)),
+		},
+	}
+}
+
+func flattenTrainingJobsSpecSchedulePolicyRequiredAffinityNodeAffinity(nodeAffinity interface{}) []map[string]interface{} {
+	if nodeAffinity == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"node_selector_terms": flattenTrainingJobsSpecSchedulePolicyNodeSelectorTerms(utils.PathSearch("nodeSelectorTerms",
+				nodeAffinity, make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}
+
+func flattenTrainingJobsSpecSchedulePolicyNodeSelectorTerms(nodeSelectorTerms []interface{}) []map[string]interface{} {
+	if len(nodeSelectorTerms) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(nodeSelectorTerms))
+	for _, term := range nodeSelectorTerms {
+		result = append(result, map[string]interface{}{
+			"match_expressions": flattenTrainingJobsNodeSelectorRequirements(utils.PathSearch("matchExpressions",
+				term, make([]interface{}, 0)).([]interface{})),
+			"match_fields": flattenTrainingJobsNodeSelectorRequirements(utils.PathSearch("matchFields",
+				term, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsNodeSelectorRequirements(requirements []interface{}) []map[string]interface{} {
+	if len(requirements) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(requirements))
+	for _, requirement := range requirements {
+		result = append(result, map[string]interface{}{
+			"key":      utils.PathSearch("key", requirement, nil),
+			"operator": utils.PathSearch("operator", requirement, nil),
+			"values":   utils.PathSearch("values", requirement, nil),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsSpecSchedulePolicyPreferredAffinity(preferredAffinity interface{}) []map[string]interface{} {
+	if preferredAffinity == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"node_affinity": flattenTrainingJobsPreferredSchedulingTerms(utils.PathSearch("node_affinity",
+				preferredAffinity, make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}
+
+func flattenTrainingJobsPreferredSchedulingTerms(terms []interface{}) []map[string]interface{} {
+	if len(terms) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(terms))
+	for _, term := range terms {
+		result = append(result, map[string]interface{}{
+			"weight":     utils.PathSearch("weight", term, nil),
+			"preference": flattenTrainingJobsNodeSelectorTerm(utils.PathSearch("preference", term, nil)),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsNodeSelectorTerm(term interface{}) []map[string]interface{} {
+	if term == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"match_expressions": flattenTrainingJobsNodeSelectorRequirements(utils.PathSearch("matchExpressions",
+				term, make([]interface{}, 0)).([]interface{})),
+			"match_fields": flattenTrainingJobsNodeSelectorRequirements(utils.PathSearch("matchFields",
+				term, make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}
+
+func flattenTrainingJobsSpecCustomMetrics(customMetrics []interface{}) []map[string]interface{} {
+	if len(customMetrics) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(customMetrics))
+	for _, metric := range customMetrics {
+		result = append(result, map[string]interface{}{
+			"exec":     flattenTrainingJobsSpecCustomMetricsExec(utils.PathSearch("exec", metric, nil)),
+			"http_get": flattenTrainingJobsSpecCustomMetricsHttpGet(utils.PathSearch("http_get", metric, nil)),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsSpecCustomMetricsExec(exec interface{}) []map[string]interface{} {
+	if exec == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"command": utils.PathSearch("command", exec, nil),
+		},
+	}
+}
+
+func flattenTrainingJobsSpecCustomMetricsHttpGet(httpGet interface{}) []map[string]interface{} {
+	if httpGet == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"path": utils.PathSearch("path", httpGet, nil),
+			"port": utils.PathSearch("port", httpGet, nil),
+		},
+	}
+}
+
+func flattenTrainingJobsEndpoints(endpoints interface{}) []map[string]interface{} {
+	if endpoints == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"ssh":         flattenTrainingJobsEndpointsSSH(utils.PathSearch("ssh", endpoints, nil)),
+			"jupyter_lab": flattenTrainingJobsEndpointsAccess(utils.PathSearch("jupyter_lab", endpoints, nil)),
+			"tensorboard": flattenTrainingJobsEndpointsAccess(utils.PathSearch("tensorboard", endpoints, nil)),
+			"mindstudio_insight": flattenTrainingJobsEndpointsAccess(utils.PathSearch("mindstudio_insight",
+				endpoints, nil)),
+		},
+	}
+}
+
+func flattenTrainingJobsEndpointsSSH(ssh interface{}) []map[string]interface{} {
+	if ssh == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"key_pair_names": utils.PathSearch("key_pair_names", ssh, nil),
+			"task_urls": flattenTrainingJobsEndpointsSSHTaskURLs(utils.PathSearch("task_urls",
+				ssh, make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}
+
+func flattenTrainingJobsEndpointsSSHTaskURLs(taskURLs []interface{}) []map[string]interface{} {
+	if len(taskURLs) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(taskURLs))
+	for _, taskURL := range taskURLs {
+		result = append(result, map[string]interface{}{
+			"task": utils.PathSearch("task", taskURL, nil),
+			"url":  utils.PathSearch("url", taskURL, nil),
+		})
+	}
+	return result
+}
+
+func flattenTrainingJobsEndpointsAccess(endpoint interface{}) []map[string]interface{} {
+	if endpoint == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"url":   utils.PathSearch("url", endpoint, nil),
+			"token": utils.PathSearch("token", endpoint, nil),
+		},
+	}
+}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_training_job.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_training_job.go
@@ -305,6 +305,7 @@ func ResourceTrainingJob() *schema.Resource {
 						"code_dir": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: `The code directory of the training job.`,
 						},
 						"boot_file": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Add a new data source(`huaweicloud_modelarts_training_jobs`) to query training jobs.
2. When creating a job using an existing algorithm, if `algorithm.code_dir` is not specified, the query API will return the value set in the algorithm.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source for Modelarts.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o modelarts -f TestAccDataTrainingJobs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccDataTrainingJobs_basic -timeout 360m -parallel 10
=== RUN   TestAccDataTrainingJobs_basic
=== PAUSE TestAccDataTrainingJobs_basic
=== CONT  TestAccDataTrainingJobs_basic
--- PASS: TestAccDataTrainingJobs_basic (80.81s)
PASS
coverage: 15.1% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 80.974s coverage: 15.1% of statements in ./huaweicloud/services/modelarts
```
<img width="1092" height="42" alt="image" src="https://github.com/user-attachments/assets/4c41ee14-e184-48e6-98ff-d40674ae6d8f" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
