### PR TITLE
feat(GeminiDB): the instance support new APIs

### DIFF
--- a/docs/resources/geminidb_instance.md
+++ b/docs/resources/geminidb_instance.md
@@ -157,6 +157,22 @@ The following arguments are supported:
   -> This parameter is valid and available for **GeminiDB Influx** and **GeminiDB Redis** instances.
     The instances across subnets are not supported.
 
+* `bucket_name` - (Optional, String) Specifies the OBS bucket name.
+
+* `data_export_switch` - (Optional, String) Specifies the instance data export switch.
+  The valid values are as follows:
+  + **open**
+  + **close**
+
+-> 1. The parameters `bucket_name` and `data_export_switch` are used to configuration instance data export.
+  <br/>2. Currently, only the performance-enhanced GeminiDB Influx instance is supported.
+
+* `cold_storage_size` - (Optional, Int) Specifies the size of the cold storage, in GB.
+  The valid value ranges from `500` to `100,000`.
+
+  -> 1. The parameter `cold_storage_size` is used to configuration cold storage.
+  <br/>2. Currently, only the single-node GeminiDB Influx instance is supported.
+
 * `access_control` - (Optional, List) Specifies the access control for Load Balancer.
   The [access_control](#access_control_struct) structure is documented below.
 
@@ -432,8 +448,9 @@ $ terraform import huaweicloud_geminidb_instance.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to the attribute missing from the
-API response. The missing attribute is: `password`, `flavor.0.storage`, `ssl_option`, `delete_node_list`, `auto_renew`,
-`period` and `period_unit`. It is generally recommended running `terraform plan` after importing a GeminiDB instance.
+API response. The missing attribute is: `password`, `flavor.0.storage`, `ssl_option`, `bucket_name`,
+`data_export_switch`, `cold_storage_size`, `delete_node_list`, `auto_renew`, `period` and `period_unit`.
+It is generally recommended running `terraform plan` after importing a GeminiDB instance.
 You can then decide if changes should be applied to the GeminiDB instance or the resource definition should be updated
 to align with the GeminiDB instance. Also you can ignore changes as below.
 
@@ -443,7 +460,8 @@ resource "huaweicloud_geminidb_instance" "test" {
 
   lifecycle {
     ignore_changes = [
-      password, flavor.0.storage, ssl_option, delete_node_list, auto_renew, period, period_unit
+      password, flavor.0.storage, ssl_option, bucket_name, data_export_switch, cold_storage_size,
+      delete_node_list, auto_renew, period, period_unit,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_instance_test.go
@@ -452,6 +452,129 @@ func TestAccGeminiDbInstance_configuration(t *testing.T) {
 	})
 }
 
+func TestAccGeminiDbInstance_dataExport(t *testing.T) {
+	var obj interface{}
+	name := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_geminidb_instance.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getGeminiDbInstance,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDBDataExport_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.type", "influxdb"),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.version", "1.8"),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.storage_engine", "rocksDB"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "EnhancedCluster"),
+					resource.TestCheckResourceAttr(resourceName, "flavor.0.num", "2"),
+					resource.TestCheckResourceAttr(resourceName, "flavor.0.size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "flavor.0.spec_code", "geminidb.influxdb.sqlstore.large.4"),
+					resource.TestCheckResourceAttr(resourceName, "data_export_switch", "open"),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket_name", "huaweicloud_obs_bucket.test1", "bucket"),
+				),
+			},
+			{
+				Config: testAccGeminiDBDataExport_update(name, "open"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "data_export_switch", "open"),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket_name", "huaweicloud_obs_bucket.test2", "bucket"),
+				),
+			},
+			{
+				Config: testAccGeminiDBDataExport_update(name, "close"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "data_export_switch", "close"),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket_name", "huaweicloud_obs_bucket.test2", "bucket"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"flavor.0.storage",
+					"ssl_option",
+					"delete_node_list",
+					"bucket_name",
+					"data_export_switch",
+				},
+			},
+		},
+	})
+}
+
+func TestAccGeminiDbInstance_coldStorage(t *testing.T) {
+	var obj interface{}
+	name := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_geminidb_instance.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getGeminiDbInstance,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDBColdStorage_basic(name, 500),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.type", "influxdb"),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.version", "1.8"),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.storage_engine", "rocksDB"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "InfluxdbSingle"),
+					resource.TestCheckResourceAttr(resourceName, "flavor.0.num", "1"),
+					resource.TestCheckResourceAttr(resourceName, "flavor.0.size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "flavor.0.spec_code", "geminidb.influxdb.single.xlarge.2"),
+					resource.TestCheckResourceAttr(resourceName, "cold_storage_size", "500"),
+				),
+			},
+			{
+				Config: testAccGeminiDBColdStorage_basic(name, 505),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "cold_storage_size", "505"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"flavor.0.storage",
+					"ssl_option",
+					"delete_node_list",
+					"cold_storage_size",
+				},
+			},
+		},
+	})
+}
+
 func testAccGeminiDbInstance_base(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
@@ -977,4 +1100,129 @@ resource "huaweicloud_geminidb_instance" "test" {
   }
 }
 `, common.TestBaseNetwork(name), name)
+}
+
+func testAccGeminiDBDataExport_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket" "test1" {
+  bucket        = "%[2]s-b1"
+  storage_class = "STANDARD"
+  acl           = "private"
+}
+
+resource "huaweicloud_obs_bucket" "test2" {
+  bucket        = "%[2]s-b2"
+  storage_class = "STANDARD"
+  acl           = "private"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "Test@1234"
+  mode              = "EnhancedCluster"
+
+  datastore {
+    type           = "influxdb"
+    version        = "1.8"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "2"
+    size      = "100"
+    storage   = "ULTRAHIGH"
+    spec_code = "geminidb.influxdb.sqlstore.large.4"
+  }
+
+  data_export_switch = "open"
+  bucket_name        = huaweicloud_obs_bucket.test1.bucket
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccGeminiDBDataExport_update(name, dataSwitch string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket" "test1" {
+  bucket        = "%[2]s-b1"
+  storage_class = "STANDARD"
+  acl           = "private"
+}
+
+resource "huaweicloud_obs_bucket" "test2" {
+  bucket        = "%[2]s-b2"
+  storage_class = "STANDARD"
+  acl           = "private"
+}
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "Test@1234"
+  mode              = "EnhancedCluster"
+
+  datastore {
+    type           = "influxdb"
+    version        = "1.8"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "2"
+    size      = "100"
+    storage   = "ULTRAHIGH"
+    spec_code = "geminidb.influxdb.sqlstore.large.4"
+  }
+
+  data_export_switch = "%[3]s"
+  bucket_name        = huaweicloud_obs_bucket.test2.bucket
+}
+`, common.TestBaseNetwork(name), name, dataSwitch)
+}
+
+func testAccGeminiDBColdStorage_basic(name string, storageSize int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "Test@1234"
+  mode              = "InfluxdbSingle"
+
+  datastore {
+    type           = "influxdb"
+    version        = "1.8"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "1"
+    size      = "100"
+    storage   = "ULTRAHIGH"
+    spec_code = "geminidb.influxdb.single.xlarge.2"
+  }
+
+  cold_storage_size = %[3]d
+}
+`, common.TestBaseNetwork(name), name, storageSize)
 }

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_instance.go
@@ -54,6 +54,9 @@ var geminiDbInstanceNonUpdatableParams = []string{"datastore", "datastore.*.type
 // @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/passwordless-config
 // @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/passwordless-config
 // @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/lb
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/data-dump
+// @API GeminiDB POST /v3/{project_id}/instances/{instance_id}/cold-volume
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/cold-volume
 // @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/lb/access-control
 // @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/lb/access-control
 // @API BSS GET /v2/orders/customer-orders/details/{order_id}
@@ -203,6 +206,18 @@ func ResourceGeminiDbInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+			},
+			"bucket_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_export_switch": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cold_storage_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
 			},
 			"delete_node_list": {
 				Type:     schema.TypeSet,
@@ -652,7 +667,56 @@ func resourceGeminiDbInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
+	// Enable data export
+	if v, ok := d.GetOk("data_export_switch"); ok && v.(string) == "open" {
+		err = updateDataExport(ctx, d, client)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Create cold storage
+	if _, ok := d.GetOk("cold_storage_size"); ok {
+		bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
+		if err != nil {
+			return diag.Errorf("error creating BSS v2 client: %s", err)
+		}
+
+		err = creatColdStorage(ctx, d, client, bssClient)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceGeminiDbInstanceRead(ctx, d, meta)
+}
+
+func creatColdStorage(ctx context.Context, d *schema.ResourceData, client, bssClient *golangsdk.ServiceClient) error {
+	_, err := updateGeminiDbInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:              "v3/{project_id}/instances/{instance_id}/cold-volume",
+		httpMethod:           "POST",
+		pathParams:           map[string]string{"instance_id": d.Id()},
+		updateBodyParams:     buildCreateOrUpdateColdStorageBodyParams(d),
+		isRetry:              true,
+		timeout:              schema.TimeoutCreate,
+		checkJobExpression:   "job_id",
+		checkOrderExpression: "order_id",
+		bssClient:            bssClient,
+		isWaitInstanceReady:  true,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating GeminiDB instance cold storage: %s", err)
+	}
+	return nil
+}
+
+func buildCreateOrUpdateColdStorageBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"size":        d.Get("cold_storage_size"),
+		"is_auto_pay": "true",
+	}
+
+	return params
 }
 
 func modifyLoadbalancerIpAddress(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
@@ -1355,6 +1419,24 @@ func resourceGeminiDbInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
+	// Update data export
+	err = updateDataExport(ctx, d, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.HasChange("cold_storage_size") {
+		oldSize, newSize := d.GetChange("cold_storage_size")
+		if newSize.(int) < oldSize.(int) {
+			return diag.Errorf("error updating GeminiDB instance cold storage: the cold storage only supports enlarge")
+		}
+
+		err = updateColdStorage(ctx, d, client, bssClient)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	// Configuring the Blacklist or Whitelist of Load Balancer IP Addresses
 	if d.HasChange("access_control") {
 		err = updateLBAccessControl(ctx, d, client)
@@ -1762,6 +1844,51 @@ func buildUpdateLoadbalancerIpAddressBodyParams(d *schema.ResourceData) map[stri
 	}
 
 	return bodyParams
+}
+
+func updateDataExport(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	if !d.HasChanges("bucket_name", "data_export_switch") {
+		return nil
+	}
+
+	_, err := updateGeminiDbInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:          "v3/{project_id}/instances/{instance_id}/data-dump",
+		httpMethod:       "PUT",
+		pathParams:       map[string]string{"instance_id": d.Id()},
+		updateBodyParams: buildUpdateDataExportBodyParams(d),
+	})
+	if err != nil {
+		return fmt.Errorf("error enabling or disabling GeminiDB instance data export: %s", err)
+	}
+	return nil
+}
+
+func buildUpdateDataExportBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"bucket_name": d.Get("bucket_name"),
+		"action":      d.Get("data_export_switch"),
+	}
+
+	return bodyParams
+}
+
+func updateColdStorage(ctx context.Context, d *schema.ResourceData, client, bssClient *golangsdk.ServiceClient) error {
+	_, err := updateGeminiDbInstanceField(ctx, d, client, updateInstanceFieldParams{
+		httpUrl:              "v3/{project_id}/instances/{instance_id}/cold-volume",
+		httpMethod:           "PUT",
+		pathParams:           map[string]string{"instance_id": d.Id()},
+		updateBodyParams:     buildCreateOrUpdateColdStorageBodyParams(d),
+		isRetry:              true,
+		timeout:              schema.TimeoutUpdate,
+		checkJobExpression:   "job_id",
+		checkOrderExpression: "order_id",
+		bssClient:            bssClient,
+		isWaitInstanceReady:  true,
+	})
+	if err != nil {
+		return fmt.Errorf("error updating GeminiDB instance cold storage: %s", err)
+	}
+	return nil
 }
 
 func updateLBAccessControl(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The instance support new APIs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the instance supports enabling or disabling data export.
2. the instance supports creating and enlarging cold storage.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDbInstance_dataExport"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDbInstance_dataExport -timeout 360m -parallel 4
=== RUN   TestAccGeminiDbInstance_dataExport
=== PAUSE TestAccGeminiDbInstance_dataExport
=== CONT  TestAccGeminiDbInstance_dataExport
--- PASS: TestAccGeminiDbInstance_dataExport (1325.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1325.966s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDbInstance_coldStorage"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDbInstance_coldStorage -timeout 360m -parallel 4
=== RUN   TestAccGeminiDbInstance_coldStorage
=== PAUSE TestAccGeminiDbInstance_coldStorage
=== CONT  TestAccGeminiDbInstance_coldStorage
--- PASS: TestAccGeminiDbInstance_coldStorage (1158.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1158.667s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
