### PR TITLE
feat(lb): the listener resource supports 'transparent_client_ip_enable' field

### DIFF
--- a/docs/resources/lb_listener.md
+++ b/docs/resources/lb_listener.md
@@ -31,7 +31,8 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) The region in which to create the listener resource. If omitted, the
   provider-level region will be used. Changing this creates a new listener.
 
-* `protocol` - (Required, String, NonUpdatable) The protocol can either be **TCP**, **UDP**, **HTTP** or **TERMINATED_HTTPS**.
+* `protocol` - (Required, String, NonUpdatable) The protocol can either be **TCP**, **UDP**, **HTTP** or
+  **TERMINATED_HTTPS**.
 
 * `protocol_port` - (Required, Int, NonUpdatable) The port on which to listen for client traffic.
 
@@ -43,42 +44,55 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Human-readable description for the listener.
 
-* `http2_enable` - (Optional, Bool) Specifies whether to use HTTP/2. The default value is false. This parameter is valid
-  only when the `protocol` is set to **TERMINATED_HTTPS**.
+* `http2_enable` - (Optional, Bool) Specifies whether to use HTTP/2. The default value is false.  
+  This parameter is valid only when the `protocol` is set to **TERMINATED_HTTPS**.
 
-* `default_tls_container_ref` - (Optional, String) Specifies the ID of the server certificate used by the listener. This
-  parameter is mandatory when `protocol` is set to **TERMINATED_HTTPS**.
+* `default_tls_container_ref` - (Optional, String) Specifies the ID of the server certificate used by the listener.  
+  This parameter is mandatory when `protocol` is set to **TERMINATED_HTTPS**.
 
-* `client_ca_tls_container_ref` - (Optional, String) Specifies the ID of the CA certificate used by the listener. This
-  parameter is mandatory when `protocol` is set to **TERMINATED_HTTPS**.
+* `client_ca_tls_container_ref` - (Optional, String) Specifies the ID of the CA certificate used by the listener.  
+  This parameter is mandatory when `protocol` is set to **TERMINATED_HTTPS**.
 
 * `sni_container_refs` - (Optional, List) Lists the IDs of SNI certificates (server certificates with a domain name)
   used by the listener. This parameter is valid when `protocol` is set to **TERMINATED_HTTPS**.
 
-* `insert_headers` - (Optional, List) Specifies whether to insert HTTP extension headers and sent them to backend servers.
+* `insert_headers` - (Optional, List) Specifies whether to insert HTTP extension headers and sent them to backend
+  servers.  
   All headers are synchronized. If this parameter is not set, default values are used. Information required by backend
