### PR TITLE
refactor: feat(er): propagation supports route policy

### DIFF
--- a/docs/resources/er_propagation.md
+++ b/docs/resources/er_propagation.md
@@ -2,7 +2,8 @@
 subcategory: "Enterprise Router (ER)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_er_propagation"
-description: ""
+description: |-
+  Manages a propagation resource under the route table for ER service within HuaweiCloud.
 ---
 
 # huaweicloud_er_propagation
@@ -30,16 +31,14 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region where the ER instance and route table are located.  
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `instance_id` - (Required, String, ForceNew) Specifies the ID of the ER instance to which the route table and the
-  attachment belongs.  
-  Changing this parameter will create a new resource.
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the ER instance to which the route table and the
+  attachment belongs.
 
-* `route_table_id` - (Required, String, ForceNew) Specifies the ID of the route table to which the propagation
-  belongs.  
-  Changing this parameter will create a new resource.
+* `route_table_id` - (Required, String, NonUpdatable) Specifies the ID of the route table to which the propagation
+  belongs.
 
-* `attachment_id` - (Required, String, ForceNew) Specifies the ID of the attachment corresponding to the propagation.  
-  Changing this parameter will create a new resource.
+* `attachment_id` - (Required, String, NonUpdatable) Specifies the ID of the attachment corresponding to the
+  propagation.
 
 ## Attribute Reference
 
@@ -48,6 +47,13 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The resource ID.
 
 * `attachment_type` - The type of the attachment corresponding to the propagation.
+  + **vpc**: Virtual Private Cloud
+  + **vpn**: VPN Gateway
+  + **vgw**: Virtual Gateway for Cloud Dedicated Line
+  + **peering**: Peer-to-peer connection (creating peer-to-peer connections by loading enterprise routers in different
+    regions via Cloud Connect CC)
+  + **gdgw**: Global Access Gateway
+  + **cfw**: Cloud Firewall
 
 * `status` - The current status of the propagation.
 

--- a/docs/resources/er_propagation.md
+++ b/docs/resources/er_propagation.md
@@ -12,15 +12,36 @@ Manages a propagation resource under the route table for ER service within Huawe
 
 ## Example Usage
 
+### Create a propagation to a route table using a VPC attachment
+
 ```hcl
 variable "instance_id" {}
 variable "route_table_id" {}
-variable "attachment_id" {}
+variable "vpc_attachment_id" {}
 
 resource "huaweicloud_er_propagation" "test" {
   instance_id    = var.instance_id
   route_table_id = var.route_table_id
-  attachment_id  = var.attachment_id
+  attachment_id  = var.vpc_attachment_id
+}
+```
+
+### Create a propagation to a route table using a VPN Gateway attachment and with a custom route policy
+
+```hcl
+variable "instance_id" {}
+variable "route_table_id" {}
+variable "vpn_gateway_attachment_id" {}
+variable "import_policy_id" {}
+
+resource "huaweicloud_er_propagation" "with_route_policy" {
+  instance_id    = var.instance_id
+  route_table_id = var.route_table_id
+  attachment_id  = var.vpn_gateway_attachment_id
+
+  route_policy {
+    import_policy_id = var.import_policy_id
+  }
 }
 ```
 
@@ -39,6 +60,17 @@ The following arguments are supported:
 
 * `attachment_id` - (Required, String, NonUpdatable) Specifies the ID of the attachment corresponding to the
   propagation.
