### PR TITLE
feat(secmaster): support `secmaster_metrics` data source

### DIFF
--- a/docs/data-sources/secmaster_metrics.md
+++ b/docs/data-sources/secmaster_metrics.md
@@ -1,0 +1,114 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_metrics"
+description: |-
+  Use this data source to get the list of SecMaster metrics within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_metrics
+
+Use this data source to get the list of SecMaster metrics within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_metrics" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data` - The result data list.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `name` - The metric name.
+
+* `id` - The metric ID.
+
+* `metric_type` - The metric type.
+
+* `data_type` - The data type.
+
+* `metric_dimension` - The metric result dimension.
+
+* `cache_ttl` - The cache TTL, in seconds.
+
+* `report_period` - The report period, in seconds.
+
+* `is_built_in` - Whether the metric is built-in.
+
+* `effective_column` - The effective column.
+
+* `max_query_range` - The maximum query range, in days.
+
+* `derived_metrics` - The derived metrics list.
+
+  The [derived_metrics](#derived_metrics_struct) structure is documented below.
+
+* `compound_expression` - The compound expression.
+
+* `metric_format` - The metric format.
+
+  The [metric_format](#metric_format_struct) structure is documented below.
+
+* `metric_expand_dim` - The metric dimension expand parameter.
+
+  The [metric_expand_dim](#metric_expand_dim_struct) structure is documented below.
+
+* `version` - The SecMaster version.
+
+<a name="derived_metrics_struct"></a>
+The `derived_metrics` block supports:
+
+* `metric_dimension` - The derived metric result dimension.
+
+* `max_query_range` - The maximum query range, in days.
+
+* `date_start` - The relative start time of the metric query range.
+
+* `date_end` - The relative end time of the metric query range.
+
+* `date_format` - The time format.
+
+* `query_type` - The query type.
+
+* `query_function` - The query function.
+
+<a name="metric_format_struct"></a>
+The `metric_format` block supports:
+
+* `data` - The data format.
+
+* `display` - The display format.
+
+* `display_param` - The display parameters.
+
+* `data_param` - The data parameters.
+
+<a name="metric_expand_dim_struct"></a>
+The `metric_expand_dim` block supports:
+
+* `labels` - The dimension expand labels.
+
+* `functions` - The dimension expand functions.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2343,6 +2343,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_layout_wizards":                  secmaster.DataSourceLayoutWizards(),
 			"huaweicloud_secmaster_layouts":                         secmaster.DataSourceLayouts(),
 			"huaweicloud_secmaster_mappings_functions":              secmaster.DataSourceMappingsFunctions(),
+			"huaweicloud_secmaster_metrics":                         secmaster.DataSourceMetrics(),
 			"huaweicloud_secmaster_metric_results":                  secmaster.DataSourceMetricResults(),
 			"huaweicloud_secmaster_modules":                         secmaster.DataSourceModules(),
 			"huaweicloud_secmaster_moniter_metric_stats":            secmaster.DataSourceMoniterMetricStats(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_metrics_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_metrics_test.go
@@ -1,0 +1,42 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceMetrics_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_metrics.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceMetrics_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceMetrics_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_metrics" "test" {
+  workspace_id = "%s"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_metrics.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_metrics.go
@@ -1,0 +1,324 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/soc/metrics
+func DataSourceMetrics() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMetricsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     metricsDataSchema(),
+			},
+		},
+	}
+}
+
+func metricsDataSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metric_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metric_dimension": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cache_ttl": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"report_period": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"is_built_in": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"effective_column": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"max_query_range": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"derived_metrics": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     metricsDerivedMetricsSchema(),
+			},
+			"compound_expression": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metric_format": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     metricsFormatSchema(),
+			},
+			"metric_expand_dim": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     metricsExpandDimSchema(),
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func metricsDerivedMetricsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"metric_dimension": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"max_query_range": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"date_start": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"date_end": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"date_format": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"query_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"query_function": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func metricsFormatSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"display": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"display_param": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"data_param": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func metricsExpandDimSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"labels": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"functions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceMetricsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/metrics"
+		product = "secmaster"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"content-type": "application/json;charset=UTF-8",
+		},
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving metrics: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenMetrics(utils.PathSearch(
+			"data", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenMetrics(metrics []interface{}) []interface{} {
+	if len(metrics) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(metrics))
+	for _, v := range metrics {
+		rst = append(rst, map[string]interface{}{
+			"name":             utils.PathSearch("name", v, nil),
+			"id":               utils.PathSearch("id", v, nil),
+			"metric_type":      utils.PathSearch("metric_type", v, nil),
+			"data_type":        utils.PathSearch("data_type", v, nil),
+			"metric_dimension": utils.PathSearch("metric_dimension", v, nil),
+			"cache_ttl":        utils.PathSearch("cache_ttl", v, nil),
+			"report_period":    utils.PathSearch("report_period", v, nil),
+			"is_built_in":      utils.PathSearch("is_built_in", v, nil),
+			"effective_column": utils.PathSearch("effective_column", v, nil),
+			"max_query_range":  utils.PathSearch("max_query_range", v, nil),
+			"derived_metrics": flattenMetricsDerivedMetrics(
+				utils.PathSearch("derived_metrics", v, make([]interface{}, 0)).([]interface{})),
+			"compound_expression": utils.PathSearch("compound_expression", v, nil),
+			"metric_format": flattenMetricsFormat(
+				utils.PathSearch("metric_format", v, make([]interface{}, 0)).([]interface{})),
+			"metric_expand_dim": flattenMetricsExpandDim(
+				utils.PathSearch("metric_expand_dim", v, nil)),
+			"version": utils.PathSearch("version", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenMetricsDerivedMetrics(derivedMetrics []interface{}) []interface{} {
+	if len(derivedMetrics) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(derivedMetrics))
+	for _, v := range derivedMetrics {
+		rst = append(rst, map[string]interface{}{
+			"metric_dimension": utils.PathSearch("metric_dimension", v, nil),
+			"max_query_range":  utils.PathSearch("max_query_range", v, nil),
+			"date_start":       utils.PathSearch("date_start", v, nil),
+			"date_end":         utils.PathSearch("date_end", v, nil),
+			"date_format":      utils.PathSearch("date_format", v, nil),
+			"query_type":       utils.PathSearch("query_type", v, nil),
+			"query_function":   utils.PathSearch("query_function", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenMetricsFormat(metricFormats []interface{}) []interface{} {
+	if len(metricFormats) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(metricFormats))
+	for _, v := range metricFormats {
+		rst = append(rst, map[string]interface{}{
+			"data":    utils.PathSearch("data", v, nil),
+			"display": utils.PathSearch("display", v, nil),
+			"display_param": utils.ExpandToStringMap(
+				utils.PathSearch("display_param", v, make(map[string]interface{})).(map[string]interface{})),
+			"data_param": utils.ExpandToStringMap(
+				utils.PathSearch("data_param", v, make(map[string]interface{})).(map[string]interface{})),
+		})
+	}
+
+	return rst
+}
+
+func flattenMetricsExpandDim(raw interface{}) []interface{} {
+	if raw == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"labels": utils.ExpandToStringList(utils.PathSearch(
+				"labels", raw, make([]interface{}, 0)).([]interface{})),
+			"functions": utils.ExpandToStringList(utils.PathSearch(
+				"functions", raw, make([]interface{}, 0)).([]interface{})),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `secmaster_metrics` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `secmaster_metrics` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o secmaster -f TestAccDataSourceMetrics_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceMetrics_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceMetrics_basic
=== PAUSE TestAccDataSourceMetrics_basic
=== CONT  TestAccDataSourceMetrics_basic
--- PASS: TestAccDataSourceMetrics_basic (20.19s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/secmaster    coverage: 4.1% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 20.482s coverage: 4.1% of statements in ./huaweicloud/services/secmaster
```
<img width="900" height="37" alt="image" src="https://github.com/user-attachments/assets/9b392d86-55d4-457d-90d4-891e62f14cb0" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
