### PR TITLE
feat(gaussdb): add GaussDB instance project tags data source

### DIFF
--- a/docs/data-sources/gaussdb_project_tags.md
+++ b/docs/data-sources/gaussdb_project_tags.md
@@ -1,0 +1,41 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_project_tags"
+description: |-
+  Use this data source to query the tags of GaussDB instances within a project in HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_project_tags
+
+Use this data source to query the tags of GaussDB instances within a project in HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_gaussdb_project_tags" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tags` - The list of tags.
+
+  The [tags](#gaussdb_project_tags_struct) structure is documented below.
+
+<a name="gaussdb_project_tags_struct"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `values` - The list of tag values.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1569,6 +1569,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_upgrade_versions":                gaussdb.DataSourceGaussDbUpgradeVersions(),
 			"huaweicloud_gaussdb_tags":                            gaussdb.DataSourceGaussDbTags(),
 			"huaweicloud_gaussdb_predefined_tags":                 gaussdb.DataSourceGaussDbPredefinedTags(),
+			"huaweicloud_gaussdb_project_tags":                    gaussdb.DataSourceProjectTags(),
 			"huaweicloud_gaussdb_slow_logs":                       gaussdb.DataSourceGaussDbSlowLogs(),
 			"huaweicloud_gaussdb_slow_sql_nodes":                  gaussdb.DataSourceGaussDbSlowSqlNodes(),
 			"huaweicloud_gaussdb_error_logs":                      gaussdb.DataSourceGaussDbErrorLogs(),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_project_tags_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_project_tags_test.go
@@ -1,0 +1,40 @@
+package gaussdb
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceProjectTags_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_gaussdb_project_tags.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceProjectTags_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "tags.#", regexp.MustCompile(`^[0-9]+$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "tags.0.key"),
+					resource.TestCheckResourceAttrSet(dataSource, "tags.0.values.#"),
+				),
+			},
+		},
+	},
+	)
+}
+
+func testDataSourceProjectTags_basic() string {
+	return `
+data "huaweicloud_gaussdb_project_tags" "test" {}
+`
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_project_tags.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_project_tags.go
@@ -1,0 +1,114 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB GET /v3/{project_id}/tags
+func DataSourceProjectTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceProjectTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     projectTagSchema(),
+			},
+		},
+	}
+}
+
+func projectTagSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"values": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceProjectTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/tags"
+	)
+
+	client, err := cfg.NewServiceClient("opengauss", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return diag.Errorf("error querying GaussDB project tags: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("tags", flattenProjectTags(respBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenProjectTags(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("tags", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	res := make([]interface{}, 0, len(curArray))
+
+	for _, v := range curArray {
+		res = append(res, map[string]interface{}{
+			"key":    utils.PathSearch("key", v, nil),
+			"values": utils.PathSearch("values", v, make([]interface{}, 0)).([]interface{}),
+		})
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source `(huaweicloud_gaussdb_project_tags) ` to query project tags.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  add a new data source  huaweicloud_gaussdb_project_tags for GaussDB.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o gaussdb -f TestAccDataSourceProjectTags_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/gaussdb" -v -coverprofile="./huaweicloud/services/acceptance/gaussdb/gaussdb_coverage.cov" -coverpkg="./huaweicloud/services/gaussdb" -run TestAccDataSourceProjectTags_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceProjectTags_basic
=== PAUSE TestAccDataSourceProjectTags_basic
=== CONT  TestAccDataSourceProjectTags_basic
--- PASS: TestAccDataSourceProjectTags_basic (15.00s)
PASS
coverage: 3.2% of statements in ./huaweicloud/services/gaussdb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   15.296s coverage: 3.2% of statements in ./huaweicloud/services/gaussdb

```

<img width="1023" height="27" alt="project_tags" src="https://github.com/user-attachments/assets/45cf6175-358f-4251-8b3e-9305638dccae" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