+
+* `route_policy` - (Optional, List) Specifies the import route policy configuration.  
+  The [route_policy](#er_propagation_route_policy) structure is documented below.
+
+  -> This parameter currently only applies to certain types of attachments, such as VPN gateway.<br>
+     For information regarding support for more attachment types, please contact the relevant service via a ticket.
+
+<a name="er_propagation_route_policy"></a>
+The `route_policy` block supports:
+
+* `import_policy_id` - (Optional, String) Specifies the import route policy ID.
 
 ## Attribute Reference
 
@@ -66,6 +98,7 @@ In addition to all arguments above, the following attributes are exported:
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 5 minutes.
+* `update` - Default is 5 minutes.
 * `delete` - Default is 2 minutes.
 
 ## Import

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_propagation_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_propagation_test.go
@@ -147,3 +147,145 @@ resource "huaweicloud_er_propagation" "test" {
 }
 `, testAccPropagation_base(name))
 }
+
+func TestAccPropagation_routePolicy(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName = "huaweicloud_er_propagation.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getPropagationResourceFunc)
+
+		name = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckERRoutePolicyIDs(t, 2)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPropagation_routePolicy_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_er_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "route_table_id",
+						"huaweicloud_er_route_table.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "attachment_id",
+						"data.huaweicloud_er_attachments.test", "attachments.0.id"),
+					resource.TestCheckResourceAttr(rName, "attachment_type", "vpn"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccPropagation_routePolicy_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_er_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "route_table_id",
+						"huaweicloud_er_route_table.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "attachment_id",
+						"data.huaweicloud_er_attachments.test", "attachments.0.id"),
+					resource.TestCheckResourceAttr(rName, "attachment_type", "vpn"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestMatchResourceAttr(rName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccPropagationImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccPropagation_routePolicy_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_er_availability_zones" "test" {}
+
+data "huaweicloud_availability_zones" "test" {}
+
+%[1]s
+
+resource "huaweicloud_er_instance" "test" {
+  availability_zones    = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
+  name                  = "%[2]s"
+  asn                   = 64512
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+}
+
+resource "huaweicloud_vpn_gateway" "test" {
+  network_type          = "private"
+  attachment_type       = "er"
+  flavor                = "Professional1"
+  er_id                 = huaweicloud_er_instance.test.id
+  availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 2)
+  name                  = "%[2]s"
+  access_vpc_id         = huaweicloud_vpc.test.id
+  access_subnet_id      = huaweicloud_vpc_subnet.test.id
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+}
+
+resource "huaweicloud_er_route_table" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  name        = "%[2]s"
+}
+
+data "huaweicloud_er_attachments" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  type        = "vpn"
+  name        = format("ErGateway_%%s", huaweicloud_vpn_gateway.test.id)
+}
+`, common.TestVpc(name), name)
+}
+
+func testAccPropagation_routePolicy_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  route_policy_ids = split(",", "%[2]s")
+}
+
+resource "huaweicloud_er_propagation" "test" {
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+  # After the VPN gateway is created, an attachment will be created automatically.
+  attachment_id  = data.huaweicloud_er_attachments.test.attachments[0].id
+
+  route_policy {
+    import_policy_id = local.route_policy_ids[0]
+  }
+}
+`, testAccPropagation_routePolicy_base(name), acceptance.HW_ER_ROUTE_POLICY_IDS)
+}
+
+func testAccPropagation_routePolicy_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  route_policy_ids = split(",", "%[2]s")
+}
+
+resource "huaweicloud_er_propagation" "test" {
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+  # The VPN Gateway attachment will exist until the VPN gateway is deleted.
+  attachment_id  = data.huaweicloud_er_attachments.test.attachments[0].id
+
+  route_policy {
+    import_policy_id = local.route_policy_ids[1]
+  }
+}
+`, testAccPropagation_routePolicy_base(name), acceptance.HW_ER_ROUTE_POLICY_IDS)
+}

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_propagation_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_propagation_test.go
@@ -5,39 +5,35 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/er/v3/propagations"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er"
 )
 
 func getPropagationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.ErV3Client(acceptance.HW_REGION_NAME)
+	client, err := cfg.NewServiceClient("er", acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating ER v3 client: %s", err)
+		return nil, fmt.Errorf("error creating ER client: %s", err)
 	}
 
