### PR TITLE
feat(gaussdb): add instance supported plugins data source

### DIFF
--- a/docs/data-sources/gaussdb_instance_supported_plugins.md
+++ b/docs/data-sources/gaussdb_instance_supported_plugins.md
@@ -1,0 +1,32 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_instance_supported_plugins"
+description: |-
+  Use this data source to query the supported plugins for GaussDB instances within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_instance_supported_plugins
+
+Use this data source to query the supported plugins for GaussDB instances within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_gaussdb_instance_supported_plugins" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `plugins` - The list of supported plugin names.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1535,6 +1535,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_instance_alarm_statistics":       gaussdb.DataSourceInstanceAlarmStatistics(),
 			"huaweicloud_gaussdb_instance_status_statistics":      gaussdb.DataSourceInstanceStatusStatistics(),
 			"huaweicloud_gaussdb_instance_installed_plugins":      gaussdb.DataSourceInstalledPlugins(),
+			"huaweicloud_gaussdb_instance_supported_plugins":      gaussdb.DataSourceSupportedPlugins(),
 			"huaweicloud_gaussdb_storage_types":                   gaussdb.DataSourceGaussDbStorageTypes(),
 			"huaweicloud_gaussdb_datastores":                      gaussdb.DataSourceGaussDbDatastores(),
 			"huaweicloud_gaussdb_flavors":                         gaussdb.DataSourceGaussDbFlavors(),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_instance_supported_plugins_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_instance_supported_plugins_test.go
@@ -1,0 +1,42 @@
+package gaussdb
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSupportedPlugins_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_gaussdb_instance_supported_plugins.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(
+		t, resource.TestCase{
+			PreCheck: func() {
+				acceptance.TestAccPreCheck(t)
+				acceptance.TestAccPreCheckGaussDBInstanceId(t)
+			},
+			ProviderFactories: acceptance.TestAccProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: testDataSourceSupportedPlugins_basic(),
+					Check: resource.ComposeTestCheckFunc(
+						dc.CheckResourceExists(),
+						resource.TestCheckResourceAttrSet(dataSource, "plugins.#"),
+					),
+				},
+			},
+		},
+	)
+}
+
+func testDataSourceSupportedPlugins_basic() string {
+	return `
+data "huaweicloud_gaussdb_instance_supported_plugins" "test" {
+}
+`
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_instance_supported_plugins.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_instance_supported_plugins.go
@@ -1,0 +1,81 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB GET /v3/{project_id}/instances/kernel-plugins
+func DataSourceSupportedPlugins() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSupportedPluginsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"plugins": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceSupportedPluginsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("opengauss", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	httpUrl := "v3/{project_id}/instances/kernel-plugins"
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return diag.Errorf("error querying supported plugins: %s", err)
+	}
+
+	resp, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("plugins", utils.PathSearch("[*]", resp, make([]interface{}, 0)).([]interface{})),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source `(huaweicloud_gaussdb_instance_supported_plugins) ` to query supported plugins list.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  add a new data source  huaweicloud_gaussdb_instance_supported_plugins for GaussDB.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o gaussdb -f TestAccDataSourceSupportedPlugins_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/gaussdb" -v -coverprofile="./huaweicloud/services/acceptance/gaussdb/gaussdb_coverage.cov" -coverpkg="./huaweicloud/services/gaussdb" -run TestAccDataSourceSupportedPlugins_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceSupportedPlugins_basic
=== PAUSE TestAccDataSourceSupportedPlugins_basic
=== CONT  TestAccDataSourceSupportedPlugins_basic
--- PASS: TestAccDataSourceSupportedPlugins_basic (14.04s)
PASS
coverage: 3.0% of statements in ./huaweicloud/services/gaussdb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   14.389s coverage: 3.0% of statements in ./huaweicloud/services/gaussdb

```
<img width="1026" height="29" alt="supported_plugins" src="https://github.com/user-attachments/assets/e5af6c64-f3d5-43f7-b7f7-91cc0fe5c2d9" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
