### PR TITLE
refactor(apig): using auto-gen style to rewrite appcode resource and data source

### DIFF
--- a/docs/data-sources/apig_appcodes.md
+++ b/docs/data-sources/apig_appcodes.md
@@ -26,7 +26,7 @@ data "huaweicloud_apig_appcodes" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the data source.
+* `region` - (Optional, String) Specifies the region where the APPCODEs are located.  
   If omitted, the provider-level region will be used.
 
 * `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the application belongs.
@@ -39,10 +39,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `appcodes` - All APPCODEs of the specified application.
-  The [app_codes](#attrblock_appcodes) structure is documented below.
+* `appcodes` - The list of the APPCODEs of the specified application.  
+  The [appcodes](#apig_appcodes_attr) structure is documented below.
 
-<a name="attrblock_appcodes"></a>
+<a name="apig_appcodes_attr"></a>
 The `appcodes` block supports:
 
 * `id` - The ID of the APPCODE.

--- a/docs/resources/apig_appcode.md
+++ b/docs/resources/apig_appcode.md
@@ -2,7 +2,8 @@
 subcategory: "API Gateway (Dedicated APIG)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_apig_appcode"
-description: ""
+description: |-
+  Manages an APPCODE in application resource within HuaweiCloud.
 ---
 
 # huaweicloud_apig_appcode
@@ -41,29 +42,26 @@ resource "huaweicloud_apig_appcode" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the region where the application and APPCODE are located.  
-  If omitted, the provider-level region will be used. Changing this will create a new resource.
+* `region` - (Optional, String, ForceNew) Specifies the region where the APPCODE is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `instance_id` - (Required, String, ForceNew) Specifies the ID of the dedicated instance to which the application
-  and APPCODE belong.  
-  Changing this will create a new resource.
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the dedicated instance to which the application
+  and APPCODE belong.
 
-* `application_id` - (Required, String, ForceNew) Specifies the ID of application to which the APPCODE belongs.
-  Changing this will create a new resource.
+* `application_id` - (Required, String, NonUpdatable) Specifies the ID of the application to which the APPCODE belongs.
 
-* `value` - (Optional, String, ForceNew) Specifies the APPCODE value (content).
-  The value can contain `64` to `180` characters, starting with a letter, plus sign (+), or slash (/), or digit.
-  Only letters, digit and the following special characters are allowed: `+_!@#$%/=`.
+* `value` - (Optional, String, NonUpdatable) Specifies the APPCODE value (content).  
+  The value can contain `64` to `180` characters, starting with a letter, plus sign (+), or slash (/), or digit.  
+  Only letters, digit and the following special characters are allowed: `+_!@#$%/=`.  
   If omitted, a random value will be generated.
-  Changing this will create a new resource.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The APPCODE ID.
+* `id` - The ID of the APPCODE.
 
