### PR TITLE
feat(TaurusDB): action resource to upgrade db version of Htap StarRocks instance

### DIFF
--- a/docs/resources/taurusdb_htap_starrocks_instance_upgrade.md
+++ b/docs/resources/taurusdb_htap_starrocks_instance_upgrade.md
@@ -1,0 +1,65 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_htap_starrocks_instance_upgrade"
+description: |-
+  Use this resource to upgrade the kernel version of a TaurusDB HTAP StarRocks instance within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_htap_starrocks_instance_upgrade
+
+Use this resource to upgrade the kernel version of a TaurusDB HTAP StarRocks instance within HuaweiCloud.
+
+-> This resource is a one-time action resource to upgrade the kernel version of a StarRocks instance. Deleting this
+   resource will not clear the corresponding request record, but will only remove the resource information from the
+   tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "starrocks_instance_id" {}
+
+resource "huaweicloud_taurusdb_htap_starrocks_instance_upgrade" "test" {
+  instance_id           = var.instance_id
+  starrocks_instance_id = var.starrocks_instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the TaurusDB instance ID to which the StarRocks
+  instance belongs.
+
+* `starrocks_instance_id` - (Required, String, NonUpdatable) Specifies the StarRocks instance ID.
+
+* `delay` - (Optional, String, NonUpdatable) Specifies whether to delay the upgrade.
+  The valid values are as follows:
+  + **true**
+  + **false**
+
+  Defaults to **false**.
+
+* `is_skip_validate` - (Optional, String, NonUpdatable) Specifies whether to skip upgrade verification.
+  The valid values are as follows:
+  + **true**
+  + **false**
+
+  Defaults to **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4531,6 +4531,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_instant_task_delete":             taurusdb.ResourceTaurusDBInstantTaskDelete(),
 			"huaweicloud_taurusdb_node_sessions_kill":              taurusdb.ResourceTaurusDBNodeSessionsKill(),
 			"huaweicloud_taurusdb_htap_starrocks_instance_restart": taurusdb.ResourceTaurusDBHtapStarrocksInstanceRestart(),
+			"huaweicloud_taurusdb_htap_starrocks_instance_upgrade": taurusdb.ResourceTaurusDBHtapStarrocksInstanceUpgrade(),
 			"huaweicloud_taurusdb_htap_starrocks_node_restart":     taurusdb.ResourceTaurusDBHtapStarrocksNodeRestart(),
 
 			"huaweicloud_tms_resource_tags": tms.ResourceResourceTags(),

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance_upgrade_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance_upgrade_test.go
@@ -1,0 +1,43 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTaurusDBHtapStarrocksInstanceUpgrade_basic(t *testing.T) {
+	resourceName := "huaweicloud_taurusdb_htap_starrocks_instance_upgrade.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBInstanceId(t)
+			acceptance.TestAccPreCheckTaurusDBHtapInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaurusDBHtapStarrocksInstanceUpgrade_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTaurusDBHtapStarrocksInstanceUpgrade_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_taurusdb_htap_starrocks_instance_upgrade" "test" {
+  instance_id           = "%[1]s"
+  starrocks_instance_id = "%[2]s"
+  delay                 = "true"
+  is_skip_validate      = "true"
+}
+`, acceptance.HW_TAURUSDB_INSTANCE_ID, acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID)
+}

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance_upgrade.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance_upgrade.go
@@ -1,0 +1,180 @@
+package taurusdb
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var starrocksInstanceUpgradeNoneUpdatableParams = []string{
+	"instance_id", "starrocks_instance_id", "delay", "is_skip_validate",
+}
+
+// @API TaurusDB POST /v3/{project_id}/instances/{instance_id}/starrocks/db-upgrade
+// @API TaurusDB GET /v3/{project_id}/jobs
+func ResourceTaurusDBHtapStarrocksInstanceUpgrade() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTaurusDBHtapStarrocksInstanceUpgradeCreate,
+		ReadContext:   resourceTaurusDBHtapStarrocksInstanceUpgradeRead,
+		UpdateContext: resourceTaurusDBHtapStarrocksInstanceUpgradeUpdate,
+		DeleteContext: resourceTaurusDBHtapStarrocksInstanceUpgradeDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(starrocksInstanceUpgradeNoneUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"starrocks_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"delay": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"true", "false",
+				}, false),
+			},
+			"is_skip_validate": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"true", "false",
+				}, false),
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceTaurusDBHtapStarrocksInstanceUpgradeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	jobId, err := upgradeStarrocksInstance(ctx, d, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	err = checkGaussDBMySQLJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for upgrading StarRocks instance job (%s) to complete: %s", jobId, err)
+	}
+	return nil
+}
+
+func upgradeStarrocksInstance(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) (string, error) {
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/starrocks/db-upgrade"
+	)
+
+	instanceId := d.Get("instance_id").(string)
+	starrocksInstanceId := d.Get("starrocks_instance_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	createOpt.JSONBody = utils.RemoveNil(buildUpgradeStarrocksInstanceBodyParams(d))
+
+	retryFunc := func() (interface{}, bool, error) {
+		res, err := client.Request("POST", createPath, &createOpt)
+		retry, err := handleMultiOperationsError(err)
+		return res, retry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     htapInstanceStateRefreshFunc(client, instanceId, starrocksInstanceId),
+		WaitTarget:   []string{"normal"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error upgrading TaurusDB Htap StarRocks instance(%s): %s", starrocksInstanceId, err)
+	}
+	createRespBody, err := utils.FlattenResponse(r.(*http.Response))
+	if err != nil {
+		return "", err
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
+	if jobId == "" {
+		return "", fmt.Errorf("error upgrading StarRocks instance(%s), job_id is not found in the response",
+			starrocksInstanceId)
+	}
+
+	return jobId, nil
+}
+
+func buildUpgradeStarrocksInstanceBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"delay":            d.Get("delay"),
+		"is_skip_validate": d.Get("is_skip_validate"),
+	}
+	return bodyParams
+}
+
+func resourceTaurusDBHtapStarrocksInstanceUpgradeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceTaurusDBHtapStarrocksInstanceUpgradeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceTaurusDBHtapStarrocksInstanceUpgradeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting upgrade resource is not supported. The upgrade resource is only removed from the state," +
+		" the StarRocks instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
action resource to upgrade db version of Htap StarRocks instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
action resource to upgrade db version of Htap StarRocks instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.
Test failed with error message: {"error_msg":"The current version is the latest. No update is available.","error_code":"DBS.05000008"}

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccTaurusDBHtapStarrocksInstanceUpgrade'
=== RUN   TestAccTaurusDBHtapStarrocksInstanceUpgrade_basic
=== PAUSE TestAccTaurusDBHtapStarrocksInstanceUpgrade_basic
=== CONT  TestAccTaurusDBHtapStarrocksInstanceUpgrade_basic   
--- FAIL: TestAccTaurusDBHtapStarrocksInstanceUpgrade_basic (20.72s)
FAILED
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 20.826s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