-	return er.QueryPropagationById(client, state.Primary.Attributes["instance_id"],
+	return er.GetPropagationById(client, state.Primary.Attributes["instance_id"],
 		state.Primary.Attributes["route_table_id"], state.Primary.ID)
 }
 
 func TestAccPropagation_basic(t *testing.T) {
 	var (
-		obj propagations.Propagation
+		obj interface{}
 
 		rName = "huaweicloud_er_propagation.test"
-		name  = acceptance.RandomAccResourceName()
-	)
+		rc    = acceptance.InitResourceCheck(rName, &obj, getPropagationResourceFunc)
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&obj,
-		getPropagationResourceFunc,
+		name = acceptance.RandomAccResourceName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -45,6 +41,10 @@ func TestAccPropagation_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
+			{
+				Config:      testAccPropagation_nonExistentParentResources(),
+				ExpectError: regexp.MustCompile(`error creating the propagation to the route table`),
+			},
 			{
 				Config: testAccPropagation_basic(name),
 				Check: resource.ComposeTestCheckFunc(
@@ -92,30 +92,31 @@ func testAccPropagationImportStateFunc(rsName string) resource.ImportStateIdFunc
 	}
 }
 
+func testAccPropagation_nonExistentParentResources() string {
+	randomUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_er_propagation" "test" {
+  instance_id    = "%[1]s"
+  route_table_id = "%[1]s"
+  attachment_id  = "%[1]s"
+}
+`, randomUUID)
+}
+
 func testAccPropagation_base(name string) string {
 	bgpAsNum := acctest.RandIntRange(64512, 65534)
 
 	return fmt.Sprintf(`
 data "huaweicloud_er_availability_zones" "test" {}
 
-resource "huaweicloud_vpc" "test" {
-  name = "%[1]s"
-  cidr = "192.168.0.0/16"
-}
-
-resource "huaweicloud_vpc_subnet" "test" {
-  vpc_id = huaweicloud_vpc.test.id
-
-  name       = "%[1]s"
-  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1)
-  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 4, 1), 1)
-}
+%[1]s
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
-
-  name = "%[1]s"
-  asn  = %[2]d
+  availability_zones    = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
+  name                  = "%[2]s"
+  asn                   = %[3]d
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
 
 resource "huaweicloud_er_vpc_attachment" "test" {
@@ -123,16 +124,16 @@ resource "huaweicloud_er_vpc_attachment" "test" {
   vpc_id      = huaweicloud_vpc.test.id
   subnet_id   = huaweicloud_vpc_subnet.test.id
 
-  name                   = "%[1]s"
+  name                   = "%[2]s"
   auto_create_vpc_routes = true
 }
 
 resource "huaweicloud_er_route_table" "test" {
   instance_id = huaweicloud_er_instance.test.id
 
-  name = "%[1]s"
+  name = "%[2]s"
 }
-`, name, bgpAsNum)
+`, common.TestVpc(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), name, bgpAsNum)
 }
 
 func testAccPropagation_basic(name string) string {

--- a/huaweicloud/services/er/resource_huaweicloud_er_association.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_association.go
@@ -121,7 +121,10 @@ func ResourceAssociation() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
-				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true},
+				),
 			},
 		},
 	}

--- a/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
@@ -3,7 +3,7 @@ package er
 import (
 	"context"
 	"fmt"
-	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -11,14 +11,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/er/v3/propagations"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var propagationNonUpdatableParams = []string{
+	"instance_id",
+	"route_table_id",
+	"attachment_id",
+}
 
 // @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/enable-propagations
 // @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/propagations
@@ -27,6 +33,7 @@ func ResourcePropagation() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourcePropagationCreate,
 		ReadContext:   resourcePropagationRead,
+		UpdateContext: resourcePropagationUpdate,
 		DeleteContext: resourcePropagationDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -38,6 +45,8 @@ func ResourcePropagation() *schema.Resource {
 			Delete: schema.DefaultTimeout(2 * time.Minute),
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(propagationNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:        schema.TypeString,
@@ -46,24 +55,25 @@ func ResourcePropagation() *schema.Resource {
 				ForceNew:    true,
 				Description: `The region where the ER instance and route table are located.`,
 			},
+
+			// Required parameters.
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The ID of the ER instance to which the route table and the attachment belongs.`,
 			},
 			"route_table_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The ID of the route table to which the propagation belongs.`,
 			},
 			"attachment_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The ID of the attachment corresponding to the propagation.`,
 			},
