### PR TITLE
feat(TaurusDB): data source to query db users of a htap instance

### DIFF
--- a/docs/data-sources/taurusdb_htap_starrocks_users.md
+++ b/docs/data-sources/taurusdb_htap_starrocks_users.md
@@ -1,0 +1,73 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_htap_starrocks_users"
+description: |-
+  Use this data source to query the database accounts of a TaurusDB HTAP StarRocks instance within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_htap_starrocks_users
+
+Use this data source to query the database accounts of a TaurusDB HTAP StarRocks instance within HuaweiCloud.
+
+## Example Usage
+
+### Query all database accounts
+
+```hcl
+variable "htap_instance_id" {}
+
+data "huaweicloud_taurusdb_htap_starrocks_users" "test" {
+  instance_id = var.htap_instance_id
+}
+```
+
+### Query a specific database account
+
+```hcl
+variable "htap_instance_id" {}
+
+data "huaweicloud_taurusdb_htap_starrocks_users" "test" {
+  instance_id = var.htap_instance_id
+  user_name   = "root"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the HTAP StarRocks database accounts.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the StarRocks instance ID.
+
+* `user_name` - (Optional, String) Specifies the database account name to query.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `user_details` - The list of database account details.
+  The [user_details](#user_details_attr) structure is documented below.
+
+<a name="user_details_attr"></a>
+The `user_details` block supports:
+
+* `user_name` - The database account name.
+
+* `databases` - The list of authorized databases names.
+
+* `dml` - The DML authorization.
+  The valid values are as follows:
+  + **0**: read and write permissions
+  + **1**: read-only permission
+  + **2**: read-only and setting permissions
+  + **3**: read-write and setting permissions
+
+* `ddl` - The DDL authorization.
+  The valid values are as follows:
+  + **0**: no DDL permission
+  + **1**: DDL permission

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2554,6 +2554,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_htap_starrocks_parameters":                taurusdb.DataSourceTaurusDBHtapStarrocksParameters(),
 			"huaweicloud_taurusdb_htap_starrocks_replications":              taurusdb.DataSourceTaurusDBHtapStarrocksReplications(),
 			"huaweicloud_taurusdb_htap_starrocks_replication_db_parameters": taurusdb.DataSourceTaurusDBHtapStarrocksReplicationDBParameters(),
+			"huaweicloud_taurusdb_htap_starrocks_users":                     taurusdb.DataSourceTaurusDBHtapStarrocksUsers(),
 			"huaweicloud_taurusdb_htap_storage_types":                       taurusdb.DataSourceTaurusDBHtapStorageTypes(),
 			"huaweicloud_taurusdb_instance":                                 taurusdb.DataSourceTaurusDBInstance(),
 			"huaweicloud_taurusdb_instances":                                taurusdb.DataSourceTaurusDBInstances(),

--- a/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_htap_starrocks_users_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_htap_starrocks_users_test.go
@@ -1,0 +1,60 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTaurusDBHtapStarrocksUsers_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_taurusdb_htap_starrocks_users.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBHtapInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceTaurusDBHtapStarrocksUsers_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "user_details.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "user_details.0.user_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "user_details.0.dml"),
+					resource.TestCheckResourceAttrSet(dataSource, "user_details.0.ddl"),
+					resource.TestCheckResourceAttrSet(dataSource, "user_details.0.databases.#"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceTaurusDBHtapStarrocksUsers_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_taurusdb_htap_starrocks_users" "test" {
+  instance_id = "%[1]s"
+}
+
+locals {
+  user_name = data.huaweicloud_taurusdb_htap_starrocks_users.test.user_details[0].user_name
+}
+
+data "huaweicloud_taurusdb_htap_starrocks_users" "filter" {
+  instance_id = "%[1]s"
+  user_name   = local.user_name
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_taurusdb_htap_starrocks_users.filter.user_details) > 0 && alltrue(
+    [for v in data.huaweicloud_taurusdb_htap_starrocks_users.filter.user_details : v.user_name == local.user_name]
+  )
+}
+`, acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID)
+}

--- a/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_htap_starrocks_users.go
+++ b/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_htap_starrocks_users.go
@@ -1,0 +1,164 @@
+package taurusdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/starrocks/users
+func DataSourceTaurusDBHtapStarrocksUsers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTaurusDBHtapStarrocksUsersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"user_details": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     starrocksUsersUserDetailsSchema(),
+			},
+		},
+	}
+}
+
+func starrocksUsersUserDetailsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"user_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"databases": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"dml": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"ddl": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTaurusDBHtapStarrocksUsersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		userName   = d.Get("user_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating TaurusDB client: %s", err)
+	}
+
+	users, err := QueryHtapStarrocksUsers(client, instanceId, userName)
+	if err != nil {
+		return diag.Errorf("error querying TaurusDB users: %s", err)
+	}
+
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id.String())
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", region),
+		d.Set("user_details", flattenStarrocksUsersUserDetails(users)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func QueryHtapStarrocksUsers(client *golangsdk.ServiceClient, instanceId, userName string) ([]interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/starrocks/users"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+
+	listOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		queryPath := buildStarrocksUsersQueryParams(listPath, userName, limit, offset)
+		resp, err := client.Request("GET", queryPath, &listOpts)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		userDetails := utils.PathSearch("user_details", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, userDetails...)
+		if len(userDetails) < limit {
+			break
+		}
+
+		offset += len(userDetails)
+	}
+	return result, nil
+}
+
+func buildStarrocksUsersQueryParams(baseUrl, userName string, limit, offset int) string {
+	rst := fmt.Sprintf("%s?limit=%d&offset=%d", baseUrl, limit, offset)
+	if userName != "" {
+		rst += fmt.Sprintf("&user_name=%s", userName)
+	}
+	return rst
+}
+
+func flattenStarrocksUsersUserDetails(users []interface{}) []interface{} {
+	res := make([]interface{}, 0, len(users))
+	for _, v := range users {
+		dataBases := utils.PathSearch("databases", v, make([]interface{}, 0)).([]interface{})
+		res = append(res, map[string]interface{}{
+			"user_name": utils.PathSearch("user_name", v, nil),
+			"databases": utils.ExpandToStringList(dataBases),
+			"dml":       utils.PathSearch("dml", v, nil),
+			"ddl":       utils.PathSearch("ddl", v, nil),
+		})
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
data source to query db users of a htap instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
data source to query db users of a htap instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccDataSourceTaurusDBHtapStarrocksUsers'
=== RUN   TestAccDataSourceTaurusDBHtapStarrocksUsers_basic
=== PAUSE TestAccDataSourceTaurusDBHtapStarrocksUsers_basic
=== CONT  TestAccDataSourceTaurusDBHtapStarrocksUsers_basic
--- PASS: TestAccDataSourceTaurusDBHtapStarrocksUsers_basic (18.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 18.201s
```
<img width="912" height="195" alt="image" src="https://github.com/user-attachments/assets/7f181b4a-4bc7-4c28-b30e-3f599bcb6c44" />

* [x] Documentation updated.x
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
