### PR TITLE
feat(servicestage): environment resources can using name to be assicated

### DIFF
--- a/docs/resources/servicestagev3_environment_associate.md
+++ b/docs/resources/servicestagev3_environment_associate.md
@@ -50,6 +50,8 @@ The `resources` block supports:
 
 * `type` - (Required, String) Specifies the type of the resource to be associated.
 
+* `name` - (Optional, String) Specifies the name of the resource to be associated.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_environment_associate_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_environment_associate_test.go
@@ -2,8 +2,10 @@ package servicestage
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -18,7 +20,7 @@ func getV3EnvAssociatedResourcesFunc(conf *config.Config, state *terraform.Resou
 	if err != nil {
 		return nil, fmt.Errorf("error creating ServiceStage client: %s", err)
 	}
-	return servicestage.QueryV3Environment(client, state.Primary.ID)
+	return servicestage.ListV3EnvironmentAssociatedResources(client, state.Primary.ID)
 }
 
 func TestAccV3EnvironmentAssociate_basic(t *testing.T) {
@@ -34,38 +36,71 @@ func TestAccV3EnvironmentAssociate_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
-			// Make sure at least one of node exist.
-			acceptance.TestAccPreCheckCceClusterId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
+				Config:      testAccV3EnvironmentAssociate_nonExistEnvironmentAndResources(),
+				ExpectError: regexp.MustCompile(`error associating resources to the environment \([a-f0-9-]+\)`),
+			},
+			{
 				Config: testAccV3EnvironmentAssociate_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "resources.0.id", "huaweicloud_vpc_eip.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "3"),
+					resource.TestCheckResourceAttrPair(resourceName, "resources.0.id", "huaweicloud_vpc_eip.test.0", "id"),
 					resource.TestCheckResourceAttr(resourceName, "resources.0.type", "eip"),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.name", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "resources.1.id", "huaweicloud_vpc_eip.test.1", "id"),
+					resource.TestCheckResourceAttr(resourceName, "resources.1.type", "eip"),
+					resource.TestCheckResourceAttr(resourceName, "resources.1.name", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "resources.2.id", "huaweicloud_vpc_eip.test.2", "id"),
+					resource.TestCheckResourceAttr(resourceName, "resources.2.type", "eip"),
+					resource.TestCheckResourceAttr(resourceName, "resources.2.name", ""),
 				),
 			},
 			{
 				Config: testAccV3EnvironmentAssociate_basic_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resources.0.id", acceptance.HW_CCE_CLUSTER_ID),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "3"),
+					resource.TestCheckResourceAttrPair(resourceName, "resources.0.id", "huaweicloud_cce_cluster.test.0", "id"),
 					resource.TestCheckResourceAttr(resourceName, "resources.0.type", "cce"),
+					resource.TestCheckResourceAttrPair(resourceName, "resources.0.name", "huaweicloud_cce_cluster.test.0", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "resources.1.id", "huaweicloud_cce_cluster.test.1", "id"),
+					resource.TestCheckResourceAttr(resourceName, "resources.1.type", "cce"),
+					resource.TestCheckResourceAttrPair(resourceName, "resources.1.name", "huaweicloud_cce_cluster.test.1", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "resources.2.id", "huaweicloud_cce_cluster.test.2", "id"),
+					resource.TestCheckResourceAttr(resourceName, "resources.2.type", "cce"),
+					resource.TestCheckResourceAttrPair(resourceName, "resources.2.name", "huaweicloud_cce_cluster.test.2", "name"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"resources_origin",
+				},
 			},
 		},
 	})
