### PR TITLE
feat(dli): add the created_at and updated_at attributes to the resource

### DIFF
--- a/docs/resources/dli_datasource_auth.md
+++ b/docs/resources/dli_datasource_auth.md
@@ -131,6 +131,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `owner` - The user name of owner.
 
+* `created_at` - The creation time of the datasource authentication, in RFC3339 format.
+
+* `updated_at` - The update time of the datasource authentication, in RFC3339 format.
+
 ## Import
 
 The DLI datasource authentication can be imported using `id` which equals the `name`, e.g.

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_auth_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_auth_test.go
@@ -2,6 +2,7 @@ package dli
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -78,6 +79,8 @@ func TestAccDatasourceAuth_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "type", "passwd"),
 					resource.TestCheckResourceAttr(rName, "user_name", "test"),
 					resource.TestCheckResourceAttrSet(rName, "owner"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 			{
@@ -86,6 +89,10 @@ func TestAccDatasourceAuth_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "user_name", "test123"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(rName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 			{

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_auth.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_auth.go
@@ -37,6 +37,8 @@ func ResourceDatasourceAuth() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+
+			// Required parameters.
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -48,6 +50,8 @@ func ResourceDatasourceAuth() *schema.Resource {
 				ForceNew:    true,
 				Description: `Data source type.`,
 			},
+
+			// Optional parameters.
 			"user_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -126,11 +130,24 @@ func ResourceDatasourceAuth() *schema.Resource {
 				Computed:    true,
 				Description: `The OBS path of the **keytab** configuration file.`,
 			},
+
+			// Attributes.
 			"owner": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `The user name of owner.`,
 			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the datasource authentication, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time of the datasource authentication, in RFC3339 format.`,
+			},
+
 			// Deprecated arguments
 			"username": {
 				Type:     schema.TypeString,
@@ -278,6 +295,10 @@ func resourceDatasourceAuthRead(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("krb5_conf", utils.PathSearch("auth_infos[0].krb5_conf", getDatasourceAuthRespBody, nil)),
 		d.Set("keytab", utils.PathSearch("auth_infos[0].keytab", getDatasourceAuthRespBody, nil)),
 		d.Set("owner", utils.PathSearch("auth_infos[0].owner", getDatasourceAuthRespBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(
+			int64(utils.PathSearch("auth_infos[0].create_time", getDatasourceAuthRespBody, float64(0)).(float64))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(
+			int64(utils.PathSearch("auth_infos[0].update_time", getDatasourceAuthRespBody, float64(0)).(float64))/1000, false)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add the `created_at` and `updated_at` attributes to the resource.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. add `created_at` and `updated_at` to the schema.
2. update the flatten logic to accommodate the `created_at` and `updated_at` attributes.
3. add descriptions for `created_at` and `updated_at` to the documentation.
```

## PR Checklist

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dli" -v -coverprofile="./huaweicloud/services/acceptance/dli/dli_coverage.cov" -coverpkg="./huaweicloud/services/dli" -run TestAccDatasourceAuth_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceAuth_basic
=== PAUSE TestAccDatasourceAuth_basic
=== CONT  TestAccDatasourceAuth_basic
--- PASS: TestAccDatasourceAuth_basic (31.23s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/dli
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       31.357s coverage: 4.1% of statements in ./huaweicloud/services/dli
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
