### PR TITLE
feat(apig): supports a new resource to manage AI API key

### DIFF
--- a/docs/resources/apig_application_ai_api_key.md
+++ b/docs/resources/apig_application_ai_api_key.md
@@ -1,0 +1,78 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_application_ai_api_key"
+description: |-
+  Manages an AI API key in application resource within HuaweiCloud.
+---
+
+# huaweicloud_apig_application_ai_api_key
+
+Manages an AI API key in application resource within HuaweiCloud.
+
+-> The `ai_api_key_enabled` feature must be enabled before the AI API key resource create.
+
+## Example Usage
+
+### Auto generate the AI API key value
+
+```hcl
+variable "instance_id" {}
+variable "application_id" {}
+
+resource "huaweicloud_apig_application_ai_api_key" "test" {
+  instance_id    = var.instance_id
+  application_id = var.application_id
+}
+```
+
+### Manually configure the AI API key value
+
+```hcl
+variable "instance_id" {}
+variable "application_id" {}
+
+resource "huaweicloud_apig_application_ai_api_key" "test" {
+  instance_id    = var.instance_id
+  application_id = var.application_id
+  value          = "bMQBWYxyln0J5QsePabHtDzN3h2n22HdzEcZbPfQNgs0tBytH5oCqcNFz7RKYcoU7lz44oo9H9uc7XeD3O5rjA"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the AI API key is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the dedicated instance to which the application
+  and AI API key belong.
+
+* `application_id` - (Required, String, NonUpdatable) Specifies the ID of the application to which the AI API key
+  belongs.
+
+* `alias` - (Optional, String, NonUpdatable) Specifies the alias of the AI API key.  
+  The value can contain `1` to `100` characters, including uppercase and lowercase letters, digits, underscores (_),
+  and hyphens (-).
+
+* `value` - (Optional, String, NonUpdatable) Specifies the value of the AI API key.  
+  The value can contain `8` to `128` characters, including uppercase and lowercase letters, digits, and the
+  following special characters: `+_-/=`.  
+  If omitted, a random value will be generated.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the AI API key.
+
+* `created_at` - The creation time of the AI API key, in RFC3339 format.
+
+## Import
+
+AI API keys can be imported using related `instance_id`, `application_id` and their `id`, separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_apig_application_ai_api_key.test <instance_id>/<application_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3068,6 +3068,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_appcode":                                    apig.ResourceAppcode(),
 			"huaweicloud_apig_application":                                apig.ResourceApigApplicationV2(),
 			"huaweicloud_apig_application_acl":                            apig.ResourceApplicationAcl(),
+			"huaweicloud_apig_application_ai_api_key":                     apig.ResourceApplicationAiApiKey(),
 			"huaweicloud_apig_application_authorization":                  apig.ResourceApplicationAuthorization(),
 			"huaweicloud_apig_application_quota":                          apig.ResourceApplicationQuota(),
 			"huaweicloud_apig_application_quota_associate":                apig.ResourceApplicationQuotaAssociate(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_ai_api_key_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_ai_api_key_test.go
@@ -1,0 +1,180 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+)
+
+func getApplicationAiApiKeyFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("apig", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG client: %s", err)
+	}
+	return apig.GetApplicationAiApiKey(client, state.Primary.Attributes["instance_id"],
+		state.Primary.Attributes["application_id"], state.Primary.ID)
+}
+
+func TestAccApplicationAiApiKey_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		autoGeneration   = "huaweicloud_apig_application_ai_api_key.auto_generate"
+		rcAutoGeneration = acceptance.InitResourceCheck(autoGeneration, &obj, getApplicationAiApiKeyFunc)
+
+		manuallyConfig   = "huaweicloud_apig_application_ai_api_key.manually_config"
+		rcManuallyConfig = acceptance.InitResourceCheck(manuallyConfig, &obj, getApplicationAiApiKeyFunc)
+
+		manuallyConfigWithAlias   = "huaweicloud_apig_application_ai_api_key.manually_config_with_alias"
+		rcManuallyConfigWithAlias = acceptance.InitResourceCheck(manuallyConfigWithAlias, &obj, getApplicationAiApiKeyFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source:            "hashicorp/random",
+				VersionConstraint: "3.0.0",
+			},
+		},
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcAutoGeneration.CheckResourceDestroy(),
+			rcManuallyConfig.CheckResourceDestroy(),
+			rcManuallyConfigWithAlias.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationAiApiKey_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					// The value of the AI API key is auto generated.
+					rcAutoGeneration.CheckResourceExists(),
+					resource.TestCheckResourceAttr(autoGeneration, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(autoGeneration, "application_id", "huaweicloud_apig_application.test", "id"),
+					resource.TestMatchResourceAttr(autoGeneration, "value", regexp.MustCompile(`^[a-zA-Z0-9_+/=-]{8,128}$`)),
+					resource.TestCheckResourceAttr(autoGeneration, "alias", ""),
+					resource.TestMatchResourceAttr(autoGeneration, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// The value of the AI API key is manually configured.
+					rcManuallyConfig.CheckResourceExists(),
+					resource.TestCheckResourceAttr(manuallyConfig, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(manuallyConfig, "application_id", "huaweicloud_apig_application.test", "id"),
+					resource.TestCheckResourceAttrPair(manuallyConfig, "value", "random_string.test.0", "result"),
+					resource.TestMatchResourceAttr(manuallyConfig, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttr(manuallyConfig, "alias", ""),
+					// The value of the AI API key is manually configured with alias.
+					rcManuallyConfigWithAlias.CheckResourceExists(),
+					resource.TestCheckResourceAttr(manuallyConfigWithAlias, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(manuallyConfigWithAlias, "application_id", "huaweicloud_apig_application.test", "id"),
+					resource.TestCheckResourceAttrPair(manuallyConfigWithAlias, "value", "random_string.test.1", "result"),
+					resource.TestMatchResourceAttr(manuallyConfigWithAlias, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttr(manuallyConfigWithAlias, "alias", name),
+				),
+			},
+			{
+				ResourceName:      autoGeneration,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApplicationAiApiKeyImportIdFunc(autoGeneration),
+			},
+			{
+				ResourceName:      manuallyConfig,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApplicationAiApiKeyImportIdFunc(manuallyConfig),
+			},
+			{
+				ResourceName:      manuallyConfigWithAlias,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApplicationAiApiKeyImportIdFunc(manuallyConfigWithAlias),
+			},
+		},
+	})
+}
+
+func testAccApplicationAiApiKey_basic(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_apig_instances" "test" {
+  instance_id = "%[1]s"
+}
+
+locals {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, null)
+}
+
+resource "huaweicloud_apig_instance_feature" "test" {
+  instance_id = local.instance_id
+  name        = "ai_api_key_enabled"
+  enabled     = true
+  config      = "{}"
+}
+
+resource "huaweicloud_apig_application" "test" {
+  depends_on = [huaweicloud_apig_instance_feature.test]
+
+  instance_id = local.instance_id
+  name        = "%[2]s"
+}
+
+resource "random_string" "test" {
+  count = 2
+
+  length           = 100
+  min_numeric      = 1
+  min_lower        = 1
+  min_upper        = 1
+  min_special      = 1
+  override_special = "-_+/="
+}
+
+resource "huaweicloud_apig_application_ai_api_key" "auto_generate" {
+  instance_id    = local.instance_id
+  application_id = huaweicloud_apig_application.test.id
+}
+
+resource "huaweicloud_apig_application_ai_api_key" "manually_config" {
+  instance_id    = local.instance_id
+  application_id = huaweicloud_apig_application.test.id
+  value          = random_string.test[0].result
+}
+
+resource "huaweicloud_apig_application_ai_api_key" "manually_config_with_alias" {
+  instance_id    = local.instance_id
+  application_id = huaweicloud_apig_application.test.id
+  value          = random_string.test[1].result
+  alias          = "%[2]s"
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+}
+
+func testAccApplicationAiApiKeyImportIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+		instanceId := rs.Primary.Attributes["instance_id"]
+		appId := rs.Primary.Attributes["application_id"]
+		aiApiKeyId := rs.Primary.ID
+		if instanceId == "" || appId == "" || aiApiKeyId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<application_id>/<id>', "+
+				"but got '%s/%s/%s'", instanceId, appId, aiApiKeyId)
+		}
+		return fmt.Sprintf("%s/%s/%s", instanceId, appId, aiApiKeyId), nil
+	}
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application_ai_api_key.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application_ai_api_key.go
@@ -1,0 +1,255 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var applicationAiApiKeyNonUpdatableParams = []string{
+	"instance_id",
+	"application_id",
+	"value",
+	"alias",
+}
+
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/ai-api-keys
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/ai-api-keys/{ai_api_key_id}
+// @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/ai-api-keys/{ai_api_key_id}
+func ResourceApplicationAiApiKey() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceApplicationAiApiKeyCreate,
+		ReadContext:   resourceApplicationAiApiKeyRead,
+		UpdateContext: resourceApplicationAiApiKeyUpdate,
+		DeleteContext: resourceApplicationAiApiKeyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceApplicationAiApiKeyImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(applicationAiApiKeyNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the AI API key is located.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the application and AI API key belong.`,
+			},
+			"application_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the application to which the AI API key belongs.`,
+			},
+
+			// Optional parameters.
+			"alias": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The alias of the AI API key.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Sensitive:   true,
+				Description: `The value of the AI API key.`,
+			},
+
+			// Attributes.
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the AI API key, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildApplicationAiApiKeyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"alias":      utils.ValueIgnoreEmpty(d.Get("alias")),
+		"ai_api_key": utils.ValueIgnoreEmpty(d.Get("value")),
+	}
+}
+
+func createApplicationAiApiKey(client *golangsdk.ServiceClient, instanceId, appId string,
+	d *schema.ResourceData) (interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/ai-api-keys"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{app_id}", appId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildApplicationAiApiKeyBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceApplicationAiApiKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		appId      = d.Get("application_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	respBody, err := createApplicationAiApiKey(client, instanceId, appId, d)
+	if err != nil {
+		return diag.Errorf("error creating AI API key: %s", err)
+	}
+
+	resourceId := utils.PathSearch("id", respBody, "").(string)
+	if resourceId == "" {
+		return diag.Errorf("unable to find the AI API key ID from the API response")
+	}
+	d.SetId(resourceId)
+
+	return resourceApplicationAiApiKeyRead(ctx, d, meta)
+}
+
+func GetApplicationAiApiKey(client *golangsdk.ServiceClient, instanceId, appId, aiApiKeyId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/ai-api-keys/{ai_api_key_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath = strings.ReplaceAll(getPath, "{app_id}", appId)
+	getPath = strings.ReplaceAll(getPath, "{ai_api_key_id}", aiApiKeyId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceApplicationAiApiKeyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		appId      = d.Get("application_id").(string)
+		aiApiKeyId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	respBody, err := GetApplicationAiApiKey(client, instanceId, appId, aiApiKeyId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying AI API key (%s) from application (%s)", aiApiKeyId, appId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("value", utils.PathSearch("ai_api_key", respBody, nil)),
+		d.Set("alias", utils.PathSearch("alias", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
+			respBody, "").(string))/1000, false)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceApplicationAiApiKeyUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func deleteApplicationAiApiKey(client *golangsdk.ServiceClient, instanceId, appId, aiApiKeyId string) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/ai-api-keys/{ai_api_key_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{app_id}", appId)
+	deletePath = strings.ReplaceAll(deletePath, "{ai_api_key_id}", aiApiKeyId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceApplicationAiApiKeyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		appId      = d.Get("application_id").(string)
+		aiApiKeyId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	err = deleteApplicationAiApiKey(client, instanceId, appId, aiApiKeyId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting AI API key (%s) from application (%s)", aiApiKeyId, appId))
+	}
+	return nil
+}
+
+func resourceApplicationAiApiKeyImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.SplitN(importedId, "/", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<application_id>/<id>', "+
+			"but got '%s'", importedId)
+	}
+
+	d.SetId(parts[2])
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+		d.Set("application_id", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to manage the AI API key under an application.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1031" height="178" alt="image" src="https://github.com/user-attachments/assets/78dc678b-84f0-44b0-ab8b-19e3ec9e00b0" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports a new resource to manage AI API key under an application
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccApplicationAiApiKey_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApplicationAiApiKey_basic -timeout 360m -parallel 10
=== RUN   TestAccApplicationAiApiKey_basic
=== PAUSE TestAccApplicationAiApiKey_basic
=== CONT  TestAccApplicationAiApiKey_basic
--- PASS: TestAccApplicationAiApiKey_basic (109.84s)
PASS
coverage: 4.3% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      109.947s        coverage: 4.3% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="2004" height="851" alt="image" src="https://github.com/user-attachments/assets/1cc752e1-4efe-49c3-bbcb-6f860b8d1f64" />

    ab. Related resources (parent resources) not found
    1. instance not found
    <img width="2047" height="859" alt="image" src="https://github.com/user-attachments/assets/1df20900-4f48-48a8-a480-2d57b6b5c2fe" />

    2. application not found
    <img width="2040" height="854" alt="image" src="https://github.com/user-attachments/assets/6a2c33d1-3a70-40c5-ad8f-b5a04298d45a" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="2023" height="867" alt="image" src="https://github.com/user-attachments/assets/e11157e0-c059-42fa-bc84-27d073810d65" />

    bb. Related resources (parent resources) not found
    1. instance not found
    <img width="2011" height="848" alt="image" src="https://github.com/user-attachments/assets/cbd08754-8c4b-4237-a66b-4ffb03f0334b" />

    2. application not found
    <img width="1982" height="883" alt="image" src="https://github.com/user-attachments/assets/0a1d59c9-a704-4477-b892-3e7ed3f61a04" />
