### PR TITLE
feat(modelarts): add new resource to save training job as image

### DIFF
--- a/docs/resources/modelarts_training_image_store.md
+++ b/docs/resources/modelarts_training_image_store.md
@@ -1,0 +1,68 @@
+---
+subcategory: "AI Development Platform (ModelArts)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_modelarts_training_image_store"
+description: |-
+  Use this resource to save a training job image to SWR within HuaweiCloud.
+---
+
+# huaweicloud_modelarts_training_image_store
+
+Use this resource to save a training job image to SWR within HuaweiCloud.
+
+~> Deleting this resource will only delete the stored SWR image tags, but will not delete the repository where the tags
+  are located.
+
+## Example Usage
+
+```hcl
+variable "training_job_id" {}
+variable "task_id" {}
+variable "image_name" {}
+variable "swr_organization_name" {}
+
+resource "huaweicloud_modelarts_training_image_store" "test" {
+  training_job_id = var.training_job_id
+  task_id         = var.task_id
+  name            = var.image_name
+  namespace       = var.swr_organization_name
+  tag             = "v1.0.0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the training job is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `training_job_id` - (Required, String, NonUpdatable) Specifies the ID of the training job.
+
+* `task_id` - (Required, String, NonUpdatable) Specifies the task name of the training job.  
+  Can be obtained from the `status.tasks` field of the data source `huaweicloud_modelarts_training_jobs`.  
+
+* `name` - (Required, String, NonUpdatable) Specifies the name of the SWR repository to which the image is stored.  
+  The maximum length is `512` characters, and only lowercase letters, digits, hyphens (-), underscores (_) and dots (.)
+  are allowed.
+
+* `namespace` - (Required, String, NonUpdatable) Specifies the name of the SWR organization to which the image is stored.
+
+* `tag` - (Required, String, NonUpdatable) Specifies the tag of the image.  
+  The maximum length is `64` characters, and only letters, digits, hyphens (-), underscores (_) and dots (.)
+  are allowed.
+
+* `description` - (Optional, String, NonUpdatable) Specifies the description of the image.  
+  The maximum length is `512` characters.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4194,6 +4194,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_resource_pool_node_batch_resize": modelarts.ResourceResourcePoolNodeBatchResize(),
 			"huaweicloud_modelarts_service":                         modelarts.ResourceModelartsService(),
 			"huaweicloud_modelarts_training_experiment":             modelarts.ResourceTrainingExperiment(),
+			"huaweicloud_modelarts_training_image_store":            modelarts.ResourceTrainingImageStore(),
 			"huaweicloud_modelarts_training_job":                    modelarts.ResourceTrainingJob(),
 			"huaweicloud_modelarts_workspace":                       modelarts.ResourceModelartsWorkspace(),
 			// Resource management via V2 APIs.

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_training_image_store_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_training_image_store_test.go
@@ -1,0 +1,153 @@
+package modelarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTrainingImageStore_basic(t *testing.T) {
+	var (
+		name  = acceptance.RandomAccResourceNameWithDash()
+		rName = "huaweicloud_modelarts_training_image_store.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDomainName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.1",
+			},
+		},
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrainingImageStore_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(rName, "training_job_id",
+						"huaweicloud_modelarts_training_job.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrSet(rName, "task_id"),
+					resource.TestCheckResourceAttr(rName, "tag", "v1.0"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(rName, "namespace", acceptance.HW_DOMAIN_NAME),
+				),
+			},
+		},
+	})
+}
+
+func testAccTrainingImageStore_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[1]s"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_obs_bucket_object" "test" {
+  bucket       = huaweicloud_obs_bucket.test.bucket
+  key          = "%[1]s/bootfile.py"
+  content      = <<EOF
+#!/usr/bin/env python
+import os
+print(os.getcwd())
+EOF
+  content_type = "text/py"
+}
+
+data "huaweicloud_modelarts_training_job_engines" "test" {}
+
+locals {
+  engine = try([for v in data.huaweicloud_modelarts_training_job_engines.test.engines : v if v.run_user != ""][0], {})
+}
+
+data "huaweicloud_modelarts_training_job_flavors" "test" {}
+
+locals {
+  flavor_id = try(
+    [
+      for v in data.huaweicloud_modelarts_training_job_flavors.test.flavors : v.flavor_id if
+      contains(startswith(trimspace(v.support_engines), "[") ?
+  jsondecode(v.support_engines) : split(",", v.support_engines), local.engine.engine_name)][0], "")
+}
+
+resource "huaweicloud_modelarts_training_job" "test" {
+  kind = "job"
+
+  metadata {
+    name = "%[1]s"
+  }
+
+  algorithm {
+    code_dir  = "/${huaweicloud_obs_bucket.test.bucket}/%[1]s/"
+    boot_file = "/${huaweicloud_obs_bucket.test.bucket}/${huaweicloud_obs_bucket_object.test.key}"
+
+    engine {
+      engine_id      = lookup(local.engine, "engine_id", "")
+      engine_version = lookup(local.engine, "engine_version", "")
+      engine_name    = lookup(local.engine, "engine_name", "")
+    }
+  }
+
+  spec {
+    resource {
+      flavor_id  = local.flavor_id
+      node_count = 1
+    }
+  }
+
+  depends_on = [huaweicloud_obs_bucket_object.test]
+}
+
+resource "null_resource" "wait_for_running" {
+  depends_on = [huaweicloud_modelarts_training_job.test]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      while true; do
+        terraform apply -refresh-only -target=huaweicloud_modelarts_training_job.test -auto-approve
+        status=$(terraform state show -no-color huaweicloud_modelarts_training_job.test \
+          | grep -E '^\s+status\s*=' | head -1 | awk -F'= ' '{print $2}' | tr -d '"')
+        [ "$status" = "Running" ] && break
+        [ "$status" = "Failed" ] || [ "$status" = "Abnormal" ] && exit 1
+        sleep 30
+      done
+    EOT
+  }
+}
+
+data "huaweicloud_modelarts_training_jobs" "test" {
+  filters {
+    key      = "id"
+    operator = "in"
+    value    = [huaweicloud_modelarts_training_job.test.id]
+  }
+}
+`, name)
+}
+
+func testAccTrainingImageStore_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelarts_training_image_store" "test" {
+  training_job_id = huaweicloud_modelarts_training_job.test.id
+  task_id         = try(data.huaweicloud_modelarts_training_jobs.test.jobs[0].status[0].tasks[0], "")
+  name            = "%[2]s"
+  namespace       = "%[3]s"
+  tag             = "v1.0"
+  description     = "Created by terraform script"
+
+  depends_on = [null_resource.wait_for_running]
+}
+`, testAccTrainingImageStore_base(name), name, acceptance.HW_DOMAIN_NAME)
+}

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_training_image_store.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_training_image_store.go
@@ -1,0 +1,265 @@
+package modelarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var trainingImageStoreNonUpdatableParams = []string{
+	"training_job_id",
+	"task_id",
+	"name",
+	"namespace",
+	"tag",
+	"description",
+}
+
+// @API ModelArts POST /v2/{project_id}/training-jobs/{training_job_id}/tasks/{task_id}/save-image-job
+// @API ModelArts GET /v2/{project_id}/training-jobs/{training_job_id}/tasks/{task_id}/save-image-job
+// @API SWR DELETE /v2/manage/namespaces/{namespace}/repos/{repository}/tags/{tag}
+func ResourceTrainingImageStore() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTrainingImageStoreCreate,
+		ReadContext:   resourceTrainingImageStoreRead,
+		UpdateContext: resourceTrainingImageStoreUpdate,
+		DeleteContext: resourceTrainingImageStoreDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(trainingImageStoreNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the training job to be stored as image is located.`,
+			},
+
+			// Required parameters.
+			"training_job_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the training job.`,
+			},
+			"task_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The task name of the training job.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the SWR repository to which the image is stored.`,
+			},
+			"namespace": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the SWR organization to which the image is stored.`,
+			},
+			"tag": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The tag of the image.`,
+			},
+
+			// Optional parameters.
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the image.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+						Required: true,
+					}),
+			},
+		},
+	}
+}
+
+func buildTrainingImageStoreBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"namespace":   d.Get("namespace"),
+		"tag":         d.Get("tag"),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+	}
+}
+
+func createTrainingImageStore(client *golangsdk.ServiceClient, trainingJobId, taskId string, d *schema.ResourceData) error {
+	httpURL := "v2/{project_id}/training-jobs/{training_job_id}/tasks/{task_id}/save-image-job"
+	createPath := client.Endpoint + httpURL
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{training_job_id}", trainingJobId)
+	createPath = strings.ReplaceAll(createPath, "{task_id}", taskId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildTrainingImageStoreBodyParams(d)),
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	return err
+}
+
+func getTrainingImageStoreById(client *golangsdk.ServiceClient, trainingJobId, taskId string) (interface{}, error) {
+	httpURL := "v2/{project_id}/training-jobs/{training_job_id}/tasks/{task_id}/save-image-job"
+	getPath := client.Endpoint + httpURL
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{training_job_id}", trainingJobId)
+	getPath = strings.ReplaceAll(getPath, "{task_id}", taskId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func refreshTrainingImageStoreStatusFunc(client *golangsdk.ServiceClient, trainingJobId, taskId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := getTrainingImageStoreById(client, trainingJobId, taskId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", respBody, "").(string)
+		if status == "CREATE_FAILED" {
+			return respBody, "ERROR", fmt.Errorf("unexpected status (%s)", status)
+		}
+
+		if status == "ACTIVE" {
+			return respBody, "COMPLETED", nil
+		}
+
+		return respBody, "PENDING", nil
+	}
+}
+
+func waitForTrainingImageStoreCompleted(ctx context.Context, client *golangsdk.ServiceClient, trainingJobId, taskId string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshTrainingImageStoreStatusFunc(client, trainingJobId, taskId),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceTrainingImageStoreCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		trainingJobId = d.Get("training_job_id").(string)
+		taskId        = d.Get("task_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("modelarts", region)
+	if err != nil {
+		return diag.Errorf("error creating ModelArts client: %s", err)
+	}
+
+	err = createTrainingImageStore(client, trainingJobId, taskId, d)
+	if err != nil {
+		return diag.Errorf("error saving image from training job (%s): %s", trainingJobId, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s/%s", trainingJobId, taskId, d.Get("tag").(string)))
+
+	if err = waitForTrainingImageStoreCompleted(ctx, client, trainingJobId, taskId, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for image saved from training job (%s) to complete: %s", trainingJobId, err)
+	}
+
+	return resourceTrainingImageStoreRead(ctx, d, meta)
+}
+
+func resourceTrainingImageStoreRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceTrainingImageStoreUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func deleteStoredImageRepositoryTag(client *golangsdk.ServiceClient, namespace, repositoryName, tag string) error {
+	httpURL := "v2/manage/namespaces/{namespace}/repos/{repository}/tags/{tag}"
+	deletePath := client.Endpoint + httpURL
+	deletePath = strings.ReplaceAll(deletePath, "{namespace}", namespace)
+	deletePath = strings.ReplaceAll(deletePath, "{repository}", repositoryName)
+	deletePath = strings.ReplaceAll(deletePath, "{tag}", tag)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	_, err := client.Request("DELETE", deletePath, &opt)
+	return err
+}
+
+func resourceTrainingImageStoreDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg            = meta.(*config.Config)
+		region         = cfg.GetRegion(d)
+		namespace      = d.Get("namespace").(string)
+		repositoryName = d.Get("name").(string)
+		tag            = d.Get("tag").(string)
+	)
+
+	client, err := cfg.NewServiceClient("swr", region)
+	if err != nil {
+		return diag.Errorf("error creating SWR client: %s", err)
+	}
+
+	err = deleteStoredImageRepositoryTag(client, namespace, repositoryName, tag)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err,
+			fmt.Sprintf("error deleting stored image tag (%s/%s:%s) from training job (%s)", namespace, repositoryName, tag,
+				d.Get("training_job_id").(string)))
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new one-time action resource(`huaweicloud_modelarts_training_image_store`) to save training job as SWR image.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o modelarts -f TestAccTrainingImageStore_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/modelarts" -v -coverprofile="./huaweicloud/services/acceptance/modelarts/modelarts_coverage.cov" -coverpkg="./huaweicloud/services/modelarts" -run TestAccTrainingImageStore_basic -timeout 360m -parallel 10
=== RUN   TestAccTrainingImageStore_basic
=== PAUSE TestAccTrainingImageStore_basic
=== CONT  TestAccTrainingImageStore_basic
--- PASS: TestAccTrainingImageStore_basic (111.93s)
PASS
coverage: 10.1% of statements in ./huaweicloud/services/modelarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 112.074s        coverage: 10.1% of statements in ./huaweicloud/services/modelarts
```
<img width="1047" height="33" alt="image" src="https://github.com/user-attachments/assets/5e2640fe-0070-4182-a380-d4b13008a751" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    The tgg or repository does not exist.
    <img width="1264" height="742" alt="image" src="https://github.com/user-attachments/assets/b4e3e429-1c0f-46fe-a2bc-2d503be31a47" />

    bb. Related resources (parent resources) not found
    The namespcae does not exist.
    <img width="1260" height="574" alt="image" src="https://github.com/user-attachments/assets/0d7d53e1-2fce-4aa8-9d7c-2a5ebd5c1cf7" />

