### PR TITLE
feat(TaurusDB): action resource to switch over primary node of TaurusDB instance

### DIFF
--- a/docs/resources/taurusdb_primary_standby_switch.md
+++ b/docs/resources/taurusdb_primary_standby_switch.md
@@ -1,0 +1,49 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_primary_standby_switch"
+description: |-
+  Use this resource to promote a read replica to primary for a TaurusDB instance within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_primary_standby_switch
+
+Use this resource to promote a read replica to primary for a TaurusDB instance within HuaweiCloud.
+
+-> This resource is a one-time action resource for promoting a read replica to the primary node. Deleting this resource
+   will not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+
+resource "huaweicloud_taurusdb_primary_standby_switch" "test" {
+  instance_id = var.instance_id
+  node_id     = var.node_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Change this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the TaurusDB instance.
+
+* `node_id` - (Required, String, NonUpdatable) Specifies the ID of the read replica that will be promoted to the primary.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4538,6 +4538,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_htap_sessions_kill":              taurusdb.ResourceTaurusDBHtapSessionsKill(),
 			"huaweicloud_taurusdb_htap_starrocks_instance_restart": taurusdb.ResourceTaurusDBHtapStarrocksInstanceRestart(),
 			"huaweicloud_taurusdb_htap_starrocks_node_restart":     taurusdb.ResourceTaurusDBHtapStarrocksNodeRestart(),
+			"huaweicloud_taurusdb_primary_standby_switch":          taurusdb.ResourceTaurusDBPrimaryStandbySwitch(),
 
 			"huaweicloud_tms_resource_tags": tms.ResourceResourceTags(),
 			"huaweicloud_tms_tags":          tms.ResourceTmsTag(),

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_primary_standby_switch_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_primary_standby_switch_test.go
@@ -1,0 +1,48 @@
+package taurusdb
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTaurusDBPrimaryStandbySwitch_basic(t *testing.T) {
+	resourceName := "huaweicloud_taurusdb_primary_standby_switch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaurusDBPrimaryStandbySwitch_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "node_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTaurusDBPrimaryStandbySwitch_basic() string {
+	return `
+data "huaweicloud_taurusdb_instances" "test" {}
+
+locals {
+  instance_id = data.huaweicloud_taurusdb_instances.test.instances.0.id
+  slave_node_ids = [for node in data.huaweicloud_taurusdb_instances.test.instances.0.nodes : node.id if node.type == "slave"]
+  slave_node_id = length(local.slave_node_ids) > 0 ? local.slave_node_ids[0] : null
+}
+
+resource "huaweicloud_taurusdb_primary_standby_switch" "test" {
+  instance_id = local.instance_id
+  node_id     = local.slave_node_id
+}
+`
+}

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_primary_standby_switch.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_primary_standby_switch.go
@@ -1,0 +1,155 @@
+package taurusdb
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var primaryStandbySwitchNonUpdatableParams = []string{"instance_id", "node_id"}
+
+// @API TaurusDB PUT /v3/{project_id}/instances/{instance_id}/switchover
+// @API TaurusDB GET /v3/{project_id}/jobs
+func ResourceTaurusDBPrimaryStandbySwitch() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTaurusDBPrimaryStandbySwitchCreate,
+		ReadContext:   resourceTaurusDBPrimaryStandbySwitchRead,
+		UpdateContext: resourceTaurusDBPrimaryStandbySwitchUpdate,
+		DeleteContext: resourceTaurusDBPrimaryStandbySwitchDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(primaryStandbySwitchNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceTaurusDBPrimaryStandbySwitchCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/switchover"
+		product    = "gaussdb"
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	createOpt.JSONBody = buildCreatePrimaryStandbySwitchBodyParams(d)
+
+	retryFunc := func() (interface{}, bool, error) {
+		res, err := client.Request("PUT", createPath, &createOpt)
+		retry, err := handleMultiOperationsError(err)
+		return res, retry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     GaussDBInstanceStateRefreshFunc(client, instanceId),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return diag.Errorf("error promoting read replica to primary for TaurusDB instance(%s): %s", instanceId, err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(r.(*http.Response))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error promoting read replica to primary for TaurusDB instance(%s): job_id is not found in the response",
+			instanceId)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	err = checkGaussDBMySQLJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for promoting read replica to primary for TaurusDB instance(%s) job to complete: %s",
+			instanceId, err)
+	}
+
+	return nil
+}
+
+func buildCreatePrimaryStandbySwitchBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"node_id": d.Get("node_id"),
+	}
+	return bodyParams
+}
+
+func resourceTaurusDBPrimaryStandbySwitchRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceTaurusDBPrimaryStandbySwitchUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceTaurusDBPrimaryStandbySwitchDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting the primary/standby switch resource is not supported. The resource is only removed from the" +
+		" state, the TaurusDB instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
action resource to switch over primary node of TaurusDB instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
action resource to switch over primary node of TaurusDB instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccTaurusDBPrimaryStandbySwitch'
=== RUN   TestAccTaurusDBPrimaryStandbySwitch_basic
=== PAUSE TestAccTaurusDBPrimaryStandbySwitch_basic
=== CONT  TestAccTaurusDBPrimaryStandbySwitch_basic
--- PASS: TestAccTaurusDBPrimaryStandbySwitch_basic (552.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 552.826s
```
<img width="1031" height="197" alt="image" src="https://github.com/user-attachments/assets/c8c4b9b6-1503-41e8-828a-1e4d47f03ae5" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