-  servers can be written into HTTP headers and passed to backend servers. This parameter is mandatory when `protocol` is
-  set to **TERMINATED_HTTPS**.
+  servers can be written into HTTP headers and passed to backend servers.  
+  This parameter is mandatory when `protocol` is set to **TERMINATED_HTTPS**.  
   The [insert_headers](#insert_headers_struct) structure is documented below.
 
-* `tls_ciphers_policy` - (Optional, String) Specifies the security policy used by the listener. This parameter takes effect
-  only when the `protocol` used by the listener is set to **TERMINATED_HTTPS**. Value options: **tls-1-0-inherit**,
-  **tls-1-0**, **tls-1-1**, **tls-1-2** or **tls-1-2-strict**. Defaults to **tls-1-0**.
+* `tls_ciphers_policy` - (Optional, String) Specifies the security policy used by the listener.  
+  This parameter takes effect only when the `protocol` used by the listener is set to **TERMINATED_HTTPS**.  
+  Value options: **tls-1-0-inherit**, **tls-1-0**, **tls-1-1**, **tls-1-2** or **tls-1-2-strict**.  
+  Defaults to **tls-1-0**.
 
 * `protection_status` - (Optional, String) Specifies whether modification protection is enabled. Value options:
   + **nonProtection (default)**: Modification protection is not enabled.
-  + **consoleProtection**: Modification protection is enabled to avoid that resources are modified by accident on the console.
+  + **consoleProtection**: Modification protection is enabled to avoid that resources are modified by accident on
+  the console.
 
-* `protection_reason` - (Optional, String) The reason to enable modification protection. This parameter is valid only when
-  `protection_status` is set to **consoleProtection**.
+* `protection_reason` - (Optional, String) The reason to enable modification protection. This parameter is valid only
+  when `protection_status` is set to **consoleProtection**.
 
 * `tags` - (Optional, Map) Specifies the reason to enable modification protection.
+
+* `transparent_client_ip_enable` - (Optional, String) Specifies whether to pass source IP addresses of the clients to
+  backend servers.  
+  The valid values are as follows:
+  + **true**
+  + **false**
+
+  When `protocol` is set to **TCP** or **UDP**, if omitted, the default value is **false**.  
+  When `protocol` is set to **HTTP** or **HTTPS**, the default value is **true** and cannot be modified.
 
 <a name="insert_headers_struct"></a>
 The `insert_headers` block supports:
 
 * `x_forwarded_elb_ip` - (Optional, String) Specifies whether to transparently transmit the load balancer EIP to backend
-  servers. After this function is enabled, the load balancer EIP is stored in the HTTP header and passes to backend servers.
+  servers. After this function is enabled, the load balancer EIP is stored in the HTTP header and passes to backend
+  servers.  
   Value options:
   + **true**: This function is enabled.
   + **false (default)**: The function is disabled.

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_listener_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_listener_test.go
@@ -44,21 +44,25 @@ func getL7ListenerResourceFunc(cfg *config.Config, state *terraform.ResourceStat
 }
 
 func TestAccLBV2Listener_basic(t *testing.T) {
-	var obj interface{}
-	rName := acceptance.RandomAccResourceNameWithDash()
-	updateName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_lb_listener.listener_1"
+	var (
+		rName      = acceptance.RandomAccResourceNameWithDash()
+		updateName = acceptance.RandomAccResourceNameWithDash()
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&obj,
-		getL7ListenerResourceFunc,
+		obj          interface{}
+		resourceName = "huaweicloud_lb_listener.listener_1"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getL7ListenerResourceFunc)
+
+		rNameWithUDP = "huaweicloud_lb_listener.with_udp"
+		rcWithUDP    = acceptance.InitResourceCheck(rNameWithUDP, &obj, getL7ListenerResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rc.CheckResourceDestroy(),
+			rcWithUDP.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLBV2ListenerConfig_basic(rName),
@@ -69,8 +73,11 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "connection_limit", "-1"),
+					resource.TestCheckResourceAttr(resourceName, "transparent_client_ip_enable", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					rcWithUDP.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithUDP, "transparent_client_ip_enable", "true"),
 				),
 			},
 			{
@@ -80,10 +87,20 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
+					rcWithUDP.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameWithUDP, "transparent_client_ip_enable", "false"),
+					resource.TestCheckResourceAttr(rNameWithUDP, "name", updateName+"_udp"),
+					resource.TestCheckResourceAttr(rNameWithUDP, "description", "Updated by terraform script"),
+					resource.TestCheckResourceAttr(rNameWithUDP, "tags.foo", "bar_update"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      rNameWithUDP,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -127,6 +144,7 @@ func TestAccLBV2Listener_https(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "protection_reason", "test protection reason"),
 					resource.TestCheckResourceAttr(resourceName, "insert_headers.0.x_forwarded_elb_ip", "true"),
 					resource.TestCheckResourceAttr(resourceName, "insert_headers.0.x_forwarded_host", "true"),
+					resource.TestCheckResourceAttr(resourceName, "transparent_client_ip_enable", "true"),
 				),
 			},
 			{
@@ -158,10 +176,10 @@ resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
 
 func testAccLBV2ListenerConfig_basic(rName string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_lb_listener" "listener_1" {
-  name            = "%s"
+  name            = "%[2]s"
   description     = "created by acceptance test"
   protocol        = "HTTP"
   protocol_port   = 8080
@@ -172,17 +190,30 @@ resource "huaweicloud_lb_listener" "listener_1" {
     owner = "terraform"
   }
 }
+
+resource "huaweicloud_lb_listener" "with_udp" {
+  loadbalancer_id              = huaweicloud_lb_loadbalancer.loadbalancer_1.id
+  name                         = "%[2]s_udp"
+  description                  = "Created by terraform script"
+  protocol                     = "UDP"
+  protocol_port                = 8080
+  transparent_client_ip_enable = "true"
+
+  tags = {
+    foo = "bar"
+  }
+}
 `, testAccLBV2ListenerConfig_base(rName), rName)
 }
 
 func testAccLBV2ListenerConfig_update(rName, rNameUpdate string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
-%s
+%[2]s
 
 resource "huaweicloud_lb_listener" "listener_1" {
-  name            = "%s"
+  name            = "%[3]s"
   protocol        = "HTTP"
   protocol_port   = 8080
   loadbalancer_id = huaweicloud_lb_loadbalancer.loadbalancer_1.id
@@ -190,6 +221,19 @@ resource "huaweicloud_lb_listener" "listener_1" {
   tags = {
     foo   = "bar"
     owner = "terraform_update"
+  }
+}
+
+resource "huaweicloud_lb_listener" "with_udp" {
+  loadbalancer_id              = huaweicloud_lb_loadbalancer.loadbalancer_1.id
+  name                         = "%[3]s_udp"
+  description                  = "Updated by terraform script"
+  protocol                     = "UDP"
+  protocol_port                = 8080
+  transparent_client_ip_enable = "false"
+
+  tags = {
+    foo = "bar_update"
   }
 }
 `, testAccLBV2ListenerConfig_base(rName), testAccLBV2CertificateConfig_basic(rName), rNameUpdate)

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_listener.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_listener.go
@@ -24,9 +24,11 @@ import (
 var listenerNonUpdatableParams = []string{"protocol", "protocol_port", "loadbalancer_id", "tenant_id"}
 
 // @API ELB POST /v2/{project_id}/elb/listeners
+// @API ELB PUT /v3/{project_id}/elb/listeners/{listener_id}
 // @API ELB GET /v2/{project_id}/elb/loadbalancers/{loadbalancer_id}
 // @API ELB POST /v2.0/{project_id}/listeners/{listener_id}/tags/action
 // @API ELB GET /v2/{project_id}/elb/listeners/{listener_id}
+// @API ELB GET /v3/{project_id}/elb/listeners/{listener_id}
 // @API ELB GET /v2.0/{project_id}/listeners/{listener_id}/tags
 // @API ELB PUT /v2/{project_id}/elb/listeners/{listener_id}
 // @API ELB DELETE /v2/{project_id}/elb/listeners/{listener_id}
@@ -126,6 +128,12 @@ func ResourceListener() *schema.Resource {
 				Optional: true,
 			},
 			"tags": common.TagsSchema(),
+			"transparent_client_ip_enable": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to pass the client IP address to the backend server.`,
+			},
 			"created_at": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -231,6 +239,12 @@ func resourceListenerV2Create(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
+	if v, ok := d.GetOk("transparent_client_ip_enable"); ok {
+		if err = updateListenerTransparentClientIP(client, listenerId, v.(string)); err != nil {
+			return diag.Errorf("error updating transparent client IP of ELB listener (%s): %s", listenerId, err)
+		}
+	}
+
 	return resourceListenerV2Read(ctx, d, meta)
 }
 
@@ -274,6 +288,29 @@ func buildListenerInsertHeaders(d *schema.ResourceData) map[string]interface{} {
 	return nil
 }
 
+func updateListenerTransparentClientIP(client *golangsdk.ServiceClient, listenerId, transparentClientIpEnable string) error {
+	httpUrl := "v3/{project_id}/elb/listeners/{listener_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{listener_id}", listenerId)
+
+	enabled, _ := strconv.ParseBool(transparentClientIpEnable)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"listener": map[string]interface{}{
+				"transparent_client_ip_enable": enabled,
+			},
+		},
+	}
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
+}
+
 func resourceListenerV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
@@ -307,6 +344,11 @@ func resourceListenerV2Read(_ context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
+	transparentClientIpEnable, err := getListenerTransparentClientIP(client, d.Id())
+	if err != nil {
+		log.Printf("[ERROR] error getting transparent client IP of ELB listener (%s): %s", d.Id(), err)
+	}
+
 	mErr = multierror.Append(
 		mErr,
 		d.Set("region", region),
@@ -324,11 +366,14 @@ func resourceListenerV2Read(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("tls_ciphers_policy", utils.PathSearch("listener.tls_ciphers_policy", getRespBody, nil)),
 		d.Set("protection_status", utils.PathSearch("listener.protection_status", getRespBody, nil)),
 		d.Set("protection_reason", utils.PathSearch("listener.protection_reason", getRespBody, nil)),
+		d.Set("transparent_client_ip_enable", transparentClientIpEnable),
+		// Attributes.
+		d.Set("created_at", utils.PathSearch("listener.created_at", getRespBody, nil)),
+		d.Set("updated_at", utils.PathSearch("listener.updated_at", getRespBody, nil)),
+		// Deprecated parameters.
 		d.Set("tenant_id", utils.PathSearch("listener.tenant_id", getRespBody, nil)),
 		d.Set("admin_state_up", utils.PathSearch("listener.admin_state_up", getRespBody, nil)),
 		d.Set("connection_limit", utils.PathSearch("listener.connection_limit", getRespBody, nil)),
-		d.Set("created_at", utils.PathSearch("listener.created_at", getRespBody, nil)),
-		d.Set("updated_at", utils.PathSearch("listener.updated_at", getRespBody, nil)),
 	)
 
 	// fetch tags
@@ -359,37 +404,63 @@ func flattenInsertHeaders(listener interface{}) []map[string]interface{} {
 	return rst
 }
 
-func resourceListenerV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+func getListenerTransparentClientIP(client *golangsdk.ServiceClient, listenerId string) (string, error) {
+	httpUrl := "v3/{project_id}/elb/listeners/{listener_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{listener_id}", listenerId)
 
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return "", err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return "", err
+	}
+
+	return strconv.FormatBool(utils.PathSearch("listener.transparent_client_ip_enable", respBody, false).(bool)), nil
+}
+
+func resourceListenerV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		httpUrl = "v2/{project_id}/elb/listeners/{listener_id}"
-		product = "elbv2"
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		product    = "elbv2"
+		listenerId = d.Id()
 	)
 	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating ELB client: %s", err)
 	}
 
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{listener_id}", d.Id())
-
-	updateOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
-	updateOpt.JSONBody = utils.RemoveNil(buildUpdateListenerBodyParams(d))
-	_, err = client.Request("PUT", updatePath, &updateOpt)
-	if err != nil {
-		return diag.Errorf("error updating ELB listener: %s", err)
+	if d.HasChangesExcept("tags", "transparent_client_ip_enable") {
+		err = updateListener(client, d, listenerId)
+		if err != nil {
+			return diag.Errorf("error updating ELB listener (%s): %s", listenerId, err)
+		}
 	}
 
 	// update tags
 	if d.HasChange("tags") {
-		tagErr := utils.UpdateResourceTags(client, d, "listeners", d.Id())
+		tagErr := utils.UpdateResourceTags(client, d, "listeners", listenerId)
 		if tagErr != nil {
-			return diag.Errorf("error updating tags of ELB listener:%s, err:%s", d.Id(), tagErr)
+			return diag.Errorf("error updating tags of ELB listener:%s, err:%s", listenerId, tagErr)
+		}
+	}
+
+	if d.HasChange("transparent_client_ip_enable") {
+		err = updateListenerTransparentClientIP(client, listenerId, d.Get("transparent_client_ip_enable").(string))
+		if err != nil {
+			return diag.Errorf("error updating transparent client IP of ELB listener %s: %s", listenerId, err)
 		}
 	}
 
@@ -415,6 +486,20 @@ func buildUpdateListenerBodyParams(d *schema.ResourceData) map[string]interface{
 		"listener": params,
 	}
 	return bodyParams
+}
+
+func updateListener(client *golangsdk.ServiceClient, d *schema.ResourceData, listenerId string) error {
+	httpUrl := "v2/{project_id}/elb/listeners/{listener_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{listener_id}", listenerId)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdateListenerBodyParams(d)),
+	}
+	_, err := client.Request("PUT", updatePath, &updateOpt)
+	return err
 }
 
 func resourceListenerV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new parameter `transparent_client_ip_enable` for `huaweicloud_lb_listener` resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the listener resource supports 'transparent_client_ip_enable' field.
2. line breaks for lines exceeding 120 characters in document.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o lb -f TestAccLBV2Listener_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/lb" -v -coverprofile="./huaweicloud/services/acceptance/lb/lb_coverage.cov" -coverpkg="./huaweicloud/services/lb" -run TestAccLBV2Listener_ -timeout 360m -parallel 10
=== RUN   TestAccLBV2Listener_basic
=== PAUSE TestAccLBV2Listener_basic
=== RUN   TestAccLBV2Listener_https
=== PAUSE TestAccLBV2Listener_https
=== CONT  TestAccLBV2Listener_basic
=== CONT  TestAccLBV2Listener_https
--- PASS: TestAccLBV2Listener_https (103.43s)
--- PASS: TestAccLBV2Listener_basic (116.45s)
PASS
coverage: 18.0% of statements in ./huaweicloud/services/lb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        116.575s        coverage: 18.0% of statements in ./huaweicloud/services/lb
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
