### PR TITLE
feat(TaurusDB): add data-source to query sessions of HTAP instance

### DIFF
--- a/docs/data-sources/gaussdb_alarms.md
+++ b/docs/data-sources/gaussdb_alarms.md
@@ -24,17 +24,18 @@ data "huaweicloud_gaussdb_alarms" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the resource. If omitted, the provider-level
-  region will be used.
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
 
-* `start_time` - (Required, String) Specifies the start time for querying alarms. The value is in the
-  **yyyy-mm-ddThh:mm:ssZ** format.
+* `start_time` - (Required, String) Specifies the start time for querying alarms.
+  The value is in the format of **yyyy-mm-ddThh:mm:ssZ**.
 
-* `level` - (Optional, Int) Specifies the alarm level. The valid values are as follows:
- + **1**: CRITICAL.
- + **2**: MAJOR.
- + **3**: MINOR.
- + **4**: WARNING.
+* `level` - (Optional, Int) Specifies the alarm level.
+  The valid values are as follows:
+  + **1**: CRITICAL.
+  + **2**: MAJOR.
+  + **3**: MINOR.
+  + **4**: WARNING.
 
 ## Attribute Reference
 

--- a/docs/data-sources/taurusdb_htap_sessions.md
+++ b/docs/data-sources/taurusdb_htap_sessions.md
@@ -1,0 +1,58 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_htap_sessions"
+description: |-
+  Use this data source to query the current sessions of a TaurusDB HTAP instance within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_htap_sessions
+
+Use this data source to query the current sessions of a TaurusDB HTAP instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "htap_instance_id" {}
+
+data "huaweicloud_taurusdb_htap_sessions" "test" {
+  instance_id = var.htap_instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the HTAP sessions.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the HTAP instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `process_list` - The list of sessions of the HTAP instance.
+  The [process_list](#taurusdb_htap_process_list_attr) structure is documented below.
+
+<a name="taurusdb_htap_process_list_attr"></a>
+The `process_list` block supports:
+
+* `id` - The session ID.
+
+* `user` - The session username.
+
+* `host` - The session host.
+
+* `state` - The session status.
+
+* `database` - The database corresponding to the session.
+
+* `sql_statement` - The SQL statement executed by the session.
+
+* `duration` - The session duration, in seconds.
+
+* `command` - The session command type.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2499,6 +2499,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_htap_instances":                  taurusdb.DataSourceTaurusDBHtapInstances(),
 			"huaweicloud_taurusdb_htap_primary_instance_databases": taurusdb.DataSourceTaurusDBHtapPrimaryInstanceDatabases(),
 			"huaweicloud_taurusdb_htap_primary_instance_tables":    taurusdb.DataSourceTaurusDBHtapPrimaryInstanceTables(),
+			"huaweicloud_taurusdb_htap_sessions":                   taurusdb.DataSourceTaurusDBHtapSessions(),
 			"huaweicloud_taurusdb_htap_starrocks_databases":        taurusdb.DataSourceTaurusDBHtapStarrocksDatabases(),
 			"huaweicloud_taurusdb_htap_starrocks_nodes":            taurusdb.DataSourceTaurusDBHtapStarrocksNodes(),
 			"huaweicloud_taurusdb_htap_storage_types":              taurusdb.DataSourceTaurusDBHtapStorageTypes(),

--- a/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_htap_sessions_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_htap_sessions_test.go
@@ -1,0 +1,48 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTaurusDBHtapSessions_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_taurusdb_htap_sessions.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBHtapInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceTaurusDBHtapSessions_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "process_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "process_list.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "process_list.0.user"),
+					resource.TestCheckResourceAttrSet(dataSource, "process_list.0.host"),
+					resource.TestCheckResourceAttrSet(dataSource, "process_list.0.state"),
+					resource.TestCheckResourceAttrSet(dataSource, "process_list.0.database"),
+					resource.TestCheckResourceAttrSet(dataSource, "process_list.0.command"),
+					resource.TestCheckResourceAttrSet(dataSource, "process_list.0.sql_statement"),
+					resource.TestCheckResourceAttrSet(dataSource, "process_list.0.duration"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceTaurusDBHtapSessions_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_taurusdb_htap_sessions" "test" {
+  instance_id = "%s"
+}
+`, acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID)
+}

--- a/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_htap_sessions.go
+++ b/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_htap_sessions.go
@@ -1,0 +1,168 @@
+package taurusdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/htap/process
+func DataSourceTaurusDBHtapSessions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTaurusDBHtapSessionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the region in which to query the resource.",
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the HTAP instance ID.`,
+			},
+			"process_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The list of sessions of the HTAP instance.",
+				Elem:        htapSessionsSchema(),
+			},
+		},
+	}
+}
+
+func htapSessionsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"database": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sql_statement": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"duration": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"command": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTaurusDBHtapSessionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/instances/{instance_id}/htap/process"
+		product = "gaussdb"
+		result  = make([]interface{}, 0)
+		limit   = 100
+		offset  = 0
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating TaurusDB Client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProviderClient.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", d.Get("instance_id").(string))
+
+	listOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s?limit=%d&offset=%v", requestPath, limit, offset)
+		resp, err := client.Request("GET", currentPath, &listOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving TaurusDB HTAP instance sessions: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		processList := utils.PathSearch("process_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(processList) == 0 {
+			break
+		}
+		result = append(result, processList...)
+
+		if len(processList) < limit {
+			break
+		}
+
+		offset += len(processList)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("process_list", flattenHtapSessionsResponseBody(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenHtapSessionsResponseBody(resp []interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	res := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		res = append(res, map[string]interface{}{
+			"id":            utils.PathSearch("id", v, nil),
+			"user":          utils.PathSearch("user", v, nil),
+			"host":          utils.PathSearch("host", v, nil),
+			"state":         utils.PathSearch("state", v, nil),
+			"database":      utils.PathSearch("database", v, nil),
+			"sql_statement": utils.PathSearch("sql_statement", v, nil),
+			"duration":      utils.PathSearch("duration", v, nil),
+			"command":       utils.PathSearch("command", v, nil),
+		})
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data-source to query sessions of HTAP instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add data-source to query sessions of HTAP instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccDataSourceTaurusDBHtapSessions'
=== RUN   TestAccDataSourceTaurusDBHtapSessions_basic
=== PAUSE TestAccDataSourceTaurusDBHtapSessions_basic
=== CONT  TestAccDataSourceTaurusDBHtapSessions_basic
--- PASS: TestAccDataSourceTaurusDBHtapSessions_basic (14.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb  14.227s
```

<img width="852" height="192" alt="image" src="https://github.com/user-attachments/assets/fcaa9450-be78-482c-a61c-f0a70b3c44f0" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
