### PR TITLE
feat(gaussdb): add instance status statistics data source

### DIFF
--- a/docs/data-sources/gaussdb_instance_status_statistics.md
+++ b/docs/data-sources/gaussdb_instance_status_statistics.md
@@ -1,0 +1,40 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_instance_status_statistics"
+description: |-
+  Use this data source to query GaussDB instance status statistics within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_instance_status_statistics
+
+Use this data source to query GaussDB instance status statistics within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_gaussdb_instance_status_statistics" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances_statistics` - The list of instance status statistics.
+  The [instances_statistics](#instances_statistics_struct) structure is documented below.
+
+<a name="instances_statistics_struct"></a>
+The `instances_statistics` block supports:
+
+* `status` - The instance status.
+
+* `count` - The number of instances in this status.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1533,6 +1533,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_gaussdb_alarms":                          gaussdb.DataSourceAlarms(),
 			"huaweicloud_gaussdb_instance_alarm_statistics":       gaussdb.DataSourceInstanceAlarmStatistics(),
+			"huaweicloud_gaussdb_instance_status_statistics":      gaussdb.DataSourceInstanceStatusStatistics(),
 			"huaweicloud_gaussdb_storage_types":                   gaussdb.DataSourceGaussDbStorageTypes(),
 			"huaweicloud_gaussdb_datastores":                      gaussdb.DataSourceGaussDbDatastores(),
 			"huaweicloud_gaussdb_flavors":                         gaussdb.DataSourceGaussDbFlavors(),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_instance_status_statistics_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_instance_status_statistics_test.go
@@ -1,0 +1,41 @@
+package gaussdb
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceInstanceStatusStatistics_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_gaussdb_instance_status_statistics.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(
+		t, resource.TestCase{
+			PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+			ProviderFactories: acceptance.TestAccProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: testDataSourceInstanceStatusStatistics_basic(),
+					Check: resource.ComposeTestCheckFunc(
+						dc.CheckResourceExists(),
+						resource.TestMatchResourceAttr(dataSource, "instances_statistics.#", regexp.MustCompile(`^[0-9]+$`)),
+						resource.TestCheckResourceAttrSet(dataSource, "instance_status_statistics.0.status"),
+						resource.TestCheckResourceAttrSet(dataSource, "instance_status_statistics.0.count"),
+					),
+				},
+			},
+		},
+	)
+}
+
+func testDataSourceInstanceStatusStatistics_basic() string {
+	return `
+data "huaweicloud_gaussdb_instance_status_statistics" "test" {}
+`
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_instance_status_statistics.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_instance_status_statistics.go
@@ -1,0 +1,113 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB GET /v3/instances-statistics
+func DataSourceInstanceStatusStatistics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceStatusStatisticsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instances_statistics": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     instanceStatusStatisticsSchema(),
+			},
+		},
+	}
+}
+
+func instanceStatusStatisticsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceInstanceStatusStatisticsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("opengauss", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	httpUrl := "v3/instances-statistics"
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return diag.Errorf("error querying instance status statistics: %s", err)
+	}
+
+	resp, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.Errorf("error flattening response: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("instances_statistics", flattenInstanceStatusStatistics(resp)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+func flattenInstanceStatusStatistics(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("instances_statistics", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	res := make([]interface{}, 0, len(curArray))
+
+	for _, v := range curArray {
+		res = append(res, map[string]interface{}{
+			"status": utils.PathSearch("status", v, nil),
+			"count":  utils.PathSearch("count", v, nil),
+		})
+	}
+	return res
+}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source `(huaweicloud_gaussdb_instance_status_statistics) ` to query instance status statistics.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  add a new data source huaweicloud_gaussdb_instance_status_statistics for GaussDB.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o gaussdb -f TestAccDataSourceInstanceStatusStatistics_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/gaussdb" -v -coverprofile="./huaweicloud/services/acceptance/gaussdb/gaussdb_coverage.cov" -coverpkg="./huaweicloud/services/gaussdb" -run TestAccDataSourceInstanceStatusStatistics_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceInstanceStatusStatistics_basic
=== PAUSE TestAccDataSourceInstanceStatusStatistics_basic
=== CONT  TestAccDataSourceInstanceStatusStatistics_basic
--- PASS: TestAccDataSourceInstanceStatusStatistics_basic (20.29s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/gaussdb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   20.583s coverage: 3.0% of statements in ./huaweicloud/services/gaussdb

```
<img width="1024" height="27" alt="status-statistics" src="https://github.com/user-attachments/assets/443928cb-6e12-41c8-8912-ec1f976bda1e" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
