### PR TITLE
feat(secmaster): new resource to manage component template

### DIFF
--- a/docs/resources/secmaster_component_template.md
+++ b/docs/resources/secmaster_component_template.md
@@ -1,0 +1,62 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_component_template"
+description: |-
+  Manages a component template resource within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_component_template
+
+Manages a component template resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "component_id" {}
+variable "template_name" {}
+variable "task_config" {}
+
+resource "huaweicloud_secmaster_component_template" "test" {
+  workspace_id  = var.workspace_id
+  component_id  = var.component_id
+  template_name = var.template_name
+  task_config   = var.task_config
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the ID of the workspace to which the component template
+  belongs.
+
+* `component_id` - (Required, String) Specifies the ID of the component to which the template belongs.
+
+* `template_name` - (Required, String) Specifies the name of the component template.
+
+* `task_config` - (Required, String) Specifies the action configuration content of the component template.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `create_time` - The creation time of the component template.
+
+* `update_time` - The latest update time of the component template.
+
+## Import
+
+The component template can be imported using the `workspace_id` and their `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_secmaster_component_template.test <workspace_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4403,6 +4403,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_clone_playbook_version":      secmaster.ResourceClonePlaybookAndVersion(),
 			"huaweicloud_secmaster_cloud_log_resource":          secmaster.ResourceCloudLogResource(),
 			"huaweicloud_secmaster_collector_channel_group":     secmaster.ResourceCollectorChannelGroup(),
+			"huaweicloud_secmaster_component_template":          secmaster.ResourceComponentTemplate(),
 			"huaweicloud_secmaster_data_object_relations":       secmaster.ResourceDataObjectRelations(),
 			"huaweicloud_secmaster_dataspace":                   secmaster.ResourceDataspace(),
 			"huaweicloud_secmaster_delete_policies":             secmaster.ResourceDeletePolicies(),

--- a/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_component_template_test.go
+++ b/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_component_template_test.go
@@ -1,0 +1,117 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/secmaster"
+)
+
+func getResourceComponentTemplateFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("secmaster", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	return secmaster.GetComponentTemplateInfo(client, state.Primary.Attributes["workspace_id"], state.Primary.ID)
+}
+
+func TestAccResourceComponentTemplate_basic(t *testing.T) {
+	var (
+		rName      = "huaweicloud_secmaster_component_template.test"
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		object interface{}
+		rc     = acceptance.InitResourceCheck(
+			rName,
+			&object,
+			getResourceComponentTemplateFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+			acceptance.TestAccPreCheckSecMasterComponentId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComponentTemplate_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_SECMASTER_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "component_id", acceptance.HW_SECMASTER_COMPONENT_ID),
+					resource.TestCheckResourceAttr(rName, "template_name", name),
+					resource.TestCheckResourceAttr(rName, "task_config", "{\"action_id\":\"test_action\"}"),
+					resource.TestCheckResourceAttrSet(rName, "create_time"),
+					resource.TestCheckResourceAttrSet(rName, "update_time"),
+				),
+			},
+			{
+				Config: testAccComponentTemplate_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "template_name", updateName),
+					resource.TestCheckResourceAttr(rName, "task_config", "{\"action_id\":\"update_action\"}"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccComponentTemplateImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccComponentTemplate_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_secmaster_component_template" "test" {
+  workspace_id  = "%[1]s"
+  component_id  = "%[2]s"
+  template_name = "%[3]s"
+  task_config   = "{\"action_id\":\"test_action\"}"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_COMPONENT_ID, name)
+}
+
+func testAccComponentTemplate_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_secmaster_component_template" "test" {
+  workspace_id  = "%[1]s"
+  component_id  = "%[2]s"
+  template_name = "%[3]s"
+  task_config   = "{\"action_id\":\"update_action\"}"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_COMPONENT_ID, name)
+}
+
+func testAccComponentTemplateImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var workspaceId, templateId string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		workspaceId = rs.Primary.Attributes["workspace_id"]
+		templateId = rs.Primary.ID
+
+		if workspaceId == "" || templateId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<id>', but got '%s/%s'",
+				workspaceId, templateId)
+		}
+
+		return fmt.Sprintf("%s/%s", workspaceId, templateId), nil
+	}
+}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_component_template.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_component_template.go
@@ -1,0 +1,272 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableParamsComponentTemplate = []string{"workspace_id"}
+
+// @API SecMaster POST /v1/{project_id}/workspaces/{workspace_id}/soc/components/template
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/soc/components/template/{template_id}
+// @API SecMaster PUT /v1/{project_id}/workspaces/{workspace_id}/soc/components/template/{template_id}
+// @API SecMaster DELETE /v1/{project_id}/workspaces/{workspace_id}/soc/components/template/{template_id}
+func ResourceComponentTemplate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceComponentTemplateCreate,
+		ReadContext:   resourceComponentTemplateRead,
+		UpdateContext: resourceComponentTemplateUpdate,
+		DeleteContext: resourceComponentTemplateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceComponentTemplateImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableParamsComponentTemplate),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"component_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"template_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"task_config": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCreateComponentTemplateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"component_id":  d.Get("component_id"),
+		"template_name": d.Get("template_name"),
+		"task_config":   d.Get("task_config"),
+	}
+
+	return bodyParams
+}
+
+func resourceComponentTemplateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		workspaceId   = d.Get("workspace_id").(string)
+		createHttpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/components/template"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{workspace_id}", workspaceId)
+
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"content-type": "application/json;charset=UTF-8"},
+		KeepResponseBody: true,
+		JSONBody:         buildCreateComponentTemplateBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster component template: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	templateId := utils.PathSearch("data.id", respBody, "").(string)
+	if templateId == "" {
+		return diag.Errorf("error creating SecMaster component template: unable to find component template ID")
+	}
+
+	d.SetId(templateId)
+
+	return resourceComponentTemplateRead(ctx, d, meta)
+}
+
+func resourceComponentTemplateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	respBody, err := GetComponentTemplateInfo(client, workspaceId, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(
+			d,
+			common.ConvertExpected400ErrInto404Err(err, "code", "SecMaster.20040220"),
+			"error retrieving SecMaster component template",
+		)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("component_id", utils.PathSearch("data.component_id", respBody, nil)),
+		d.Set("template_name", utils.PathSearch("data.template_name", respBody, nil)),
+		d.Set("task_config", utils.PathSearch("data.task_config", respBody, nil)),
+		d.Set("create_time", utils.PathSearch("data.create_time", respBody, nil)),
+		d.Set("update_time", utils.PathSearch("data.update_time", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func GetComponentTemplateInfo(client *golangsdk.ServiceClient, workspaceId, templateId string) (interface{}, error) {
+	getPath := client.Endpoint + "v1/{project_id}/workspaces/{workspace_id}/soc/components/template/{template_id}"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{workspace_id}", workspaceId)
+	getPath = strings.ReplaceAll(getPath, "{template_id}", templateId)
+	getOpts := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"content-type": "application/json;charset=UTF-8"},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func buildUpdateComponentTemplateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"component_id":  d.Get("component_id"),
+		"template_name": d.Get("template_name"),
+		"task_config":   d.Get("task_config"),
+	}
+
+	return bodyParams
+}
+
+func resourceComponentTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/soc/components/template/{template_id}"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{workspace_id}", workspaceId)
+	updatePath = strings.ReplaceAll(updatePath, "{template_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"content-type": "application/json;charset=UTF-8"},
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateComponentTemplateBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating SecMaster component template: %s", err)
+	}
+
+	return resourceComponentTemplateRead(ctx, d, meta)
+}
+
+func resourceComponentTemplateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/soc/components/template/{template_id}"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{workspace_id}", workspaceId)
+	deletePath = strings.ReplaceAll(deletePath, "{template_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"content-type": "application/json;charset=UTF-8"},
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting SecMaster component template: %s", err)
+	}
+
+	return nil
+}
+
+func resourceComponentTemplateImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<id>', but got '%s'",
+			importedId)
+	}
+
+	d.SetId(parts[1])
+
+	mErr := multierror.Append(nil,
+		d.Set("workspace_id", parts[0]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage component template

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccResourceComponentTemplate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccResourceComponentTemplate_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceComponentTemplate_basic
=== PAUSE TestAccResourceComponentTemplate_basic
=== CONT  TestAccResourceComponentTemplate_basic
--- PASS: TestAccResourceComponentTemplate_basic (28.35s)
PASS
coverage: 4.5% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 28.476s coverage: 4.5% of statements in ./huaweicloud/services/secmaster
```
<img width="1476" height="84" alt="image" src="https://github.com/user-attachments/assets/75c28d3c-cfee-4afa-b4a6-1528870ae507" />


* [X] Documentation updated.
* [X] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="939" height="479" alt="image" src="https://github.com/user-attachments/assets/ee569b8a-c6bb-4b58-bc55-82efd53129af" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
