### PR TITLE
feat(VPN): add vpn connection peer configuration export data source

### DIFF
--- a/docs/data-sources/vpn_connection_peer_configuration_export.md
+++ b/docs/data-sources/vpn_connection_peer_configuration_export.md
@@ -1,0 +1,50 @@
+---
+subcategory: "VPN"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_vpn_connection_peer_configuration_export"
+description: |-
+  Use this data source to export VPN connection peer configuration within HuaweiCloud.
+---
+
+# huaweicloud_vpn_connection_peer_configuration_export
+
+Use this data source to export VPN connection peer configuration within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "vpn_connection_id" {}
+
+data "huaweicloud_vpn_connection_peer_configuration_export" "test" {
+  vpn_connection_id = var.vpn_connection_id
+  vendor            = "Huawei"
+  type              = "USG"
+  model             = "USG6655F"
+  version           = "default"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `vpn_connection_id` - (Required, String) Specifies the VPN connection ID.
+
+* `vendor` - (Required, String) Specifies the vendor of the peer device.
+
+* `type` - (Required, String) Specifies the series of the peer device.
+
+* `model` - (Required, String) Specifies the model of the peer device.
+
+* `version` - (Required, String) Specifies the version of the peer device.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `peer_config` - The peer device configuration information.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2649,6 +2649,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpn_metrics":                              vpn.DataSourceVpnMetrics(),
 			"huaweicloud_vpn_connection_ipsec_sa":                  vpn.DataSourceVpnConnectionIpsecSa(),
 			"huaweicloud_vpn_peer_configuration_supported_devices": vpn.DataSourceVpnPeerConfigurationSupportedDevices(),
+			"huaweicloud_vpn_connection_peer_configuration_export": vpn.DataSourceVpnConnectionPeerConfigurationExport(),
 
 			"huaweicloud_waf_address_groups":                       waf.DataSourceWafAddressGroups(),
 			"huaweicloud_waf_alarm_notifications":                  waf.DataSourceWafAlarmNotifications(),

--- a/huaweicloud/services/acceptance/vpn/data_source_huaweicloud_vpn_connection_peer_configuration_export_test.go
+++ b/huaweicloud/services/acceptance/vpn/data_source_huaweicloud_vpn_connection_peer_configuration_export_test.go
@@ -1,0 +1,48 @@
+package vpn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceVpnConnectionPeerConfigurationExport_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_vpn_connection_peer_configuration_export.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceVpnConnectionPeerConfigurationExport_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "peer_config"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceVpnConnectionPeerConfigurationExport_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpn_peer_configuration_supported_devices" "test" {}
+
+data "huaweicloud_vpn_connection_peer_configuration_export" "test" {
+  vpn_connection_id = huaweicloud_vpn_connection.test.id
+  vendor            = data.huaweicloud_vpn_peer_configuration_supported_devices.test.supported_devices[0].vendor
+  type              = data.huaweicloud_vpn_peer_configuration_supported_devices.test.supported_devices[0].type
+  model             = data.huaweicloud_vpn_peer_configuration_supported_devices.test.supported_devices[0].model
+  version           = data.huaweicloud_vpn_peer_configuration_supported_devices.test.supported_devices[0].version
+}
+`, testConnection_basic(name, "172.16.1.4"))
+}

--- a/huaweicloud/services/vpn/data_source_huaweicloud_vpn_connection_peer_configuration_export.go
+++ b/huaweicloud/services/vpn/data_source_huaweicloud_vpn_connection_peer_configuration_export.go
@@ -1,0 +1,111 @@
+package vpn
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API VPN POST /v5/{project_id}/vpn-connection/{vpn_connection_id}/peer-configuration/export
+func DataSourceVpnConnectionPeerConfigurationExport() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVpnConnectionPeerConfigurationExportRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"vpn_connection_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"vendor": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"model": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"peer_config": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceVpnConnectionPeerConfigurationExportRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v5/{project_id}/vpn-connection/{vpn_connection_id}/peer-configuration/export"
+		product = "vpn"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating VPN client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{vpn_connection_id}", d.Get("vpn_connection_id").(string))
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildExportPeerConfigBodyParams(d),
+	}
+
+	getResp, err := client.Request("POST", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error exporting VPN connection peer configuration: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("peer_config", utils.PathSearch("peer_config", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildExportPeerConfigBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"vendor":  d.Get("vendor").(string),
+		"type":    d.Get("type").(string),
+		"model":   d.Get("model").(string),
+		"version": d.Get("version").(string),
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add vpn connection peer configuration export data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add vpn connection peer configuration export data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/vpn/ TESTARGS='-run TestAccDataSourceVpnConnectionPeerConfigurationExport_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn/ -v -run TestAccDataSourceVpnConnectionPeerConfigurationExport_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceVpnConnectionPeerConfigurationExport_basic
=== PAUSE TestAccDataSourceVpnConnectionPeerConfigurationExport_basic
=== CONT  TestAccDataSourceVpnConnectionPeerConfigurationExport_basic
--- PASS: TestAccDataSourceVpnConnectionPeerConfigurationExport_basic (518.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       518.272s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
