### PR TITLE
feat(TaurusDB): support htap instance modify node parameters

### DIFF
--- a/docs/resources/taurusdb_htap_starrocks_instance.md
+++ b/docs/resources/taurusdb_htap_starrocks_instance.md
@@ -229,6 +229,12 @@ The following arguments are supported:
 * `enable_users_sync` - (Optional, String) Specifies whether users synchronization is enabled.
   Valid values are **true** and **false**.
 
+* `be_parameter_values` - (Optional, Map) Specifies a map contains mappings of parameter name and value to modify.
+  The parameter name must be based on the default parameter template of the backend nodes.
+
+* `fe_parameter_values` - (Optional, Map) Specifies a map contains mappings of parameter name and value to modify.
+  The parameter name must be based on the default parameter template of the frontend nodes.
+
 * `charging_mode` - (Optional, String, NoneUpdatable) Specifies the charging mode of the HTAP StarRocks instance.
   Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.
 
@@ -377,6 +383,18 @@ In addition to all arguments above, the following attributes are exported:
 
 * `project_id` - The project ID of a tenant in a region.
 
+* `be_configurations` - The parameter configuration information of the backend nodes.
+  The [configurations](#htap_starrocks_parameters_configurations_attr) structure is documented below.
+
+* `be_parameters` - The list of parameter objects of the backend nodes.
+  The [parameter_values](#htap_starrocks_parameters_parameter_values_attr) structure is documented below.
+
+* `fe_configurations` - The parameter configuration information of the frontend nodes.
+  The [configurations](#htap_starrocks_parameters_configurations_attr) structure is documented below.
+
+* `fe_parameters` - The list of parameter objects of the frontend nodes.
+  The [parameter_values](#htap_starrocks_parameters_parameter_values_attr) structure is documented below.
+
 <a name="groups_block"></a>
 The `groups` block supports:
 
@@ -521,6 +539,36 @@ The `port_info` block supports:
 
 * `mysql_port` - The MySQL port number.
 
+<a name="htap_starrocks_parameters_configurations_attr"></a>
+The `configurations` block supports:
+
+* `configuration_id` - The parameter template ID.
+
+* `datastore_version_name` - The DB version name.
+
+* `datastore_name` - The DB engine name in the parameter template.
+
+* `created` - The time when the parameter template was created.
+
+* `updated` - The time when the parameter template was updated.
+
+<a name="htap_starrocks_parameters_parameter_values_attr"></a>
+The `parameter_values` block supports:
+
+* `name` - The parameter name.
+
+* `value` - The parameter value.
+
+* `restart_required` - Whether a reboot is required.
+
+* `readonly` - Whether the parameter is read-only.
+
+* `value_range` - The value range of the parameter.
+
+* `type` - The parameter type.
+
+* `description` - The parameter description.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:
@@ -538,19 +586,19 @@ terraform import huaweicloud_taurusdb_htap_starrocks_instance.test <taurusdb_ins
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `db_root_pwd`, `period_unit`, `period`,
-`auto_renew`. It is generally recommended running `terraform plan` after importing a TaurusDB HTAP StarRocks instance.
-You can then decide if changes should be applied to the instance, or the resource definition should be updated to
-align with the instance. Also, you can ignore changes as below.
+API response, security or some other reason. The missing attributes include: `db_root_pwd`, `be_parameter_values`,
+`fe_parameter_values`, `period_unit`, `period`, `auto_renew`. It is generally recommended running `terraform plan` after
+importing a TaurusDB HTAP StarRocks instance. You can then decide if changes should be applied to the instance,
+or the resource definition should be updated to align with the instance. Also, you can ignore changes as below.
 
 ```hcl
 resource "huaweicloud_taurusdb_htap_starrocks_instance" "test" {
   ...
 
-  lifecycle {
-    ignore_changes = [
-      "db_root_pwd", "period_unit", "period", "auto_renew"
-    ]
-  }
+lifecycle {
+  ignore_changes = [
+    "db_root_pwd", "be_parameter_values", "fe_parameter_values", "period_unit", "period", "auto_renew"
+  ]
+}
 }
 ```

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance_test.go
@@ -143,6 +143,30 @@ func TestAccTaurusDBHtapStarrocksInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags_info.0.sys_tags.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags_info.0.sys_tags.0.key", "_sys_enterprise_project_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags_info.0.sys_tags.0.value", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "be_configurations.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "be_configurations.0.configuration_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "be_configurations.0.datastore_version_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "be_configurations.0.datastore_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "be_parameters.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "be_parameters.0.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "be_parameters.0.value"),
+					resource.TestCheckResourceAttrSet(resourceName, "be_parameters.0.restart_required"),
+					resource.TestCheckResourceAttrSet(resourceName, "be_parameters.0.readonly"),
+					resource.TestCheckResourceAttrSet(resourceName, "be_parameters.0.value_range"),
+					resource.TestCheckResourceAttrSet(resourceName, "be_parameters.0.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "be_parameters.0.description"),
+					resource.TestCheckResourceAttr(resourceName, "fe_configurations.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "fe_configurations.0.configuration_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "fe_configurations.0.datastore_version_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "fe_configurations.0.datastore_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "fe_parameters.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "fe_parameters.0.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "fe_parameters.0.value"),
+					resource.TestCheckResourceAttrSet(resourceName, "fe_parameters.0.restart_required"),
+					resource.TestCheckResourceAttrSet(resourceName, "fe_parameters.0.readonly"),
+					resource.TestCheckResourceAttrSet(resourceName, "fe_parameters.0.value_range"),
+					resource.TestCheckResourceAttrSet(resourceName, "fe_parameters.0.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "fe_parameters.0.description"),
 				),
 			},
 			{
@@ -162,7 +186,7 @@ func TestAccTaurusDBHtapStarrocksInstance_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccTaurusDBHtapStarrocksInstanceImportStateIdFunc(resourceName),
 				ImportStateVerifyIgnore: []string{
-					"db_root_pwd", "period", "period_unit", "auto_renew",
+					"db_root_pwd", "be_parameter_values", "fe_parameter_values", "period", "period_unit", "auto_renew",
 				},
 			},
 		},
@@ -409,7 +433,7 @@ func TestAccTaurusDBHtapStarrocksInstance_prePaid(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccTaurusDBHtapStarrocksInstanceImportStateIdFunc(resourceName),
 				ImportStateVerifyIgnore: []string{
-					"db_root_pwd", "period", "period_unit", "auto_renew",
+					"db_root_pwd", "be_parameter_values", "fe_parameter_values", "period", "period_unit", "auto_renew",
 				},
 			},
 		},
@@ -517,6 +541,16 @@ resource "huaweicloud_taurusdb_htap_starrocks_instance" "test" {
       value = "%[3]s"
     }
   }
+  
+  be_parameter_values = {
+    "alter_tablet_worker_count"            = "1"
+    "base_compaction_num_threads_per_disk" = "1"
+  }
+  
+  fe_parameter_values = {
+    "alter_table_timeout_second"     = "21600"
+    "bdbje_heartbeat_timeout_second" = "10"
+  }
 }
 `, testAccHtapInstanceConfig_base(rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
@@ -562,6 +596,16 @@ resource "huaweicloud_taurusdb_htap_starrocks_instance" "test" {
       key   = "_sys_enterprise_project_id"
       value = "%[3]s"
     }
+  }
+  
+  be_parameter_values = {
+    "alter_tablet_worker_count"            = "20"
+    "base_compaction_num_threads_per_disk" = "5"
+  }
+  
+  fe_parameter_values = {
+    "alter_table_timeout_second"     = "259200"
+    "bdbje_heartbeat_timeout_second" = "100"
   }
 }
 `, testAccHtapInstanceConfig_base(rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)