+
+			// Attributes.
 			"attachment_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -84,66 +94,104 @@ func ResourcePropagation() *schema.Resource {
 				Computed:    true,
 				Description: `The latest update time.`,
 			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true},
+				),
+			},
 		},
 	}
 }
 
-func resourcePropagationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	client, err := cfg.ErV3Client(cfg.GetRegion(d))
+func createPropagation(client *golangsdk.ServiceClient, instanceId, attachmentId, routeTableId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/enable-propagations"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{er_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{route_table_id}", routeTableId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"attachment_id": attachmentId,
+		},
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
-		return diag.Errorf("error creating ER v3 client: %s", err)
+		return nil, err
 	}
 
-	var (
-		instanceId   = d.Get("instance_id").(string)
-		routeTableId = d.Get("route_table_id").(string)
-
-		opts = propagations.CreateOpts{
-			AttachmentId: d.Get("attachment_id").(string),
-		}
-	)
-
-	resp, err := propagations.Create(client, instanceId, routeTableId, opts)
-	if err != nil {
-		return diag.Errorf("error creating the propagation to the route table: %s", err)
-	}
-	d.SetId(resp.ID)
-
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING"},
-		Target:  []string{"COMPLETED"},
-		Refresh: propagationStatusRefreshFunc(client, instanceId, routeTableId, d.Id(), []string{"available"}),
-		Timeout: d.Timeout(schema.TimeoutDelete),
-		// After the creation request is sent, it will briefly enter the pending status.
-		Delay:        10 * time.Second,
-		PollInterval: 10 * time.Second,
-	}
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	return resourcePropagationRead(ctx, d, meta)
+	return utils.FlattenResponse(requestResp)
 }
 
-// QueryPropagationById is a method to query association details from a specified route table using given parameters.
-func QueryPropagationById(client *golangsdk.ServiceClient, instanceId, routeTableId,
-	propagationId string) (*propagations.Propagation, error) {
-	// The query parameter list does not contain the ID parameter, so can only filter it manually.
-	resp, err := propagations.List(client, instanceId, routeTableId, propagations.ListOpts{})
+func listPropagations(client *golangsdk.ServiceClient, instanceId, routeTableId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/propagations?limit={limit}"
+		limit   = 200
+		marker  string
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{er_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{route_table_id}", routeTableId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		requestPath := listPath
+		if marker != "" {
+			requestPath += fmt.Sprintf("&marker=%s", marker)
+		}
+
+		requestResp, err := client.Request("GET", requestPath, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		propagations := utils.PathSearch("propagations", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, propagations...)
+		nextMarker := utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" || nextMarker == marker {
+			break
+		}
+		marker = nextMarker
+	}
+
+	return result, nil
+}
+
+// GetPropagationById queries propagation details from a specified route table using given parameters.
+func GetPropagationById(client *golangsdk.ServiceClient, instanceId, routeTableId, propagationId string) (interface{}, error) {
+	propagations, err := listPropagations(client, instanceId, routeTableId)
 	if err != nil {
 		return nil, err
 	}
 
-	filter := map[string]interface{}{
-		"ID": propagationId,
-	}
-	result, err := utils.FilterSliceWithField(resp, filter)
-	if err != nil {
-		return nil, err
-	}
-	if len(result) < 1 {
+	propagation := utils.PathSearch(fmt.Sprintf("[?id=='%s']|[0]", propagationId), propagations, nil)
+	if propagation == nil {
 		return nil, golangsdk.ErrDefault404{
 			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
 				Body: []byte(fmt.Sprintf("the propagation (%s) does not exist", propagationId)),
@@ -151,98 +199,153 @@ func QueryPropagationById(client *golangsdk.ServiceClient, instanceId, routeTabl
 		}
 	}
 
-	log.Printf("[DEBUG] The result filtered by resource ID (%s) is: %#v", propagationId, result)
-	association, ok := result[0].(propagations.Propagation)
-	if !ok {
-		return nil, golangsdk.ErrDefault400{
-			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
-				Body: []byte(fmt.Sprintf("the element type of filter result is incorrect, want 'propagations.Propagation', but got '%T'", result[0])),
-			},
-		}
-	}
-
-	return &association, nil
+	return propagation, nil
 }
 
 func propagationStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId, routeTableId, propagationId string,
 	targets []string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		resp, err := QueryPropagationById(client, instanceId, routeTableId, propagationId)
+		respBody, err := GetPropagationById(client, instanceId, routeTableId, propagationId)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
-				return resp, "COMPLETED", nil
+				return "not_found", "COMPLETED", nil
 			}
 
-			return nil, "", err
+			return respBody, "ERROR", err
 		}
 
