### PR TITLE
feat(gaussdb): add instance alarm statistics data source

### DIFF
--- a/docs/data-sources/gaussdb_instance_alarm_statistics.md
+++ b/docs/data-sources/gaussdb_instance_alarm_statistics.md
@@ -1,0 +1,76 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_instance_alarm_statistics"
+description: |-
+  Use this data source to query GaussDB instance alarm statistics within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_instance_alarm_statistics
+
+Use this data source to query GaussDB instance alarm statistics within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "start_time" {}
+
+variable "top_num" {}
+
+data "huaweicloud_gaussdb_instance_alarm_statistics" "test" {
+  start_time = var.start_time
+  top_num    = var.top_num
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `start_time` - (Required, String) Specifies the start time for querying alarm statistics.
+  The value is in the format of **yyyy-mm-ddThh:mm:ss+0000**.
+
+* `top_num` - (Required, Int) Specifies the number of instances with the most alarms to return.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `ring_percentage` - The ring percentage of alarms.
+
+* `instance_alarm_level_statistics` - The list of alarm level statistics by instance.
+  The [instance_alarm_level_statistics](#instance_alarm_level_statistics_struct) structure is documented below.
+
+* `total_alarm_level_statistics` - The list of total alarm level statistics.
+  The [total_alarm_level_statistics](#total_alarm_level_statistics_struct) structure is documented below.
+
+<a name="instance_alarm_level_statistics_struct"></a>
+The `instance_alarm_level_statistics` block supports:
+
+* `instance_id` - The ID of the GaussDB instance.
+
+* `instance_name` - The name of the GaussDB instance.
+
+* `total_count` - The total number of alarms for the instance.
+
+* `alarm_level_statistics` - The list of alarm level statistics for the instance.
+  The [alarm_level_statistics](#alarm_level_statistics_struct) structure is documented below.
+
+<a name="total_alarm_level_statistics_struct"></a>
+The `total_alarm_level_statistics` block supports:
+
+* `count` - The count of alarms at this level.
+
+* `level_name` - The name of the alarm level.
+
+<a name="alarm_level_statistics_struct"></a>
+The `alarm_level_statistics` block supports:
+
+* `count` - The count of alarms at this level.
+
+* `level_name` - The name of the alarm level.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1528,6 +1528,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_table_restored_tables":         geminidb.DataSourceGeminiDBTableRestoredTables(),
 
 			"huaweicloud_gaussdb_alarms":                          gaussdb.DataSourceAlarms(),
+			"huaweicloud_gaussdb_instance_alarm_statistics":       gaussdb.DataSourceInstanceAlarmStatistics(),
 			"huaweicloud_gaussdb_storage_types":                   gaussdb.DataSourceGaussDbStorageTypes(),
 			"huaweicloud_gaussdb_datastores":                      gaussdb.DataSourceGaussDbDatastores(),
 			"huaweicloud_gaussdb_flavors":                         gaussdb.DataSourceGaussDbFlavors(),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_instance_alarm_statistics_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_instance_alarm_statistics_test.go
@@ -1,0 +1,57 @@
+package gaussdb
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceInstanceAlarmStatistics_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_gaussdb_instance_alarm_statistics.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(
+		t, resource.TestCase{
+			PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+			ProviderFactories: acceptance.TestAccProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: testDataSourceInstanceAlarmStatistics_basic(),
+					Check: resource.ComposeTestCheckFunc(
+						dc.CheckResourceExists(),
+						resource.TestCheckResourceAttrSet(all, "ring_percentage"),
+						resource.TestMatchResourceAttr(all, "instance_alarm_level_statistics.#", regexp.MustCompile(`^[0-9]+$`)),
+						resource.TestCheckResourceAttrSet(all, "instance_alarm_level_statistics.0.instance_id"),
+						resource.TestCheckResourceAttrSet(all, "instance_alarm_level_statistics.0.instance_name"),
+						resource.TestCheckResourceAttrSet(all, "instance_alarm_level_statistics.0.total_count"),
+						resource.TestMatchResourceAttr(all, "instance_alarm_level_statistics.0.alarm_level_statistics.#",
+							regexp.MustCompile(`^[0-9]+$`)),
+						resource.TestCheckResourceAttrSet(all, "instance_alarm_level_statistics.0.alarm_level_statistics.0.count"),
+						resource.TestCheckResourceAttrSet(all, "instance_alarm_level_statistics.0.alarm_level_statistics.0.level_name"),
+						resource.TestMatchResourceAttr(all, "total_alarm_level_statistics.#", regexp.MustCompile(`^[0-9]+$`)),
+						resource.TestCheckResourceAttrSet(all, "total_alarm_level_statistics.0.count"),
+						resource.TestCheckResourceAttrSet(all, "total_alarm_level_statistics.0.level_name"),
+					),
+				},
+			},
+		},
+	)
+}
+
+func testDataSourceInstanceAlarmStatistics_basic() string {
+	startTime := time.Now().UTC().Add(-30 * 24 * time.Hour).Format("2006-01-02T15:04:05+0000")
+
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_instance_alarm_statistics" "test" {
+  start_time = "%s"
+  top_num    = 10
+}
+`, startTime)
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_instance_alarm_statistics.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_instance_alarm_statistics.go
@@ -1,0 +1,189 @@
+package gaussdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB GET /v3/{project_id}/instances/alarm-statistics
+func DataSourceInstanceAlarmStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceAlarmStatisticsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"top_num": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"ring_percentage": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"instance_alarm_level_statistics": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     gaussDbInstanceAlarmLevelStatisticsSchema(),
+			},
+			"total_alarm_level_statistics": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     gaussDbTotalAlarmLevelStatisticsSchema(),
+			},
+		},
+	}
+}
+
+func gaussDbInstanceAlarmLevelStatisticsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"total_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"alarm_level_statistics": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     gaussDbTotalAlarmLevelStatisticsSchema(),
+			},
+		},
+	}
+}
+
+func gaussDbTotalAlarmLevelStatisticsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"level_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func queryInstanceAlarmStatistics(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	httpUrl := "v3/{project_id}/instances/alarm-statistics"
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	startTime := strings.ReplaceAll(d.Get("start_time").(string), "+", "%2B")
+	listPath += fmt.Sprintf("?start_time=%s&top_num=%d", startTime, d.Get("top_num").(int))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func dataSourceInstanceAlarmStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("opengauss", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	resp, err := queryInstanceAlarmStatistics(client, d)
+	if err != nil {
+		return diag.Errorf("error querying instance alarm statistics: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("ring_percentage", utils.PathSearch("ring_percentage", resp, nil)),
+		d.Set("instance_alarm_level_statistics", flattenInstanceAlarmLevelStatistics(resp)),
+		d.Set("total_alarm_level_statistics", flattenTotalAlarmLevelStatistics(resp)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInstanceAlarmLevelStatistics(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("instance_alarm_level_statistics", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	res := make([]interface{}, 0, len(curArray))
+
+	for _, v := range curArray {
+		res = append(
+			res, map[string]interface{}{
+				"instance_id":            utils.PathSearch("instance_id", v, nil),
+				"instance_name":          utils.PathSearch("instance_name", v, nil),
+				"total_count":            utils.PathSearch("total_count", v, nil),
+				"alarm_level_statistics": flattenTotalAlarmLevelStatistics(v),
+			},
+		)
+	}
+	return res
+}
+
+func flattenTotalAlarmLevelStatistics(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("alarm_level_statistics", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	res := make([]interface{}, 0, len(curArray))
+
+	for _, v := range curArray {
+		res = append(
+			res, map[string]interface{}{
+				"count":      utils.PathSearch("count", v, nil),
+				"level_name": utils.PathSearch("level_name", v, nil),
+			},
+		)
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source `(huaweicloud_gaussdb_instance_alarm_statistics) `  to query instance alarm statistics.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  add a new data source  `(huaweicloud_gaussdb_instance_alarm_statistics) ` for GaussDB.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o gaussdb -f TestAccDataSourceInstanceAlarmStatistics_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/gaussdb" -v -coverprofile="./huaweicloud/services/acceptance/gaussdb/gaussdb_coverage.cov" -coverpkg="./huaweicloud/services/gaussdb" -run TestAccDataSourceInstanceAlarmStatistics_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceInstanceAlarmStatistics_basic
=== PAUSE TestAccDataSourceInstanceAlarmStatistics_basic
=== CONT  TestAccDataSourceInstanceAlarmStatistics_basic
--- PASS: TestAccDataSourceInstanceAlarmStatistics_basic (15.12s)
PASS
coverage: 3.4% of statements in ./huaweicloud/services/gaussdb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   15.246s coverage: 3.4% of statements in ./huaweicloud/services/gaussdb

```

<img width="1021" height="25" alt="instance_alarm_statistics" src="https://github.com/user-attachments/assets/bbefbc09-7378-4989-85d6-1f38555ffcd6" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
