### PR TITLE
feat(obs): bucket object resource and data source supports tags

### DIFF
--- a/docs/data-sources/obs_bucket_object.md
+++ b/docs/data-sources/obs_bucket_object.md
@@ -49,3 +49,5 @@ In addition to all arguments above, the following attributes are exported:
 * `body` - The content of an object which is available only for objects which have a human-readable Content-Type
   (text/* and application/json) and smaller than **64KB**. This is to prevent printing unsafe characters and
   potentially downloading large amount of data.
+
+* `tags` - The key/value pairs associated with the object.

--- a/docs/resources/obs_bucket_object.md
+++ b/docs/resources/obs_bucket_object.md
@@ -77,6 +77,8 @@ The following arguments are supported:
 * `etag` - (Optional, String) Specifies the unique identifier of the object content. It can be used to trigger updates.
   The only meaningful value is `md5(file("path_to_file"))`.
 
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the object.
+
 Either `source` or `content` must be provided to specify the bucket content. These two arguments are mutually-exclusive.
 
 ## Attribute Reference
@@ -99,18 +101,18 @@ $ terraform import huaweicloud_obs_bucket_object.object bucket/key
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `encryption`, `source`, `acl` and
+API response, security or some other reason. The missing attributes include: `encryption`, `source`, `content`, `acl` and
 `kms_key_id`. It is generally recommended running `terraform plan` after importing an object.
 You can then decide if changes should be applied to the object, or the resource
 definition should be updated to align with the object. Also you can ignore changes as below.
 
 ```hcl
 resource "huaweicloud_obs_bucket_object" "object" {
-    ...
+  ...
 
   lifecycle {
     ignore_changes = [
-      encryption, source, acl, kms_key_id,
+      encryption, source, content, acl, kms_key_id
     ]
   }
 }

--- a/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
@@ -39,6 +39,7 @@ func TestAccObsBucketObjectDataSource_content(t *testing.T) {
 					testAccCheckObsObjectDataSourceExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "content_type", "binary/octet-stream"),
 					resource.TestCheckResourceAttr(dataSourceName, "storage_class", "STANDARD"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.foo", "bar"),
 				),
 			},
 		},
@@ -176,6 +177,10 @@ resource "huaweicloud_obs_bucket_object" "object" {
   bucket  = huaweicloud_obs_bucket.object_bucket.bucket
   key     = "test-key-%d"
   content = "some_bucket_content"
+
+  tags = {
+    foo = "bar"
+  }
 }
 `, randInt, randInt)
 

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
@@ -3,9 +3,9 @@ package obs
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -16,8 +16,8 @@ import (
 )
 
 func TestAccObsBucketObject_source(t *testing.T) {
-	rInt := acctest.RandInt()
-	resourceName := "huaweicloud_obs_bucket_object.object"
+	name := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_obs_bucket_object.test"
 
 	tmpFile, err := os.CreateTemp("", "tf-acc-obs-obj-source")
 	if err != nil {
@@ -40,26 +40,30 @@ func TestAccObsBucketObject_source(t *testing.T) {
 		CheckDestroy:      testAccCheckObsBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObsBucketObjectConfigSource(rInt, tmpFile.Name()),
+				Config: testAccObsBucketObjectConfigSource(name, tmpFile.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObsBucketObjectExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "key", "test-key"),
+					resource.TestCheckResourceAttr(resourceName, "key", name),
 					resource.TestCheckResourceAttr(resourceName, "content_type", "binary/octet-stream"),
 					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
 			},
 			{
 				// update with encryption
-				Config: testAccObsBucketObjectConfig_withSSE(rInt, tmpFile.Name()),
+				Config: testAccObsBucketObjectConfig_withSSE(name, tmpFile.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccObsBucketObjecImportStateIdFunc(),
+				ImportStateIdFunc: testAccBucketObjectImportStateIdFunc(),
 				ImportStateVerifyIgnore: []string{
 					"encryption", "source",
 				},
@@ -69,8 +73,8 @@ func TestAccObsBucketObject_source(t *testing.T) {
 }
 
 func TestAccObsBucketObject_content(t *testing.T) {
-	rInt := acctest.RandInt()
-	resourceName := "huaweicloud_obs_bucket_object.object"
+	name := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_obs_bucket_object.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -81,13 +85,30 @@ func TestAccObsBucketObject_content(t *testing.T) {
 		CheckDestroy:      testAccCheckObsBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() {},
-				Config:    testAccObsBucketObjectConfigContent(rInt),
+				Config: testAccBucketObjectConfigContent_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObsBucketObjectExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "key", "test-key"),
-					resource.TestCheckResourceAttr(resourceName, "size", "19"),
+					resource.TestCheckResourceAttr(resourceName, "key", name),
+					resource.TestMatchResourceAttr(resourceName, "size", regexp.MustCompile("^[1-9][0-9]*$")),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
+			},
+			{
+				Config: testAccBucketObjectConfigContent_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBucketObjectImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"content",
+				},
 			},
 		},
 	})
@@ -177,13 +198,13 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccObsBucketObjecImportStateIdFunc() resource.ImportStateIdFunc {
+func testAccBucketObjectImportStateIdFunc() resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
-		bucket, ok := s.RootModule().Resources["huaweicloud_obs_bucket.object_bucket"]
+		bucket, ok := s.RootModule().Resources["huaweicloud_obs_bucket.test"]
 		if !ok {
 			return "", fmt.Errorf("Bucket not found: %s", bucket)
 		}
-		object, ok := s.RootModule().Resources["huaweicloud_obs_bucket_object.object"]
+		object, ok := s.RootModule().Resources["huaweicloud_obs_bucket_object.test"]
 		if !ok {
 			return "", fmt.Errorf("Object not found: %s", object)
 		}
@@ -194,47 +215,77 @@ func testAccObsBucketObjecImportStateIdFunc() resource.ImportStateIdFunc {
 	}
 }
 
-func testAccObsBucketObjectConfigSource(randInt int, source string) string {
+func testAccBucketObject_base(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_obs_bucket" "object_bucket" {
-  bucket = "tf-acc-test-bucket-%d"
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[1]s"
+  acl           = "private"
+  force_destroy = true
+}
+`, name)
 }
 
-resource "huaweicloud_obs_bucket_object" "object" {
-  bucket       = huaweicloud_obs_bucket.object_bucket.bucket
-  key          = "test-key"
-  source       = "%s"
+func testAccObsBucketObjectConfigSource(name, source string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "%[2]s"
+  source       = "%[3]s"
   content_type = "binary/octet-stream"
+
+  tags = {
+    foo = "bar"
+  }
 }
-`, randInt, source)
+`, testAccBucketObject_base(name), name, source)
 }
 
-func testAccObsBucketObjectConfigContent(randInt int) string {
+func testAccObsBucketObjectConfig_withSSE(name, source string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_obs_bucket" "object_bucket" {
-  bucket = "tf-acc-test-bucket-%d"
+%[1]s
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "%[2]s"
+  source       = "%[3]s"
+  content_type = "binary/octet-stream"
+  encryption   = true
+
+  tags = {
+    owner = "terraform"
+  }
+}
+`, testAccBucketObject_base(name), name, source)
 }
 
-resource "huaweicloud_obs_bucket_object" "object" {
-  bucket  = huaweicloud_obs_bucket.object_bucket.bucket
-  key     = "test-key"
+func testAccBucketObjectConfigContent_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket  = huaweicloud_obs_bucket.test.bucket
+  key     = "%[2]s"
   content = "some_bucket_content"
+
+  tags = {
+    foo = "bar"
+  }
 }
-`, randInt)
+`, testAccBucketObject_base(name), name)
 }
 
-func testAccObsBucketObjectConfig_withSSE(randInt int, source string) string {
+func testAccBucketObjectConfigContent_step2(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_obs_bucket" "object_bucket" {
-  bucket = "tf-acc-test-bucket-%d"
-}
+%[1]s
 
-resource "huaweicloud_obs_bucket_object" "object" {
-bucket       = huaweicloud_obs_bucket.object_bucket.bucket
-key          = "test-key"
-source       = "%s"
-content_type = "binary/octet-stream"
-encryption   = true
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket  = huaweicloud_obs_bucket.test.bucket
+  key     = "%[2]s"
+  content = "update_some_bucket_content"
+
+  tags = {}
 }
-`, randInt, source)
+`, testAccBucketObject_base(name), name)
 }

--- a/huaweicloud/services/obs/data_source_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/services/obs/data_source_huaweicloud_obs_bucket_object.go
@@ -13,11 +13,13 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/obs"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
 // @API OBS HEAD /{ObjectName}
 // @API OBS GET /{ObjectName}
+// @API OBS GET /{ObjectName}?tagging
 func DataSourceObsBucketObject() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceObsBucketObjectRead,
@@ -62,6 +64,7 @@ func DataSourceObsBucketObject() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"tags": common.TagsComputedSchema(`The key/value pairs associated with the object.`),
 		},
 	}
 }
@@ -99,6 +102,11 @@ func dataSourceObsBucketObjectRead(_ context.Context, d *schema.ResourceData, me
 		class = normalizeStorageClass(class)
 	}
 
+	tags, err := getBucketObjectTags(obsClient, bucket, key, objectMeta.VersionId)
+	if err != nil {
+		log.Printf("[ERROR] error getting tags of bucket object(%s/%s): %s", bucket, key, err)
+	}
+
 	size := objectMeta.ContentLength
 	mErr := multierror.Append(
 		d.Set("region", region),
@@ -107,6 +115,7 @@ func dataSourceObsBucketObjectRead(_ context.Context, d *schema.ResourceData, me
 		d.Set("etag", strings.Trim(objectMeta.ETag, `"`)),
 		d.Set("version_id", objectMeta.VersionId),
 		d.Set("content_type", objectMeta.ContentType),
+		d.Set("tags", tags),
 	)
 
 	// body is available only for objects which have a human-readable Content-Type

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/obs"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
@@ -21,11 +22,14 @@ import (
 // @API OBS HEAD /{ObjectName}
 // @API OBS PUT /{ObjectName}
 // @API OBS DELETE /{ObjectName}
+// @API OBS PUT /{ObjectName}?tagging
+// @API OBS GET /{ObjectName}?tagging
+// @API OBS DELETE /{ObjectName}?tagging
 func ResourceObsBucketObject() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceObsBucketObjectPut,
+		CreateContext: resourceObsBucketObjectCreate,
 		ReadContext:   resourceObsBucketObjectRead,
-		UpdateContext: resourceObsBucketObjectPut,
+		UpdateContext: resourceObsBucketObjectUpdate,
 		DeleteContext: resourceObsBucketObjectDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceObsBucketObjectImport,
@@ -95,6 +99,7 @@ func ResourceObsBucketObject() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"tags": common.TagsSchema(`The key/value pairs to associate with the object.`),
 
 			"version_id": {
 				Type:     schema.TypeString,
@@ -109,10 +114,7 @@ func ResourceObsBucketObject() *schema.Resource {
 	}
 }
 
-func resourceObsBucketObjectPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var resp *obs.PutObjectOutput
-	var err error
-
+func resourceObsBucketObjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	obsClient, err := conf.ObjectStorageClient(conf.GetRegion(d))
 	if err != nil {
@@ -123,51 +125,22 @@ func resourceObsBucketObjectPut(ctx context.Context, d *schema.ResourceData, met
 	key := d.Get("key").(string)
 	_, err = obsClient.HeadBucket(bucket)
 	if err != nil {
-		if obsError, ok := err.(obs.ObsError); ok && obsError.StatusCode == 404 {
-			return diag.Errorf("OBS bucket(%s) not found", bucket)
-		}
 		return diag.Errorf("error reading OBS bucket %s: %s", bucket, err)
 	}
 
-	source := d.Get("source").(string)
-	content := d.Get("content").(string)
-	if source != "" {
-		// check source file whether exist
-		_, err = os.Stat(source)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return diag.Errorf("source file %s is not exist", source)
-			}
-			return diag.FromErr(err)
-		}
-
-		// put source file
-		resp, err = putFileToObject(obsClient, d)
-	}
-
-	if content != "" {
-		// put content
-		resp, err = putContentToObject(obsClient, d)
-	}
-
+	versionId, err := updateBucketObject(obsClient, d, bucket, key)
 	if err != nil {
-		return diag.FromErr(getObsError("Error putting object to OBS bucket", bucket, err))
-	}
-	if resp == nil {
-		return diag.Errorf("putting object to OBS bucket %s without null response", bucket)
+		return diag.Errorf("error creating object (%s) for OBS bucket (%s): %s", key, bucket, err)
 	}
 
-	log.Printf("[DEBUG] Response of putting %s to OBS Bucket %s: %#v", key, bucket, resp)
-	mErr := &multierror.Error{}
-	if resp.VersionId != "null" {
-		mErr = multierror.Append(mErr, d.Set("version_id", resp.VersionId))
-	} else {
-		mErr = multierror.Append(mErr, d.Set("version_id", ""))
-	}
-	if mErr.ErrorOrNil() != nil {
-		return diag.Errorf("error saving versionId of OBS bucket %s: %s", bucket, mErr)
-	}
 	d.SetId(key)
+
+	if v, ok := d.GetOk("tags"); ok {
+		err = updateBucketObjectTags(obsClient, bucket, key, versionId, v.(map[string]interface{}))
+		if err != nil {
+			return diag.Errorf("error adding tags to bucket object (%s/%s): %s", bucket, key, err)
+		}
+	}
 
 	return resourceObsBucketObjectRead(ctx, d, meta)
 }
@@ -236,6 +209,45 @@ func putFileToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.Put
 	return obsClient.PutFile(putInput)
 }
 
+func deleteBucketObjectTags(obsClient *obs.ObsClient, bucket, key, versionId string) error {
+	opt := &obs.DeleteObjectTaggingInput{
+		ObjectTaggingInput: obs.ObjectTaggingInput{
+			Bucket:    bucket,
+			Key:       key,
+			VersionId: versionId,
+		},
+	}
+	_, err := obsClient.DeleteObjectTagging(opt)
+	return err
+}
+
+func updateBucketObjectTags(obsClient *obs.ObsClient, bucket, key, versionId string, tagMap map[string]interface{}) error {
+	if len(tagMap) == 0 {
+		return deleteBucketObjectTags(obsClient, bucket, key, versionId)
+	}
+
+	var tags []obs.Tag
+	for k, v := range tagMap {
+		tag := obs.Tag{
+			Key:   k,
+			Value: v.(string),
+		}
+		tags = append(tags, tag)
+	}
+
+	opt := &obs.SetObjectTaggingInput{
+		ObjectTaggingInput: obs.ObjectTaggingInput{
+			Bucket:    bucket,
+			Key:       key,
+			VersionId: versionId,
+		},
+		Tags: tags,
+	}
+	// This API will overwrite the existing tags, but can't clear the tags.
+	_, err := obsClient.SetObjectTagging(opt)
+	return err
+}
+
 func resourceObsBucketObjectRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
@@ -272,13 +284,20 @@ func resourceObsBucketObjectRead(_ context.Context, d *schema.ResourceData, meta
 		class = normalizeStorageClass(class)
 	}
 
+	tags, err := getBucketObjectTags(obsClient, bucket, key, objectMeta.VersionId)
+	if err != nil {
+		log.Printf("[ERROR] error getting tags of bucket object(%s/%s): %s", bucket, key, err)
+	}
+
 	mErr := multierror.Append(
 		d.Set("region", region),
 		d.Set("storage_class", class),
 		d.Set("content_type", objectMeta.ContentType),
+		d.Set("etag", strings.Trim(objectMeta.ETag, `"`)),
+		d.Set("tags", tags),
+		// Attributes.
 		d.Set("version_id", objectMeta.VersionId),
 		d.Set("size", objectMeta.ContentLength),
-		d.Set("etag", strings.Trim(objectMeta.ETag, `"`)),
 	)
 
 	if err = mErr.ErrorOrNil(); err != nil {
@@ -286,6 +305,109 @@ func resourceObsBucketObjectRead(_ context.Context, d *schema.ResourceData, meta
 	}
 
 	return nil
+}
+
+func getBucketObjectTags(obsClient *obs.ObsClient, bucket, key, versionId string) (map[string]string, error) {
+	output, err := obsClient.GetObjectTagging(&obs.GetObjectTaggingInput{
+		ObjectTaggingInput: obs.ObjectTaggingInput{
+			Bucket:    bucket,
+			Key:       key,
+			VersionId: versionId,
+		},
+	})
+	if err != nil {
+		if obsError, ok := err.(obs.ObsError); ok {
+			// 'NoSuchTagSet' means the object tags have been deleted or never had tags.
+			if obsError.Code == "NoSuchTagSet" {
+				return nil, nil
+			}
+		}
+		return nil, err
+	}
+
+	tags := make(map[string]string)
+	for _, tag := range output.Tags {
+		tags[tag.Key] = tag.Value
+	}
+
+	return tags, nil
+}
+
+func resourceObsBucketObjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	obsClient, err := conf.ObjectStorageClient(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating OBS client: %s", err)
+	}
+
+	bucket := d.Get("bucket").(string)
+	key := d.Get("key").(string)
+	_, err = obsClient.HeadBucket(bucket)
+	if err != nil {
+		return diag.Errorf("error getting OBS bucket %s: %s", bucket, err)
+	}
+
+	versionId := d.Get("version_id").(string)
+	if d.HasChangeExcept("tags") {
+		newVersionId, err := updateBucketObject(obsClient, d, bucket, key)
+		if err != nil {
+			return diag.Errorf("error updating bucket object (%s/%s): %s", bucket, key, err)
+		}
+
+		versionId = newVersionId
+	}
+
+	// After updating an object, tags will be cleared, so tags need to be set again after each object update.
+	err = updateBucketObjectTags(obsClient, bucket, key, versionId, d.Get("tags").(map[string]interface{}))
+	if err != nil {
+		return diag.Errorf("error updating tags of bucket object (%s/%s): %s", bucket, key, err)
+	}
+
+	return resourceObsBucketObjectRead(ctx, d, meta)
+}
+
+func updateBucketObject(obsClient *obs.ObsClient, d *schema.ResourceData, bucket, key string) (string, error) {
+	var (
+		resp   *obs.PutObjectOutput
+		err    error
+		source = d.Get("source").(string)
+	)
+
+	if source != "" {
+		// Check source file whether exist.
+		_, err = os.Stat(source)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", fmt.Errorf("source file %s is not exist", source)
+			}
+
+			return "", err
+		}
+
+		// Put source file.
+		resp, err = putFileToObject(obsClient, d)
+	}
+
+	content := d.Get("content").(string)
+	if content != "" {
+		// Put content.
+		resp, err = putContentToObject(obsClient, d)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	log.Printf("[DEBUG] Response of putting object (%s) to OBS bucket (%s): %#v", key, bucket, resp)
+	if resp == nil {
+		return "", fmt.Errorf("putting object to OBS bucket %s without null response", bucket)
+	}
+
+	if resp.VersionId != "null" {
+		return resp.VersionId, nil
+	}
+
+	return "", nil
 }
 
 func resourceObsBucketObjectDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add the 'tags' field to the resource and data source of the bucket object.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
The bucket object resource and data source supports tags.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o obs -f TestAccBucketObject_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccBucketObject_ -timeout 360m -parallel 10
versions === RUN   TestAccBucketObject_source
=== PAUSE TestAccBucketObject_source
=== RUN   TestAccBucketObject_content
=== PAUSE TestAccBucketObject_content
=== CONT  TestAccBucketObject_source
=== CONT  TestAccBucketObject_content
--- PASS: TestAccBucketObject_content (102.55s)
--- PASS: TestAccBucketObject_source (109.46s)
PASS
coverage: 23.8% of statements in ./huaweicloud/services/obs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       109.575s        coverage: 23.8% of statements in ./huaweicloud/services/obs
```
```
./scripts/coverage.sh -o obs -f TestAccObsBucketObjectDataSource_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccObsBucketObjectDataSource_ -timeout 360m -parallel 10
=== RUN   TestAccObsBucketObjectDataSource_content
=== PAUSE TestAccObsBucketObjectDataSource_content
=== RUN   TestAccObsBucketObjectDataSource_source
=== PAUSE TestAccObsBucketObjectDataSource_source
=== RUN   TestAccObsBucketObjectDataSource_allParams
=== PAUSE TestAccObsBucketObjectDataSource_allParams
=== CONT  TestAccObsBucketObjectDataSource_content
=== CONT  TestAccObsBucketObjectDataSource_allParams
=== CONT  TestAccObsBucketObjectDataSource_source
--- PASS: TestAccObsBucketObjectDataSource_allParams (430.57s)
--- PASS: TestAccObsBucketObjectDataSource_source (430.59s)
--- PASS: TestAccObsBucketObjectDataSource_content (439.07s)
PASS
coverage: 23.3% of statements in ./huaweicloud/services/obs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       439.213s        coverage: 23.3% of statements in ./huaweicloud/services/obs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
