### PR TITLE
feat(TaurusDB): add action resource to kill sessions of HTAP instance

### DIFF
--- a/docs/resources/taurusdb_htap_sessions_kill.md
+++ b/docs/resources/taurusdb_htap_sessions_kill.md
@@ -1,0 +1,53 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_htap_sessions_kill"
+description: |-
+  Use this resource to delete sessions of a TaurusDB HTAP instance within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_htap_sessions_kill
+
+Use this resource to delete sessions of a TaurusDB HTAP instance within HuaweiCloud.
+
+-> This resource is a one-time action resource for deleting sessions of an HTAP instance. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "htap_instance_id" {}
+variable "session_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_taurusdb_htap_sessions_kill" "test" {
+  instance_id  = var.htap_instance_id
+  process_list = var.session_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the HTAP instance ID.
+
+* `process_list` - (Required, List, NonUpdatable) Specifies the session IDs of the HTAP instance to be deleted.
+  A maximum of 20 session IDs can be specified at a time.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The response result of the session deletion.
+  The valid values are as follows:
+  + **success**
+  + **failed**
+
+* `msg` - The response error information of the session deletion.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4521,6 +4521,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_scheduled_task_delete":           taurusdb.ResourceTaurusDBScheduledTaskDelete(),
 			"huaweicloud_taurusdb_instant_task_delete":             taurusdb.ResourceTaurusDBInstantTaskDelete(),
 			"huaweicloud_taurusdb_node_sessions_kill":              taurusdb.ResourceTaurusDBNodeSessionsKill(),
+			"huaweicloud_taurusdb_htap_sessions_kill":              taurusdb.ResourceTaurusDBHtapSessionsKill(),
 			"huaweicloud_taurusdb_htap_starrocks_instance_restart": taurusdb.ResourceTaurusDBHtapStarrocksInstanceRestart(),
 			"huaweicloud_taurusdb_htap_starrocks_node_restart":     taurusdb.ResourceTaurusDBHtapStarrocksNodeRestart(),
 

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_sessions_kill_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_sessions_kill_test.go
@@ -1,0 +1,43 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTaurusDBHtapSessionsKill_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBHtapInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaurusDBHtapSessionsKill_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("huaweicloud_taurusdb_htap_sessions_kill.test", "status", "success"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTaurusDBHtapSessionsKill_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_taurusdb_htap_sessions" "test"{
+  instance_id = "%[1]s"
+}
+
+resource "huaweicloud_taurusdb_htap_sessions_kill" "test" {
+  instance_id  = "%[1]s"
+  process_list = [data.huaweicloud_taurusdb_htap_sessions.test.process_list[0].id]
+}
+`, acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID)
+}

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_sessions_kill.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_sessions_kill.go
@@ -1,0 +1,141 @@
+package taurusdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var (
+	htapSessionsKillNonUpdatableParams = []string{"instance_id", "process_list"}
+)
+
+// @API TaurusDB DELETE /v3/{project_id}/instances/{instance_id}/htap/process
+func ResourceTaurusDBHtapSessionsKill() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTaurusDBHtapSessionsKillCreate,
+		ReadContext:   resourceTaurusDBHtapSessionsKillRead,
+		UpdateContext: resourceTaurusDBHtapSessionsKillUpdate,
+		DeleteContext: resourceTaurusDBHtapSessionsKillDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(htapSessionsKillNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"process_list": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceTaurusDBHtapSessionsKillCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/htap/process"
+		product    = "gaussdb"
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating TaurusDB client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProviderClient.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{instance_id}", instanceId)
+
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildCreateTaurusDBHtapSessionsKillBodyParams(d),
+	}
+
+	resp, err := client.Request("DELETE", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error killing TaurusDB HTAP instance sessions: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error parsing response: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("msg", utils.PathSearch("msg", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildCreateTaurusDBHtapSessionsKillBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"process_list": utils.ExpandToStringList(d.Get("process_list").([]interface{})),
+	}
+	return bodyParams
+}
+
+func resourceTaurusDBHtapSessionsKillRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceTaurusDBHtapSessionsKillUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceTaurusDBHtapSessionsKillDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting TaurusDB HTAP sessions kill resource is not supported. The TaurusDB HTAP sessions " +
+		"kill resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add action resource to kill sessions of HTAP instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add action resource to kill sessions of HTAP instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccDataSourceTaurusDBHtapSessions'
=== RUN   TestAccTaurusDBHtapSessionsKill_basic
=== PAUSE TestAccTaurusDBHtapSessionsKill_basic
=== CONT  TestAccTaurusDBHtapSessionsKill_basic
--- PASS: TestAccTaurusDBHtapSessionsKill_basic (36.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb  36.298s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
