### PR TITLE
feat(SecMaster): support `secmaster_collector_nodes` data source

### DIFF
--- a/docs/data-sources/secmaster_collector_nodes.md
+++ b/docs/data-sources/secmaster_collector_nodes.md
@@ -1,0 +1,157 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_collector_nodes"
+description: |-
+  Use this data source to get the list of collector nodes.
+---
+
+# huaweicloud_secmaster_collector_nodes
+
+Use this data source to get the list of collector nodes.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_secmaster_collector_nodes" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID.
+
+* `health_status` - (Optional, String) Specifies the health status of the node.  
+  The valid values are as follows:
+  + **NORMAL**
+  + **ANOMALIES**
+  + **FAULTS**
+  + **LOST_CONTACT**
+
+* `node_id` - (Optional, String) Specifies the node ID.
+
+* `node_name` - (Optional, String) Specifies the node name.
+
+* `ip_address` - (Optional, String) Specifies the IP address.
+
+* `sort_key` - (Optional, String) Specifies the sort field.
+
+* `sort_dir` - (Optional, String) Specifies the sort direction.
+  The value can be **asc** or **desc**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The result data list.
+
+  The [records](#records_struct) structure is documented below.
+
+<a name="records_struct"></a>
+The `records` block supports:
+
+* `channel_instance_refer_count` - The channel instance refer count.
+
+* `create_by` - The IAM user ID.
+
+* `custom_label` - The custom label.
+
+* `description` - The description.
+
+* `device_type` - The device type.
+
+* `ip_address` - The IP address.
+
+* `monitor` - The monitor information.
+
+  The [monitor](#monitor_struct) structure is documented below.
+
+* `node_expansion` - The node expansion information.
+
+  The [node_expansion](#node_expansion_struct) structure is documented below.
+
+* `node_id` - The node ID.
+
+* `node_name` - The node name.
+
+* `os_type` - The OS type.
+
+* `private_ip_address` - The private IP address.
+
+* `project_id` - The project ID.
+
+* `region` - The region.
+
+* `specification` - The specification.
+
+* `update_time` - The update time, in milliseconds.
+
+* `vpc_endpoint_address` - The VPC endpoint address.
+
+* `vpc_endpoint_id` - The VPC endpoint ID.
+
+* `vpc_id` - The VPC ID.
+
+* `workspace_id` - The workspace ID.
+
+<a name="monitor_struct"></a>
+The `monitor` block supports:
+
+* `cpu_idle` - The CPU idle percentage.
+
+* `cpu_usage` - The CPU usage.
+
+* `disk_count` - The disk count.
+
+* `disk_usage` - The disk usage.
+
+* `down_pps` - The download packets per second.
+
+* `health_status` - The health status.
+
+* `heart_beat` - The heartbeat status.
+
+* `heart_beat_time` - The last heartbeat time.
+
+* `memory_cache` - The memory cache size.
+
+* `memory_count` - The memory count.
+
+* `memory_free` - The free memory size.
+
+* `memory_shared` - The shared memory size.
+
+* `memory_usage` - The memory usage.
+
+* `mini_on_online` - Whether the node is online.
+
+* `read_rate` - The disk read rate.
+
+* `up_pps` - The upload packets per second.
+
+* `write_rate` - The disk write rate.
+
+<a name="node_expansion_struct"></a>
+The `node_expansion` block supports:
+
+* `custom_label` - The custom label.
+
+* `data_center` - The data center.
+
+* `description` - The description.
+
+* `maintainer` - The maintainer.
+
+* `network_plane` - The network plane.
+
+* `node_id` - The node ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2334,6 +2334,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_collector_logstash_parsers":      secmaster.DataSourceCollectorLogstashParsers(),
 			"huaweicloud_secmaster_collector_module_restrictions":   secmaster.DataSourceCollectorModuleRestrictions(),
 			"huaweicloud_secmaster_collector_module_templates":      secmaster.DataSourceCollectorModuleTemplates(),
+			"huaweicloud_secmaster_collector_nodes":                 secmaster.DataSourceCollectorNodes(),
 			"huaweicloud_secmaster_collector_parser_templates":      secmaster.DataSourceSecmasterCollectorParserTemplates(),
 			"huaweicloud_secmaster_component_all_templates":         secmaster.DataSourceComponentAllTemplates(),
 			"huaweicloud_secmaster_component_detail":                secmaster.DataSourceComponentDetail(),

--- a/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_collector_nodes_test.go
+++ b/huaweicloud/services/acceptance/secmaster/data_source_huaweicloud_secmaster_collector_nodes_test.go
@@ -1,0 +1,98 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCollectorNodes_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_secmaster_collector_nodes.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCollectorNodes_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "records.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.channel_instance_refer_count"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.monitor.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.monitor.0.cpu_idle"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.monitor.0.cpu_usage"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.node_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.node_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.ip_address"),
+
+					resource.TestCheckOutput("is_node_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_node_name_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCollectorNodes_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_secmaster_collector_nodes" "test" {
+  workspace_id  = "%[1]s"
+  health_status = "NORMAL"
+  sort_key      = "node_id"
+  sort_dir      = "desc"
+}
+
+# Filter using node_id.
+locals {
+  node_id = data.huaweicloud_secmaster_collector_nodes.test.records[0].node_id
+}
+
+data "huaweicloud_secmaster_collector_nodes" "node_id_filter" {
+  workspace_id = "%[1]s"
+  node_id      = local.node_id
+}
+
+output "is_node_id_filter_useful" {
+  value = length(data.huaweicloud_secmaster_collector_nodes.node_id_filter.records) > 0 && alltrue(
+    [for v in data.huaweicloud_secmaster_collector_nodes.node_id_filter.records[*].node_id : v == local.node_id]
+  )
+}
+
+# Filter using node_name.
+locals {
+  node_name = data.huaweicloud_secmaster_collector_nodes.test.records[0].node_name
+}
+
+data "huaweicloud_secmaster_collector_nodes" "node_name_filter" {
+  workspace_id = "%[1]s"
+  node_name    = local.node_name
+}
+
+output "is_node_name_filter_useful" {
+  value = length(data.huaweicloud_secmaster_collector_nodes.node_name_filter.records) > 0 && alltrue(
+    [for v in data.huaweicloud_secmaster_collector_nodes.node_name_filter.records[*].node_name : v == local.node_name]
+  )
+}
+
+# Filter using non existent name.
+data "huaweicloud_secmaster_collector_nodes" "not_found" {
+  workspace_id = "%[1]s"
+  node_name    = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_secmaster_collector_nodes.not_found.records) == 0
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_collector_nodes.go
+++ b/huaweicloud/services/secmaster/data_source_huaweicloud_secmaster_collector_nodes.go
@@ -1,0 +1,430 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/collector/nodes
+func DataSourceCollectorNodes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCollectorNodesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"health_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"node_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sort_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"records": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     collectorNodesRecordsSchema(),
+			},
+		},
+	}
+}
+
+func collectorNodesRecordsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"channel_instance_refer_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"create_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"custom_label": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"device_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"monitor": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     collectorNodesMonitorSchema(),
+			},
+			"node_expansion": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     collectorNodesExpansionSchema(),
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"node_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"os_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"specification": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"vpc_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_endpoint_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func collectorNodesMonitorSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cpu_idle": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cpu_usage": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disk_count": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disk_usage": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"down_pps": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"health_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"heart_beat": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"heart_beat_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"memory_cache": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"memory_count": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"memory_free": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"memory_shared": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"memory_usage": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mini_on_online": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"read_rate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"up_pps": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"write_rate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func collectorNodesExpansionSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"custom_label": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_center": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"maintainer": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network_plane": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCollectorNodesQueryParams(d *schema.ResourceData, offset int) string {
+	rst := fmt.Sprintf("?limit=500&offset=%d", offset)
+
+	if v, ok := d.GetOk("health_status"); ok {
+		rst += fmt.Sprintf("&health_status=%v", v)
+	}
+
+	if v, ok := d.GetOk("node_id"); ok {
+		rst += fmt.Sprintf("&node_id=%v", v)
+	}
+
+	if v, ok := d.GetOk("node_name"); ok {
+		rst += fmt.Sprintf("&node_name=%v", v)
+	}
+
+	if v, ok := d.GetOk("ip_address"); ok {
+		rst += fmt.Sprintf("&ip_address=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		rst += fmt.Sprintf("&sort_key=%v", v)
+	}
+
+	if v, ok := d.GetOk("sort_dir"); ok {
+		rst += fmt.Sprintf("&sort_dir=%v", v)
+	}
+
+	return rst
+}
+
+func dataSourceCollectorNodesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v1/{project_id}/workspaces/{workspace_id}/collector/nodes"
+		product    = "secmaster"
+		offset     = 0
+		allRecords = make([]interface{}, 0)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		currentPath := requestPath + buildCollectorNodesQueryParams(d, offset)
+		resp, err := client.Request("GET", currentPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving SecMaster collector nodes: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		recordsResp := utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{})
+		if len(recordsResp) == 0 {
+			break
+		}
+
+		allRecords = append(allRecords, recordsResp...)
+		offset += len(recordsResp)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("records", flattenCollectorNodesRecords(allRecords)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCollectorNodesRecords(nodes []interface{}) []interface{} {
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(nodes))
+	for _, v := range nodes {
+		rst = append(rst, map[string]interface{}{
+			"channel_instance_refer_count": utils.PathSearch(
+				"channel_instance_refer_count", v, nil),
+			"create_by":    utils.PathSearch("create_by", v, nil),
+			"custom_label": utils.PathSearch("custom_label", v, nil),
+			"description":  utils.PathSearch("description", v, nil),
+			"device_type":  utils.PathSearch("device_type", v, nil),
+			"ip_address":   utils.PathSearch("ip_address", v, nil),
+			"monitor": flattenRecordsMonitor(
+				utils.PathSearch("monitor", v, nil)),
+			"node_expansion": flattenRecordsExpansion(
+				utils.PathSearch("node_expansion", v, nil)),
+			"node_id":              utils.PathSearch("node_id", v, nil),
+			"node_name":            utils.PathSearch("node_name", v, nil),
+			"os_type":              utils.PathSearch("os_type", v, nil),
+			"private_ip_address":   utils.PathSearch("private_ip_address", v, nil),
+			"project_id":           utils.PathSearch("project_id", v, nil),
+			"region":               utils.PathSearch("region", v, nil),
+			"specification":        utils.PathSearch("specification", v, nil),
+			"update_time":          utils.PathSearch("update_time", v, nil),
+			"vpc_endpoint_address": utils.PathSearch("vpc_endpoint_address", v, nil),
+			"vpc_endpoint_id":      utils.PathSearch("vpc_endpoint_id", v, nil),
+			"vpc_id":               utils.PathSearch("vpc_id", v, nil),
+			"workspace_id":         utils.PathSearch("workspace_id", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func flattenRecordsMonitor(raw interface{}) []interface{} {
+	if raw == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"cpu_idle":        utils.PathSearch("cpu_idle", raw, nil),
+			"cpu_usage":       utils.PathSearch("cpu_usage", raw, nil),
+			"disk_count":      utils.PathSearch("disk_count", raw, nil),
+			"disk_usage":      utils.PathSearch("disk_usage", raw, nil),
+			"down_pps":        utils.PathSearch("down_pps", raw, nil),
+			"health_status":   utils.PathSearch("health_status", raw, nil),
+			"heart_beat":      utils.PathSearch("heart_beat", raw, nil),
+			"heart_beat_time": utils.PathSearch("heart_beat_time", raw, nil),
+			"memory_cache":    utils.PathSearch("memory_cache", raw, nil),
+			"memory_count":    utils.PathSearch("memory_count", raw, nil),
+			"memory_free":     utils.PathSearch("memory_free", raw, nil),
+			"memory_shared":   utils.PathSearch("memory_shared", raw, nil),
+			"memory_usage":    utils.PathSearch("memory_usage", raw, nil),
+			"mini_on_online":  utils.PathSearch("mini_on_online", raw, nil),
+			"read_rate":       utils.PathSearch("read_rate", raw, nil),
+			"up_pps":          utils.PathSearch("up_pps", raw, nil),
+			"write_rate":      utils.PathSearch("write_rate", raw, nil),
+		},
+	}
+}
+
+func flattenRecordsExpansion(raw interface{}) []interface{} {
+	if raw == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"custom_label":  utils.PathSearch("custom_label", raw, nil),
+			"data_center":   utils.PathSearch("data_center", raw, nil),
+			"description":   utils.PathSearch("description", raw, nil),
+			"maintainer":    utils.PathSearch("maintainer", raw, nil),
+			"network_plane": utils.PathSearch("network_plane", raw, nil),
+			"node_id":       utils.PathSearch("node_id", raw, nil),
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support `secmaster_collector_nodes` data source

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

support `secmaster_collector_nodes` data source

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o secmaster -f TestAccDataSourceCollectorNodes_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccDataSourceCollectorNodes_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceCollectorNodes_basic
=== PAUSE TestAccDataSourceCollectorNodes_basic
=== CONT  TestAccDataSourceCollectorNodes_basic
--- PASS: TestAccDataSourceCollectorNodes_basic (17.31s)
PASS
        github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/secmaster    coverage: 4.4% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 17.450s coverage: 4.4% of statements in ./huaweicloud/services/secmaster
```
<img width="978" height="34" alt="image" src="https://github.com/user-attachments/assets/16d594aa-2e91-4337-83b4-ed1cc299cfef" />



* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