-* `created_at` - The creation time of the APPCODE.
+* `created_at` - The creation time of the APPCODE, in RFC3339 format.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_appcodes_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_appcodes_test.go
@@ -2,21 +2,24 @@ package apig
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func TestAccDataSourceAppcodes_basic(t *testing.T) {
+func TestAccDataAppcodes_basic(t *testing.T) {
 	var (
-		rName = "data.huaweicloud_apig_appcodes.test"
-		dc    = acceptance.InitDataSourceCheck(rName)
+		rName = acceptance.RandomAccResourceName()
 
-		rNameNotFound = "data.huaweicloud_apig_appcodes.not_found"
-		dcNotFound    = acceptance.InitDataSourceCheck(rNameNotFound)
+		dataSource = "data.huaweicloud_apig_appcodes.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		notFound   = "data.huaweicloud_apig_appcodes.not_found"
+		dcNotFound = acceptance.InitDataSourceCheck(notFound)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -27,26 +30,59 @@ func TestAccDataSourceAppcodes_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAppcodes_basic(),
+				Config:      testAccDataAppcodes_nonExistentInstance(),
+				ExpectError: regexp.MustCompile(`error querying APPCODEs`),
+			},
+			{
+				Config:      testAccDataAppcodes_nonExistentApplication(),
+				ExpectError: regexp.MustCompile(`App [0-9a-fA-F-]{36} does not exist`),
+			},
+			{
+				Config: testAccDataAppcodes_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "appcodes.#", "1"),
+					resource.TestCheckResourceAttr(dataSource, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(dataSource, "application_id", "huaweicloud_apig_application.test.0", "id"),
+					resource.TestCheckResourceAttr(dataSource, "appcodes.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSource, "appcodes.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "appcodes.0.value"),
+					resource.TestCheckResourceAttrPair(dataSource, "appcodes.0.application_id", "huaweicloud_apig_application.test.0", "id"),
+					resource.TestMatchResourceAttr(dataSource, "appcodes.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 					dcNotFound.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rNameNotFound, "appcodes.#", "0"),
+					resource.TestCheckResourceAttr(notFound, "appcodes.#", "0"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAppcodes_basic_base() string {
-	name := acceptance.RandomAccResourceName()
+func testAccDataAppcodes_nonExistentInstance() string {
+	randomUUID, _ := uuid.GenerateUUID()
 
 	return fmt.Sprintf(`
-%[1]s
+data "huaweicloud_apig_appcodes" "test" {
+  instance_id    = "%[1]s"
+  application_id = "%[1]s"
+}
+`, randomUUID)
+}
 
+func testAccDataAppcodes_nonExistentApplication() string {
+	randomUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+data "huaweicloud_apig_appcodes" "test" {
+  instance_id    = "%[1]s"
+  application_id = "%[2]s"
+}
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, randomUUID)
+}
+
+func testAccDataAppcodes_base(name string) string {
+	return fmt.Sprintf(`
 data "huaweicloud_apig_instances" "test" {
-  instance_id = "%[2]s"
+  instance_id = "%[1]s"
 }
 
 locals {
@@ -57,23 +93,23 @@ resource "huaweicloud_apig_application" "test" {
   count = 2
 
   instance_id = local.instance_id
-  name        = format("%[3]s_%%d", count.index)
+  name        = format("%[2]s_%%d", count.index)
 }
 
 resource "huaweicloud_apig_appcode" "test" {
   instance_id    = local.instance_id
   application_id = huaweicloud_apig_application.test[0].id
 }
-`, common.TestBaseNetwork(name), acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
+`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
 }
 
-func testAccDataSourceAppcodes_basic() string {
+func testAccDataAppcodes_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
 data "huaweicloud_apig_appcodes" "test" {
   depends_on = [
-    huaweicloud_apig_appcode.test
+    huaweicloud_apig_appcode.test,
   ]
 
   instance_id    = local.instance_id
@@ -84,5 +120,5 @@ data "huaweicloud_apig_appcodes" "not_found" {
   instance_id    = local.instance_id
   application_id = huaweicloud_apig_application.test[1].id
 }
-`, testAccDataSourceAppcodes_basic_base())
+`, testAccDataAppcodes_base(name))
 }

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_appcode_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_appcode_test.go
@@ -2,142 +2,152 @@ package apig
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/applications"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 func getAppcodeFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.ApigV2Client(acceptance.HW_REGION_NAME)
+	client, err := cfg.NewServiceClient("apig", acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
+		return nil, fmt.Errorf("error creating APIG client: %s", err)
 	}
-	return applications.GetAppCode(client, state.Primary.Attributes["instance_id"],
-		state.Primary.Attributes["application_id"], state.Primary.ID).Extract()
+	return apig.GetAppcode(client, state.Primary.Attributes["instance_id"],
+		state.Primary.Attributes["application_id"], state.Primary.ID)
 }
 
-// Auto generate APPCODE.
 func TestAccAppcode_basic(t *testing.T) {
 	var (
-		appCode applications.AppCode
+		obj interface{}
 
-		rName = "huaweicloud_apig_appcode.test"
-		rc    = acceptance.InitResourceCheck(rName, &appCode, getAppcodeFunc)
-	)
+		autoGeneration   = "huaweicloud_apig_appcode.auto_generate"
+		rcAutoGeneration = acceptance.InitResourceCheck(autoGeneration, &obj, getAppcodeFunc)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAppcode_basic(),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-				),
-			},
-			{
-				ResourceName:      rName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testAccAppcodeImportIdFunc(),
-			},
-		},
-	})
-}
+		manuallyConfig   = "huaweicloud_apig_appcode.manually_config"
+		rcManuallyConfig = acceptance.InitResourceCheck(manuallyConfig, &obj, getAppcodeFunc)
 
-func testAccAppcodeImportIdFunc() resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rName := "huaweicloud_apig_appcode.test"
-		rs, ok := s.RootModule().Resources[rName]
-		if !ok {
-			return "", fmt.Errorf("Resource (%s) not found: %s", rName, rs)
-		}
-		instanceId := rs.Primary.Attributes["instance_id"]
-		appId := rs.Primary.Attributes["application_id"]
-		appCodeId := rs.Primary.ID
-		if instanceId == "" || appId == "" || appCodeId == "" {
-			return "", fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<application_id>/<id>', but got '%s/%s/%s'",
-				instanceId, appId, appCodeId)
-		}
-		return fmt.Sprintf("%s/%s/%s", instanceId, appId, appCodeId), nil
-	}
-}
-
-func testAccAppcode_basic() string {
-	name := acceptance.RandomAccResourceName()
-	return fmt.Sprintf(`
-resource "huaweicloud_apig_application" "test" {
-  instance_id = "%[1]s"
-  name        = "%[2]s"
-}
-
-resource "huaweicloud_apig_appcode" "test" {
-  instance_id    = "%[1]s"
-  application_id = huaweicloud_apig_application.test.id
-}
-`, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name)
-}
-
-// Manually configure APPCODE.
-func TestAccAppcode_manuallyConfig(t *testing.T) {
-	var (
-		appCode applications.AppCode
-
-		rName = "huaweicloud_apig_appcode.test"
-		rc    = acceptance.InitResourceCheck(rName, &appCode, getAppcodeFunc)
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAppcode_manuallyConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-				),
-			},
-			{
-				ResourceName:      rName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testAccAppcodeImportIdFunc(),
-			},
-		},
-	})
-}
-
-func testAccAppcode_manuallyConfig() string {
-	var (
 		name = acceptance.RandomAccResourceName()
 		code = utils.Base64EncodeString(acctest.RandString(64))
 	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckApigSubResourcesRelatedInfo(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcAutoGeneration.CheckResourceDestroy(),
+			rcManuallyConfig.CheckResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAppcode_withValueAndNonExistentParentResources(code),
+				ExpectError: regexp.MustCompile(`error creating APPCODE`),
+			},
+			{
+				Config:      testAccAppcode_withoutValueAndNonExistentParentResources(),
+				ExpectError: regexp.MustCompile(`error auto generating APPCODE`),
+			},
+			{
+				Config: testAccAppcode_basic(name, code),
+				Check: resource.ComposeTestCheckFunc(
+					rcAutoGeneration.CheckResourceExists(),
+					resource.TestCheckResourceAttr(autoGeneration, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(autoGeneration, "application_id", "huaweicloud_apig_application.test", "id"),
+					resource.TestMatchResourceAttr(autoGeneration, "value",
+						regexp.MustCompile(`^[a-zA-Z0-9/+][a-zA-Z0-9+_!@#$%/=-]{63,179}$`)),
+					resource.TestMatchResourceAttr(autoGeneration, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					rcManuallyConfig.CheckResourceExists(),
+					resource.TestCheckResourceAttr(manuallyConfig, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
+					resource.TestCheckResourceAttrPair(manuallyConfig, "application_id", "huaweicloud_apig_application.test", "id"),
+					resource.TestCheckResourceAttr(manuallyConfig, "value", code),
+					resource.TestMatchResourceAttr(manuallyConfig, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      autoGeneration,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAppcodeImportIdFunc(autoGeneration),
+			},
+			{
+				ResourceName:      manuallyConfig,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAppcodeImportIdFunc(manuallyConfig),
+			},
+		},
+	})
+}
+
+func testAccAppcode_withValueAndNonExistentParentResources(code string) string {
+	randomUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_appcode" "test" {
+  instance_id    = "%[1]s"
+  application_id = "%[1]s"
+  value          = "%[2]s"
+}
+`, randomUUID, code)
+}
+
+func testAccAppcode_withoutValueAndNonExistentParentResources() string {
+	randomUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_apig_appcode" "test" {
+  instance_id    = "%[1]s"
+  application_id = "%[1]s"
+}
+`, randomUUID)
+}
+
+func testAccAppcode_basic(name, code string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_apig_application" "test" {
   instance_id = "%[1]s"
   name        = "%[2]s"
 }
 
-resource "huaweicloud_apig_appcode" "test" {
+resource "huaweicloud_apig_appcode" "auto_generate" {
+  instance_id    = "%[1]s"
+  application_id = huaweicloud_apig_application.test.id
+}
+
+resource "huaweicloud_apig_appcode" "manually_config" {
   instance_id    = "%[1]s"
   application_id = huaweicloud_apig_application.test.id
   value          = "%[3]s"
 }
 `, acceptance.HW_APIG_DEDICATED_INSTANCE_ID, name, code)
+}
+
+func testAccAppcodeImportIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+		instanceId := rs.Primary.Attributes["instance_id"]
+		appId := rs.Primary.Attributes["application_id"]
+		appCodeId := rs.Primary.ID
+		if instanceId == "" || appId == "" || appCodeId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<application_id>/<id>', "+
+				"but got '%s/%s/%s'", instanceId, appId, appCodeId)
+		}
+		return fmt.Sprintf("%s/%s/%s", instanceId, appId, appCodeId), nil
+	}
 }

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_appcodes.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_appcodes.go
@@ -3,6 +3,7 @@ package apig
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -23,10 +24,13 @@ func DataSourceAppcodes() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the APPCODEs are located.`,
 			},
+
+			// Required parameters.
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -37,44 +41,51 @@ func DataSourceAppcodes() *schema.Resource {
 				Required:    true,
 				Description: `The ID of the application to be queried.`,
 			},
+
+			// Attributes.
 			"appcodes": {
 				Type:        schema.TypeList,
 				Computed:    true,
-				Description: `All APPCODEs of the specified application.`,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: `The ID of the APPCODE.`,
-						},
-						"value": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: `The APPCODE value (content).`,
-						},
-						"application_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: `The ID of the application.`,
-						},
-						"created_at": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: `The creation time of the APPCODE, in RFC3339 format.`,
-						},
-					},
-				},
+				Elem:        appcodeSchema(),
+				Description: `The list of the APPCODEs of the specified application.`,
 			},
 		},
 	}
 }
 
