### PR TITLE
feat(secmaster): new datasource to query component templates

### DIFF
--- a/docs/data-sources/secmaster_component_all_templates.md
+++ b/docs/data-sources/secmaster_component_all_templates.md
@@ -1,0 +1,59 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_component_all_templates"
+description: |-
+  Use this data source to get the list of component all templates.
+---
+
+# huaweicloud_secmaster_component_all_templates
+
+Use this data source to get the list of component all templates.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_component_all_templates" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID to which the component all templates belong.
+
+* `search_value` - (Optional, String) Specifies the template name to search.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `data` - The list of component all template details.
+
+  The [data](#data_struct) structure is documented below.
+
+<a name="data_struct"></a>
+The `data` block supports:
+
+* `id` - The ID of the component template.
+
+* `component_id` - The component ID of the component template.
+
+* `template_name` - The name of the component template.
+
+* `task_config` - The task config of the component template.
+
+* `create_time` - The creation time of the component template.
+
+* `update_time` - The update time of the component template.
+
+* `project_id` - The project ID of the component template.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2334,6 +2334,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_collector_module_restrictions":   secmaster.DataSourceCollectorModuleRestrictions(),
 			"huaweicloud_secmaster_collector_module_templates":      secmaster.DataSourceCollectorModuleTemplates(),
 			"huaweicloud_secmaster_collector_parser_templates":      secmaster.DataSourceSecmasterCollectorParserTemplates(),
+			"huaweicloud_secmaster_component_all_templates":         secmaster.DataSourceComponentAllTemplates(),
 			"huaweicloud_secmaster_component_detail":                secmaster.DataSourceComponentDetail(),
 			"huaweicloud_secmaster_component_running_nodes":         secmaster.DataSourceComponentRunningNodes(),
 			"huaweicloud_secmaster_component_templates":             secmaster.DataSourceComponentTemplates(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_component_all_templates_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_component_all_templates_test.go
@@ -1,0 +1,66 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceComponentAllTemplates_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_secmaster_component_all_templates.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Before running test, prepare component templates in SecMaster.
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceComponentAllTemplates_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.component_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.template_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.task_config"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.update_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "data.0.project_id"),
+
+					resource.TestCheckOutput("is_search_value_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceComponentAllTemplates_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_component_all_templates" "test" {
+  workspace_id = "%[1]s"
+}
+
+# Filter by search_value
+locals {
+  search_value = data.huaweicloud_secmaster_component_all_templates.test.data[0].template_name
+}
+
+data "huaweicloud_secmaster_component_all_templates" "filter_by_search_value" {
+  workspace_id  = "%[1]s"
+  search_value  = local.search_value
+}
+
+output "is_search_value_filter_useful" {
+  value = length(data.huaweicloud_secmaster_component_all_templates.filter_by_search_value.data) > 0 && alltrue(
+    [for v in data.huaweicloud_secmaster_component_all_templates.filter_by_search_value.data[*].template_name :
+    v == local.search_value]
+  )
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_component_all_templates.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_component_all_templates.go
@@ -1,0 +1,148 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/soc/components/template
+func DataSourceComponentAllTemplates() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceComponentAllTemplatesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"search_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"component_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"template_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"task_config": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildComponentAllTemplatesQueryParams(d *schema.ResourceData) string {
+	if v, ok := d.GetOk("search_value"); ok {
+		return fmt.Sprintf("?search_value=%s", v.(string))
+	}
+
+	return ""
+}
+
+func dataSourceComponentAllTemplatesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/soc/components/template"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{workspace_id}", workspaceId)
+	getPath += buildComponentAllTemplatesQueryParams(d)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	// The pagination functionality of this API has issues, so it is not currently supported.
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving component all templates: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	dataList := utils.PathSearch("data", getRespBody, make([]interface{}, 0)).([]interface{})
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("data", flattenComponentAllTemplatesData(dataList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenComponentAllTemplatesData(allResult []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(allResult))
+	for _, v := range allResult {
+		rst = append(rst, map[string]interface{}{
+			"id":            utils.PathSearch("id", v, nil),
+			"component_id":  utils.PathSearch("component_id", v, nil),
+			"template_name": utils.PathSearch("template_name", v, nil),
+			"task_config":   utils.PathSearch("task_config", v, nil),
+			"create_time":   utils.PathSearch("create_time", v, nil),
+			"update_time":   utils.PathSearch("update_time", v, nil),
+			"project_id":    utils.PathSearch("project_id", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new datasource to query component templates

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccDataSourceComponentAllTemplates_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceComponentAllTemplates_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceComponentAllTemplates_basic
=== PAUSE TestAccDataSourceComponentAllTemplates_basic
=== CONT  TestAccDataSourceComponentAllTemplates_basic
--- PASS: TestAccDataSourceComponentAllTemplates_basic (13.04s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 13.151s coverage: 4.0% of statements in ./huaweicloud/services/secmaster
```
<img width="1396" height="81" alt="image" src="https://github.com/user-attachments/assets/943db50b-1ee7-4952-9091-139d8bae5ebc" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