-		if utils.StrSliceContains([]string{"failed"}, resp.Status) {
-			return resp, "", fmt.Errorf("unexpected status '%s'", resp.Status)
+		statusResp := utils.PathSearch("state", respBody, "").(string)
+		if utils.StrSliceContains([]string{"failed"}, statusResp) {
+			return respBody, "ERROR", fmt.Errorf("unexpect status (%s)", statusResp)
 		}
-		if utils.StrSliceContains(targets, resp.Status) {
-			return resp, "COMPLETED", nil
+		if utils.StrSliceContains(targets, statusResp) {
+			return respBody, "COMPLETED", nil
 		}
 
-		return resp, "PENDING", nil
+		return respBody, "PENDING", nil
 	}
 }
 
-func resourcePropagationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ErV3Client(region)
+func resourcePropagationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		instanceId   = d.Get("instance_id").(string)
+		attachmentId = d.Get("attachment_id").(string)
+		routeTableId = d.Get("route_table_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("er", region)
 	if err != nil {
-		return diag.Errorf("error creating ER v3 client: %s", err)
+		return diag.Errorf("error creating ER client: %s", err)
 	}
 
+	respBody, err := createPropagation(client, instanceId, attachmentId, routeTableId)
+	if err != nil {
+		return diag.Errorf("error creating the propagation to the route table: %s", err)
+	}
+
+	propagationId := utils.PathSearch("propagation.id", respBody, "").(string)
+	if propagationId == "" {
+		return diag.Errorf("unable to find the propagation ID from the API response")
+	}
+	d.SetId(propagationId)
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: propagationStatusRefreshFunc(client, instanceId, routeTableId, d.Id(), []string{"available"}),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+		// After the creation request is sent, it will briefly enter the pending status.
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the propagation (%s) to become available: %s", d.Id(), err)
+	}
+
+	return resourcePropagationRead(ctx, d, meta)
+}
+
+func resourcePropagationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
 		instanceId    = d.Get("instance_id").(string)
 		routeTableId  = d.Get("route_table_id").(string)
 		propagationId = d.Id()
 	)
 
-	resp, err := QueryPropagationById(client, instanceId, routeTableId, propagationId)
+	client, err := cfg.NewServiceClient("er", region)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "ER propagation")
+		return diag.Errorf("error creating ER client: %s", err)
+	}
+
+	respBody, err := GetPropagationById(client, instanceId, routeTableId, propagationId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving ER propagation")
 	}
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("route_table_id", resp.RouteTableId),
-		d.Set("attachment_id", resp.AttachmentId),
-		d.Set("attachment_type", resp.ResourceType),
-		d.Set("status", resp.Status),
+		d.Set("route_table_id", utils.PathSearch("route_table_id", respBody, nil)),
+		d.Set("attachment_id", utils.PathSearch("attachment_id", respBody, nil)),
+		d.Set("attachment_type", utils.PathSearch("resource_type", respBody, nil)),
+		d.Set("status", utils.PathSearch("state", respBody, nil)),
 		// The time results are not the time in RF3339 format without milliseconds.
-		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(resp.CreatedAt)/1000, false)),
-		d.Set("updated_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(resp.UpdatedAt)/1000, false)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+			utils.PathSearch("created_at", respBody, "").(string))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
+			utils.PathSearch("updated_at", respBody, "").(string))/1000, false)),
 	)
 
