### PR TITLE
feat(apig): API debug resource supports new parameters

### DIFF
--- a/docs/resources/apig_api_debug.md
+++ b/docs/resources/apig_api_debug.md
@@ -108,6 +108,18 @@ located.
   This parameter is only valid when mode is **CONSUMER**.
   If not provided, the default value is **RELEASE**.
 
+* `app_key` - (Optional, String, NonUpdatable) Specifies the app key for debug request.
+
+* `app_secret` - (Optional, String, NonUpdatable) Specifies the app secret for debug request.
+
+* `domain` - (Optional, String, NonUpdatable) Specifies the domain for debug request.  
+  If the custom inbound port is used, the port information and separate it from the domain name with a colon (:),
+  for example, `test.com:8080`.  
+  If not provided, the following default values will be used based on the mode:
+  + **DEVELOPER**: The subdomain name of the API group will be used.
+  + **MARKET**: The domain name of the API group allocated by KooGallery will be used.
+  + **CONSUMER**: The subdomain name of the API group will be used.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_debug_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_debug_test.go
@@ -52,6 +52,11 @@ resource "huaweicloud_apig_group" "test" {
   name        = "%[2]s"
 }
 
+resource "huaweicloud_apig_application" "test" {
+  instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
+  name        = "%[2]s"
+}
+
 resource "huaweicloud_apig_environment" "test" {
   instance_id = try(data.huaweicloud_apig_instances.test.instances[0].id, "NOT_FOUND")
   name        = "%[2]s"
@@ -150,6 +155,9 @@ resource "huaweicloud_apig_api_debug" "test_with_fgs" {
   method      = "POST"
   path        = "/test/function"
   body        = "{\"test\": \"data\"}"
+  app_key     = huaweicloud_apig_application.test.app_key
+  app_secret  = huaweicloud_apig_application.test.app_secret
+  domain      = "test.com:8080"
 
   header = jsonencode({
     "Content-Type": ["application/json"],

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api_debug.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api_debug.go
@@ -16,8 +16,21 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-var apigApiDebugNonUpdatableParams = []string{"instance_id", "api_id", "mode", "scheme", "method", "path", "body",
-	"header", "query", "stage"}
+var apigApiDebugNonUpdatableParams = []string{
+	"instance_id",
+	"api_id",
+	"mode",
+	"scheme",
+	"method",
+	"path",
+	"body",
+	"header",
+	"query",
+	"stage",
+	"app_key",
+	"app_secret",
+	"domain",
+}
 
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/apis/debug/{api_id}
 func ResourceApigApiDebug() *schema.Resource {
@@ -91,6 +104,21 @@ func ResourceApigApiDebug() *schema.Resource {
 				Optional:    true,
 				Description: `The runtime environment for debug request.`,
 			},
+			"app_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The app key for debug request.`,
+			},
+			"app_secret": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The app secret for debug request.`,
+			},
+			"domain": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The domain for debug request.`,
+			},
 
 			// Attributes.
 			"request": {
@@ -122,14 +150,17 @@ func ResourceApigApiDebug() *schema.Resource {
 
 func buildApiDebugBodyParams(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{
-		"mode":   d.Get("mode"),
-		"scheme": d.Get("scheme"),
-		"method": d.Get("method"),
-		"path":   d.Get("path"),
-		"body":   utils.ValueIgnoreEmpty(d.Get("body")),
-		"header": utils.StringToJson(d.Get("header").(string)),
-		"query":  utils.StringToJson(d.Get("query").(string)),
-		"stage":  utils.ValueIgnoreEmpty(d.Get("stage")),
+		"mode":       d.Get("mode"),
+		"scheme":     d.Get("scheme"),
+		"method":     d.Get("method"),
+		"path":       d.Get("path"),
+		"body":       utils.ValueIgnoreEmpty(d.Get("body")),
+		"header":     utils.StringToJson(d.Get("header").(string)),
+		"query":      utils.StringToJson(d.Get("query").(string)),
+		"stage":      utils.ValueIgnoreEmpty(d.Get("stage")),
+		"app_key":    utils.ValueIgnoreEmpty(d.Get("app_key")),
+		"app_secret": utils.ValueIgnoreEmpty(d.Get("app_secret")),
+		"domain":     utils.ValueIgnoreEmpty(d.Get("domain")),
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The API debug resource supports new parameters:
- app_key
- app_secret
- domain

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. API debug resource supports new parameters
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccApigApiDebug_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccApigApiDebug_basic -timeout 360m -parallel 10
=== RUN   TestAccApigApiDebug_basic
=== PAUSE TestAccApigApiDebug_basic
=== CONT  TestAccApigApiDebug_basic
--- PASS: TestAccApigApiDebug_basic (79.82s)
PASS
coverage: 7.1% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      79.975s coverage: 7.1% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
