### PR TITLE
fix: test: docs(apig): remove traffic bandwidth support and repair out of range panic

### DIFF
--- a/docs/resources/apig_instance.md
+++ b/docs/resources/apig_instance.md
@@ -127,7 +127,6 @@ The following arguments are supported:
 * `ingress_bandwidth_charging_mode` - (Optional, String) Specifies the ingress bandwidth billing type of the dedicated instance.
   The valid values are as follows:
   + **bandwidth**: Billed by bandwidth.
-  + **traffic**: Billed by traffic.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the dedicated instance.
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
@@ -105,7 +105,7 @@ func TestAccInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "bandwidth_size", "6"),
-					resource.TestCheckResourceAttr(resourceName, "ingress_bandwidth_charging_mode", "traffic"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_bandwidth_charging_mode", "bandwidth"),
 					resource.TestCheckResourceAttr(resourceName, "ingress_bandwidth_size", "6"),
 					resource.TestCheckResourceAttrSet(resourceName, "egress_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "ingress_address"),
@@ -185,9 +185,9 @@ resource "huaweicloud_apig_instance" "test" {
   enterprise_project_id = "%[3]s"
   maintain_begin        = "18:00:00"
 
-  // Network configuration
+  # Network configuration
   bandwidth_size                  = 5 # The bandwidth value must be greater than or equal to 5
-  ingress_bandwidth_charging_mode = "bandwidth"
+  ingress_bandwidth_charging_mode = "bandwidth" # Currently, only bandwidth mode is supported.
   ingress_bandwidth_size          = 5
 
   tags = {
@@ -230,9 +230,9 @@ resource "huaweicloud_apig_instance" "test" {
   enterprise_project_id = "%[3]s"
   maintain_begin        = "18:00:00"
 
-  // Network configuration
+  # Network configuration
   bandwidth_size                  = 6
-  ingress_bandwidth_charging_mode = "traffic"
+  ingress_bandwidth_charging_mode = "bandwidth" # Currently, only bandwidth mode is supported.
   ingress_bandwidth_size          = 6
 
   tags = {

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -571,9 +571,9 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("error waiting for the status of dedicated instance (%s) to become running: %s", instanceId, err)
 	}
 
-	extraElbIds := d.Get("elb_ids").(*schema.Set).List()[1:]
-	if len(extraElbIds) > 0 {
-		if err := batchCreateExtraElbs(ctx, client, instanceId, extraElbIds, d.Timeout(schema.TimeoutCreate)); err != nil {
+	elbIds := d.Get("elb_ids").(*schema.Set).List()
+	if len(elbIds) > 1 {
+		if err := batchCreateExtraElbs(ctx, client, instanceId, elbIds[1:], d.Timeout(schema.TimeoutCreate)); err != nil {
 			return diag.FromErr(err)
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

During the acceptance test, we found the traffic value of `ingress_bandwidth_charging_mode` parameter is not supported now, and the creation step will trigger a panic when the length of `elb_ids` array is zero.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The `traffic` value of `ingress_bandwidth_charging_mode` parameter is not supported both in document and real request now.
<img width="1562" height="228" alt="image" src="https://github.com/user-attachments/assets/a44bf47b-4896-4eb7-8c57-1e4c71214927" />


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. repair the out of range panic when elb_ids is empty
2. remove traffic  value for the bandwidth charging mode
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccInstance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccInstance_basic -timeout 360m -parallel 10
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (1358.21s)
PASS
coverage: 5.3% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      1358.298s       coverage: 5.3% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
