### PR TITLE
feat(drs): support `drs_batch_set_definer` resource

### DIFF
--- a/docs/resources/drs_batch_set_definer.md
+++ b/docs/resources/drs_batch_set_definer.md
@@ -1,0 +1,89 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_batch_set_definer"
+description: |-
+  Manages a resource to batch set DRS job definer within HuaweiCloud.
+---
+
+# huaweicloud_drs_batch_set_definer
+
+Manages a resource to batch set DRS job definer within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource used to batch set DRS job definer. Deleting this resource will not
+  restore the definer setting or undo the set action, but will only remove the resource information from the
+  tf state file.
+  <br/>2. You must specify existing DRS job IDs. The job status must be **CONFIGURATION** before calling this API.
+  If a job does not exist or is not in the correct status, the operation may fail.<br/>3. The execution result of this
+  operation is based on the `status` field in the `results` block.
+
+## Example Usage
+
+```hcl
+variable "jobs" {
+  type = list(object({
+    job_id          = string
+    replace_definer = bool
+  }))
+}
+
+resource "huaweicloud_drs_batch_set_definer" "test" {
+  dynamic "jobs" {
+    for_each = var.jobs
+
+    content {
+      job_id          = jobs.value.job_id
+      replace_definer = jobs.value.replace_definer
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `jobs` - (Required, List, NonUpdatable) Specifies the batch set replace definer request list.
+
+  The [jobs](#jobs_struct) structure is documented below.
+
+<a name="jobs_struct"></a>
+The `jobs` block supports:
+
+* `job_id` - (Required, String, NonUpdatable) Specifies the job ID.
+
+* `replace_definer` - (Required, Bool, NonUpdatable) Specifies whether to use the target database user to replace the
+  definer.  
+  The valid values are as follows:
+  + **true**: After migration, the definer of all source database objects will be migrated to the target user. Other
+    users need to be authorized to have database object permissions.
+  + **false**: After migration, the definer definition of source database objects will remain unchanged. This option
+    requires migrating all source database users together with the user permission migration function to keep the
+    source database permission system unchanged.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `results` - The batch modify task return list.
+
+  The [results](#results_struct) structure is documented below.
+
+<a name="results_struct"></a>
+The `results` block supports:
+
+* `id` - The job ID.
+
+* `status` - The status of the operation.  
+  The valid values are as follows:
+  + **success**: The operation succeeded.
+  + **failed**: The operation failed.
+
+* `error_code` - The error code.
+
+* `error_msg` - The error message.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3651,6 +3651,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_batch_delete_jobs":              drs.ResourceBatchDeleteJobs(),
 			"huaweicloud_drs_batch_pause_task":               drs.ResourceBatchPauseTask(),
 			"huaweicloud_drs_batch_retry_task":               drs.ResourceBatchRetryTask(),
+			"huaweicloud_drs_batch_set_definer":              drs.ResourceBatchSetDefiner(),
 			"huaweicloud_drs_check_data_filter":              drs.ResourceDrsCheckDataFilter(),
 			"huaweicloud_drs_update_data_progress_rules":     drs.ResourceDrsUpdateDataProgressRules(),
 			"huaweicloud_drs_compare_job_cancel":             drs.ResourceCancelCompareJob(),

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_batch_set_definer_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_batch_set_definer_test.go
@@ -1,0 +1,44 @@
+package drs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBatchSetDefiner_basic(t *testing.T) {
+	resourceName := "huaweicloud_drs_batch_set_definer.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDrsJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchSetDefiner_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.status"),
+				),
+			},
+		},
+	})
+}
+
+func testBatchSetDefiner_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_drs_batch_set_definer" "test" {
+  jobs {
+    job_id          = "%s"
+    replace_definer = true
+  }
+}
+`, acceptance.HW_DRS_JOB_ID)
+}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_batch_set_definer.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_batch_set_definer.go
@@ -1,0 +1,212 @@
+package drs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var batchSetDefinerNonUpdatableParams = []string{
+	"jobs",
+	"jobs.*.job_id",
+	"jobs.*.replace_definer",
+}
+
+// @API DRS POST /v3/{project_id}/jobs/batch-replace-definer
+func ResourceBatchSetDefiner() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBatchSetDefinerCreate,
+		ReadContext:   resourceBatchSetDefinerRead,
+		UpdateContext: resourceBatchSetDefinerUpdate,
+		DeleteContext: resourceBatchSetDefinerDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(batchSetDefinerNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"jobs": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     batchSetDefinerJobsSchema(),
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     batchSetDefinerResultsSchema(),
+			},
+		},
+	}
+}
+
+func batchSetDefinerJobsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"replace_definer": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+		},
+	}
+}
+
+func batchSetDefinerResultsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"error_msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildBatchSetDefinerBodyParams(d *schema.ResourceData) map[string]interface{} {
+	jobsRaw := d.Get("jobs").([]interface{})
+	jobs := make([]map[string]interface{}, 0, len(jobsRaw))
+
+	for _, jobRaw := range jobsRaw {
+		job, ok := jobRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		jobs = append(jobs, map[string]interface{}{
+			"job_id":          job["job_id"],
+			"replace_definer": job["replace_definer"],
+		})
+	}
+
+	return map[string]interface{}{
+		"jobs": jobs,
+	}
+}
+
+func resourceBatchSetDefinerCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/jobs/batch-replace-definer"
+	)
+
+	client, err := cfg.NewServiceClient("drs", region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildBatchSetDefinerBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error batch setting DRS job definer: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	results := utils.PathSearch("results", respBody, make([]interface{}, 0)).([]interface{})
+	if len(results) == 0 {
+		return diag.Errorf("unable to find the results from the API response")
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(resourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("results", flattenBatchSetDefinerResults(results)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting batch set DRS job definer fields: %s", mErr)
+	}
+
+	return nil
+}
+
+func flattenBatchSetDefinerResults(results []interface{}) []interface{} {
+	if len(results) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(results))
+	for _, result := range results {
+		rst = append(rst, map[string]interface{}{
+			"id":         utils.PathSearch("id", result, nil),
+			"status":     utils.PathSearch("status", result, nil),
+			"error_code": utils.PathSearch("error_code", result, nil),
+			"error_msg":  utils.PathSearch("error_msg", result, nil),
+		})
+	}
+
+	return rst
+}
+
+func resourceBatchSetDefinerRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchSetDefinerUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceBatchSetDefinerDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used to batch set DRS job definer. Deleting this resource
+    will not restore the definer setting or undo the set action, but will only remove the resource information from the
+    tf state file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `drs_batch_set_definer` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `drs_batch_set_definer` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o drs -f TestAccBatchSetDefiner_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/drs" -v -coverprofile="./huaweicloud/services/acceptance/drs/drs_coverage.cov" -coverpkg="./huaweicloud/services/drs" -run TestAccBatchSetDefiner_basic -timeout 360m -parallel 10
=== RUN   TestAccBatchSetDefiner_basic
=== PAUSE TestAccBatchSetDefiner_basic
=== CONT  TestAccBatchSetDefiner_basic
--- PASS: TestAccBatchSetDefiner_basic (26.74s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs  coverage: 5.3% of statements in ./huaweicloud/services/drs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       27.082s coverage: 5.3% of statements in ./huaweicloud/services/drs
```
<img width="879" height="38" alt="image" src="https://github.com/user-attachments/assets/9b30ce04-f885-4259-aa95-aa112674434c" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
