### PR TITLE
feat(TaurusDB): action resource to batch delete backups of TaurusDB

### DIFF
--- a/docs/resources/taurusdb_backups_batch_delete.md
+++ b/docs/resources/taurusdb_backups_batch_delete.md
@@ -1,0 +1,58 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_backups_batch_delete"
+description: |-
+  Use this resource to batch delete TaurusDB manual backups within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_backups_batch_delete
+
+Use this resource to batch delete TaurusDB manual backups within HuaweiCloud.
+
+-> This resource is a one-time action resource for batch deleting TaurusDB manual backups. Deleting this resource will
+   not restore the deleted backups, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "backup_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_taurusdb_backups_batch_delete" "test" {
+  backup_ids = var.backup_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to batch delete the TaurusDB backups.
+  If omitted, the provider-level region will be used.
+
+* `backup_ids` - (Required, List, NoneUpdatable) Specifies the IDs of the manual backups to be deleted.
+  A maximum of 50 IDs are allowed.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `success_count` - Indicates the number of backups that have been deleted.
+
+* `failed_count` - Indicates the number of backups that failed to be deleted.
+
+* `failed_results` - Indicates the backup deletion errors.
+  The [failed_results](#backups_batch_delete_failed_results) structure is documented below.
+
+<a name="backups_batch_delete_failed_results"></a>
+The `failed_results` block supports:
+
+* `backup_id` - Indicates the backup ID.
+
+* `error_code` - Indicates the error code returned when a task submission exception occurs.
+
+* `error_msg` - Indicates the error message returned when a task submission exception occurs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4536,6 +4536,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_parameter_template_apply":        taurusdb.ResourceTaurusDBTemplateApply(),
 			"huaweicloud_taurusdb_parameter_template_compare":      taurusdb.ResourceTaurusDBTemplateCompare(),
 			"huaweicloud_taurusdb_backup":                          taurusdb.ResourceTaurusDBBackup(),
+			"huaweicloud_taurusdb_backups_batch_delete":            taurusdb.ResourceTaurusDBBackupsBatchDelete(),
 			"huaweicloud_taurusdb_lts_log":                         taurusdb.ResourceTaurusDBLtsLog(),
 			"huaweicloud_taurusdb_restore":                         taurusdb.ResourceTaurusDBRestore(),
 			"huaweicloud_taurusdb_table_restore":                   taurusdb.ResourceTaurusDBTableRestore(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -279,6 +279,7 @@ var (
 	HW_TAURUSDB_DATABASE_NAME             = os.Getenv("HW_TAURUSDB_DATABASE_NAME")
 	HW_TAURUSDB_TABLE_NAME                = os.Getenv("HW_TAURUSDB_TABLE_NAME")
 	HW_TAURUSDB_INSTANCE_CONFIGURATION_ID = os.Getenv("HW_TAURUSDB_INSTANCE_CONFIGURATION_ID")
+	HW_TAURUSDB_BACKUP_ID                 = os.Getenv("HW_TAURUSDB_BACKUP_ID")
 	HW_TAURUSDB_BACKUP_BEGIN_TIME         = os.Getenv("HW_TAURUSDB_BACKUP_BEGIN_TIME")
 	HW_TAURUSDB_BACKUP_END_TIME           = os.Getenv("HW_TAURUSDB_BACKUP_END_TIME")
 	HW_TAURUSDB_JOB_ID                    = os.Getenv("HW_TAURUSDB_JOB_ID")
@@ -2350,6 +2351,13 @@ func TestAccPreCheckTaurusDBTableName(t *testing.T) {
 func TestAccPreCheckTaurusDBInstanceConfigurationId(t *testing.T) {
 	if HW_TAURUSDB_INSTANCE_CONFIGURATION_ID == "" {
 		t.Skip("HW_TAURUSDB_INSTANCE_CONFIGURATION_ID must be set for TaurusDB acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckTaurusDBBackupId(t *testing.T) {
+	if HW_TAURUSDB_BACKUP_ID == "" {
+		t.Skip("HW_TAURUSDB_BACKUP_ID must be set for TaurusDB acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_backups_batch_delete_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_backups_batch_delete_test.go
@@ -1,0 +1,38 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTaurusDBBackupsBatchDelete_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBBackupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaurusDBBackupsBatchDelete_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("huaweicloud_taurusdb_backups_batch_delete.test", "id"),
+					resource.TestCheckResourceAttr("huaweicloud_taurusdb_backups_batch_delete.test", "success_count", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTaurusDBBackupsBatchDelete_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_taurusdb_backups_batch_delete" "test" {
+  backup_ids = ["%s"]
+}
+`, acceptance.HW_TAURUSDB_BACKUP_ID)
+}

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_backups_batch_delete.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_backups_batch_delete.go
@@ -1,0 +1,169 @@
+package taurusdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var backupsBatchDeleteNoneUpdatableParams = []string{"backup_ids"}
+
+// @API TaurusDB DELETE /v3/{project_id}/backups
+func ResourceTaurusDBBackupsBatchDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTaurusDBBackupsBatchDeleteCreate,
+		ReadContext:   resourceTaurusDBBackupsBatchDeleteRead,
+		UpdateContext: resourceTaurusDBBackupsBatchDeleteUpdate,
+		DeleteContext: resourceTaurusDBBackupsBatchDeleteDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(backupsBatchDeleteNoneUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"backup_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"success_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"failed_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"failed_results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"backup_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"error_msg": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceTaurusDBBackupsBatchDeleteCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/backups"
+		product = "gaussdb"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	deleteOpt.JSONBody = utils.RemoveNil(buildDeleteGaussDBBackupsBatchDeleteBodyParams(d))
+
+	deleteResp, err := client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error batch deleting TaurusDB backups: %s", err)
+	}
+
+	deleteRespBody, err := utils.FlattenResponse(deleteResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("success_count", int(utils.PathSearch("success_count", deleteRespBody, 0).(float64))),
+		d.Set("failed_count", int(utils.PathSearch("failed_count", deleteRespBody, 0).(float64))),
+		d.Set("failed_results", flattenBatchDeleteBackupFailedResults(deleteRespBody)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildDeleteGaussDBBackupsBatchDeleteBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"backup_ids": utils.ExpandToStringList(d.Get("backup_ids").([]interface{})),
+	}
+	return bodyParams
+}
+
+func flattenBatchDeleteBackupFailedResults(respBody interface{}) []interface{} {
+	failedResults := utils.PathSearch("failed_results", respBody, make([]interface{}, 0)).([]interface{})
+	if len(failedResults) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(failedResults))
+	for _, item := range failedResults {
+		rst = append(rst, map[string]interface{}{
+			"backup_id":  utils.PathSearch("backup_id", item, nil),
+			"error_code": utils.PathSearch("error_code", item, nil),
+			"error_msg":  utils.PathSearch("error_msg", item, nil),
+		})
+	}
+	return rst
+}
+
+func resourceTaurusDBBackupsBatchDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceTaurusDBBackupsBatchDeleteUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+func resourceTaurusDBBackupsBatchDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting TaurusDB backups batch delete resource is not supported. The TaurusDB backups " +
+		"batch delete resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
action resource to batch delete backups of TaurusDB
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
action resource to batch delete backups of TaurusDB
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccTaurusDBBackupsBatchDelete'
=== RUN   TestAccTaurusDBBackupsBatchDelete_basic
=== PAUSE TestAccTaurusDBBackupsBatchDelete_basic
=== CONT  TestAccTaurusDBBackupsBatchDelete_basic
--- PASS: TestAccTaurusDBBackupsBatchDelete_basic (29.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 30.013s
```
<img width="929" height="221" alt="image" src="https://github.com/user-attachments/assets/c7f5b51d-f095-4dba-8813-12991e5c5f6d" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
