### PR TITLE
fix(apig): repair the misspell words and set region value in read context

### DIFF
--- a/huaweicloud/services/apig/common.go
+++ b/huaweicloud/services/apig/common.go
@@ -14,7 +14,7 @@ type requestErr struct {
 	ErrMsg string `json:"error_msg"`
 }
 
-// The APIG API is limited to only one attach operation at a time for standrad policy and plugin policy.
+// The APIG API is limited to only one attach operation at a time for standard policy and plugin policy.
 // In addition to locking and waiting between multiple operations, a retry method is required to ensure that the
 // request can be executed correctly.
 func handleMultiOperationsError(err error) (bool, error) {

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_acl_policy_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_acl_policy_associate.go
@@ -214,7 +214,11 @@ func resourceAclPolicyAssociateRead(_ context.Context, d *schema.ResourceData, m
 		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 	}
 
-	return diag.FromErr(d.Set("publish_ids", flattenApiPublishIdsForAclPolicy(resp)))
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("publish_ids", flattenApiPublishIdsForAclPolicy(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func aclPolicyUnbindingRefreshFunc(client *golangsdk.ServiceClient, instanceId, policyId string,

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api_publishment.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api_publishment.go
@@ -288,7 +288,8 @@ func getPublishIdByEnvId(client *golangsdk.ServiceClient, instanceId, apiId, env
 // ResourceApiPublishmentRead is a method to obtain informations of API publishment and save to the local storage.
 func ResourceApiPublishmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	region := cfg.GetRegion(d)
+	client, err := cfg.ApigV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -308,6 +309,7 @@ func ResourceApiPublishmentRead(_ context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 	mErr := multierror.Append(nil,
+		d.Set("region", region),
 		d.Set("env_id", publishInfo.EnvId),
 		d.Set("api_id", publishInfo.ApiId),
 		d.Set("description", publishInfo.Description),

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_channel_member.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_channel_member.go
@@ -251,6 +251,7 @@ func resourceChannelMemberRead(_ context.Context, d *schema.ResourceData, meta i
 	}
 
 	mErr := multierror.Append(
+		d.Set("region", region),
 		d.Set("port", utils.PathSearch("port", member, nil)),
 		d.Set("member_ip_address", utils.PathSearch("host", member, nil)),
 		d.Set("ecs_id", utils.PathSearch("ecs_id", member, nil)),

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_channel_member_group.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_channel_member_group.go
@@ -270,6 +270,7 @@ func resourceChannelMemberGroupRead(_ context.Context, d *schema.ResourceData, m
 	}
 
 	mErr := multierror.Append(
+		d.Set("region", region),
 		d.Set("name", utils.PathSearch("member_group_name", memberGroup, nil)),
 		d.Set("description", utils.PathSearch("member_group_remark", memberGroup, nil)),
 		d.Set("weight", utils.PathSearch("member_group_weight", memberGroup, nil)),

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -644,7 +644,7 @@ func queryInstanceTags(client *golangsdk.ServiceClient, instanceId string) inter
 
 	requestResp, err := client.Request("GET", createPath, &opt)
 	if err != nil {
-		log.Printf("[WARN] error qeurying tag list of the dedicated instance (%s): %s", instanceId, err)
+		log.Printf("[WARN] error querying tag list of the dedicated instance (%s): %s", instanceId, err)
 		return nil
 	}
 	respBody, err := utils.FlattenResponse(requestResp)
@@ -668,7 +668,7 @@ func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interf
 	instanceId := d.Id()
 	respBody, err := QueryInstanceDetail(client, instanceId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error qeurying dedicated instance (%s) detail", instanceId))
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying dedicated instance (%s) detail", instanceId))
 	}
 
 	extraElbs, err := getInstanceExtraElbs(client, instanceId)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance_feature.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance_feature.go
@@ -215,6 +215,7 @@ func resourceInstanceFeatureRead(_ context.Context, d *schema.ResourceData, meta
 	}
 
 	mErr := multierror.Append(nil,
+		d.Set("region", region),
 		d.Set("name", utils.PathSearch("name", feature, nil)),
 		d.Set("enabled", utils.PathSearch("enable", feature, false)),
 		d.Set("config", utils.PathSearch("config", feature, nil)),

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance_routes.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance_routes.go
@@ -101,7 +101,8 @@ func resourceInstanceRoutesCreate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceInstanceRoutesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	region := cfg.GetRegion(d)
+	client, err := cfg.ApigV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating APIG V2 client: %s", err)
 	}
@@ -134,7 +135,11 @@ func resourceInstanceRoutesRead(_ context.Context, d *schema.ResourceData, meta 
 		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "Instance routes")
 	}
 
-	return diag.FromErr(d.Set("nexthops", result.UserRoutes))
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("nexthops", result.UserRoutes),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func resourceInstanceRoutesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_signature.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_signature.go
@@ -116,7 +116,8 @@ func resourceSignatureCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 func resourceSignatureRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	region := cfg.GetRegion(d)
+	client, err := cfg.ApigV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %s", err)
 	}
@@ -140,6 +141,7 @@ func resourceSignatureRead(_ context.Context, d *schema.ResourceData, meta inter
 
 	signature := resp[0]
 	mErr := multierror.Append(nil,
+		d.Set("region", region),
 		d.Set("name", signature.Name),
 		d.Set("type", signature.SignType),
 		d.Set("key", signature.SignKey),

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_signature_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_signature_associate.go
@@ -214,7 +214,11 @@ func resourceSignatureAssociateRead(_ context.Context, d *schema.ResourceData, m
 		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 	}
 
-	return diag.FromErr(d.Set("publish_ids", flattenApiPublishIdsForSignature(resp)))
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("publish_ids", flattenApiPublishIdsForSignature(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func signatureUnbindingRefreshFunc(client *golangsdk.ServiceClient, instanceId, signId string,

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_throttling_policy_associate.go
@@ -196,7 +196,8 @@ func flattenApiPublishIds(apiList []throttles.ApiForThrottle) []string {
 func resourceThrottlingPolicyAssociateRead(_ context.Context, d *schema.ResourceData,
 	meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	region := cfg.GetRegion(d)
+	client, err := cfg.ApigV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating APIG v2 client: %v", err)
 	}
@@ -215,7 +216,10 @@ func resourceThrottlingPolicyAssociateRead(_ context.Context, d *schema.Resource
 		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 	}
 
-	mErr := multierror.Append(nil, d.Set("publish_ids", flattenApiPublishIds(resp)))
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("publish_ids", flattenApiPublishIds(resp)),
+	)
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There are some resources are missing region's setting and found some misspell words.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update some misspell words
2. set region if resource is not one-time action resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