-func queryAppcodes(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+func appcodeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the APPCODE.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The APPCODE value (content).`,
+			},
+			"application_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the application.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the APPCODE, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func listAppcodes(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
 	var (
-		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes"
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes?limit={limit}"
 		instanceId = d.Get("instance_id").(string)
 		appId      = d.Get("application_id").(string)
+		limit      = 100
 		offset     = 0
 		result     = make([]interface{}, 0)
 	)
@@ -83,57 +94,36 @@ func queryAppcodes(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]i
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
 	listPath = strings.ReplaceAll(listPath, "{app_id}", appId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
 
 	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
 	for {
-		listPathWithOffset := fmt.Sprintf("%s?limit=100&offset=%d", listPath, offset)
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
 		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
 		if err != nil {
-			return nil, fmt.Errorf("error retrieving APPCODEs under specified application (%s): %s", appId, err)
+			return nil, err
 		}
+
 		respBody, err := utils.FlattenResponse(requestResp)
 		if err != nil {
 			return nil, err
 		}
+
 		appcodes := utils.PathSearch("app_codes", respBody, make([]interface{}, 0)).([]interface{})
-		if len(appcodes) < 1 {
+		result = append(result, appcodes...)
+		if len(appcodes) < limit {
 			break
 		}
-		result = append(result, appcodes...)
 		offset += len(appcodes)
 	}
+
 	return result, nil
-}
-
-func dataSourceAppcodesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
-	)
-
-	client, err := cfg.NewServiceClient("apig", region)
-	if err != nil {
-		return diag.Errorf("error creating APIG client: %s", err)
-	}
-	signatures, err := queryAppcodes(client, d)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	dataSourceId, err := uuid.GenerateUUID()
-	if err != nil {
-		return diag.Errorf("unable to generate ID: %s", err)
-	}
-	d.SetId(dataSourceId)
-
-	mErr := multierror.Append(nil,
-		d.Set("region", region),
-		d.Set("appcodes", flattenAppcodes(signatures)),
-	)
-	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func flattenAppcodes(appcodes []interface{}) []interface{} {
@@ -151,5 +141,35 @@ func flattenAppcodes(appcodes []interface{}) []interface{} {
 				appcode, "").(string))/1000, false),
 		})
 	}
+
 	return result
+}
+
+func dataSourceAppcodesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	resp, err := listAppcodes(client, d)
+	if err != nil {
+		return diag.Errorf("error querying APPCODEs: %s", err)
+	}
+
+	randomUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randomUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("appcodes", flattenAppcodes(resp)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
 }

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_appcode.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_appcode.go
@@ -8,26 +8,37 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/applications"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes/{app_code_id}
-// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes/{app_code_id}
+var apigAppcodeNonUpdatableParams = []string{
+	"instance_id",
+	"application_id",
+	"value",
+}
+
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes/{app_code_id}
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes
+// @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes/{app_code_id}
 func ResourceAppcode() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceAppcodeCreate,
 		ReadContext:   resourceAppcodeRead,
+		UpdateContext: resourceAppcodeUpdate,
 		DeleteContext: resourceAppcodeDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceAppcodeImportState,
 		},
+
+		CustomizeDiff: config.FlexibleForceNew(apigAppcodeNonUpdatableParams),
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -35,122 +46,216 @@ func ResourceAppcode() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				Description: "The region where the application and APPCODE are located.",
+				Description: `The region where the APPCODE is located.`,
 			},
+
+			// Required parameters.
 			"instance_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: "The ID of the dedicated instance to which the application and APPCODE belong.",
+				Description: `The ID of the dedicated instance to which the application and APPCODE belong.`,
 			},
 			"application_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: "The ID of the application to which the APPCODE belongs.",
+				Description: `The ID of the application to which the APPCODE belongs.`,
 			},
+
+			// Optional parameters.
 			"value": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				ForceNew:    true,
-				Description: "The APPCODE value (content).",
+				Description: `The APPCODE value (content).`,
 			},
+
+			// Attributes.
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The creation time of the APPCODE.",
+				Description: `The creation time of the APPCODE, in RFC3339 format.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{Internal: true,
+						Required: true,
+					}),
 			},
 		},
 	}
 }
 
