### PR TITLE
feat(dli): flink_template resource support query created_at, update_at attributes

### DIFF
--- a/docs/resources/dli_flink_template.md
+++ b/docs/resources/dli_flink_template.md
@@ -56,6 +56,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
 
+* `created_at` - The creation time of the flink template, in RFC3339 format.
+
+* `updated_at` - The latest update time of the flink template, in RFC3339 format.
+
 ## Import
 
 The flink template can be imported using the `id`, e.g.

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flink_template_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flink_template_test.go
@@ -2,6 +2,7 @@ package dli
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -85,6 +86,8 @@ func TestAccFlinkTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "type", "flink_sql_job"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 			{
@@ -98,6 +101,10 @@ func TestAccFlinkTemplate_basic(t *testing.T) {
 					// The tags is ForceNew.
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(rName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 			{

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_flink_template.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_flink_template.go
@@ -69,6 +69,16 @@ func ResourceFlinkTemplate() *schema.Resource {
 				Description: `The type of the flink template.`,
 			},
 			"tags": common.TagsForceNewSchema(),
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the flink template, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the flink template, in RFC3339 format.`,
+			},
 		},
 	}
 }
@@ -188,6 +198,10 @@ func resourceFlinkTemplateRead(_ context.Context, d *schema.ResourceData, meta i
 		d.Set("description", utils.PathSearch("desc", flinkTemplate, nil)),
 		d.Set("type", utils.PathSearch("job_type", flinkTemplate, nil)),
 		d.Set("tags", d.Get("tags")),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(
+			int64(utils.PathSearch("create_time", flinkTemplate, float64(0)).(float64))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(
+			int64(utils.PathSearch("update_time", flinkTemplate, float64(0)).(float64))/1000, false)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `created_at` and `updated_at` attributes to flink_template.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. Add created_at and updated_at attributes to the schema.
2. Add corresponding tests.
3. Add corresponding descriptions to the documentation.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dli" -v -coverprofile="./huaweicloud/services/acceptance/dli/dli_coverage.cov" -coverpkg="./huaweicloud/services/dli" -run TestAccFlinkTemplate_basic -timeout 360m -parallel 10
=== RUN   TestAccFlinkTemplate_basic
=== PAUSE TestAccFlinkTemplate_basic
=== CONT  TestAccFlinkTemplate_basic
--- PASS: TestAccFlinkTemplate_basic (32.58s)
PASS
coverage: 4.1% of statements in ./huaweicloud/services/dli
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       32.710s coverage: 4.1% of statements in ./huaweicloud/services/dli
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.