### PR TITLE
feat(secmaster): add data source to get SOC attachment

### DIFF
--- a/docs/data-sources/secmaster_soc_attachment.md
+++ b/docs/data-sources/secmaster_soc_attachment.md
@@ -1,0 +1,73 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_soc_attachment"
+description: |-
+  Use this data source to get the SecMaster soc attachment detail within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_soc_attachment
+
+Use this data source to get the SecMaster soc attachment detail within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "attach_id" {}
+
+data "huaweicloud_secmaster_soc_attachment" "test" {
+  workspace_id = var.workspace_id
+  attach_id    = var.attach_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+* `attach_id` - (Required, String) Specifies the attachment ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data` - The soc attachment detail.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `id` - The attachment ID.
+
+* `file_name` - The attachment name.
+
+* `file_folder` - The folder.
+
+* `workspace_id` - The workspace ID.
+
+* `creator_id` - The creator ID.
+
+* `creator_name` - The creator name.
+
+* `create_time` - The creation time.
+
+* `update_time` - The update time.
+
+* `modifier_id` - The modifier ID.
+
+* `modifier_name` - The modifier name.
+
+* `is_deleted` - Whether the attachment is deleted.
+
+* `storage_type` - The storage type.
+
+* `storage_url` - The storage URL.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2396,6 +2396,7 @@ func Provider() *schema.Provider {
 			// and their API URLs are both named with "components". To differentiate them, all resources under the
 			// Plugin Management group are prefixed with "soc", since the API URLs in the Plugin Management group
 			// also contain "soc".
+			"huaweicloud_secmaster_soc_attachment":              secmaster.DataSourceSocAttachment(),
 			"huaweicloud_secmaster_soc_components":              secmaster.DataSourceSocComponents(),
 			"huaweicloud_secmaster_soc_component_detail":        secmaster.DataSourceSocComponentDetail(),
 			"huaweicloud_secmaster_soc_component_actions":       secmaster.DataSourceSocComponentActions(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -555,6 +555,7 @@ var (
 	HW_SECMASTER_INDICATOR_TYPE_ID_UPDATE = os.Getenv("HW_SECMASTER_INDICATOR_TYPE_ID_UPDATE")
 	HW_SECMASTER_METRIC_ID                = os.Getenv("HW_SECMASTER_METRIC_ID")
 	HW_SECMASTER_COMPONENT_VERSION_ID     = os.Getenv("HW_SECMASTER_COMPONENT_VERSION_ID")
+	HW_SECMASTER_ATTACH_ID                = os.Getenv("HW_SECMASTER_ATTACH_ID")
 
 	// The SecMaster pipeline ID
 	HW_SECMASTER_PIPELINE_ID = os.Getenv("HW_SECMASTER_PIPELINE_ID")
@@ -3410,6 +3411,13 @@ func TestAccPreCheckSecMasterWorkflowId(t *testing.T) {
 func TestAccPreCheckSecMasterFieldId(t *testing.T) {
 	if HW_SECMASTER_FIELD_ID == "" {
 		t.Skip("HW_SECMASTER_FIELD_ID must be set for SecMaster acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSecMasterAttachID(t *testing.T) {
+	if HW_SECMASTER_ATTACH_ID == "" {
+		t.Skip("HW_SECMASTER_ATTACH_ID must be set for SecMaster acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_soc_attachment_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_soc_attachment_test.go
@@ -1,0 +1,51 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSocAttachment_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_secmaster_soc_attachment.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+			acceptance.TestAccPreCheckSecMasterAttachID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSocAttachment_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data.0.file_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data.0.file_folder"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data.0.workspace_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data.0.storage_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "data.0.update_time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSocAttachment_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_soc_attachment" "test" {
+  workspace_id = "%[1]s"
+  attach_id    = "%[2]s"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_ATTACH_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_soc_attachment.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_soc_attachment.go
@@ -1,0 +1,171 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/soc/attachment/{attach_id}
+func DataSourceSocAttachment() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSocAttachmentRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"attach_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"file_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"file_folder": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"workspace_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creator_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creator_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"modifier_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"modifier_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_deleted": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage_url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSocAttachmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "secmaster"
+		httpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/attachment/{attach_id}"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestPath = strings.ReplaceAll(requestPath, "{attach_id}", d.Get("attach_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving SecMaster soc attachment: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataResp := utils.PathSearch("data", respBody, nil)
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenSocAttachmentData(dataResp)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenSocAttachmentData(dataResp interface{}) []interface{} {
+	if dataResp == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"id":            utils.PathSearch("id", dataResp, nil),
+			"file_name":     utils.PathSearch("file_name", dataResp, nil),
+			"file_folder":   utils.PathSearch("file_folder", dataResp, nil),
+			"workspace_id":  utils.PathSearch("workspace_id", dataResp, nil),
+			"creator_id":    utils.PathSearch("creator_id", dataResp, nil),
+			"creator_name":  utils.PathSearch("creator_name", dataResp, nil),
+			"create_time":   utils.PathSearch("create_time", dataResp, nil),
+			"update_time":   utils.PathSearch("update_time", dataResp, nil),
+			"modifier_id":   utils.PathSearch("modifier_id", dataResp, nil),
+			"modifier_name": utils.PathSearch("modifier_name", dataResp, nil),
+			"is_deleted":    utils.PathSearch("is_deleted", dataResp, nil),
+			"storage_type":  utils.PathSearch("storage_type", dataResp, nil),
+			"storage_url":   utils.PathSearch("storage_url", dataResp, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add secmaster_soc_attachment data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add secmaster_soc_attachment data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/secmaster' TESTARGS='-run=TestAccDataSourceSocAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run=TestAccDataSourceSocAttachment_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSocAttachment_basic
=== PAUSE TestAccDataSourceSocAttachment_basic
=== CONT  TestAccDataSourceSocAttachment_basic
--- PASS: TestAccDataSourceSocAttachment_basic (22.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 22.548s
```
<img width="483" height="19" alt="Snipaste_2026-06-11_10-47-37" src="https://github.com/user-attachments/assets/0b2fff96-0fdd-4ae6-b11e-e693a2e0f7e8" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
