### PR TITLE
refactor: feat(er): association supports route policy

### DIFF
--- a/docs/data-sources/er_associations.md
+++ b/docs/data-sources/er_associations.md
@@ -35,6 +35,14 @@ The following arguments are supported:
 * `attachment_id` - (Optional, String) Specifies the attachment ID corresponding to the association.  
 
 * `attachment_type` - (Optional, String) Specifies the attachment type corresponding to the association.  
+  The valid values are as follows:
+  + **vpc**: Virtual Private Cloud
+  + **vpn**: VPN Gateway
+  + **vgw**: Virtual Gateway for Cloud Dedicated Line
+  + **peering**: Peer-to-peer connection (creating peer-to-peer connections by loading enterprise routers in different
+    regions via Cloud Connect CC)
+  + **gdgw**: Global Access Gateway
+  + **cfw**: Cloud Firewall
 
 * `status` - (Optional, String) Specifies the status of the association. Default value is `available`.
   The valid values are as follows:
@@ -59,7 +67,14 @@ The `associations` block supports:
 
 * `attachment_id` -The attachment ID corresponding to the association.
 
-* `attachment_type` -The type of the attachment corresponding to the association.
+* `attachment_type` - The type of the attachment corresponding to the association.
+  + **vpc**: Virtual Private Cloud
+  + **vpn**: VPN Gateway
+  + **vgw**: Virtual Gateway for Cloud Dedicated Line
+  + **peering**: Peer-to-peer connection (creating peer-to-peer connections by loading enterprise routers in different
+    regions via Cloud Connect CC)
+  + **gdgw**: Global Access Gateway
+  + **cfw**: Cloud Firewall
 
 * `resource_id` - The resource ID of the attachment corresponding to the association.
 

--- a/docs/resources/er_association.md
+++ b/docs/resources/er_association.md
@@ -2,7 +2,8 @@
 subcategory: "Enterprise Router (ER)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_er_association"
-description: ""
+description: |-
+  Manages an association resource under the route table for ER service within HuaweiCloud.
 ---
 
 # huaweicloud_er_association
@@ -30,16 +31,14 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region where the ER instance and route table are located.  
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `instance_id` - (Required, String, ForceNew) Specifies the ID of the ER instance to which the route table and the
-  attachment belongs.  
-  Changing this parameter will create a new resource.
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the ER instance to which the route table and the
+  attachment belongs.
 
-* `route_table_id` - (Required, String, ForceNew) Specifies the ID of the route table to which the association
-  belongs.  
-  Changing this parameter will create a new resource.
+* `route_table_id` - (Required, String, NonUpdatable) Specifies the ID of the route table to which the association
+  belongs.
 
-* `attachment_id` - (Required, String, ForceNew) Specifies the ID of the attachment corresponding to the association.  
-  Changing this parameter will create a new resource.
+* `attachment_id` - (Required, String, NonUpdatable) Specifies the ID of the attachment corresponding to the
+  association.
 
 ## Attribute Reference
 
@@ -48,6 +47,13 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The resource ID.
 
 * `attachment_type` - The type of the attachment corresponding to the association.
+  + **vpc**: Virtual Private Cloud
+  + **vpn**: VPN Gateway
+  + **vgw**: Virtual Gateway for Cloud Dedicated Line
+  + **peering**: Peer-to-peer connection (creating peer-to-peer connections by loading enterprise routers in different
+    regions via Cloud Connect CC)
+  + **gdgw**: Global Access Gateway
+  + **cfw**: Cloud Firewall
 
 * `status` - The current status of the association.
 

--- a/docs/resources/er_association.md
+++ b/docs/resources/er_association.md
@@ -12,15 +12,36 @@ Manages an association resource under the route table for ER service within Huaw
 
 ## Example Usage
 
+### Create an association to a route table using a VPC attachment
+
 ```hcl
 variable "instance_id" {}
 variable "route_table_id" {}
-variable "attachment_id" {}
+variable "vpc_attachment_id" {}
 
 resource "huaweicloud_er_association" "test" {
   instance_id    = var.instance_id
   route_table_id = var.route_table_id
-  attachment_id  = var.attachment_id
+  attachment_id  = var.vpc_attachment_id
+}
+```
+
+### Create an association to a route table using a VPN Gateway attachment and with a custom route policy
+
+```hcl
+variable "instance_id" {}
+variable "route_table_id" {}
+variable "vpn_gateway_attachment_id" {}
+variable "export_policy_id" {}
+
+resource "huaweicloud_er_association" "with_route_policy" {
+  instance_id    = var.instance_id
+  route_table_id = var.route_table_id
+  attachment_id  = var.vpn_gateway_attachment_id
+
+  route_policy {
+    export_policy_id = var.export_policy_id
+  }
 }
 ```
 
