### PR TITLE
feat(GeminiDB): add resource to manage GeminiDB instance node bind EIP

### DIFF
--- a/docs/resources/geminidb_eip_bind.md
+++ b/docs/resources/geminidb_eip_bind.md
@@ -1,0 +1,63 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_eip_bind"
+description: |-
+  Manages a resource to bind the EIP to the GeminiDB instance node within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_eip_bind
+
+Manages a resource to bind the EIP to the GeminiDB instance node within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+var "instance_id" {}
+var "node_id" {}
+var "eip_ip_address" {}
+var "eip_id" {}
+
+resource "huaweicloud_geminidb_eip_bind" "test" {
+  instance_id  = var.instance_id
+  node_id      = var.node_id
+  public_ip    = var.eip_ip_address
+  public_ip_id = eip_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the GeminiDB instance.
+
+* `node_id` - (Required, String, NonUpdatable) Specifies the ID of the node.
+
+* `public_ip` - (Required, String, NonUpdatable) Specifies the EIP IP address.
+
+* `public_ip_id` - (Required, String, NonUpdatable) Specifies the EIP ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also is the node ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The resource can be imported using the `instance_id` and `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_geminidb_eip_bind.test <instance_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3828,6 +3828,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_backup_stop":                geminidb.ResourceGeminiDBBackupStop(),
 			"huaweicloud_geminidb_database_operation":         geminidb.ResourceGeminiDBDatabaseOperation(),
 			"huaweicloud_geminidb_database_upgrade":           geminidb.ResourceDatabaseUpgrade(),
+			"huaweicloud_geminidb_eip_bind":                   geminidb.ResourceEipBind(),
 			"huaweicloud_geminidb_enlarge_fail_node_delete":   geminidb.ResourceEnlargeFailNodeDelete(),
 			"huaweicloud_geminidb_instance":                   geminidb.ResourceGeminiDbInstance(),
 			"huaweicloud_geminidb_instance_restart":           geminidb.ResourceInstanceRestart(),

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_eip_bind_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_eip_bind_test.go
@@ -1,0 +1,147 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/geminidb"
+)
+
+func getResourceEipBindFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("geminidb", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	return geminidb.GetEipBindInfo(client, state.Primary.Attributes["instance_id"], state.Primary.ID)
+}
+
+func TestAccEipBind_basic(t *testing.T) {
+	var obj interface{}
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_geminidb_eip_bind.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getResourceEipBindFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEipBind_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id", "huaweicloud_geminidb_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "public_ip_id", "huaweicloud_vpc_eip.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "public_ip", "huaweicloud_vpc_eip.test", "address"),
+					resource.TestCheckResourceAttrSet(rName, "node_id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccEipBindImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccEipBind_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus             = 2
+  engine            = "redis"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}
+
+resource "huaweicloud_vpc_eip" "test" {
+  name = "%[2]s"
+
+  publicip {
+    type       = "5_sbgp"
+    ip_version = 4
+  }
+
+  bandwidth {
+    name        = "%[2]s"
+    share_type  = "PER"
+    size        = 1
+    charge_mode = "bandwidth"
+  }
+}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "test_1234"
+  mode              = "Cluster"
+
+  datastore {
+    type           = "redis"
+    version        = "5.0"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "3"
+    size      = "16"
+    storage   = "ULTRAHIGH"
+    spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccEipBind_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_geminidb_eip_bind" "test" {
+  instance_id  = huaweicloud_geminidb_instance.test.id
+  node_id      = huaweicloud_geminidb_instance.test.groups[0].nodes[0].id
+  public_ip    = huaweicloud_vpc_eip.test.address
+  public_ip_id = huaweicloud_vpc_eip.test.id
+}
+`, testAccEipBind_base(name))
+}
+
+func testAccEipBindImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var instanceId, nodeId string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		instanceId = rs.Primary.Attributes["instance_id"]
+		nodeId = rs.Primary.ID
+
+		if instanceId == "" || nodeId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<id>', but got '%s/%s'",
+				instanceId, nodeId)
+		}
+
+		return fmt.Sprintf("%s/%s", instanceId, nodeId), nil
+	}
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_eip_bind.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_eip_bind.go
@@ -1,0 +1,333 @@
+package geminidb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var eipBindNonUpdatableParams = []string{
+	"instance_id",
+	"node_id",
+	"public_ip",
+	"public_ip_id",
+}
+
+// @API GeminiDB POST /v3/{project_id}/instances/{instance_id}/nodes/{node_id}/public-ip
+// @API GeminiDB POST /v3/{project_id}/instances
+// @API GeminiDB GET /v3/{project_id}/jobs
+// @API EIP GET /v1/{project_id}/publicips
+func ResourceEipBind() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEipBindCreate,
+		ReadContext:   resourceEipBindRead,
+		UpdateContext: resourceEipBindUpdate,
+		DeleteContext: resourceEipBindDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceEipBindImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(eipBindNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"public_ip_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildCreateEipBindBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"action":       "BIND",
+		"public_ip":    d.Get("public_ip"),
+		"public_ip_id": d.Get("public_ip_id"),
+	}
+
+	return bodyParams
+}
+
+func resourceEipBindCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId    = d.Get("instance_id").(string)
+		nodeId        = d.Get("node_id").(string)
+		createHttpUrl = "v3/{project_id}/instances/{instance_id}/nodes/{node_id}/public-ip"
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{node_id}", nodeId)
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildCreateEipBindBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error binding EIP to GeminiDB instance node: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(nodeId)
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error binding EIP to GeminiDB instance node: unable to find job ID from API response")
+	}
+
+	err = checkGeminiDbInstanceJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the GeminiDB instance node bind EIP to complete: %s", err)
+	}
+
+	return resourceEipBindRead(ctx, d, meta)
+}
+
+func resourceEipBindRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	eipInfo, err := GetEipBindInfo(client, instanceId, d.Id())
+	if err != nil {
+		// When the GeminiDB instance does not exist, the response HTTP status code of the query API is 200
+		// and return empty list
+		return common.CheckDeletedDiag(d, err, "error retrieving the GeminiDB instance node EIP information")
+	}
+
+	ipAddress := utils.PathSearch("public_ip", eipInfo, "").(string)
+	if ipAddress == "" {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving the GeminiDB instance node EIP information")
+	}
+
+	var publicIpInfo interface{}
+	if ipAddress != "" {
+		vpcClient, err := cfg.NewServiceClient("vpc", region)
+		if err != nil {
+			return diag.Errorf("error creating VPC client: %s", err)
+		}
+
+		publicIpInfo, err = getAssociateEipInfo(vpcClient, ipAddress)
+		if err != nil {
+			log.Printf("[Warn] error retrieving the EIP information")
+		}
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("instance_id", instanceId),
+		d.Set("node_id", utils.PathSearch("id", eipInfo, nil)),
+		d.Set("public_ip", utils.PathSearch("public_ip", eipInfo, nil)),
+		d.Set("public_ip_id", utils.PathSearch("id", publicIpInfo, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func GetEipBindInfo(client *golangsdk.ServiceClient, instanceId, nodeId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/instances?id={instance_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getOpts := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	eipInfo := utils.PathSearch(fmt.Sprintf("instances[].groups[].nodes[]|[?id=='%s']|[0]", nodeId), respBody, nil)
+	if eipInfo == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return eipInfo, nil
+}
+
+func getAssociateEipInfo(client *golangsdk.ServiceClient, ipAddress string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/publicips?public_ip_address={public_ip_address}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{public_ip_address}", ipAddress)
+	getOpts := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	ipAddressInfo := utils.PathSearch("publicips|[0]", respBody, nil)
+	if ipAddressInfo == nil {
+		return nil, errors.New("error retrieving EIP information")
+	}
+
+	return ipAddressInfo, nil
+}
+
+func resourceEipBindUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func buildDeleteEipBindBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"action":       "UNBIND",
+		"public_ip":    d.Get("public_ip"),
+		"public_ip_id": d.Get("public_ip_id"),
+	}
+
+	return bodyParams
+}
+
+func resourceEipBindDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		nodeId     = d.Get("node_id").(string)
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/nodes/{node_id}/public-ip"
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{node_id}", nodeId)
+	deleteOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildDeleteEipBindBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "DBS.238009"),
+			"error unbinding EIP from GeminiDB instance node")
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error unbinding EIP from GeminiDB instance node: unable to find job ID from API response")
+	}
+
+	err = checkGeminiDbInstanceJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return diag.Errorf("error waiting for the GeminiDB instance node unbind EIP to complete: %s", err)
+	}
+
+	return nil
+}
+
+func resourceEipBindImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<id>', but got '%s'", importedId)
+	}
+
+	d.SetId(parts[1])
+
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add resource to manage GeminiDB instance node bind EIP.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new resource to manage GeminiDB instance node bind EIP.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o geminidb -f TestAccBindEip_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/geminidb" -v -coverprofile="./huaweicloud/services/acceptance/geminidb/geminidb_coverage.cov" -coverpkg="./huaweicloud/services/geminidb" -run TestAccBindEip_basic -timeout 360m -parallel 10
=== RUN   TestAccBindEip_basic
=== PAUSE TestAccBindEip_basic
=== CONT  TestAccBindEip_basic
--- PASS: TestAccBindEip_basic (1441.95s)
PASS
coverage: 10.9% of statements in ./huaweicloud/services/geminidb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1442.094s 
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/7eec5a9f-c522-4a75-80e5-bd2b0f872a42" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
<img width="738" height="206" alt="1111" src="https://github.com/user-attachments/assets/23b9ccba-35a7-432a-84cb-84688f751336" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
<img width="725" height="134" alt="222" src="https://github.com/user-attachments/assets/4724c7bb-2bf1-4386-91da-fd5cbf5757bb" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
