### PR TITLE
feat(dli): the resource dli_table support create view by select_statement

### DIFF
--- a/docs/resources/dli_table.md
+++ b/docs/resources/dli_table.md
@@ -60,9 +60,17 @@ The following arguments are supported:
   + **DLI**: Data stored in DLI tables is applicable to delay-sensitive services, such as interactive queries.
   + **OBS**: Data stored in OBS tables is applicable to delay-insensitive services, such as historical data statistics
    and analysis.
+  + **View**: Indicates creating a view. The view is a virtual table based on the result set of an SQL query.
 
-* `description` - (Optional, String, ForceNew) Specifies description of the table.
+* `select_statement` - (Optional, String, ForceNew) Specifies the data source for the view.  
   Changing this parameter will create a new resource.
+
+  -> Require if the `data_location` is **View**.
+
+* `description` - (Optional, String, ForceNew) Specifies description of the table.  
+  Changing this parameter will create a new resource.
+
+  -> `description` becomes unavailable when the value of `data_location` is **View**.
 
 * `columns` - (Optional, List, ForceNew) Specifies Columns of the new table. Structure is documented below.
   Changing this parameter will create a new resource.
@@ -129,3 +137,20 @@ DLI table can be imported by `id`. It is composed of the name of database which 
 ```bash
 terraform import huaweicloud_dli_table.example <database_name>/<table_name>
 ```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `select_statement`.
+It is generally recommended running `terraform plan` after importing a DLI table.
+You can then decide if changes should be applied to the DLI table, or the resource definition
+should be updated to align with the DLI table. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_dli_table" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      select_statement,
+    ]
+  }
+}

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_table_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_table_test.go
@@ -174,3 +174,97 @@ resource "huaweicloud_dli_table" "test" {
 }
 `, obsBucketName, name, name)
 }
+
+func TestAccResourceDliTable_VIEW(t *testing.T) {
+	var (
+		resourceName = "huaweicloud_dli_table.test_view"
+		name         = acceptance.RandomAccResourceName()
+
+		tableObj tables.CreateTableOpts
+		rc       = acceptance.InitResourceCheck(
+			resourceName,
+			&tableObj,
+			getDliTableResourceFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDliTableResource_VIEW(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "database_name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_view", name)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"select_statement",
+				},
+			},
+		},
+	})
+}
+
+func testAccDliTableResource_VIEW(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_database" "test" {
+  name        = "%[1]s"
+  description = "For terraform acc test"
+}
+
+resource "huaweicloud_dli_table" "test" {
+  database_name = huaweicloud_dli_database.test.name
+  name          = "%[1]s"
+  data_location = "DLI"
+  description   = "dli table test"
+
+  columns {
+    name = "name"
+    type        = "string"
+    description = "person name"
+  }
+  columns {
+    name        = "address"
+    type        = "string"
+    description = "home address"
+  }
+
+  depends_on = [
+    huaweicloud_dli_database.test
+  ]
+}
+
+resource "huaweicloud_dli_table" "test_view" {
+  database_name    = huaweicloud_dli_database.test.name
+  name             = "%[1]s_view"
+  data_location    = "View"
+  select_statement = "SELECT * FROM ${huaweicloud_dli_database.test.name}.${huaweicloud_dli_table.test.name}"
+
+  columns {
+    name        = "name"
+    type        = "string"
+    description = "person name"
+  }
+  columns {
+    name        = "address"
+    type        = "string"
+    description = "home address"
+  }
+
+  depends_on = [
+    huaweicloud_dli_table.test
+  ]
+}
+`, name)
+}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_table.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_table.go
@@ -61,6 +61,11 @@ func ResourceDliTable() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"select_statement": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"columns": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -188,6 +193,7 @@ func resourceDliTableCreate(ctx context.Context, d *schema.ResourceData, meta in
 	opts := tables.CreateTableOpts{
 		TableName:       tableName,
 		DataLocation:    d.Get("data_location").(string),
+		SelectStatement: d.Get("select_statement").(string),
 		Columns:         buildColumnParam(d),
 		Description:     d.Get("description").(string),
 		DataType:        d.Get("data_format").(string),


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhance the original resource to create VIEW-type table resources through the select_statement attribute.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. Add the select_statement attribute to the schema.
2. Add corresponding type tests to the acceptance test.
3. Add attribute description to the corresponding documentation.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dli" -v -coverprofile="./huaweicloud/services/acceptance/dli/dli_coverage.cov" -coverpkg="./huaweicloud/services/dli" -run TestAccResourceDliTable_VIEW -timeout 360m -parallel 10
=== RUN   TestAccResourceDliTable_VIEW
=== PAUSE TestAccResourceDliTable_VIEW
=== CONT  TestAccResourceDliTable_VIEW
--- PASS: TestAccResourceDliTable_VIEW (35.39s)
PASS
coverage: 4.8% of statements in ./huaweicloud/services/dli
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       35.587s coverage: 4.8% of statements in ./huaweicloud/services/dli
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.