--- a/huaweicloud/services/taurusdb/common.go
+++ b/huaweicloud/services/taurusdb/common.go
@@ -10,13 +10,14 @@ import (
 )
 
 var (
-	// Some error codes that need to be retried coming from https://support.huaweicloud.com/api-gaussdbformysql/ErrorCode.html
+	// Some error codes that need to be retried coming from https://support.huaweicloud.com/api-taurusdb/ErrorCode.html
 	retryErrCodes = map[string]struct{}{
 		"DBS.200019":   {},
 		"DBS.201014":   {},
 		"DBS.201015":   {},
 		"DBS.200047":   {},
 		"DBS.05000084": {},
+		"DBS.212033":   {}, // Instance is currently being operated
 	}
 )
 

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance.go
@@ -126,6 +126,16 @@ var htapStarrocksInstanceSchema = map[string]*schema.Schema{
 		Optional:     true,
 		ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
 	},
+	"be_parameter_values": {
+		Type:     schema.TypeMap,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	},
+	"fe_parameter_values": {
+		Type:     schema.TypeMap,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	},
 	// charge info: charging_mode, period_unit, period, auto_renew
 	"charging_mode": {
 		Type:     schema.TypeString,
@@ -323,6 +333,26 @@ var htapStarrocksInstanceSchema = map[string]*schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
 	},
