### PR TITLE
feat(obs): bucket object supports 'metadata'

### DIFF
--- a/docs/data-sources/obs_bucket_object.md
+++ b/docs/data-sources/obs_bucket_object.md
@@ -51,3 +51,5 @@ In addition to all arguments above, the following attributes are exported:
   potentially downloading large amount of data.
 
 * `tags` - The key/value pairs associated with the object.
+
+* `metadata` - The custom metadata of the object.

--- a/docs/resources/obs_bucket_object.md
+++ b/docs/resources/obs_bucket_object.md
@@ -79,6 +79,14 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the object.
 
+* `metadata` - (Optional, Map) Specifies the custom metadata key/value pairs of the object.  
+  + Key must start with `x-obs-meta-`.
+  + When the bucket is enabled for versioning, the latest version of the object supports setting metadata,
+    and the history version of the object does not support setting metadata.
+  + For objects with archive storage or deep archive storage, the object metadata cannot be set.
+  + The total size of custom metadata is limited to `8` KB. The size of each custom metadata is calculated as the
+    total number of bytes in the UTF-8 encoding of the key and value.
+
 Either `source` or `content` must be provided to specify the bucket content. These two arguments are mutually-exclusive.
 
 ## Attribute Reference

--- a/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/data_source_huaweicloud_obs_bucket_object_test.go
@@ -40,6 +40,8 @@ func TestAccObsBucketObjectDataSource_content(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "content_type", "binary/octet-stream"),
 					resource.TestCheckResourceAttr(dataSourceName, "storage_class", "STANDARD"),
 					resource.TestCheckResourceAttr(dataSourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.x-obs-meta-test", "meta test"),
 				),
 			},
 		},
@@ -180,6 +182,10 @@ resource "huaweicloud_obs_bucket_object" "object" {
 
   tags = {
     foo = "bar"
+  }
+
+  metadata = {
+    "x-obs-meta-test" = "meta test"
   }
 }
 `, randInt, randInt)

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_object_test.go
@@ -40,7 +40,7 @@ func TestAccObsBucketObject_source(t *testing.T) {
 		CheckDestroy:      testAccCheckObsBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObsBucketObjectConfigSource(name, tmpFile.Name()),
+				Config: testAccBucketObject_source_step1(name, tmpFile.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObsBucketObjectExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "key", name),
@@ -48,15 +48,27 @@ func TestAccObsBucketObject_source(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.x-obs-meta-test1", "meta test1"),
 				),
 			},
 			{
 				// update with encryption
-				Config: testAccObsBucketObjectConfig_withSSE(name, tmpFile.Name()),
+				Config: testAccBucketObject_source_step2(name, tmpFile.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.x-obs-meta-test-update", "update meta test1"),
+				),
+			},
+			{
+				// update with encryption
+				Config: testAccBucketObject_source_step3(name, tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "0"),
 				),
 			},
 			{
@@ -85,20 +97,33 @@ func TestAccObsBucketObject_content(t *testing.T) {
 		CheckDestroy:      testAccCheckObsBucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketObjectConfigContent_step1(name),
+				Config: testAccBucketObject_content_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObsBucketObjectExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "key", name),
 					resource.TestMatchResourceAttr(resourceName, "size", regexp.MustCompile("^[1-9][0-9]*$")),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "0"),
 				),
 			},
 			{
-				Config: testAccBucketObjectConfigContent_step2(name),
+				Config: testAccBucketObject_content_step2(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObsBucketObjectExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.x-obs-meta-test", "tf_test"),
+				),
+			},
+			{
+				Config: testAccBucketObject_content_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.x-obs-meta-update", "tf_test_update"),
 				),
 			},
 			{
@@ -225,7 +250,7 @@ resource "huaweicloud_obs_bucket" "test" {
 `, name)
 }
 
-func testAccObsBucketObjectConfigSource(name, source string) string {
+func testAccBucketObject_source_step1(name, source string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -238,11 +263,15 @@ resource "huaweicloud_obs_bucket_object" "test" {
   tags = {
     foo = "bar"
   }
+
+  metadata = {
+    "x-obs-meta-test1" = "meta test1"
+  }
 }
 `, testAccBucketObject_base(name), name, source)
 }
 
-func testAccObsBucketObjectConfig_withSSE(name, source string) string {
+func testAccBucketObject_source_step2(name, source string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -256,11 +285,31 @@ resource "huaweicloud_obs_bucket_object" "test" {
   tags = {
     owner = "terraform"
   }
+
+  metadata = {
+    "x-obs-meta-test-update" = "update meta test1"
+  }
 }
 `, testAccBucketObject_base(name), name, source)
 }
 
-func testAccBucketObjectConfigContent_step1(name string) string {
+func testAccBucketObject_source_step3(name, source string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "%[2]s"
+  source       = "%[3]s"
+  content_type = "binary/octet-stream"
+  encryption   = true
+
+  tags = {}
+}
+`, testAccBucketObject_base(name), name, source)
+}
+
+func testAccBucketObject_content_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -268,15 +317,11 @@ resource "huaweicloud_obs_bucket_object" "test" {
   bucket  = huaweicloud_obs_bucket.test.bucket
   key     = "%[2]s"
   content = "some_bucket_content"
-
-  tags = {
-    foo = "bar"
-  }
 }
 `, testAccBucketObject_base(name), name)
 }
 