@@ -39,6 +60,17 @@ The following arguments are supported:
 
 * `attachment_id` - (Required, String, NonUpdatable) Specifies the ID of the attachment corresponding to the
   association.
+
+* `route_policy` - (Optional, List) Specifies the export route policy configuration.  
+  The [route_policy](#er_association_route_policy) structure is documented below.
+
+  -> This parameter currently only applies to certain types of attachments, such as VPN gateway.<br>
+     For information regarding support for more attachment types, please contact the relevant service via a ticket.
+
+<a name="er_association_route_policy"></a>
+The `route_policy` block supports:
+
+* `export_policy_id` - (Optional, String) Specifies the export route policy ID.
 
 ## Attribute Reference
 
@@ -66,6 +98,7 @@ In addition to all arguments above, the following attributes are exported:
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 5 minutes.
+* `update` - Default is 5 minutes.
 * `delete` - Default is 2 minutes.
 
 ## Import

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -424,8 +424,11 @@ var (
 	HW_IDENTITY_ORIGINAL_PASSWORD = os.Getenv("HW_IDENTITY_ORIGINAL_PASSWORD")
 	HW_IDENTITY_NEW_PASSWORD      = os.Getenv("HW_IDENTITY_NEW_PASSWORD")
 
-	HW_ER_TEST_ON     = os.Getenv("HW_ER_TEST_ON")     // Whether to run the ER related tests.
-	HW_ER_INSTANCE_ID = os.Getenv("HW_ER_INSTANCE_ID") // Whether to run the ER related tests.
+	HW_ER_INSTANCE_ID          = os.Getenv("HW_ER_INSTANCE_ID") // Whether to run the ER related tests.
+	HW_ER_ROUTE_POLICY_IDS     = os.Getenv("HW_ER_ROUTE_POLICY_IDS")
+	HW_ER_SHARED_INSTANCE_ID   = os.Getenv("HW_ER_SHARED_INSTANCE_ID")
+	HW_ER_SHARED_ATTACHMENT_ID = os.Getenv("HW_ER_SHARED_ATTACHMENT_ID")
+	HW_ER_TEST_ON              = os.Getenv("HW_ER_TEST_ON") // Whether to run the ER related tests.
 
 	// The OBS address where the HCL/JSON template archive (No variables) is located.
 	HW_RF_TEMPLATE_ARCHIVE_NO_VARS_URI = os.Getenv("HW_RF_TEMPLATE_ARCHIVE_NO_VARS_URI")
@@ -737,9 +740,6 @@ var (
 	HW_DATAARTS_SECURITY_PERMISSSIONSET_MEMBER_OBJECT_NAME = os.Getenv("HW_DATAARTS_SECURITY_PERMISSSIONSET_MEMBER_OBJECT_NAME")
 
 	HW_DAS_INSTANCE_IDS = os.Getenv("HW_DAS_INSTANCE_IDS")
-
-	HW_ER_SHARED_INSTANCE_ID   = os.Getenv("HW_ER_SHARED_INSTANCE_ID")
-	HW_ER_SHARED_ATTACHMENT_ID = os.Getenv("HW_ER_SHARED_ATTACHMENT_ID")
 
 	HW_DEH_DEDICATED_HOST_ID = os.Getenv("HW_DEH_DEDICATED_HOST_ID")
 
@@ -1877,13 +1877,6 @@ func TestAccPreCheckChargingMode(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckErSharedAttachmentAccepter(t *testing.T) {
-	if HW_ER_SHARED_INSTANCE_ID == "" || HW_ER_SHARED_ATTACHMENT_ID == "" {
-		t.Skip("HW_ER_SHARED_INSTANCE_ID and HW_ER_SHARED_ATTACHMENT_ID must be set for the acceptance test")
-	}
-}
-
-// lintignore:AT003
 func TestAccPreCheckDehDedicatedHostId(t *testing.T) {
 	if HW_DEH_DEDICATED_HOST_ID == "" {
 		t.Skip("HW_DEH_DEDICATED_HOST_ID must be set for the acceptance test")
@@ -2827,16 +2820,30 @@ func TestAccPreCheckWorkspaceAppFileName(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckER(t *testing.T) {
-	if HW_ER_TEST_ON == "" {
-		t.Skip("Skip all ER acceptance tests.")
+func TestAccPreCheckERInstanceID(t *testing.T) {
+	if HW_ER_INSTANCE_ID == "" {
+		t.Skip("HW_ER_INSTANCE_ID must be set for this acceptance test")
 	}
 }
 
 // lintignore:AT003
-func TestAccPreCheckERInstanceID(t *testing.T) {
-	if HW_ER_INSTANCE_ID == "" {
-		t.Skip("HW_ER_INSTANCE_ID must be set for this acceptance test")
+func TestAccPreCheckERRoutePolicyIDs(t *testing.T, min int) {
+	if HW_ER_ROUTE_POLICY_IDS == "" || len(strings.Split(HW_ER_ROUTE_POLICY_IDS, ",")) < min {
+		t.Skipf("At least %d route policy IDs must be supported during the HW_ER_ROUTE_POLICY_IDS, separated by commas (,).", min)
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckErSharedAttachmentAccepter(t *testing.T) {
+	if HW_ER_SHARED_INSTANCE_ID == "" || HW_ER_SHARED_ATTACHMENT_ID == "" {
+		t.Skip("HW_ER_SHARED_INSTANCE_ID and HW_ER_SHARED_ATTACHMENT_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckER(t *testing.T) {
+	if HW_ER_TEST_ON == "" {
+		t.Skip("Skip all ER acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
@@ -5,39 +5,35 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/er/v3/associations"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er"
 )
 
 func getAssociationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.ErV3Client(acceptance.HW_REGION_NAME)
+	client, err := cfg.NewServiceClient("er", acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating ER v3 client: %s", err)
+		return nil, fmt.Errorf("error creating ER client: %s", err)
 	}
 
-	return er.QueryAssociationById(client, state.Primary.Attributes["instance_id"],
+	return er.GetAssociationById(client, state.Primary.Attributes["instance_id"],
 		state.Primary.Attributes["route_table_id"], state.Primary.ID)
 }
 
 func TestAccAssociation_basic(t *testing.T) {
 	var (
-		obj associations.Association
+		obj interface{}
 
 		rName = "huaweicloud_er_association.test"
-		name  = acceptance.RandomAccResourceName()
-	)
+		rc    = acceptance.InitResourceCheck(rName, &obj, getAssociationResourceFunc)
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getAssociationResourceFunc,
+		name = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -45,6 +41,10 @@ func TestAccAssociation_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
+			{
+				Config:      testAccAssociation_nonExistentParentResources(),
+				ExpectError: regexp.MustCompile(`error creating the association to the route table`),
+			},
 			{
 				Config: testAccAssociation_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
@@ -92,30 +92,31 @@ func testAccAssociationImportStateFunc(rsName string) resource.ImportStateIdFunc
 	}
 }
 
+func testAccAssociation_nonExistentParentResources() string {
+	randomUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_er_association" "test" {
+  instance_id    = "%[1]s"
+  route_table_id = "%[1]s"
+  attachment_id  = "%[1]s"
+}
+`, randomUUID)
+}
+
 func testAccAssociation_base(name string) string {
 	bgpAsNum := acctest.RandIntRange(64512, 65534)
 
 	return fmt.Sprintf(`
 data "huaweicloud_er_availability_zones" "test" {}
 
-resource "huaweicloud_vpc" "test" {
-  name = "%[1]s"
-  cidr = "192.168.0.0/16"
-}
-
-resource "huaweicloud_vpc_subnet" "test" {
-  vpc_id = huaweicloud_vpc.test.id
-
-  name       = "%[1]s"
-  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)
-  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)
-}
+%[1]s
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
-
-  name = "%[1]s"
-  asn  = %[2]d
+  availability_zones    = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
+  name                  = "%[2]s"
+  asn                   = %[3]d
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
 
 resource "huaweicloud_er_vpc_attachment" "test" {
@@ -123,16 +124,16 @@ resource "huaweicloud_er_vpc_attachment" "test" {
   vpc_id      = huaweicloud_vpc.test.id
   subnet_id   = huaweicloud_vpc_subnet.test.id
 
-  name                   = "%[1]s"
+  name                   = "%[2]s"
   auto_create_vpc_routes = true
 }
 
 resource "huaweicloud_er_route_table" "test" {
   instance_id = huaweicloud_er_instance.test.id
 
-  name = "%[1]s"
+  name = "%[2]s"
 }
-`, name, bgpAsNum)
+`, common.TestVpc(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), name, bgpAsNum)
 }
 
 func testAccAssociation_basic_step1(name string) string {

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
@@ -147,3 +147,145 @@ resource "huaweicloud_er_association" "test" {
 }
 `, testAccAssociation_base(name))
 }
+
+func TestAccAssociation_routePolicy(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName = "huaweicloud_er_association.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getAssociationResourceFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckERRoutePolicyIDs(t, 2)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssociation_routePolicy_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_er_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "route_table_id",
+						"huaweicloud_er_route_table.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "attachment_id",
+						"data.huaweicloud_er_attachments.test", "attachments.0.id"),
+					resource.TestCheckResourceAttr(rName, "attachment_type", "vpn"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccAssociation_routePolicy_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_er_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "route_table_id",
+						"huaweicloud_er_route_table.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "attachment_id",
+						"data.huaweicloud_er_attachments.test", "attachments.0.id"),
+					resource.TestCheckResourceAttr(rName, "attachment_type", "vpn"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestMatchResourceAttr(rName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAssociationImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccAssociation_routePolicy_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_er_availability_zones" "test" {}
+
+data "huaweicloud_availability_zones" "test" {}
+
+%[1]s
+
+resource "huaweicloud_er_instance" "test" {
+  availability_zones    = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
+  name                  = "%[2]s"
+  asn                   = 64512
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+}
+
+resource "huaweicloud_vpn_gateway" "test" {
+  network_type          = "private"
+  attachment_type       = "er"
+  flavor                = "Professional1"
+  er_id                 = huaweicloud_er_instance.test.id
+  availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 2)
+  name                  = "%[2]s"
+  access_vpc_id         = huaweicloud_vpc.test.id
+  access_subnet_id      = huaweicloud_vpc_subnet.test.id
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+}
+
+resource "huaweicloud_er_route_table" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  name        = "%[2]s"
+}
+
+data "huaweicloud_er_attachments" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  type        = "vpn"
+  name        = format("ErGateway_%%s", huaweicloud_vpn_gateway.test.id)
+}
+`, common.TestVpc(name), name)
+}
+
+func testAccAssociation_routePolicy_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  route_policy_ids = split(",", "%[2]s")
+}
+
+resource "huaweicloud_er_association" "test" {
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+  # After the VPN gateway is created, an attachment will be created automatically.
+  attachment_id  = data.huaweicloud_er_attachments.test.attachments[0].id
+
+  route_policy {
+    export_policy_id = local.route_policy_ids[0]
+  }
+}
+`, testAccAssociation_routePolicy_base(name), acceptance.HW_ER_ROUTE_POLICY_IDS)
+}
+
+func testAccAssociation_routePolicy_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  route_policy_ids = split(",", "%[2]s")
+}
+
+resource "huaweicloud_er_association" "test" {
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+  # The VPN Gateway attachment will exist until the VPN gateway is deleted.
+  attachment_id  = data.huaweicloud_er_attachments.test.attachments[0].id
+
+  route_policy {
+    export_policy_id = local.route_policy_ids[1]
+  }
+}
+`, testAccAssociation_routePolicy_base(name), acceptance.HW_ER_ROUTE_POLICY_IDS)
+}

--- a/huaweicloud/services/er/resource_huaweicloud_er_association.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_association.go
@@ -3,7 +3,7 @@ package er
 import (
 	"context"
 	"fmt"
-	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -11,14 +11,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/er/v3/associations"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var associationNonUpdatableParams = []string{
+	"instance_id",
+	"route_table_id",
+	"attachment_id",
+}
 
 // @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associate
 // @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associations
@@ -27,6 +33,7 @@ func ResourceAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceAssociationCreate,
 		ReadContext:   resourceAssociationRead,
+		UpdateContext: resourceAssociationUpdate,
 		DeleteContext: resourceAssociationDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -38,6 +45,8 @@ func ResourceAssociation() *schema.Resource {
 			Delete: schema.DefaultTimeout(2 * time.Minute),
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(associationNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -46,24 +55,25 @@ func ResourceAssociation() *schema.Resource {
 				ForceNew:    true,
 				Description: `The region where the ER instance and route table are located.`,
 			},
+
+			// Required parameters.
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The ID of the ER instance to which the route table and the attachment belongs.`,
 			},
 			"route_table_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The ID of the route table to which the association belongs.`,
 			},
 			"attachment_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The ID of the attachment corresponding to the association.`,
 			},
+
+			// Attributes.
 			"attachment_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -84,66 +94,100 @@ func ResourceAssociation() *schema.Resource {
 				Computed:    true,
 				Description: `The latest update time.`,
 			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
 		},
 	}
 }
 
-func resourceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.ErV3Client(cfg.GetRegion(d))
+func createAssociation(client *golangsdk.ServiceClient, instanceId, attachmentId, routeTableId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associate"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{er_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{route_table_id}", routeTableId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"attachment_id": attachmentId,
+		},
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
-		return diag.Errorf("error creating ER v3 client: %s", err)
+		return nil, err
 	}
 
-	var (
-		instanceId   = d.Get("instance_id").(string)
-		routeTableId = d.Get("route_table_id").(string)
-
-		opts = associations.CreateOpts{
-			AttachmentId: d.Get("attachment_id").(string),
-		}
-	)
-
-	resp, err := associations.Create(client, instanceId, routeTableId, opts)
-	if err != nil {
-		return diag.Errorf("error creating the association to the route table: %s", err)
-	}
-	d.SetId(resp.ID)
-
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING"},
-		Target:  []string{"COMPLETED"},
-		Refresh: associationStatusRefreshFunc(client, instanceId, routeTableId, d.Id(), []string{"available"}),
-		Timeout: d.Timeout(schema.TimeoutDelete),
-		// After the creation request is sent, it will briefly enter the pending status.
-		Delay:        10 * time.Second,
-		PollInterval: 10 * time.Second,
-	}
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	return resourceAssociationRead(ctx, d, meta)
+	return utils.FlattenResponse(requestResp)
 }
 
-// QueryAssociationById is a method to query association details from a specified route table using given parameters.
-func QueryAssociationById(client *golangsdk.ServiceClient, instanceId, routeTableId,
-	associationId string) (*associations.Association, error) {
-	// The query parameter list does not contain the ID parameter, so can only filter it manually.
-	resp, err := associations.List(client, instanceId, routeTableId, associations.ListOpts{})
+func listAssociations(client *golangsdk.ServiceClient, instanceId, routeTableId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associations?limit={limit}"
+		limit   = 200
+		marker  string
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{er_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{route_table_id}", routeTableId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		requestPath := listPath
+		if marker != "" {
+			requestPath += fmt.Sprintf("&marker=%s", marker)
+		}
+
+		requestResp, err := client.Request("GET", requestPath, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		associations := utils.PathSearch("associations", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, associations...)
+		nextMarker := utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" || nextMarker == marker {
+			break
+		}
+		marker = nextMarker
+	}
+
+	return result, nil
+}
+
+func GetAssociationById(client *golangsdk.ServiceClient, instanceId, routeTableId, associationId string) (interface{}, error) {
+	associations, err := listAssociations(client, instanceId, routeTableId)
 	if err != nil {
 		return nil, err
 	}
 
-	filter := map[string]interface{}{
-		"ID": associationId,
-	}
-	result, err := utils.FilterSliceWithField(resp, filter)
-	if err != nil {
-		return nil, err
-	}
-	if len(result) < 1 {
+	association := utils.PathSearch(fmt.Sprintf("[?id=='%s']|[0]", associationId), associations, nil)
+	if association == nil {
 		return nil, golangsdk.ErrDefault404{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
 				Body: []byte(fmt.Sprintf("the association (%s) does not exist", associationId)),
@@ -151,94 +195,153 @@ func QueryAssociationById(client *golangsdk.ServiceClient, instanceId, routeTabl
 		}
 	}
 
-	log.Printf("[DEBUG] The result filtered by resource ID (%s) is: %#v", associationId, result)
-	association, ok := result[0].(associations.Association)
-	if !ok {
-		return nil, fmt.Errorf("the element type of filter result is incorrect, want 'associations.Association', but got '%T'", result[0])
-	}
-
-	return &association, nil
+	return association, nil
 }
 
 func associationStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId, routeTableId, associationId string,
 	targets []string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		resp, err := QueryAssociationById(client, instanceId, routeTableId, associationId)
+		respBody, err := GetAssociationById(client, instanceId, routeTableId, associationId)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
-				return resp, "COMPLETED", nil
+				return "not_found", "COMPLETED", nil
 			}
 
-			return nil, "", err
+			return respBody, "ERROR", err
 		}
 
-		if utils.StrSliceContains([]string{"failed"}, resp.Status) {
-			return resp, "", fmt.Errorf("unexpected status '%s'", resp.Status)
+		statusResp := utils.PathSearch("state", respBody, "").(string)
+		if utils.StrSliceContains([]string{"failed"}, statusResp) {
+			return respBody, "ERROR", fmt.Errorf("unexpect status (%s)", statusResp)
 		}
-		if utils.StrSliceContains(targets, resp.Status) {
-			return resp, "COMPLETED", nil
+		if utils.StrSliceContains(targets, statusResp) {
+			return respBody, "COMPLETED", nil
 		}
 
-		return resp, "PENDING", nil
+		return respBody, "PENDING", nil
 	}
 }
 
-func resourceAssociationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ErV3Client(region)
+func resourceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		instanceId   = d.Get("instance_id").(string)
+		attachmentId = d.Get("attachment_id").(string)
+		routeTableId = d.Get("route_table_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("er", region)
 	if err != nil {
-		return diag.Errorf("error creating ER v3 client: %s", err)
+		return diag.Errorf("error creating ER client: %s", err)
 	}
 
+	respBody, err := createAssociation(client, instanceId, attachmentId, routeTableId)
+	if err != nil {
+		return diag.Errorf("error creating the association to the route table: %s", err)
+	}
+
+	associationId := utils.PathSearch("association.id", respBody, "").(string)
+	if associationId == "" {
+		return diag.Errorf("unable to find the association ID from the API response")
+	}
+	d.SetId(associationId)
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: associationStatusRefreshFunc(client, instanceId, routeTableId, d.Id(), []string{"available"}),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+		// After the creation request is sent, it will briefly enter the pending status.
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the association (%s) to become available: %s", d.Id(), err)
+	}
+
+	return resourceAssociationRead(ctx, d, meta)
+}
+
+func resourceAssociationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
 		instanceId    = d.Get("instance_id").(string)
 		routeTableId  = d.Get("route_table_id").(string)
 		associationId = d.Id()
 	)
 
-	resp, err := QueryAssociationById(client, instanceId, routeTableId, associationId)
+	client, err := cfg.NewServiceClient("er", region)
 	if err != nil {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "ER association")
+		return diag.Errorf("error creating ER client: %s", err)
+	}
+
+	respBody, err := GetAssociationById(client, instanceId, routeTableId, associationId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving ER association")
 	}
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("route_table_id", resp.RouteTableId),
-		d.Set("attachment_id", resp.AttachmentId),
-		d.Set("attachment_type", resp.ResourceType),
-		d.Set("status", resp.Status),
+		d.Set("route_table_id", utils.PathSearch("route_table_id", respBody, nil)),
+		d.Set("attachment_id", utils.PathSearch("attachment_id", respBody, nil)),
+		d.Set("attachment_type", utils.PathSearch("resource_type", respBody, nil)),
+		d.Set("status", utils.PathSearch("state", respBody, nil)),
 		// The time results are not the time in RF3339 format without milliseconds.
-		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(resp.CreatedAt)/1000, false)),
-		d.Set("updated_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(resp.UpdatedAt)/1000, false)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+			utils.PathSearch("created_at", respBody, "").(string))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+			utils.PathSearch("updated_at", respBody, "").(string))/1000, false)),
 	)
 