+}
+
+func testAccV3EnvironmentAssociate_nonExistEnvironmentAndResources() string {
+	randomUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_servicestagev3_environment_associate" "test" {
+  environment_id = "%[1]s"
+
+  resources {
+	id   = "%[1]s"
+	type = "eip"
+  }
+}
+`, randomUUID)
 }
 
 func testAccV3EnvironmentAssociate_base(name string) string {
@@ -73,24 +108,41 @@ func testAccV3EnvironmentAssociate_base(name string) string {
 %[1]s
 
 resource "huaweicloud_vpc_eip" "test" {
+  count = 3
+
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
   publicip {
     type = "5_bgp"
   }
 
   bandwidth {
-    name        = "%[2]s"
+    name        = format("%[2]s-%%d", count.index)
     size        = 5
     share_type  = "PER"
     charge_mode = "traffic"
   }
 }
 
+resource "huaweicloud_cce_cluster" "test" {
+  count = 3
+
+  name                   = format("%[2]s-%%d", count.index)
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+  container_network_cidr = "172.16.0.0/24"
+  security_group_id      = huaweicloud_networking_secgroup.test.id
+}
+
 resource "huaweicloud_servicestagev3_environment" "test" {
   name                  = "%[2]s"
   vpc_id                = huaweicloud_vpc.test.id
-  enterprise_project_id = "0"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
-`, common.TestVpc(name), name)
+`, common.TestBaseNetwork(name), name)
 }
 
 func testAccV3EnvironmentAssociate_basic_step1(name string) string {
@@ -100,9 +152,14 @@ func testAccV3EnvironmentAssociate_basic_step1(name string) string {
 resource "huaweicloud_servicestagev3_environment_associate" "test" {
   environment_id = huaweicloud_servicestagev3_environment.test.id
 
-  resources {
-    id   = huaweicloud_vpc_eip.test.id
-    type = "eip"
+  dynamic "resources" {
+    for_each = huaweicloud_vpc_eip.test
+
+	# Associate all EIPs to the environment and without configuring the EIP name.
+    content {
+      id   = resources.value.id
+      type = "eip"
+    }
   }
 }
 `, testAccV3EnvironmentAssociate_base(name))
