### PR TITLE
feat(geminidb): add resource geminidb Canceling a Scheduled Task

### DIFF
--- a/docs/resources/geminidb_scheduled_task_cancel.md
+++ b/docs/resources/geminidb_scheduled_task_cancel.md
@@ -1,0 +1,40 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_scheduled_task_cancel"
+description: |-
+  Manages a resource to cancel a scheduled job for GeminiDB within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_scheduled_task_cancel
+
+Manages a resource to cancel a scheduled job for GeminiDB within HuaweiCloud.
+
+-> This resource is only a one-time action resource for stopping a backup of GeminDB.
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+resource "huaweicloud_geminidb_scheduled_task_cancel" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the rds instance resource. If omitted, the
+  provider-level region will be used. Changing this creates a new geminidb instance resource.
+
+* `job_id` - (Required, String, NonUpdatable) Specifies the scheduled job ID to cancel. The job ID can be obtained
+  from the scheduled job list API. Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as the job ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3856,6 +3856,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_parameter_template_reset":    geminidb.ResourceGeminiDBParameterTemplateReset(),
 			"huaweicloud_geminidb_primary_standby_switch":      geminidb.ResourcePrimaryStandbySwitch(),
 			"huaweicloud_geminidb_recycling_policy":            geminidb.ResourceGeminiDBRecyclingPolicy(),
+			"huaweicloud_geminidb_scheduled_task_cancel":       geminidb.ResourceGeminiDBScheduledTaskCancel(),
 
 			"huaweicloud_gaussdb_cassandra_instance":  geminidb.ResourceGeminiDBInstanceV3(),
 			"huaweicloud_gaussdb_redis_instance":      geminidb.ResourceGaussRedisInstanceV3(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -932,6 +932,7 @@ var (
 	HW_GEMINIDB_INSATNCE_ID = os.Getenv("HW_GEMINIDB_INSATNCE_ID")
 	HW_GEMINIDB_BACKUP_ID   = os.Getenv("HW_GEMINIDB_BACKUP_ID")
 	HW_GEMINIDB_CONFIG_ID   = os.Getenv("HW_GEMINIDB_CONFIG_ID")
+	HW_GEMINIDB_JOB_ID      = os.Getenv("HW_GEMINIDB_JOB_ID")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -5527,5 +5528,12 @@ func TestAccCheckGeminidbBackupID(t *testing.T) {
 func TestAccCheckGeminidbConfigID(t *testing.T) {
 	if HW_GEMINIDB_CONFIG_ID == "" {
 		t.Skip("HW_GEMINIDB_CONFIG_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccCheckGeminidbJobID(t *testing.T) {
+	if HW_GEMINIDB_JOB_ID == "" {
+		t.Skip("HW_GEMINIDB_JOB_ID must be set for this acceptance test")
 	}
 }

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_scheduled_task_cancel_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_scheduled_task_cancel_test.go
@@ -1,0 +1,39 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGeminiDBScheduledTaskCancel_basic(t *testing.T) {
+	resourceName := "huaweicloud_geminidb_scheduled_task_cancel.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccCheckGeminidbJobID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDBScheduledTaskCancel_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "job_id", acceptance.HW_GEMINIDB_JOB_ID),
+				),
+			},
+		},
+	})
+}
+
+func testAccGeminiDBScheduledTaskCancel_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_geminidb_scheduled_task_cancel" "test" {
+  job_id = "%s"
+}
+`, acceptance.HW_GEMINIDB_JOB_ID)
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_scheduled_task_cancel.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_scheduled_task_cancel.go
@@ -1,0 +1,100 @@
+package geminidb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var geminiDbScheduledTaskCancelParams = []string{
+	"job_id",
+}
+
+// @API GeminiDB PUT /v3/{project_id}/instances/disaster-recovery/settings
+func ResourceGeminiDBScheduledTaskCancel() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGeminiDBScheduledTaskCancelCreate,
+		UpdateContext: resourceGeminiDBScheduledTaskCancelUpdate,
+		ReadContext:   resourceGeminiDBScheduledTaskCancelRead,
+		DeleteContext: resourceGeminiDBScheduledTaskCancelDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(geminiDbScheduledTaskCancelParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceGeminiDBScheduledTaskCancelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	jobID := d.Get("job_id").(string)
+
+	httpUrl := "v3/{project_id}/scheduled-jobs/{job_id}"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{job_id}", jobID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = client.Request("DELETE", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error canceling scheduled task: %s", err)
+	}
+
+	d.SetId(jobID)
+
+	return resourceGeminiDBScheduledTaskCancelRead(ctx, d, meta)
+}
+
+func resourceGeminiDBScheduledTaskCancelUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGeminiDBScheduledTaskCancelRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGeminiDBScheduledTaskCancelDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting Geminidb scheduled task cancel resource is not supported. The Geminidb scheduled " +
+		"task cancel resource is only removed from the state, the Geminidb scheduled task remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource geminidb Canceling a Scheduled Task
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add resource geminidb Canceling a Scheduled Task
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDBScheduledTaskCancel_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDBScheduledTaskCancel_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBScheduledTaskCancel_basic
=== PAUSE TestAccGeminiDBScheduledTaskCancel_basic
=== CONT  TestAccGeminiDBScheduledTaskCancel_basic
--- PASS: TestAccGeminiDBScheduledTaskCancel_basic (19.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  19.378s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