+	"be_configurations": {
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem:     starrocksParametersConfigurationsSchema(),
+	},
+	"be_parameters": {
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem:     starrocksParametersParameterValuesSchema(),
+	},
+	"fe_configurations": {
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem:     starrocksParametersConfigurationsSchema(),
+	},
+	"fe_parameters": {
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem:     starrocksParametersParameterValuesSchema(),
+	},
 }
 
 // @API BSS POST /v3/orders/customer-orders/pay
@@ -330,6 +360,8 @@ var htapStarrocksInstanceSchema = map[string]*schema.Schema{
 // @API BSS POST /v2/{project_id}/orders/auto-renew
 // @API BSS POST /v2/orders/subscriptions/resources/unsubscribe
 // @API TaurusDB POST /v3/{project_id}/instances/{instance_id}/starrocks
+// @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/starrocks/configurations
+// @API TaurusDB PUT /v3/{project_id}/instances/{instance_id}/starrocks/configurations
 // @API TaurusDB PUT /v3/{project_id}/instances/{starrocks_instance_id}/starrocks/restart
 // @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/starrocks/{starrocks_instance_id}
 // @API TaurusDB DELETE /v3/{project_id}/instances/{instance_id}/starrocks/{starrocks_instance_id}
@@ -779,6 +811,39 @@ func handlePostPaidInstanceCreation(ctx context.Context, client *golangsdk.Servi
 	return nil
 }
 
+// configureStarRocksParameters configures BE and FE parameters after instance creation
+func configureStarRocksParameters(ctx context.Context, client *golangsdk.ServiceClient,
+	d *schema.ResourceData, taurusdbInstanceId string) error {
+	restartRequired := false
+
+	beParamValues := d.Get("be_parameter_values").(map[string]interface{})
+	if len(beParamValues) > 0 {
+		var err error
+		restartRequired, err = modifyStarrocksParameters(ctx, client, d, "be", beParamValues)
+		if err != nil {
+			return err
+		}
+	}
+
+	feParamValues := d.Get("fe_parameter_values").(map[string]interface{})
+	if len(feParamValues) > 0 {
+		var err error
+		restartRequired, err = modifyStarrocksParameters(ctx, client, d, "fe", feParamValues)
+		if err != nil {
+			return err
+		}
+	}
+
+	if restartRequired {
+		err := restartStarrocksInstance(ctx, client, taurusdbInstanceId, d.Id(), d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func resourceTaurusDBHtapStarrocksInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
@@ -835,6 +900,11 @@ func resourceTaurusDBHtapStarrocksInstanceCreate(ctx context.Context, d *schema.
 		if err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	// Configure StarRocks parameters (BE and FE)
+	if err := configureStarRocksParameters(ctx, client, d, taurusdbInstanceId); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return resourceTaurusDBHtapStarrocksInstanceRead(ctx, d, meta)
@@ -987,6 +1057,66 @@ func updateStarRocksInstanceUsersSyncSwitch(ctx context.Context, client *golangs
 			"after updating users sync switch: %s", htapInstanceId, err)
 	}
 	return nil
+}
+
+func modifyStarrocksParameters(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	nodeType string, paramValues map[string]interface{}) (bool, error) {
+	var (
+		taurusdbInstanceId  = d.Get("instance_id").(string)
+		starrocksInstanceId = d.Id()
+		timeout             = d.Timeout(schema.TimeoutCreate)
+	)
+	modifyPath := client.Endpoint + "v3/{project_id}/instances/{instance_id}/starrocks/configurations"
+	modifyPath = strings.ReplaceAll(modifyPath, "{project_id}", client.ProjectID)
+	modifyPath = strings.ReplaceAll(modifyPath, "{instance_id}", starrocksInstanceId)
+
+	modifyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"node_type":        nodeType,
+			"parameter_values": utils.ExpandToStringMap(paramValues),
+		},
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		res, err := client.Request("PUT", modifyPath, &modifyOpt)
+		shouldRetry, err := handleMultiOperationsError(err)
+		return res, shouldRetry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     htapInstanceStateRefreshFunc(client, taurusdbInstanceId, starrocksInstanceId),
+		WaitTarget:   []string{"normal"},
+		Timeout:      timeout,
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return false, fmt.Errorf("error modifying TaurusDB Htap StarRocks instance(%s) parameters: %s",
+			starrocksInstanceId, err)
+	}
+	modifyRespBody, err := utils.FlattenResponse(r.(*http.Response))
+	if err != nil {
+		return false, err
+	}
+
+	jobId := utils.PathSearch("job_id", modifyRespBody, "").(string)
+	if jobId == "" {
+		return false, fmt.Errorf("error modifying TaurusDB Htap StarRocks instance(%s) parameters, job_id is not found in the response",
+			starrocksInstanceId)
+	}
+
+	// Wait for the modify job to complete
+	err = checkGaussDBMySQLJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return false, fmt.Errorf("error waiting for modifying TaurusDB Htap StarRocks parameters job (%s) to complete: %s", jobId, err)
+	}
+
+	restartRequired := utils.PathSearch("restart_required", modifyRespBody, false).(bool)
+
+	return restartRequired, nil
 }
 
 func waitHtapInstanceStatusNormal(ctx context.Context, client *golangsdk.ServiceClient,
@@ -1148,6 +1278,25 @@ func resourceTaurusDBHtapStarrocksInstanceRead(_ context.Context, d *schema.Reso
 			}
 		}
 	}
