### PR TITLE
feat(TaurusDB): data source to query replications of htap instance

### DIFF
--- a/docs/data-sources/taurusdb_htap_starrocks_replications.md
+++ b/docs/data-sources/taurusdb_htap_starrocks_replications.md
@@ -1,0 +1,67 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_htap_starrocks_replications"
+description: |-
+  Use this data source to query the data replication tasks of a TaurusDB HTAP StarRocks instance within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_htap_starrocks_replications
+
+Use this data source to query the data replication tasks of a TaurusDB HTAP StarRocks instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "htap_instance_id" {}
+
+data "huaweicloud_taurusdb_htap_starrocks_replications" "test" {
+  instance_id = var.htap_instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the HTAP StarRocks data replication tasks.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the HTAP StarRocks instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `replications` - The list of data replication tasks.
+  The [replications](#htap_starrocks_replications_attr) structure is documented below.
+
+<a name="htap_starrocks_replications_attr"></a>
+The `replications` block supports:
+
+* `source_database` - The source TaurusDB database name.
+
+* `target_database` - The target StarRocks database name.
+
+* `task_name` - The replication task name.
+
+* `status` - The current status.
+  The valid values are as follows:
+  + **Yes**: Normal.
+  + **No**: Abnormal.
+
+* `stage` - The synchronization stage.
+  The valid values are as follows:
+  + **wait**: Waiting for synchronization.
+  + **incremental**: Incremental synchronization.
+  + **full**: Full synchronization.
+  + **cancelled**: Synchronization cancelled.
+  + **paused**: Synchronization paused.
+
+* `percentage` - The progress percentage.
+
+* `is_need_repair` - Whether the task need to be repaired.
+
+* `is_main_task` - Whether the task is the main task.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2536,6 +2536,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_htap_starrocks_databases":        taurusdb.DataSourceTaurusDBHtapStarrocksDatabases(),
 			"huaweicloud_taurusdb_htap_starrocks_nodes":            taurusdb.DataSourceTaurusDBHtapStarrocksNodes(),
 			"huaweicloud_taurusdb_htap_starrocks_parameters":       taurusdb.DataSourceTaurusDBHtapStarrocksParameters(),
+			"huaweicloud_taurusdb_htap_starrocks_replications":     taurusdb.DataSourceTaurusDBHtapStarrocksReplications(),
 			"huaweicloud_taurusdb_htap_storage_types":              taurusdb.DataSourceTaurusDBHtapStorageTypes(),
 			"huaweicloud_taurusdb_instance":                        taurusdb.DataSourceTaurusDBInstance(),
 			"huaweicloud_taurusdb_instances":                       taurusdb.DataSourceTaurusDBInstances(),

--- a/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_htap_starrocks_replications_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_htap_starrocks_replications_test.go
@@ -1,0 +1,48 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTaurusDBHtapStarrocksReplications_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_taurusdb_htap_starrocks_replications.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBHtapInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceTaurusDBHtapStarrocksReplications_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "replications.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "replications.0.source_database"),
+					resource.TestCheckResourceAttrSet(dataSource, "replications.0.target_database"),
+					resource.TestCheckResourceAttrSet(dataSource, "replications.0.task_name"),
+					resource.TestCheckResourceAttr(dataSource, "replications.0.status", "Yes"),
+					resource.TestCheckResourceAttr(dataSource, "replications.0.stage", "Wait"),
+					resource.TestCheckResourceAttr(dataSource, "replications.0.percentage", "0"),
+					resource.TestCheckResourceAttr(dataSource, "replications.0.is_need_repair", "false"),
+					resource.TestCheckResourceAttr(dataSource, "replications.0.is_main_task", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceTaurusDBHtapStarrocksReplications_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_taurusdb_htap_starrocks_replications" "test" {
+  instance_id = "%[1]s"
+}
+`, acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID)
+}

--- a/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_htap_starrocks_replications.go
+++ b/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_htap_starrocks_replications.go
@@ -1,0 +1,159 @@
+package taurusdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/starrocks/databases/replication
+func DataSourceTaurusDBHtapStarrocksReplications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTaurusDBHtapStarrocksReplicationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"replications": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     starrocksReplicationsSchema(),
+			},
+		},
+	}
+}
+
+func starrocksReplicationsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"source_database": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_database": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"task_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"stage": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"percentage": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_need_repair": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_main_task": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTaurusDBHtapStarrocksReplicationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		limit  = 100
+		offset = 0
+		result = make([]interface{}, 0)
+	)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating TaurusDB client: %s", err)
+	}
+
+	httpUrl := "v3/{project_id}/instances/{instance_id}/starrocks/databases/replication"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+
+	listOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	for {
+		queryPath := fmt.Sprintf("%s?limit=%d&offset=%d", listPath, limit, offset)
+		resp, err := client.Request("GET", queryPath, &listOpts)
+		if err != nil {
+			return diag.Errorf("error retrieving TaurusDB HTAP StarRocks replications: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		replications := utils.PathSearch("replications", respBody, make([]interface{}, 0)).([]interface{})
+		if len(replications) == 0 {
+			break
+		}
+
+		result = append(result, replications...)
+
+		offset += len(replications)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("replications", flattenStarrocksReplications(result)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenStarrocksReplications(resp interface{}) []interface{} {
+	curArray := resp.([]interface{})
+	res := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		res = append(res, map[string]interface{}{
+			"source_database": utils.PathSearch("source_database", v, nil),
+			"target_database": utils.PathSearch("target_database", v, nil),
+			"task_name":       utils.PathSearch("task_name", v, nil),
+			"status":          utils.PathSearch("status", v, nil),
+			"stage":           utils.PathSearch("stage", v, nil),
+			"percentage":      utils.PathSearch("percentage", v, nil),
+			"is_need_repair":  utils.PathSearch("is_need_repair", v, nil),
+			"is_main_task":    utils.PathSearch("is_main_task", v, nil),
+		})
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
data source to query replications of htap instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
data source to query replications of htap instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccDataSourceTaurusDBHtapStarrocksReplications'
=== RUN   TestAccDataSourceTaurusDBHtapStarrocksReplications_basic
=== PAUSE TestAccDataSourceTaurusDBHtapStarrocksReplications_basic
=== CONT  TestAccDataSourceTaurusDBHtapStarrocksReplications_basic
--- PASS: TestAccDataSourceTaurusDBHtapStarrocksReplications_basic (23.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 23.701s
```
<img width="852" height="197" alt="image" src="https://github.com/user-attachments/assets/317c001d-b300-4650-a53a-9637f4750b65" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