-	if mErr.ErrorOrNil() != nil {
-		return diag.Errorf("error saving propagation (%s) fields: %s", propagationId, mErr)
-	}
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourcePropagationUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	return nil
 }
 
-func resourcePropagationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	client, err := cfg.ErV3Client(region)
-	if err != nil {
-		return diag.Errorf("error creating ER v3 client: %s", err)
+func deletePropagation(client *golangsdk.ServiceClient, instanceId, attachmentId, routeTableId string) error {
+	httpUrl := "v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/disable-propagations"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{er_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{route_table_id}", routeTableId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"attachment_id": attachmentId,
+		},
 	}
 
+	_, err := client.Request("POST", deletePath, &deleteOpt)
+	return err
+}
+
+func resourcePropagationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
 		instanceId    = d.Get("instance_id").(string)
+		attachmentId  = d.Get("attachment_id").(string)
 		routeTableId  = d.Get("route_table_id").(string)
 		propagationId = d.Id()
-
-		opts = propagations.DeleteOpts{
-			AttachmentId: d.Get("attachment_id").(string),
-		}
 	)
-	err = propagations.Delete(client, instanceId, routeTableId, opts)
+
+	client, err := cfg.NewServiceClient("er", region)
 	if err != nil {
-		return diag.Errorf("error deleting propagation (%s): %s", propagationId, err)
+		return diag.Errorf("error creating ER client: %s", err)
+	}
+
+	err = deletePropagation(client, instanceId, attachmentId, routeTableId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting propagation (%s)", propagationId))
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -250,13 +353,13 @@ func resourcePropagationDelete(ctx context.Context, d *schema.ResourceData, meta
 		Target:  []string{"COMPLETED"},
 		Refresh: propagationStatusRefreshFunc(client, instanceId, routeTableId, propagationId, nil),
 		Timeout: d.Timeout(schema.TimeoutDelete),
-		// After the creation request is sent, it will briefly enter the pending status.
+		// After the deletion request is sent, it will briefly enter the pending status.
 		Delay:        5 * time.Second,
 		PollInterval: 10 * time.Second,
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("error waiting for the propagation (%s) to be deleted: %s", propagationId, err)
 	}
 
 	return nil
@@ -264,9 +367,10 @@ func resourcePropagationDelete(ctx context.Context, d *schema.ResourceData, meta
 
 func resourcePropagationImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
 	error) {
-	parts := strings.SplitN(d.Id(), "/", 3)
+	importId := d.Id()
+	parts := strings.SplitN(importId, "/", 3)
 	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid format for import ID, want '<instance_id>/<route_table_id>/<propagation_id>', but got '%s'", d.Id())
+		return nil, fmt.Errorf("invalid format for import ID, want '<instance_id>/<route_table_id>/<id>', but got '%s'", importId)
 	}
 
 	d.SetId(parts[2])

--- a/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
@@ -28,6 +28,7 @@ var propagationNonUpdatableParams = []string{
 
 // @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/enable-propagations
 // @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/propagations
+// @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/propagations/{propagation_id}/change-route-policy
 // @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/disable-propagations
 func ResourcePropagation() *schema.Resource {
 	return &schema.Resource{
@@ -42,6 +43,7 @@ func ResourcePropagation() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(2 * time.Minute),
 		},
 
@@ -71,6 +73,25 @@ func ResourcePropagation() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `The ID of the attachment corresponding to the propagation.`,
+			},
+
+			// Optional parameters.
+			"route_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"import_policy_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The import route policy ID.`,
+						},
+					},
+				},
+				Description: `The import route policy configuration.`,
 			},
 
 			// Attributes.
@@ -109,7 +130,26 @@ func ResourcePropagation() *schema.Resource {
 	}
 }
 
-func createPropagation(client *golangsdk.ServiceClient, instanceId, attachmentId, routeTableId string) (interface{}, error) {
+func buildPropagationRoutePolicy(routePolicies []interface{}) map[string]interface{} {
+	if len(routePolicies) < 1 {
+		return nil
+	}
+
+	routePolicy := routePolicies[0]
+	return map[string]interface{}{
+		"import_policy_id": utils.ValueIgnoreEmpty(utils.PathSearch("import_policy_id", routePolicy, nil)),
+	}
+}
+
+func buildCreatePropagationBodyParams(attachmentId string, routePolicies []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"attachment_id": attachmentId,
+		"route_policy":  buildPropagationRoutePolicy(routePolicies),
+	}
+}
+
+func createPropagation(client *golangsdk.ServiceClient, instanceId, attachmentId, routeTableId string,
+	routePolicies []interface{}) (interface{}, error) {
 	httpUrl := "v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/enable-propagations"
 	createPath := client.Endpoint + httpUrl
 	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
@@ -121,9 +161,7 @@ func createPropagation(client *golangsdk.ServiceClient, instanceId, attachmentId
 		MoreHeaders: map[string]string{
 			"Content-Type": "application/json",
 		},
-		JSONBody: map[string]interface{}{
-			"attachment_id": attachmentId,
-		},
+		JSONBody: utils.RemoveNil(buildCreatePropagationBodyParams(attachmentId, routePolicies)),
 	}
 
 	requestResp, err := client.Request("POST", createPath, &createOpt)
@@ -228,11 +266,12 @@ func propagationStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId, r
 
 func resourcePropagationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg          = meta.(*config.Config)
-		region       = cfg.GetRegion(d)
-		instanceId   = d.Get("instance_id").(string)
-		attachmentId = d.Get("attachment_id").(string)
-		routeTableId = d.Get("route_table_id").(string)
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId    = d.Get("instance_id").(string)
+		attachmentId  = d.Get("attachment_id").(string)
+		routeTableId  = d.Get("route_table_id").(string)
+		routePolicies = d.Get("route_policy").([]interface{})
 	)
 
 	client, err := cfg.NewServiceClient("er", region)
@@ -240,7 +279,7 @@ func resourcePropagationCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error creating ER client: %s", err)
 	}
 
-	respBody, err := createPropagation(client, instanceId, attachmentId, routeTableId)
+	respBody, err := createPropagation(client, instanceId, attachmentId, routeTableId, routePolicies)
 	if err != nil {
 		return diag.Errorf("error creating the propagation to the route table: %s", err)
 	}
@@ -268,6 +307,23 @@ func resourcePropagationCreate(ctx context.Context, d *schema.ResourceData, meta
 	return resourcePropagationRead(ctx, d, meta)
 }
 
+func flattenPropagationRoutePolicy(routePolicy map[string]interface{}) []map[string]interface{} {
+	if len(routePolicy) < 1 {
+		return nil
+	}
+
+	importPolicyId := utils.PathSearch("import_policy_id", routePolicy, nil)
+	if importPolicyId == nil || importPolicyId == "" {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"import_policy_id": importPolicyId,
+		},
+	}
+}
+
 func resourcePropagationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg           = meta.(*config.Config)
@@ -292,6 +348,8 @@ func resourcePropagationRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("route_table_id", utils.PathSearch("route_table_id", respBody, nil)),
 		d.Set("attachment_id", utils.PathSearch("attachment_id", respBody, nil)),
 		d.Set("attachment_type", utils.PathSearch("resource_type", respBody, nil)),
+		d.Set("route_policy", flattenPropagationRoutePolicy(utils.PathSearch("route_policy", respBody,
+			make(map[string]interface{})).(map[string]interface{}))),
 		d.Set("status", utils.PathSearch("state", respBody, nil)),
 		// The time results are not the time in RF3339 format without milliseconds.
 		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(
@@ -303,8 +361,71 @@ func resourcePropagationRead(_ context.Context, d *schema.ResourceData, meta int
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourcePropagationUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	return nil
+func buildUpdatePropagationRoutePolicyBodyParams(routePolicies []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"route_policy": buildPropagationRoutePolicy(routePolicies),
+	}
+}
+
+func changePropagationRoutePolicy(client *golangsdk.ServiceClient, instanceId, routeTableId, propagationId string,
+	routePolicies []interface{}) (interface{}, error) {
+	httpUrl := "v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/propagations/{propagation_id}/change-route-policy"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{er_id}", instanceId)
+	updatePath = strings.ReplaceAll(updatePath, "{route_table_id}", routeTableId)
+	updatePath = strings.ReplaceAll(updatePath, "{propagation_id}", propagationId)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildUpdatePropagationRoutePolicyBodyParams(routePolicies)),
+	}
+
+	requestResp, err := client.Request("POST", updatePath, &updateOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourcePropagationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId    = d.Get("instance_id").(string)
+		routeTableId  = d.Get("route_table_id").(string)
+		propagationId = d.Id()
+		routePolicies = d.Get("route_policy").([]interface{})
+	)
+
+	client, err := cfg.NewServiceClient("er", region)
+	if err != nil {
+		return diag.Errorf("error creating ER client: %s", err)
+	}
+
+	_, err = changePropagationRoutePolicy(client, instanceId, routeTableId, propagationId, routePolicies)
+	if err != nil {
+		return diag.Errorf("error updating the route policy of propagation (%s): %s", propagationId, err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      propagationStatusRefreshFunc(client, instanceId, routeTableId, propagationId, []string{"available"}),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the propagation (%s) route policy update to complete: %s", propagationId, err)
+	}
+
+	return resourcePropagationRead(ctx, d, meta)
 }
 
 func deletePropagation(client *golangsdk.ServiceClient, instanceId, attachmentId, routeTableId string) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Before supports route policy, refactor the propagation resource and using auto-gen style for coding.
Then, supports new object structure for route policy (even if the APIs for CRUD about this feature are not opened).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**Special notes for your reviewer**:

The coverage of the basic acceptance test:
<img width="869" height="74" alt="image" src="https://github.com/user-attachments/assets/82efd664-e1f6-464f-9c99-03f0606ff3a2" />

The coverage of the route policy acceptance test:
<img width="865" height="54" alt="image" src="https://github.com/user-attachments/assets/7f5d621f-2996-4601-a643-87d67b6b7ca7" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using auto-gen style to rewrite propagation resource
2. propagation resource supports route policy
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o er -f TestAccPropagation_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/er" -v -coverprofile="./huaweicloud/services/acceptance/er/er_coverage.cov" -coverpkg="./huaweicloud/services/er" -run TestAccPropagation_basic -timeout 360m -parallel 10
=== RUN   TestAccPropagation_basic
=== PAUSE TestAccPropagation_basic
=== CONT  TestAccPropagation_basic
--- PASS: TestAccPropagation_basic (135.02s)
PASS
coverage: 24.8% of statements in ./huaweicloud/services/er
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        135.116s        coverage: 24.8% of statements in ./huaweicloud/services/er
```
```
./scripts/coverage.sh -o er -f TestAccPropagation_routePolicy
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/er" -v -coverprofile="./huaweicloud/services/acceptance/er/er_coverage.cov" -coverpkg="./huaweicloud/services/er" -run TestAccPropagation_routePolicy -timeout 360m -parallel 10
=== RUN   TestAccPropagation_routePolicy
=== PAUSE TestAccPropagation_routePolicy
=== CONT  TestAccPropagation_routePolicy
--- PASS: TestAccPropagation_routePolicy (379.82s)
PASS
coverage: 26.1% of statements in ./huaweicloud/services/er
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        379.902s        coverage: 26.1% of statements in ./huaweicloud/services/er
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1242" height="975" alt="image" src="https://github.com/user-attachments/assets/1f340f7c-51ae-41b1-a6ae-1a5667672a54" />

    ab. Related resources (parent resources) not found
    <img width="1552" height="1118" alt="image" src="https://github.com/user-attachments/assets/ca723a54-dc0f-4862-8f56-49870ccdf2ea" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1519" height="1134" alt="image" src="https://github.com/user-attachments/assets/6e6785d1-8f36-477d-9a56-90ca2ecd73ce" />

    bb. Related resources (parent resources) not found
    <img width="1491" height="1095" alt="image" src="https://github.com/user-attachments/assets/84eff59f-6922-4dac-a62d-1be2c8843917" />