+func buildAppcodeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"app_code": d.Get("value"),
+	}
+}
+
+func createAppcode(client *golangsdk.ServiceClient, instanceId, appId string, d *schema.ResourceData) (interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{app_id}", appId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildAppcodeBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func autoGenerateAppcode(client *golangsdk.ServiceClient, instanceId, appId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{app_id}", appId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("PUT", createPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
 func resourceAppcodeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		resp *applications.AppCode
-
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
-
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
 		instanceId = d.Get("instance_id").(string)
 		appId      = d.Get("application_id").(string)
-		appCode    = d.Get("value").(string)
 	)
-	client, err := cfg.ApigV2Client(region)
+
+	client, err := cfg.NewServiceClient("apig", region)
 	if err != nil {
-		return diag.Errorf("error creating APIG v2 client: %s", err)
+		return diag.Errorf("error creating APIG client: %s", err)
 	}
 
-	if appCode != "" {
-		opt := applications.AppCodeOpts{
-			AppCode: appCode,
-		}
-		resp, err = applications.CreateAppCode(client, instanceId, appId, opt).Extract()
+	var respBody interface{}
+	if _, ok := d.GetOk("value"); ok {
+		respBody, err = createAppcode(client, instanceId, appId, d)
 		if err != nil {
-			return diag.Errorf("generating APPCODE failed: %s", err)
+			return diag.Errorf("error creating APPCODE: %s", err)
 		}
 	} else {
-		resp, err = applications.AutoGenerateAppCode(client, instanceId, appId).Extract()
+		respBody, err = autoGenerateAppcode(client, instanceId, appId)
 		if err != nil {
-			return diag.Errorf("auto generating APPCODE failed: %s", err)
+			return diag.Errorf("error auto generating APPCODE: %s", err)
 		}
 	}
 
-	d.SetId(resp.Id)
+	resourceId := utils.PathSearch("id", respBody, "").(string)
+	if resourceId == "" {
+		return diag.Errorf("unable to find the APPCODE ID from the API response")
+	}
+	d.SetId(resourceId)
 
 	return resourceAppcodeRead(ctx, d, meta)
 }
 
+func GetAppcode(client *golangsdk.ServiceClient, instanceId, appId, appCodeId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes/{app_code_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getPath = strings.ReplaceAll(getPath, "{app_id}", appId)
+	getPath = strings.ReplaceAll(getPath, "{app_code_id}", appCodeId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
 func resourceAppcodeRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
-
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
 		instanceId = d.Get("instance_id").(string)
 		appId      = d.Get("application_id").(string)
 		appCodeId  = d.Id()
 	)
-	client, err := cfg.ApigV2Client(region)
+
+	client, err := cfg.NewServiceClient("apig", region)
 	if err != nil {
-		return diag.Errorf("error creating APIG v2 client: %s", err)
+		return diag.Errorf("error creating APIG client: %s", err)
 	}
 
-	resp, err := applications.GetAppCode(client, instanceId, appId, appCodeId).Extract()
+	respBody, err := GetAppcode(client, instanceId, appId, appCodeId)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err,
-			fmt.Sprintf("error querying APPCODE (%s) from specified application (%s) under dedicated instance (%s)",
-				appCodeId, appId, instanceId))
+			fmt.Sprintf("error querying APPCODE (%s) from application (%s)", appCodeId, appId))
 	}
