### PR TITLE
feat(GeminiDB): add resource to manage GeminiDB Redis command disable

### DIFF
--- a/docs/resources/geminidb_command_disable.md
+++ b/docs/resources/geminidb_command_disable.md
@@ -1,0 +1,112 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_command_disable"
+description: |-
+  Manages a GeminiDB Redis command disabled resource within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_command_disable
+
+Manages a memory acceleration rule resource within HuaweiCloud.
+
+-> This resource only supports GeminiDB Redis instance.
+
+## Example Usage
+
+### create a disable command resource
+
+```hcl
+var "instance_id" {}
+var "commands" {
+  type = list(string)
+}
+
+resource "huaweicloud_geminidb_command_disable" "test" {
+  instance_id   = var.instance_id
+  disabled_type = "command"
+  commands      = var.commands
+}
+```
+
+### create a disable key command resource
+
+```hcl
+var "instance_id" {}
+variable "keys" {
+  type = list(object({
+    db_id    = string
+    key      = string
+    commands = list(string)
+  }))
+}
+
+resource "huaweicloud_geminidb_command_disable" "test" {
+  instance_id   = var.instance_id
+  disabled_type = "key"
+  
+  dynamic "keys" {
+    for_each = var.keys
+
+    content {
+      db_id    = keys.value.db_id
+      key      = keys.value.key
+      commands = keys.value.command
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the GeminiDB Redis instance.
+
+* `disabled_type` - (Required, String, NonUpdatable) Specifies the disable type.
+  The valid values are as follows:
+  + **command**
+  + **key**
+
+* `commands` - (Optional, List) Specifies the list of disabled commands.
+  The valid values are as follows:
+  + **keys**
+  + **hkeys**
+  + **hvals**
+  + **hgetall**
+  + **smembers**
+  + **flushdb**
+  + **flushall**
+
+  -> This parameter is available and required when the `disabled_type` is set to **command**.
+
+* `keys` - (Optional, List) Specifies the list of keys information. A maximum of `20` keys are supported.
+  The [keys](#keys_struct) structure is documented below.
+
+  -> This parameter is available and required when the `disabled_type` is set to **key**.
+
+<a name="keys_struct"></a>
+The `keys` block supports:
+
+* `db_id` - (Required, String) Specifies the DB ID where a key is located.
+
+* `key` - (Required, String) Specifies the key name.
+
+* `commands` - (Required, List) Specifies the list of commands.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also is the instance ID.
+
+## Import
+
+The resource can be imported using the `instance_id` and `disabled_type`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_geminidb_command_disable.test <instance_id>/<disabled_type>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3845,6 +3845,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_account":                     geminidb.ResourceGeminidbAccount(),
 			"huaweicloud_geminidb_backup":                      geminidb.ResourceGeminiDBBackup(),
 			"huaweicloud_geminidb_backup_stop":                 geminidb.ResourceGeminiDBBackupStop(),
+			"huaweicloud_geminidb_command_disable":             geminidb.ResourceCommandDisable(),
 			"huaweicloud_geminidb_database_operation":          geminidb.ResourceGeminiDBDatabaseOperation(),
 			"huaweicloud_geminidb_database_upgrade":            geminidb.ResourceDatabaseUpgrade(),
 			"huaweicloud_geminidb_dr_switchover_configuration": geminidb.ResourceGeminiDBDRSwitchoverConfiguration(),

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_command_disable_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_command_disable_test.go
@@ -1,0 +1,262 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/geminidb"
+)
+
+func getResourceCommandDisableFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("geminidb", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	return geminidb.GetCommandDisableInfo(client, state.Primary.ID, state.Primary.Attributes["disabled_type"])
+}
+
+func TestAccResourceCommandDisable_basic(t *testing.T) {
+	var (
+		rName  = "huaweicloud_geminidb_command_disable.test"
+		name   = acceptance.RandomAccResourceName()
+		object interface{}
+		rc     = acceptance.InitResourceCheck(
+			rName,
+			&object,
+			getResourceCommandDisableFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCommandDisable_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_geminidb_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "disabled_type", "command"),
+					resource.TestCheckResourceAttr(rName, "commands.#", "2"),
+				),
+			},
+			{
+				Config: testAccCommandDisable_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "commands.#", "3"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCommandDisableImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func TestAccResourceCommandDisable_keyCommand(t *testing.T) {
+	var (
+		rName  = "huaweicloud_geminidb_command_disable.test"
+		name   = acceptance.RandomAccResourceName()
+		object interface{}
+		rc     = acceptance.InitResourceCheck(
+			rName,
+			&object,
+			getResourceCommandDisableFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCommandDisable_keyCommand_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_geminidb_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "disabled_type", "key"),
+					resource.TestCheckResourceAttr(rName, "keys.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "keys.*", map[string]string{
+						"db_id": "0",
+						"key":   "name",
+					}),
+				),
+			},
+			{
+				Config: testAccCommandDisable_keyCommand_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "keys.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(rName, "keys.*", map[string]string{
+						"db_id": "2",
+						"key":   "grade",
+					}),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCommandDisableImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccCommandDisable_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus             = 2
+  engine            = "redis"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "test_1234"
+  mode              = "Cluster"
+
+  datastore {
+    type           = "redis"
+    version        = "5.0"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "3"
+    size      = "16"
+    storage   = "ULTRAHIGH"
+    spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccCommandDisable_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_geminidb_command_disable" "test" {
+  instance_id   = huaweicloud_geminidb_instance.test.id
+  disabled_type = "command"
+  commands      = ["keys","hkeys"]
+}
+`, testAccCommandDisable_base(name))
+}
+
+func testAccCommandDisable_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_geminidb_command_disable" "test" {
+  instance_id   = huaweicloud_geminidb_instance.test.id
+  disabled_type = "command"
+  commands      = ["hkeys","hvals","hgetall"]
+}
+`, testAccCommandDisable_base(name))
+}
+
+func testAccCommandDisable_keyCommand_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_geminidb_command_disable" "test" {
+  instance_id   = huaweicloud_geminidb_instance.test.id
+  disabled_type = "key"
+
+  keys {
+    db_id    = "0"
+    key      = "name"
+    commands = ["get"]
+  }
+
+  keys {
+    db_id    = "0"
+    key      = "age"
+    commands = ["get","set"]
+  }
+
+  keys {
+    db_id    = "1"
+    key      = "address"
+    commands = ["lrange"]
+  }
+}
+`, testAccCommandDisable_base(name))
+}
+
+func testAccCommandDisable_keyCommand_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_geminidb_command_disable" "test" {
+  instance_id   = huaweicloud_geminidb_instance.test.id
+  disabled_type = "key"
+
+  keys {
+    db_id    = "0"
+    key      = "name"
+    commands = ["get","set"]
+  }
+
+  keys {
+    db_id    = "1"
+    key      = "age"
+    commands = ["set"]
+  }
+
+  keys {
+    db_id    = "2"
+    key      = "grade"
+    commands = ["sort"]
+  }
+}
+`, testAccCommandDisable_base(name))
+}
+
+func testAccCommandDisableImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var instanceId, disableType string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		instanceId = rs.Primary.Attributes["instance_id"]
+		disableType = rs.Primary.Attributes["disabled_type"]
+
+		if instanceId == "" || disableType == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<disabled_type>', but got '%s/%s'",
+				instanceId, disableType)
+		}
+
+		return fmt.Sprintf("%s/%s", instanceId, disableType), nil
+	}
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_command_disable.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_command_disable.go
@@ -1,0 +1,441 @@
+package geminidb
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var commandDisableNonUpdatableParams = []string{
+	"instance_id",
+	"disabled_type",
+}
+
+// @API GeminiDB POST /v3/{project_id}/redis/instances/{instance_id}/disabled-commands
+// @API GeminiDB GET /v3/{project_id}/redis/instances/{instance_id}/disabled-commands
+// @API GeminiDB DELETE /v3/{project_id}/redis/instances/{instance_id}/disabled-commands
+func ResourceCommandDisable() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCommandDisableCreate,
+		ReadContext:   resourceCommandDisableRead,
+		UpdateContext: resourceCommandDisableUpdate,
+		DeleteContext: resourceCommandDisableDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCommandDisableImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(commandDisableNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"disabled_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"commands": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"keys"},
+			},
+			"keys": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				Elem:          disableCommandKeysSchema(),
+				ConflictsWith: []string{"commands"},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func disableCommandKeysSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"db_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"commands": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+	return &sc
+}
+
+func buildCreateCommandDisableBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"disabled_type": d.Get("disabled_type"),
+		"commands": utils.ValueIgnoreEmpty(
+			utils.ExpandToStringList(d.Get("commands").(*schema.Set).List())),
+		"keys": buildKeysInfoBodyParams(d.Get("keys").(*schema.Set).List()),
+	}
+
+	return bodyParams
+}
+
+func buildKeysInfoBodyParams(keysInfo []interface{}) []map[string]interface{} {
+	if len(keysInfo) == 0 {
+		return nil
+	}
+
+	keyInfos := make([]map[string]interface{}, 0, len(keysInfo))
+	for _, v := range keysInfo {
+		raw, ok := v.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+
+		params := map[string]interface{}{
+			"db_id":    raw["db_id"],
+			"key":      raw["key"],
+			"commands": utils.ExpandToStringList(raw["commands"].(*schema.Set).List()),
+		}
+		keyInfos = append(keyInfos, params)
+	}
+
+	return keyInfos
+}
+
+func resourceCommandDisableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId    = d.Get("instance_id").(string)
+		createHttpUrl = "v3/{project_id}/redis/instances/{instance_id}/disabled-commands"
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateCommandDisableBodyParams(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB Redis disable command: %s", err)
+	}
+
+	d.SetId(instanceId)
+
+	return resourceCommandDisableRead(ctx, d, meta)
+}
+
+func resourceCommandDisableRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		commandType = d.Get("disabled_type").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	commandInfos, err := GetCommandDisableInfo(client, d.Id(), commandType)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving GeminiDB Redis disabled command")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("instance_id", d.Id()),
+		d.Set("disabled_type", commandType),
+	)
+
+	if commandType == "command" {
+		mErr = multierror.Append(mErr,
+			d.Set("commands", commandInfos),
+			d.Set("keys", make([]interface{}, 0)),
+		)
+	} else {
+		mErr = multierror.Append(mErr,
+			d.Set("commands", make([]interface{}, 0)),
+			d.Set("keys", flattenCommandDisableKeys(commandInfos)),
+		)
+	}
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCommandDisableKeys(keysInfo []interface{}) []map[string]interface{} {
+	if len(keysInfo) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(keysInfo))
+	for _, item := range keysInfo {
+		result = append(result, map[string]interface{}{
+			"db_id":    utils.PathSearch("db_id", item, nil),
+			"key":      utils.PathSearch("key", item, nil),
+			"commands": utils.PathSearch("commands", item, nil),
+		})
+	}
+
+	return result
+}
+
+func GetCommandDisableInfo(client *golangsdk.ServiceClient, instanceId, commandType string) ([]interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/redis/instances/{instance_id}/disabled-commands?type={type}&limit={limit}"
+		offset  = 0
+		limit   = 50
+		result  = make([]interface{}, 0)
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{type}", commandType)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listOpts := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		resp, err := client.Request("GET", listPathWithOffset, &listOpts)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		if commandType == "command" {
+			commands := utils.PathSearch("commands", respBody, make([]interface{}, 0)).([]interface{})
+			result = append(result, commands...)
+			if len(commands) < limit {
+				break
+			}
+
+			offset += len(commands)
+		}
+
+		if commandType == "key" {
+			keys := utils.PathSearch("keys", respBody, make([]interface{}, 0)).([]interface{})
+			result = append(result, keys...)
+			if len(keys) < limit {
+				break
+			}
+
+			offset += len(keys)
+		}
+	}
+
+	if len(result) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return result, nil
+}
+
+func resourceCommandDisableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	if d.HasChange("commands") {
+		oldCommands, newCommands := d.GetChange("commands")
+		addCommands := newCommands.(*schema.Set).Difference(oldCommands.(*schema.Set))
+		removeCommands := oldCommands.(*schema.Set).Difference(newCommands.(*schema.Set))
+
+		if removeCommands.Len() > 0 {
+			err = removeDisableCommands(client, d, "command", removeCommands.List())
+			if err != nil {
+				return diag.Errorf("error removing GeminiDB Redis disabled command: %s", err)
+			}
+		}
+
+		if addCommands.Len() > 0 {
+			err = addDisableCommands(client, d, "command", addCommands.List())
+			if err != nil {
+				return diag.Errorf("error adding GeminiDB Redis disabled command: %s", err)
+			}
+		}
+	}
+
+	if d.HasChange("keys") {
+		oldKeys, newKeys := d.GetChange("keys")
+		addKeys := newKeys.(*schema.Set).Difference(oldKeys.(*schema.Set))
+		removeKeys := oldKeys.(*schema.Set).Difference(newKeys.(*schema.Set))
+
+		if removeKeys.Len() > 0 {
+			err = removeDisableCommands(client, d, "key", removeKeys.List())
+			if err != nil {
+				return diag.Errorf("error removing GeminiDB Redis disabled command: %s", err)
+			}
+		}
+
+		if addKeys.Len() > 0 {
+			err = addDisableCommands(client, d, "key", addKeys.List())
+			if err != nil {
+				return diag.Errorf("error adding GeminiDB Redis disabled command: %s", err)
+			}
+		}
+	}
+
+	return resourceCommandDisableRead(ctx, d, meta)
+}
+
+func addDisableCommands(client *golangsdk.ServiceClient, d *schema.ResourceData, commandType string, commands []interface{}) error {
+	addHttpUrl := "v3/{project_id}/redis/instances/{instance_id}/disabled-commands"
+	addPath := client.Endpoint + addHttpUrl
+	addPath = strings.ReplaceAll(addPath, "{project_id}", client.ProjectID)
+	addPath = strings.ReplaceAll(addPath, "{instance_id}", d.Id())
+	addIpsOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateCommandsBodyParams(commandType, commands),
+	}
+
+	_, err := client.Request("POST", addPath, &addIpsOpt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func buildUpdateCommandsBodyParams(commandType string, commands []interface{}) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"disabled_type": commandType,
+	}
+
+	if commandType == "command" {
+		bodyParams["commands"] = utils.ExpandToStringList(commands)
+	} else {
+		bodyParams["keys"] = buildKeysInfoBodyParams(commands)
+	}
+
+	return bodyParams
+}
+
+func removeDisableCommands(client *golangsdk.ServiceClient, d *schema.ResourceData, commandType string, commands []interface{}) error {
+	removeHttpUrl := "v3/{project_id}/redis/instances/{instance_id}/disabled-commands"
+	removePath := client.Endpoint + removeHttpUrl
+	removePath = strings.ReplaceAll(removePath, "{project_id}", client.ProjectID)
+	removePath = strings.ReplaceAll(removePath, "{instance_id}", d.Id())
+	removeOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateCommandsBodyParams(commandType, commands),
+	}
+
+	_, err := client.Request("DELETE", removePath, &removeOpt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceCommandDisableDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/redis/instances/{instance_id}/disabled-commands"
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateCommandDisableBodyParams(d)),
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		// whether the disabled command exist or not, the response HTTP status code of the deletion API is 200.
+		return diag.Errorf("error deleting GeminiDB Redis disabled command: %s", err)
+	}
+
+	return nil
+}
+
+func resourceCommandDisableImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<disabled_type>', but got '%s'", importedId)
+	}
+
+	d.SetId(parts[0])
+
+	mErr := multierror.Append(nil,
+		d.Set("disabled_type", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add resource to manage GeminiDB Redis command disable.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add resource to manage GeminiDB Redis command disable.
2. support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccResourceCommandDisable_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccResourceCommandDisable_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceCommandDisable_basic
=== PAUSE TestAccResourceCommandDisable_basic
=== CONT  TestAccResourceCommandDisable_basic
--- PASS: TestAccResourceCommandDisable_basic (1516.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1516.548s
```
```
$ ./scripts/coverage.sh -o geminidb -f TestAccResourceCommandDisable_keyCommand
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/geminidb" -v -coverprofile="./huaweicloud/services/acceptance/geminidb/geminidb_coverage.cov" -coverpkg="./huaweicloud/services/geminidb" -run TestAccResourceCommandDisable_keyCommand -timeout 360m -parallel 10
=== RUN   TestAccResourceCommandDisable_keyCommand
=== PAUSE TestAccResourceCommandDisable_keyCommand
=== CONT  TestAccResourceCommandDisable_keyCommand
--- PASS: TestAccResourceCommandDisable_keyCommand (1545.54s)
PASS
coverage: 11.8% of statements in ./huaweicloud/services/geminidb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1545.703s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/5fb61f33-b9db-41c6-b454-c1991787a79d" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
<img width="720" height="205" alt="111" src="https://github.com/user-attachments/assets/b6d30939-a879-434d-a0b6-6ab85e701c5a" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