@@ -115,10 +172,16 @@ func testAccV3EnvironmentAssociate_basic_step2(name string) string {
 resource "huaweicloud_servicestagev3_environment_associate" "test" {
   environment_id = huaweicloud_servicestagev3_environment.test.id
 
-  resources {
-    id   = "%[2]s"
-    type = "cce"
+  dynamic "resources" {
+    for_each = huaweicloud_cce_cluster.test
+
+	# Associate all CCE clusters to the environment and configure the CCE cluster name.
+    content {
+      id   = resources.value.id
+      name = resources.value.name
+      type = "cce"
+    }
   }
 }
-`, testAccV3EnvironmentAssociate_base(name), acceptance.HW_CCE_CLUSTER_ID)
+`, testAccV3EnvironmentAssociate_base(name))
 }

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_environment_associate.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_environment_associate.go
@@ -16,6 +16,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var environmentAssociateObjSliceParamKeys = []string{
+	"resources",
+}
+
 // @API ServiceStage PUT /v3/{project_id}/cas/environments/{environment_id}/resources
 // @API ServiceStage GET /v3/{project_id}/cas/environments/{environment_id}/resources
 func ResourceV3EnvironmentAssociate() *schema.Resource {
@@ -44,7 +48,7 @@ func ResourceV3EnvironmentAssociate() *schema.Resource {
 				Description: `The environment ID associated with the resources.`,
 			},
 			"resources": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -58,26 +62,67 @@ func ResourceV3EnvironmentAssociate() *schema.Resource {
 							Required:    true,
 							Description: `The type of the resource to be associated.`,
 						},
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The name of the resource to be associated.`,
+						},
 					},
 				},
 				Description: "The information about the associated resources.",
+			},
+
+			// Internal attributes.
+			"resources_origin": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: utils.SuppressDiffAll,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the resource to be associated.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the resource to be associated.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the resource to be associated.`,
+						},
+					},
+				},
+				Description: utils.SchemaDesc(
+					`The script configuration value of this change is also the original value used for comparison with
+ the new value next time the change is made. The corresponding parameter name is 'resources'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
 			},
 		},
 	}
 }
 
-func buildV3EnvironmentAssociatedResources(resources *schema.Set) []interface{} {
-	result := make([]interface{}, 0, resources.Len())
-	for _, v := range resources.List() {
+func buildV3EnvironmentAssociatedResources(resources []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(resources))
+	for _, v := range resources {
 		result = append(result, map[string]interface{}{
 			"id":   utils.PathSearch("id", v, nil),
 			"type": utils.PathSearch("type", v, nil),
+			"name": utils.PathSearch("name", v, nil),
 		})
 	}
 	return result
 }
 
-func modifyAssociatedResourcesUnderEnvironment(client *golangsdk.ServiceClient, envId string, resources *schema.Set) error {
+func modifyAssociatedResourcesUnderEnvironment(client *golangsdk.ServiceClient, envId string, resources []interface{}) error {
 	httpUrl := "v3/{project_id}/cas/environments/{environment_id}/resources"
 	createPath := client.Endpoint + httpUrl
 	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
@@ -102,7 +147,7 @@ func resourceV3EnvironmentAssociateCreate(ctx context.Context, d *schema.Resourc
 		cfg       = meta.(*config.Config)
 		region    = cfg.GetRegion(d)
 		envId     = d.Get("environment_id").(string)
-		resources = d.Get("resources").(*schema.Set)
+		resources = d.Get("resources").([]interface{})
 	)
 	client, err := cfg.NewServiceClient("servicestage", region)
 	if err != nil {
@@ -115,10 +160,18 @@ func resourceV3EnvironmentAssociateCreate(ctx context.Context, d *schema.Resourc
 	}
 	d.SetId(envId)
 
+	// If the request is successful, obtain the values ​​of all JSON parameters first and save them to the
+	// corresponding '_origin' attributes for subsequent determination and construction of the request body during
+	// next updates.
+	err = utils.RefreshObjectParamOriginValues(d, environmentAssociateObjSliceParamKeys)
+	if err != nil {
+		return diag.Errorf("unable to refresh the origin values: %s", err)
+	}
+
 	return resourceV3EnvironmentAssociateRead(ctx, d, meta)
 }
 
-func QueryV3EnvironmentAssociatedResources(client *golangsdk.ServiceClient, envId string) (interface{}, error) {
+func ListV3EnvironmentAssociatedResources(client *golangsdk.ServiceClient, envId string) (interface{}, error) {
 	httpUrl := "v3/{project_id}/cas/environments/{environment_id}/resources"
 
 	queryPath := client.Endpoint + httpUrl
@@ -140,19 +193,48 @@ func QueryV3EnvironmentAssociatedResources(client *golangsdk.ServiceClient, envI
 	return utils.FlattenResponse(requestResp)
 }
 
-func flattenV3EnvironmentAssociatedResources(resources []interface{}) []map[string]interface{} {
+func orderV3EnvironmentAssociatedResourcesByResourcesOrigin(resources []map[string]interface{},
+	resourcesOrigin []interface{}) []map[string]interface{} {
+	if len(resourcesOrigin) < 1 {
+		return resources
+	}
+
+	sortedResources := make([]map[string]interface{}, 0, len(resources))
+	resourcesCopy := resources
+	for _, resourceOrigin := range resourcesOrigin {
+		idOrigin := utils.PathSearch("id", resourceOrigin, "").(string)
+		typeOrigin := utils.PathSearch("type", resourceOrigin, "").(string)
+		for index, resource := range resourcesCopy {
+			if utils.PathSearch("id", resource, "").(string) != idOrigin || utils.PathSearch("type", resource, "").(string) != typeOrigin {
+				continue
+			}
+
+			sortedResources = append(sortedResources, resourcesCopy[index])
+			resourcesCopy = append(resourcesCopy[:index], resourcesCopy[index+1:]...)
+			break
+		}
+	}
+
+	// Add any remaining unsorted resources to the end of the sorted list.
+	sortedResources = append(sortedResources, resourcesCopy...)
+	return sortedResources
+}
+
+func flattenV3EnvironmentAssociatedResources(resources []interface{}, resourcesOrigin []interface{}) []map[string]interface{} {
 	if len(resources) < 1 {
 		return nil
 	}
 
-	result := make([]map[string]interface{}, 0, len(resources))
+	parsedResources := make([]map[string]interface{}, 0, len(resources))
 	for _, resource := range resources {
-		result = append(result, map[string]interface{}{
+		parsedResources = append(parsedResources, map[string]interface{}{
 			"id":   utils.PathSearch("id", resource, nil),
 			"type": utils.PathSearch("type", resource, nil),
+			"name": utils.PathSearch("name", resource, nil),
 		})
 	}
-	return result
+
+	return orderV3EnvironmentAssociatedResourcesByResourcesOrigin(parsedResources, resourcesOrigin)
 }
 
 func resourceV3EnvironmentAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -166,19 +248,26 @@ func resourceV3EnvironmentAssociateRead(_ context.Context, d *schema.ResourceDat
 		return diag.Errorf("error creating ServiceStage client: %s", err)
 	}
 
-	respBody, err := QueryV3EnvironmentAssociatedResources(client, envId)
+	respBody, err := ListV3EnvironmentAssociatedResources(client, envId)
 	if err != nil {
 		return common.CheckDeletedDiag(d, common.ConvertExpected401ErrInto404Err(err, "error_code", v3EnvNotFoundCodes...),
 			fmt.Sprintf("error getting environment (%s)", envId))
 	}
 	associatedResources := utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{})
 	if len(associatedResources) < 1 {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "associated resources not found")
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Method:    "GET",
+				URL:       "/v3/{project_id}/cas/environments/{environment_id}/resources",
+				RequestId: "NONE",
+				Body:      []byte(fmt.Sprintf("All assiciated resources have been dissociated from the environment (%s)", envId)),
+			},
+		}, "error retrieving associated resources")
 	}
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("resources", flattenV3EnvironmentAssociatedResources(associatedResources)),
+		d.Set("resources", flattenV3EnvironmentAssociatedResources(associatedResources, d.Get("resources_origin").([]interface{}))),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -189,7 +278,7 @@ func resourceV3EnvironmentAssociateUpdate(ctx context.Context, d *schema.Resourc
 		cfg       = meta.(*config.Config)
 		region    = cfg.GetRegion(d)
 		envId     = d.Id()
-		resources = d.Get("resources").(*schema.Set)
+		resources = d.Get("resources").([]interface{})
 	)
 	client, err := cfg.NewServiceClient("servicestage", region)
 	if err != nil {
@@ -199,6 +288,14 @@ func resourceV3EnvironmentAssociateUpdate(ctx context.Context, d *schema.Resourc
 	err = modifyAssociatedResourcesUnderEnvironment(client, envId, resources)
 	if err != nil {
 		return diag.Errorf("error modifying associated resources under the environment (%s): %s", envId, err)
+	}
+
+	// If the request is successful, obtain the values ​​of all JSON parameters first and save them to the
+	// corresponding '_origin' attributes for subsequent determination and construction of the request body during
+	// next updates.
+	err = utils.RefreshObjectParamOriginValues(d, environmentAssociateObjSliceParamKeys)
+	if err != nil {
+		return diag.Errorf("unable to refresh the origin values: %s", err)
 	}
 
 	return resourceV3EnvironmentAssociateRead(ctx, d, meta)
@@ -215,7 +312,7 @@ func resourceV3EnvironmentAssociateDelete(_ context.Context, d *schema.ResourceD
 		return diag.Errorf("error creating ServiceStage client: %s", err)
 	}
 
-	err = modifyAssociatedResourcesUnderEnvironment(client, envId, schema.NewSet(schema.HashString, nil))
+	err = modifyAssociatedResourcesUnderEnvironment(client, envId, make([]interface{}, 0))
 	if err != nil {
 		return common.CheckDeletedDiag(d, common.ConvertExpected401ErrInto404Err(err, "error_code", v3EnvNotFoundCodes...),
 			fmt.Sprintf("error dissociating the resources from the environment (%s)", envId))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

For some regions and resources, parameter `resources.id` is not enough to make sure association successfully.
Supports new parameter `resources.name` can help it well.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the acceptance test:
<img width="1067" height="103" alt="image" src="https://github.com/user-attachments/assets/35ba99ea-3bdc-4f99-9ec7-6a3c8ad02f9d" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. environment resources can using name to be assicated
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccV3EnvironmentAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccV3EnvironmentAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccV3EnvironmentAssociate_basic
=== PAUSE TestAccV3EnvironmentAssociate_basic
=== CONT  TestAccV3EnvironmentAssociate_basic
--- PASS: TestAccV3EnvironmentAssociate_basic (638.01s)
PASS
coverage: 7.7% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      638.092s        coverage: 7.7% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