+
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("value", resp.Code),
-		d.Set("created_at", resp.CreateTime),
+		d.Set("application_id", utils.PathSearch("app_id", respBody, nil)),
+		d.Set("value", utils.PathSearch("app_code", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
+			respBody, "").(string))/1000, false)),
 	)
-	if err = mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error saving APPCODE resource fields: %s", err)
-	}
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceAppcodeUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	return nil
+}
+
+func deleteAppcode(client *golangsdk.ServiceClient, instanceId, appId, appCodeId string) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes/{app_code_id}"
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceId)
+	deletePath = strings.ReplaceAll(deletePath, "{app_id}", appId)
+	deletePath = strings.ReplaceAll(deletePath, "{app_code_id}", appCodeId)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err := client.Request("DELETE", deletePath, &deleteOpt)
+	return err
 }
 
 func resourceAppcodeDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg    = meta.(*config.Config)
-		region = cfg.GetRegion(d)
-
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
 		instanceId = d.Get("instance_id").(string)
 		appId      = d.Get("application_id").(string)
 		appCodeId  = d.Id()
 	)
-	client, err := cfg.ApigV2Client(region)
+
+	client, err := cfg.NewServiceClient("apig", region)
 	if err != nil {
-		return diag.Errorf("error creating APIG v2 client: %s", err)
+		return diag.Errorf("error creating APIG client: %s", err)
 	}
 
