### PR TITLE
feat(SecMaster): support soc_mapping_status resource

### DIFF
--- a/docs/resources/secmaster_soc_mapping_status.md
+++ b/docs/resources/secmaster_soc_mapping_status.md
@@ -1,0 +1,51 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_soc_mapping_status"
+description: |-
+  Manages a SecMaster mapping status resource within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_soc_mapping_status
+
+Manages a SecMaster mapping status resource within HuaweiCloud.
+
+-> This resource is a one-time action resource. Deleting this resource will not change the current mapping status,
+  but will only remove the resource information from the tf state file.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "mapping_id" {}
+variable "status" {}
+
+resource "huaweicloud_secmaster_soc_mapping_status" "test" {
+  workspace_id = var.workspace_id
+  mapping_id   = var.mapping_id
+  status       = var.status
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the workspace ID.
+
+* `mapping_id` - (Required, String, NonUpdatable) Specifies the mapping ID.
+
+* `status` - (Required, String) Specifies the status of the mapping.
+  The valid values are as follows:
+  + **enabled**: Enabled.
+  + **disabled**: Disabled.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4451,6 +4451,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_search_condition":            secmaster.ResourceSearchCondition(),
 			"huaweicloud_secmaster_soc_mapping_clone":           secmaster.ResourceSocMappingClone(),
 			"huaweicloud_secmaster_soc_mapping_delete":          secmaster.ResourceSocMappingDelete(),
+			"huaweicloud_secmaster_soc_mapping_status":          secmaster.ResourceSocMappingStatus(),
 			"huaweicloud_secmaster_update_workflow_instance":    secmaster.ResourceUpdateWorkflowInstance(),
 			"huaweicloud_secmaster_workflow_action":             secmaster.ResourceWorkflowAction(),
 			"huaweicloud_secmaster_workflow_version_approval":   secmaster.ResourceWorkflowVersionApproval(),

--- a/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_soc_mapping_status_test.go
+++ b/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_soc_mapping_status_test.go
@@ -1,0 +1,37 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccSocMappingStatus_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+			acceptance.TestAccPreCheckSecMasterMappingId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSocMappingStatus_basic(),
+			},
+		},
+	})
+}
+
+func testAccSocMappingStatus_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_secmaster_soc_mapping_status" "test" {
+  workspace_id = "%[1]s"
+  mapping_id   = "%[2]s"
+  status       = "enabled"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_MAPPING_ID)
+}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_soc_mapping_status.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_soc_mapping_status.go
@@ -1,0 +1,145 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var socMappingStatusNonUpdatableParams = []string{"workspace_id", "mapping_id"}
+
+// @API SecMaster PUT /v1/{project_id}/workspaces/{workspace_id}/soc/mappings/{mapping_id}/status
+func ResourceSocMappingStatus() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSocMappingStatusCreate,
+		UpdateContext: resourceSocMappingStatusUpdate,
+		ReadContext:   resourceSocMappingStatusRead,
+		DeleteContext: resourceSocMappingStatusDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(socMappingStatusNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mapping_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildSocMappingStatusBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"status": d.Get("status"),
+	}
+}
+
+func resourceSocMappingStatusCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		createHttpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/mappings/{mapping_id}/status"
+		workspaceId   = d.Get("workspace_id").(string)
+		mappingId     = d.Get("mapping_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{workspace_id}", workspaceId)
+	createPath = strings.ReplaceAll(createPath, "{mapping_id}", mappingId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"content-type": "application/json;charset=UTF-8"},
+		JSONBody:         buildSocMappingStatusBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error updating mapping status: %s", err)
+	}
+
+	d.SetId(mappingId)
+
+	return nil
+}
+
+func resourceSocMappingStatusRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceSocMappingStatusUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		updateHttpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/mappings/{mapping_id}/status"
+		workspaceId   = d.Get("workspace_id").(string)
+		mappingId     = d.Get("mapping_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	updatePath := client.Endpoint + updateHttpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{workspace_id}", workspaceId)
+	updatePath = strings.ReplaceAll(updatePath, "{mapping_id}", mappingId)
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"content-type": "application/json;charset=UTF-8"},
+		JSONBody:         buildSocMappingStatusBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating mapping status: %s", err)
+	}
+
+	return nil
+}
+
+func resourceSocMappingStatusDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource to update mapping status. Deleting this resource will not change
+		the status of the currently mapping, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support soc_mapping_status resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support soc_mapping_status resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/secmaster' TESTARGS='-run=TestAccSocMappingStatus_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run=TestAccSocMappingStatus_basic -timeout 360m -parallel 4
=== RUN   TestAccSocMappingStatus_basic
=== PAUSE TestAccSocMappingStatus_basic
=== CONT  TestAccSocMappingStatus_basic
--- PASS: TestAccSocMappingStatus_basic (28.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 28.324s
```
<img width="420" height="18" alt="Snipaste_2026-06-12_10-20-38" src="https://github.com/user-attachments/assets/57b0daaf-f7fe-4c61-93ce-77011d4dd478" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
