### PR TITLE
feat(GeminiDB): add resource to delete enlarge failed GeminiDB instance node

### DIFF
--- a/docs/incubating/geminidb_enlarge_fail_node_delete.md
+++ b/docs/incubating/geminidb_enlarge_fail_node_delete.md
@@ -1,0 +1,52 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_enlarge_fail_node_delete"
+description: |-
+  Manages a resource to delete GeminiDB instance enlarge failed node within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_enlarge_fail_node_delete
+
+Manages a resource to delete GeminiDB instance enlarge failed node within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource. Deleting this resource will not clear the corresponding request
+  record, but will only remove the resource information from the tf state file.
+  <br/>2. The instance types that support the database patch upgrade are as follows:
+  **GeminiDB Cassandra**, **GeminiDB Redis**.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+
+resource "huaweicloud_geminidb_enlarge_fail_node_delete" "test" {
+  instance_id = var.instance_id
+  node_id     = var.node_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the instance ID.
+
+* `node_id` - (Required, String, NonUpdatable) Specifies the node ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3810,6 +3810,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_backup_stop":                geminidb.ResourceGeminiDBBackupStop(),
 			"huaweicloud_geminidb_database_operation":         geminidb.ResourceGeminiDBDatabaseOperation(),
 			"huaweicloud_geminidb_database_upgrade":           geminidb.ResourceDatabaseUpgrade(),
+			"huaweicloud_geminidb_enlarge_fail_node_delete":   geminidb.ResourceEnlargeFailNodeDelete(),
 			"huaweicloud_geminidb_instance":                   geminidb.ResourceGeminiDbInstance(),
 			"huaweicloud_geminidb_instance_restart":           geminidb.ResourceInstanceRestart(),
 			"huaweicloud_geminidb_memory_mapping":             geminidb.ResourceMemoryMapping(),

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_enlarge_fail_node_delete_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_enlarge_fail_node_delete_test.go
@@ -1,0 +1,39 @@
+package geminidb
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Due to the lack of testing conditions, only the error situations of API calls were verified.
+func TestAccEnlargeFailNodeDelete_basic(t *testing.T) {
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccCheckGeminidbInstanceID(t)
+			acceptance.TestAccPreCheckGeminiDBNodeId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testEnlargeFailNodeDelete_basic(),
+				ExpectError: regexp.MustCompile("error deleting GeminiDB instance enlarge failed node"),
+			},
+		},
+	})
+}
+
+func testEnlargeFailNodeDelete_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_geminidb_enlarge_fail_node_delete" "test" {
+  instance_id = "%[1]s"
+  node_id     = "%[2]s"
+}
+`, acceptance.HW_GEMINIDB_INSATNCE_ID, acceptance.HW_GEMINIDB_NODE_ID)
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_enlarge_fail_node_delete.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_enlarge_fail_node_delete.go
@@ -1,0 +1,137 @@
+package geminidb
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var enlargeFailNodeDeleteNonUpdatableParams = []string{
+	"instance_id",
+	"node_id",
+}
+
+// @API GeminiDB DELETE /v3/{project_id}/instances/{instance_id}/enlarge-failed-nodes
+func ResourceEnlargeFailNodeDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEnlargeFailNodeDeleteCreate,
+		ReadContext:   resourceEnlargeFailNodeDeleteRead,
+		UpdateContext: resourceEnlargeFailNodeDeleteUpdate,
+		DeleteContext: resourceEnlargeFailNodeDeleteDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(enlargeFailNodeDeleteNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildEnlargeFailNodeDeleteBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"node_id": d.Get("node_id"),
+	}
+
+	return bodyParams
+}
+
+func resourceEnlargeFailNodeDeleteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/instances/{instance_id}/enlarge-failed-nodes"
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", d.Get("instance_id").(string))
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildEnlargeFailNodeDeleteBodyParams(d),
+	}
+
+	resp, err := client.Request("DELETE", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error deleting GeminiDB instance enlarge failed node: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error deleting GeminiDB instance enlarge failed node: unable to find job ID from API response")
+	}
+
+	d.SetId(jobId)
+
+	err = checkGeminiDbInstanceJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for delete enlarge failed node to complete: %s", err)
+	}
+
+	return nil
+}
+
+func resourceEnlargeFailNodeDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceEnlargeFailNodeDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Update()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceEnlargeFailNodeDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GeminiDB enlarge failed node resource is not supported. The resource is only removed from the " +
+		"state, the resource remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add resource to delete enlarge failed GeminiDB instance node.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.add resource to delete enlarge failed GeminiDB instance node.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
