### PR TITLE
feat(secmaster): support `secmaster_platform_managed` data source

### DIFF
--- a/docs/data-sources/secmaster_platform_managed.md
+++ b/docs/data-sources/secmaster_platform_managed.md
@@ -1,0 +1,44 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_platform_managed"
+description: |-
+  Use this data source to get the platform managed information.
+---
+
+# huaweicloud_secmaster_platform_managed
+
+Use this data source to get the platform managed information.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_secmaster_platform_managed" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `create_time` - The creation time.
+
+* `dw_region` - The region.
+
+* `platform_managed_domain_id` - The platform tenant ID.
+
+* `publish_status` - The publish status.
+
+* `tenant_managed_domain_id` - The tenant managed domain ID.
+
+* `update_time` - The update time.
+
+* `whitelist` - Whether the tenant is in the whitelist.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2360,6 +2360,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_security_reports":              secmaster.DataSourceSecurityReports(),
 			"huaweicloud_secmaster_siem_directories":              secmaster.DataSourceSiemDirectories(),
 			"huaweicloud_secmaster_siem_shippers":                 secmaster.DataSourceSiemShippers(),
+			"huaweicloud_secmaster_platform_managed":              secmaster.DataSourcePlatformManaged(),
 			"huaweicloud_secmaster_soc_mappers":                   secmaster.DataSourceSocMapper(),
 			"huaweicloud_secmaster_soc_mappings":                  secmaster.DataSourceSocMappings(),
 			"huaweicloud_secmaster_soc_preprocess_rules":          secmaster.DataSourceSocPreprocessRules(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_platform_managed_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_platform_managed_test.go
@@ -1,0 +1,43 @@
+package secmaster
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcePlatformManaged_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_platform_managed.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourcePlatformManaged_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "dw_region"),
+					resource.TestCheckResourceAttrSet(dataSource, "publish_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "tenant_managed_domain_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "update_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "whitelist"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourcePlatformManaged_basic() string {
+	return `
+data "huaweicloud_secmaster_platform_managed" "test" {}
+`
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_platform_managed.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_platform_managed.go
@@ -1,0 +1,111 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Secmaster GET /v1/{project_id}/siem/cloud-logs/managers
+func DataSourcePlatformManaged() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePlatformManagedRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"dw_region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"platform_managed_domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"publish_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tenant_managed_domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"whitelist": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePlatformManagedRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "secmaster"
+		httpUrl = "v1/{project_id}/siem/cloud-logs/managers"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving SecMaster platform managed information: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("create_time", utils.PathSearch("result[0].create_time", respBody, nil)),
+		d.Set("dw_region", utils.PathSearch("result[0].dw_region", respBody, nil)),
+		d.Set("platform_managed_domain_id", utils.PathSearch(
+			"result[0].platform_managed_domain_id", respBody, nil)),
+		d.Set("publish_status", utils.PathSearch("result[0].publish_status", respBody, nil)),
+		d.Set("tenant_managed_domain_id", utils.PathSearch(
+			"result[0].tenant_managed_domain_id", respBody, nil)),
+		d.Set("update_time", utils.PathSearch("result[0].update_time", respBody, nil)),
+		d.Set("whitelist", utils.PathSearch("result[0].whitelist", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `secmaster_platform_managed` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `secmaster_platform_managed` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o secmaster -f TestAccDataSourcePlatformManaged_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourcePlatformManaged_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourcePlatformManaged_basic
=== PAUSE TestAccDataSourcePlatformManaged_basic
=== CONT  TestAccDataSourcePlatformManaged_basic
--- PASS: TestAccDataSourcePlatformManaged_basic (12.21s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/secmaster    coverage: 3.8% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 12.316s coverage: 3.8% of statements in ./huaweicloud/services/secmaster
```
<img width="970" height="33" alt="image" src="https://github.com/user-attachments/assets/1b9fb809-6e37-47c5-b17c-d42cfa34e62b" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