-func testAccBucketObjectConfigContent_step2(name string) string {
+func testAccBucketObject_content_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -285,7 +330,33 @@ resource "huaweicloud_obs_bucket_object" "test" {
   key     = "%[2]s"
   content = "update_some_bucket_content"
 
-  tags = {}
+  tags = {
+    foo = "bar"
+  }
+
+  metadata = {
+    "x-obs-meta-test" = "tf_test"
+  }
+}
+`, testAccBucketObject_base(name), name)
+}
+
+func testAccBucketObject_content_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket  = huaweicloud_obs_bucket.test.bucket
+  key     = "%[2]s"
+  content = "update_some_bucket_content"
+
+  tags = {
+    owner = "terraform"
+  }
+
+  metadata = {
+    "x-obs-meta-update" = "tf_test_update"
+  }
 }
 `, testAccBucketObject_base(name), name)
 }

--- a/huaweicloud/services/obs/data_source_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/services/obs/data_source_huaweicloud_obs_bucket_object.go
@@ -65,6 +65,12 @@ func DataSourceObsBucketObject() *schema.Resource {
 				Computed: true,
 			},
 			"tags": common.TagsComputedSchema(`The key/value pairs associated with the object.`),
+			"metadata": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The custom metadata of the object.`,
+			},
 		},
 	}
 }
@@ -116,6 +122,7 @@ func dataSourceObsBucketObjectRead(_ context.Context, d *schema.ResourceData, me
 		d.Set("version_id", objectMeta.VersionId),
 		d.Set("content_type", objectMeta.ContentType),
 		d.Set("tags", tags),
+		d.Set("metadata", objectMeta.Metadata),
 	)
 
 	// body is available only for objects which have a human-readable Content-Type

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket_object.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API OBS HEAD /
@@ -100,6 +101,12 @@ func ResourceObsBucketObject() *schema.Resource {
 				Computed: true,
 			},
 			"tags": common.TagsSchema(`The key/value pairs to associate with the object.`),
+			"metadata": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The custom metadata key/value pairs of the object.`,
+			},
 
 			"version_id": {
 				Type:     schema.TypeString,
@@ -164,6 +171,10 @@ func putContentToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.
 		putInput.ContentType = v.(string)
 	}
 
+	if v, ok := d.GetOk("metadata"); ok {
+		putInput.Metadata = utils.ExpandToStringMap(v.(map[string]interface{}))
+	}
+
 	var sseKmsHeader = obs.SseKmsHeader{}
 	if d.Get("encryption").(bool) {
 		sseKmsHeader.Encryption = obs.DEFAULT_SSE_KMS_ENCRYPTION
@@ -196,6 +207,10 @@ func putFileToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.Put
 	}
 	if v, ok := d.GetOk("content_type"); ok {
 		putInput.ContentType = v.(string)
+	}
+
+	if v, ok := d.GetOk("metadata"); ok {
+		putInput.Metadata = utils.ExpandToStringMap(v.(map[string]interface{}))
 	}
 
 	var sseKmsHeader = obs.SseKmsHeader{}
@@ -295,6 +310,7 @@ func resourceObsBucketObjectRead(_ context.Context, d *schema.ResourceData, meta
 		d.Set("content_type", objectMeta.ContentType),
 		d.Set("etag", strings.Trim(objectMeta.ETag, `"`)),
 		d.Set("tags", tags),
+		d.Set("metadata", objectMeta.Metadata),
 		// Attributes.
 		d.Set("version_id", objectMeta.VersionId),
 		d.Set("size", objectMeta.ContentLength),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add `metadata` field for bucket object resource and data source.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. bucket object resource and data source supports 'metadata'
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o obs -f TestAccObsBucketObject_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccObsBucketObject_ -timeout 360m -parallel 10
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== CONT  TestAccObsBucketObject_source
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucketObject_source (52.55s)
--- PASS: TestAccObsBucketObject_content (52.82s)
PASS
coverage: 23.4% of statements in ./huaweicloud/services/obs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       52.927s coverage: 23.4% of statements in ./huaweicloud/services/obs
```
```
 ./scripts/coverage.sh -o obs -f TestAccObsBucketObjectDataSource_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAccObsBucketObjectDataSource_ -timeout 360m -parallel 10
=== RUN   TestAccObsBucketObjectDataSource_content
=== PAUSE TestAccObsBucketObjectDataSource_content
=== RUN   TestAccObsBucketObjectDataSource_source
=== PAUSE TestAccObsBucketObjectDataSource_source
=== RUN   TestAccObsBucketObjectDataSource_allParams
=== PAUSE TestAccObsBucketObjectDataSource_allParams
=== CONT  TestAccObsBucketObjectDataSource_content
=== CONT  TestAccObsBucketObjectDataSource_allParams
=== CONT  TestAccObsBucketObjectDataSource_source
--- PASS: TestAccObsBucketObjectDataSource_allParams (110.91s)
--- PASS: TestAccObsBucketObjectDataSource_content (119.42s)
--- PASS: TestAccObsBucketObjectDataSource_source (123.34s)
PASS
coverage: 23.7% of statements in ./huaweicloud/services/obs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       123.445s        coverage: 23.7% of statements in ./huaweicloud/services/obs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