+	// Set configurations and parameters of be nodes
+	beConfiguration, beParameterValues, err := getStarrocksParameters(client, htapInstanceId, "be")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	mErr = multierror.Append(mErr,
+		d.Set("be_configurations", flattenStarrocksParametersConfigurationsBody(beConfiguration)),
+		d.Set("be_parameters", flattenStarrocksParametersParameterValuesBody(beParameterValues)),
+	)
+
+	// Set configurations and parameters of fe nodes
+	feConfiguration, feParameterValues, err := getStarrocksParameters(client, htapInstanceId, "fe")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	mErr = multierror.Append(mErr,
+		d.Set("fe_configurations", flattenStarrocksParametersConfigurationsBody(feConfiguration)),
+		d.Set("fe_parameters", flattenStarrocksParametersParameterValuesBody(feParameterValues)),
+	)
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 func flattenStarrocksInstanceActions(instance interface{}) []interface{} {
@@ -1470,6 +1619,36 @@ func handleUpdateFlavor(ctx context.Context, d *schema.ResourceData, client, bss
 	return nil
 }
 
+// handleUpdateParameters handles BE and FE parameters update
+func handleUpdateParameters(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) (context.Context, error) {
+	restartRequired := false
+
+	beParamValues := d.Get("be_parameter_values").(map[string]interface{})
+	if len(beParamValues) > 0 {
+		var err error
+		restartRequired, err = modifyStarrocksParameters(ctx, client, d, "be", beParamValues)
+		if err != nil {
+			return ctx, err
+		}
+	}
+
+	feParamValues := d.Get("fe_parameter_values").(map[string]interface{})
+	if len(feParamValues) > 0 {
+		var err error
+		restartRequired, err = modifyStarrocksParameters(ctx, client, d, "fe", feParamValues)
+		if err != nil {
+			return ctx, err
+		}
+	}
+
+	if restartRequired {
+		// Sending needRestartByParametersChanged to Read to warn users the instance needs a reboot.
+		ctx = context.WithValue(ctx, ctxType("needRestartByParametersChanged"), "true")
+	}
+
+	return ctx, nil
+}
+
 func resourceTaurusDBHtapStarrocksInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg     = meta.(*config.Config)
@@ -1520,6 +1699,15 @@ func resourceTaurusDBHtapStarrocksInstanceUpdate(ctx context.Context, d *schema.
 	// Update flavor
 	if d.HasChanges("fe_flavor_id", "be_flavor_id") {
 		if err := handleUpdateFlavor(ctx, d, client, bssClient); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Update parameters
+	if d.HasChanges("be_parameter_values", "fe_parameter_values") {
+		var err error
+		ctx, err = handleUpdateParameters(ctx, d, client)
+		if err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance_restart.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_instance_restart.go
@@ -65,38 +65,29 @@ func ResourceTaurusDBHtapStarrocksInstanceRestart() *schema.Resource {
 }
 
 func resourceTaurusDBHtapStarrocksInstanceRestartCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
+	var (
+		cfg                 = meta.(*config.Config)
+		region              = cfg.GetRegion(d)
+		instanceId          = d.Get("taurusdb_instance_id").(string)
+		starrocksInstanceId = d.Get("starrocks_instance_id").(string)
+	)
 	client, err := cfg.NewServiceClient("gaussdb", region)
 	if err != nil {
 		return diag.Errorf("error creating GaussDB client: %s", err)
 	}
 
-	starrocksInstanceId := d.Get("starrocks_instance_id").(string)
-	jobId, err := restartStarrocksInstance(ctx, d, client)
+	err = restartStarrocksInstance(ctx, client, instanceId, starrocksInstanceId, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	d.SetId(starrocksInstanceId)
 
-	err = checkGaussDBMySQLJobFinish(ctx, client, jobId, d.Timeout(schema.TimeoutCreate))
-	if err != nil {
-		return diag.Errorf("error waiting for restarting StarRocks instance(%s) job to complete: %s",
-			starrocksInstanceId, err)
-	}
-
 	return nil
 }
 
-func restartStarrocksInstance(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) (string, error) {
-	var (
-		httpUrl = "v3/{project_id}/instances/{starrocks_instance_id}/starrocks/restart"
-	)
-
-	instanceId := d.Get("taurusdb_instance_id").(string)
-	starrocksInstanceId := d.Get("starrocks_instance_id").(string)
-	createPath := client.Endpoint + httpUrl
+func restartStarrocksInstance(ctx context.Context, client *golangsdk.ServiceClient,
+	instanceId, starrocksInstanceId string, timeout time.Duration) error {
+	createPath := client.Endpoint + "v3/{project_id}/instances/{starrocks_instance_id}/starrocks/restart"
 	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
 	createPath = strings.ReplaceAll(createPath, "{starrocks_instance_id}", starrocksInstanceId)
 
@@ -115,25 +106,30 @@ func restartStarrocksInstance(ctx context.Context, d *schema.ResourceData, clien
 		RetryFunc:    retryFunc,
 		WaitFunc:     htapInstanceStateRefreshFunc(client, instanceId, starrocksInstanceId),
 		WaitTarget:   []string{"normal"},
-		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Timeout:      timeout,
 		DelayTimeout: 10 * time.Second,
 		PollInterval: 10 * time.Second,
 	})
 	if err != nil {
-		return "", fmt.Errorf("error restarting TaurusDB Htap StarRocks instance(%s): %s", starrocksInstanceId, err)
+		return fmt.Errorf("error restarting TaurusDB Htap StarRocks instance(%s): %s", starrocksInstanceId, err)
 	}
 	createRespBody, err := utils.FlattenResponse(r.(*http.Response))
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
 	if jobId == "" {
-		return "", fmt.Errorf("error restarting StarRocks instance(%s), job_id is not found in the response",
+		return fmt.Errorf("error restarting StarRocks instance(%s), job_id is not found in the response",
 			starrocksInstanceId)
 	}
 
-	return jobId, nil
+	err = checkGaussDBMySQLJobFinish(ctx, client, jobId, timeout)
+	if err != nil {
+		return fmt.Errorf("error waiting for restarting StarRocks instance(%s) job to complete: %s",
+			starrocksInstanceId, err)
+	}
+	return nil
 }
 
 func htapInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceId, htapInstanceId string) retry.StateRefreshFunc {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support htap_starrocks_instance to modify node parameters
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccTaurusDBHtapStarrocksInstance'
=== RUN   TestAccTaurusDBHtapStarrocksInstance_basic
=== PAUSE TestAccTaurusDBHtapStarrocksInstance_basic
=== CONT  TestAccTaurusDBHtapStarrocksInstance_basic
--- PASS: TestAccTaurusDBHtapStarrocksInstance_basic (2254.98s)
=== RUN   TestAccTaurusDBHtapStarrocksInstance_cluster
=== PAUSE TestAccTaurusDBHtapStarrocksInstance_cluster
=== CONT  TestAccTaurusDBHtapStarrocksInstance_cluster
--- PASS: TestAccTaurusDBHtapStarrocksInstance_cluster (1989.72s)
=== RUN   TestAccTaurusDBHtapStarrocksInstance_prePaid
=== PAUSE TestAccTaurusDBHtapStarrocksInstance_prePaid
=== CONT  TestAccTaurusDBHtapStarrocksInstance_prePaid
--- PASS: TestAccTaurusDBHtapStarrocksInstance_prePaid (2198.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 2255.114s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