-	if mErr.ErrorOrNil() != nil {
-		return diag.Errorf("error saving association (%s) fields: %s", associationId, mErr)
-	}
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceAssociationUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourceAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ErV3Client(region)
-	if err != nil {
-		return diag.Errorf("error creating ER v3 client: %s", err)
+func deleteAssociation(client *golangsdk.ServiceClient, instanceId, attachmentId, routeTableId string) error {
+	httpUrl := "v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/disassociate"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{er_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{route_table_id}", routeTableId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"attachment_id": attachmentId,
+		},
 	}
 
+	_, err := client.Request("POST", deletePath, &deleteOpt)
+	return err
+}
+
+func resourceAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
 		instanceId    = d.Get("instance_id").(string)
+		attachmentId  = d.Get("attachment_id").(string)
 		routeTableId  = d.Get("route_table_id").(string)
 		associationId = d.Id()
-
-		opts = associations.DeleteOpts{
-			AttachmentId: d.Get("attachment_id").(string),
-		}
 	)
-	err = associations.Delete(client, instanceId, routeTableId, opts)
+
+	client, err := cfg.NewServiceClient("er", region)
 	if err != nil {
-		return diag.Errorf("error deleting association (%s): %s", associationId, err)
+		return diag.Errorf("error creating ER client: %s", err)
+	}
+
+	err = deleteAssociation(client, instanceId, attachmentId, routeTableId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting association (%s)", associationId))
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -246,13 +349,13 @@ func resourceAssociationDelete(ctx context.Context, d *schema.ResourceData, meta
 		Target:  []string{"COMPLETED"},
 		Refresh: associationStatusRefreshFunc(client, instanceId, routeTableId, associationId, nil),
 		Timeout: d.Timeout(schema.TimeoutDelete),
-		// After the creation request is sent, it will briefly enter the pending status.
+		// After the deletion request is sent, it will briefly enter the pending status.
 		Delay:        5 * time.Second,
 		PollInterval: 10 * time.Second,
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("error waiting for the association (%s) to be deleted: %s", associationId, err)
 	}
 
 	return nil
@@ -260,9 +363,10 @@ func resourceAssociationDelete(ctx context.Context, d *schema.ResourceData, meta
 
 func resourceAssociationImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
 	error) {
-	parts := strings.SplitN(d.Id(), "/", 3)
+	importId := d.Id()
+	parts := strings.SplitN(importId, "/", 3)
 	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid format for import ID, want '<instance_id>/<route_table_id>/<association_id>', but got '%s'", d.Id())
+		return nil, fmt.Errorf("invalid format for import ID, want '<instance_id>/<route_table_id>/<id>', but got '%s'", importId)
 	}
 
 	d.SetId(parts[2])

--- a/huaweicloud/services/er/resource_huaweicloud_er_association.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_association.go
@@ -28,6 +28,7 @@ var associationNonUpdatableParams = []string{
 
 // @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associate
 // @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associations
+// @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associations/{association_id}/change-route-policy
 // @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/disassociate
 func ResourceAssociation() *schema.Resource {
 	return &schema.Resource{
@@ -42,6 +43,7 @@ func ResourceAssociation() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(2 * time.Minute),
 		},
 
@@ -71,6 +73,25 @@ func ResourceAssociation() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `The ID of the attachment corresponding to the association.`,
+			},
+
+			// Optional parameters.
+			"route_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"export_policy_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The export route policy ID.`,
+						},
+					},
+				},
+				Description: `The export route policy configuration.`,
 			},
 
 			// Attributes.
@@ -106,7 +127,26 @@ func ResourceAssociation() *schema.Resource {
 	}
 }
 
-func createAssociation(client *golangsdk.ServiceClient, instanceId, attachmentId, routeTableId string) (interface{}, error) {
+func buildAssociationRoutePolicy(routePolicies []interface{}) map[string]interface{} {
+	if len(routePolicies) < 1 {
+		return nil
+	}
+
+	routePolicy := routePolicies[0]
+	return map[string]interface{}{
+		"export_policy_id": utils.ValueIgnoreEmpty(utils.PathSearch("export_policy_id", routePolicy, nil)),
+	}
+}
+
+func buildCreateAssociationBodyParams(attachmentId string, routePolicies []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"attachment_id": attachmentId,
+		"route_policy":  buildAssociationRoutePolicy(routePolicies),
+	}
+}
+
+func createAssociation(client *golangsdk.ServiceClient, instanceId, attachmentId, routeTableId string,
+	routePolicies []interface{}) (interface{}, error) {
 	httpUrl := "v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associate"
 	createPath := client.Endpoint + httpUrl
 	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
@@ -118,9 +158,7 @@ func createAssociation(client *golangsdk.ServiceClient, instanceId, attachmentId
 		MoreHeaders: map[string]string{
 			"Content-Type": "application/json",
 		},
-		JSONBody: map[string]interface{}{
-			"attachment_id": attachmentId,
-		},
+		JSONBody: utils.RemoveNil(buildCreateAssociationBodyParams(attachmentId, routePolicies)),
 	}
 
 	requestResp, err := client.Request("POST", createPath, &createOpt)
@@ -224,11 +262,12 @@ func associationStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId, r
 
 func resourceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg          = meta.(*config.Config)
-		region       = cfg.GetRegion(d)
-		instanceId   = d.Get("instance_id").(string)
-		attachmentId = d.Get("attachment_id").(string)
-		routeTableId = d.Get("route_table_id").(string)
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId    = d.Get("instance_id").(string)
+		attachmentId  = d.Get("attachment_id").(string)
+		routeTableId  = d.Get("route_table_id").(string)
+		routePolicies = d.Get("route_policy").([]interface{})
 	)
 
 	client, err := cfg.NewServiceClient("er", region)
@@ -236,7 +275,7 @@ func resourceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error creating ER client: %s", err)
 	}
 
-	respBody, err := createAssociation(client, instanceId, attachmentId, routeTableId)
+	respBody, err := createAssociation(client, instanceId, attachmentId, routeTableId, routePolicies)
 	if err != nil {
 		return diag.Errorf("error creating the association to the route table: %s", err)
 	}
@@ -264,6 +303,23 @@ func resourceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta
 	return resourceAssociationRead(ctx, d, meta)
 }
 
+func flattenAssociationRoutePolicy(routePolicy map[string]interface{}) []map[string]interface{} {
+	if len(routePolicy) < 1 {
+		return nil
+	}
+
+	exportPolicyId := utils.PathSearch("export_policy_id", routePolicy, nil)
+	if exportPolicyId == nil || exportPolicyId == "" {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"export_policy_id": exportPolicyId,
+		},
+	}
+}
+
 func resourceAssociationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg           = meta.(*config.Config)
@@ -288,6 +344,8 @@ func resourceAssociationRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("route_table_id", utils.PathSearch("route_table_id", respBody, nil)),
 		d.Set("attachment_id", utils.PathSearch("attachment_id", respBody, nil)),
 		d.Set("attachment_type", utils.PathSearch("resource_type", respBody, nil)),
+		d.Set("route_policy", flattenAssociationRoutePolicy(utils.PathSearch("route_policy", respBody,
+			make(map[string]interface{})).(map[string]interface{}))),
 		d.Set("status", utils.PathSearch("state", respBody, nil)),
 		// The time results are not the time in RF3339 format without milliseconds.
 		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
@@ -299,8 +357,71 @@ func resourceAssociationRead(_ context.Context, d *schema.ResourceData, meta int
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceAssociationUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	return nil
+func buildUpdateAssociationRoutePolicyBodyParams(routePolicies []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"route_policy": buildAssociationRoutePolicy(routePolicies),
+	}
+}
+
+func changeAssociationRoutePolicy(client *golangsdk.ServiceClient, instanceId, routeTableId, associationId string,
+	routePolicies []interface{}) (interface{}, error) {
+	httpUrl := "v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associations/{association_id}/change-route-policy"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{er_id}", instanceId)
+	updatePath = strings.ReplaceAll(updatePath, "{route_table_id}", routeTableId)
+	updatePath = strings.ReplaceAll(updatePath, "{association_id}", associationId)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildUpdateAssociationRoutePolicyBodyParams(routePolicies)),
+	}
+
+	requestResp, err := client.Request("POST", updatePath, &updateOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId    = d.Get("instance_id").(string)
+		routeTableId  = d.Get("route_table_id").(string)
+		associationId = d.Id()
+		routePolicies = d.Get("route_policy").([]interface{})
+	)
+
+	client, err := cfg.NewServiceClient("er", region)
+	if err != nil {
+		return diag.Errorf("error creating ER client: %s", err)
+	}
+
+	_, err = changeAssociationRoutePolicy(client, instanceId, routeTableId, associationId, routePolicies)
+	if err != nil {
+		return diag.Errorf("error updating the route policy of association (%s): %s", associationId, err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      associationStatusRefreshFunc(client, instanceId, routeTableId, associationId, []string{"available"}),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the association (%s) route policy update to complete: %s", associationId, err)
+	}
+
+	return resourceAssociationRead(ctx, d, meta)
 }
 
 func deleteAssociation(client *golangsdk.ServiceClient, instanceId, attachmentId, routeTableId string) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Before supports route policy, refactor the association resource and using auto-gen style for coding.
Then, supports new object structure for route policy (even if the APIs for CRUD about this feature are not opened).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**Special notes for your reviewer**:

The coverage of the basic acceptance test:
<img width="884" height="57" alt="image" src="https://github.com/user-attachments/assets/9b1c759d-968a-45a6-a03e-96a7565edce1" />

The coverage of the route policy acceptance test:
<img width="882" height="80" alt="image" src="https://github.com/user-attachments/assets/72369540-6234-4681-af9a-c9104b5d2adc" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using auto-gen style to rewrite association resource
2. association resource supports route policy
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o er -f TestAccAssociation_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/er" -v -coverprofile="./huaweicloud/services/acceptance/er/er_coverage.cov" -coverpkg="./huaweicloud/services/er" -run TestAccAssociation_basic -timeout 360m -parallel 10
=== RUN   TestAccAssociation_basic
=== PAUSE TestAccAssociation_basic
=== CONT  TestAccAssociation_basic
--- PASS: TestAccAssociation_basic (162.58s)
PASS
coverage: 26.5% of statements in ./huaweicloud/services/er
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        162.671s        coverage: 26.5% of statements in ./huaweicloud/services/er
```
```
./scripts/coverage.sh -o er -f TestAccAssociation_routePolicy
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/er" -v -coverprofile="./huaweicloud/services/acceptance/er/er_coverage.cov" -coverpkg="./huaweicloud/services/er" -run TestAccAssociation_routePolicy -timeout 360m -parallel 10
=== RUN   TestAccAssociation_routePolicy
=== PAUSE TestAccAssociation_routePolicy
=== CONT  TestAccAssociation_routePolicy
--- PASS: TestAccAssociation_routePolicy (432.94s)
PASS
coverage: 28.0% of statements in ./huaweicloud/services/er
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        433.042s        coverage: 28.0% of statements in ./huaweicloud/services/er
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1300" height="1016" alt="image" src="https://github.com/user-attachments/assets/99b09c85-15bd-41f5-b2ef-ed86a6d501b5" />

    ab. Related resources (parent resources) not found
    <img width="1172" height="1159" alt="image" src="https://github.com/user-attachments/assets/82baff4c-0d3f-4a90-8986-757d78e12e9c" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1433" height="1138" alt="image" src="https://github.com/user-attachments/assets/d2b2dd5a-1251-4777-a4cb-3287357672f5" />

    bb. Related resources (parent resources) not found
    <img width="1517" height="1191" alt="image" src="https://github.com/user-attachments/assets/0dac1c42-a148-4cfd-90e1-302268851cec" />