-	err = applications.RemoveAppCode(client, instanceId, appId, appCodeId).ExtractErr()
+	err = deleteAppcode(client, instanceId, appId, appCodeId)
 	if err != nil {
 		return common.CheckDeletedDiag(d, err,
-			fmt.Sprintf("error deleting APPCODE (%s) from specified application (%s) under dedicated instance (%s)",
-				appCodeId, appId, instanceId))
+			fmt.Sprintf("error deleting APPCODE (%s) from application (%s)", appCodeId, appId))
 	}
 	return nil
 }
@@ -158,18 +263,16 @@ func resourceAppcodeDelete(_ context.Context, d *schema.ResourceData, meta inter
 func resourceAppcodeImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
 	error) {
 	importedId := d.Id()
-	parts := strings.Split(importedId, "/")
+	parts := strings.SplitN(importedId, "/", 3)
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<application_id>/<id>', "+
 			"but got '%s'", importedId)
 	}
+
 	d.SetId(parts[2])
 	mErr := multierror.Append(nil,
 		d.Set("instance_id", parts[0]),
 		d.Set("application_id", parts[1]),
 	)
-	if err := mErr.ErrorOrNil(); err != nil {
-		return []*schema.ResourceData{d}, fmt.Errorf("error saving APPCODE resource fields during import: %s", err)
-	}
-	return []*schema.ResourceData{d}, nil
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Using auto-gen style to refactor the AppCode resource's code and data source's code.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

**Special notes for your reviewer**:

The coverage of the resource basic's acceptance test:
<img width="1038" height="89" alt="image" src="https://github.com/user-attachments/assets/8b2fb1cf-b612-49b7-9a4c-cb6967d4e54e" />

The coverage of the data source basic's acceptance test:
<img width="1025" height="51" alt="image" src="https://github.com/user-attachments/assets/e827e950-8df1-47a7-bc4f-61737fe721f5" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using auto-gen style to rewrite appcode resource and data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccAppcode_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccAppcode_basic -timeout 360m -parallel 10
=== RUN   TestAccAppcode_basic
=== PAUSE TestAccAppcode_basic
=== CONT  TestAccAppcode_basic
--- PASS: TestAccAppcode_basic (68.66s)
PASS
coverage: 3.2% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      68.764s coverage: 3.2% of statements in ./huaweicloud/services/apig
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    <img width="1451" height="937" alt="image" src="https://github.com/user-attachments/assets/fea25065-4f57-4f19-aa70-32d270ce54c1" />

    ab. Related resources (parent resources) not found
    <img width="1448" height="978" alt="image" src="https://github.com/user-attachments/assets/d3443263-1314-4554-8859-97db5382ee48" />

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    <img width="1482" height="949" alt="image" src="https://github.com/user-attachments/assets/f1b154fe-0068-437e-a603-1dad17384c49" />

    bb. Related resources (parent resources) not found
    <img width="1488" height="909" alt="image" src="https://github.com/user-attachments/assets/dea5ee97-2d48-41ba-a70c-e2c99fb2a240" />


