### PR TITLE
feat(secmaster): new resource to manage node expansion

### DIFF
--- a/docs/resources/secmaster_node_expansion.md
+++ b/docs/resources/secmaster_node_expansion.md
@@ -1,0 +1,64 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_node_expansion"
+description: |-
+  Manages a node expansion resource within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_node_expansion
+
+Manages a node expansion resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "node_id" {}
+
+resource "huaweicloud_secmaster_node_expansion" "test" {
+  workspace_id   = var.workspace_id
+  node_id        = var.node_id
+  custom_label   = "test custom label"
+  data_center    = "test data center"
+  description    = "test description"
+  maintainer     = "admin"
+  network_plane  = "business"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the ID of the workspace to which the node belongs.
+
+* `node_id` - (Required, String, NonUpdatable) Specifies the ID of the node.
+
+* `custom_label` - (Optional, String) Specifies the custom label of the node.
+
+* `data_center` - (Optional, String) Specifies the data center of the node.
+
+* `description` - (Optional, String) Specifies the description of the node.
+
+* `maintainer` - (Optional, String) Specifies the maintainer of the node.
+
+* `network_plane` - (Optional, String) Specifies the network plane of the node.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the node ID.
+
+## Import
+
+The node expansion can be imported using the `workspace_id` and the `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_secmaster_node_expansion.test <workspace_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4440,6 +4440,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_indicator":                   secmaster.ResourceIndicator(),
 			"huaweicloud_secmaster_layout_field":                secmaster.ResourceLayoutField(),
 			"huaweicloud_secmaster_module":                      secmaster.ResourceModule(),
+			"huaweicloud_secmaster_node_expansion":              secmaster.ResourceNodeExpansion(),
 			"huaweicloud_secmaster_operation_connection":        secmaster.ResourceOperationConnection(),
 			"huaweicloud_secmaster_pipe_consumption":            secmaster.ResourcePipeConsumption(),
 			"huaweicloud_secmaster_playbook_action":             secmaster.ResourcePlaybookAction(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -596,6 +596,9 @@ var (
 	// The SecMaster dataspace ID
 	HW_SECMASTER_DATASPACE_ID = os.Getenv("HW_SECMASTER_DATASPACE_ID")
 
+	// The SecMaster node ID
+	HW_SECMASTER_NODE_ID = os.Getenv("HW_SECMASTER_NODE_ID")
+
 	HW_MODELARTS_ALGORITHM_ENGINE_ID                         = os.Getenv("HW_MODELARTS_ALGORITHM_ENGINE_ID")
 	HW_MODELARTS_ALGORITHM_ENGINE_NAME                       = os.Getenv("HW_MODELARTS_ALGORITHM_ENGINE_NAME")
 	HW_MODELARTS_ALGORITHM_IMAGE_URL                         = os.Getenv("HW_MODELARTS_ALGORITHM_IMAGE_URL")
@@ -3463,6 +3466,13 @@ func TestAccPreCheckSecMasterPipeId(t *testing.T) {
 func TestAccPreCheckSecMasterDataspaceId(t *testing.T) {
 	if HW_SECMASTER_DATASPACE_ID == "" {
 		t.Skip("HW_SECMASTER_DATASPACE_ID must be set for SecMaster acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSecMasterNodeId(t *testing.T) {
+	if HW_SECMASTER_NODE_ID == "" {
+		t.Skip("HW_SECMASTER_NODE_ID must be set for SecMaster acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_node_expansion_test.go
+++ b/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_node_expansion_test.go
@@ -1,0 +1,125 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/secmaster"
+)
+
+func getResourceNodeExpansionFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("secmaster", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	return secmaster.GetNodeExpansionByNodeId(client, state.Primary.Attributes["workspace_id"], state.Primary.ID)
+}
+
+func TestAccResourceNodeExpansion_basic(t *testing.T) {
+	var (
+		rName = "huaweicloud_secmaster_node_expansion.test"
+
+		object interface{}
+		rc     = acceptance.InitResourceCheck(
+			rName,
+			&object,
+			getResourceNodeExpansionFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+			acceptance.TestAccPreCheckSecMasterNodeId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodeExpansion_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_SECMASTER_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "node_id", acceptance.HW_SECMASTER_NODE_ID),
+					resource.TestCheckResourceAttr(rName, "custom_label", "test_label"),
+					resource.TestCheckResourceAttr(rName, "data_center", "test_center"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "maintainer", "admin"),
+					resource.TestCheckResourceAttr(rName, "network_plane", "business"),
+				),
+			},
+			{
+				Config: testAccNodeExpansion_update(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "custom_label", "update_label"),
+					resource.TestCheckResourceAttr(rName, "data_center", "update_center"),
+					resource.TestCheckResourceAttr(rName, "description", "update description"),
+					resource.TestCheckResourceAttr(rName, "maintainer", "operator"),
+					resource.TestCheckResourceAttr(rName, "network_plane", "management"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccNodeExpansionImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccNodeExpansion_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_secmaster_node_expansion" "test" {
+  workspace_id   = "%[1]s"
+  node_id        = "%[2]s"
+  custom_label   = "test_label"
+  data_center    = "test_center"
+  description    = "test description"
+  maintainer     = "admin"
+  network_plane  = "business"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_NODE_ID)
+}
+
+func testAccNodeExpansion_update() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_secmaster_node_expansion" "test" {
+  workspace_id   = "%[1]s"
+  node_id        = "%[2]s"
+  custom_label   = "update_label"
+  data_center    = "update_center"
+  description    = "update description"
+  maintainer     = "operator"
+  network_plane  = "management"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_NODE_ID)
+}
+
+func testAccNodeExpansionImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var workspaceId, nodeId string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", rName)
+		}
+
+		workspaceId = rs.Primary.Attributes["workspace_id"]
+		nodeId = rs.Primary.ID
+
+		if workspaceId == "" || nodeId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<id>', but got '%s/%s'",
+				workspaceId, nodeId)
+		}
+
+		return fmt.Sprintf("%s/%s", workspaceId, nodeId), nil
+	}
+}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_node_expansion.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_node_expansion.go
@@ -1,0 +1,294 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nodeExpansionNonUpdatableParams = []string{"workspace_id", "node_id"}
+
+// @API SecMaster PUT /v1/{project_id}/workspaces/{workspace_id}/nodes/{node_id}
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/nodes
+func ResourceNodeExpansion() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNodeExpansionCreate,
+		ReadContext:   resourceNodeExpansionRead,
+		UpdateContext: resourceNodeExpansionUpdate,
+		DeleteContext: resourceNodeExpansionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceNodeExpansionImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(nodeExpansionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// Fields `custom_label`, `data_center`, `description`, `maintainer`, `network_plane` can be updated to empty,
+			// so Computed is not added.
+			"custom_label": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"data_center": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"maintainer": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"network_plane": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+// To prevent the program from making unexpected check delete judgments, it is necessary to restrict the input parameters.
+func precheckExpansionParamsAllEmpty(d *schema.ResourceData) error {
+	fields := []string{"custom_label", "data_center", "description", "maintainer", "network_plane"}
+	for _, field := range fields {
+		if d.Get(field).(string) != "" {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("the fields %v cannot all be empty, at least one must be configured", fields)
+}
+
+func buildNodeExpansionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"custom_label":  d.Get("custom_label"),
+		"data_center":   d.Get("data_center"),
+		"description":   d.Get("description"),
+		"maintainer":    d.Get("maintainer"),
+		"network_plane": d.Get("network_plane"),
+	}
+
+	return bodyParams
+}
+
+func configNodeExpansion(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	requestPath := client.Endpoint + "v1/{project_id}/workspaces/{workspace_id}/nodes/{node_id}"
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath = strings.ReplaceAll(requestPath, "{workspace_id}", d.Get("workspace_id").(string))
+	requestPath = strings.ReplaceAll(requestPath, "{node_id}", d.Get("node_id").(string))
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildNodeExpansionBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", requestPath, &requestOpt)
+	return err
+}
+
+func resourceNodeExpansionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		nodeId = d.Get("node_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	if err := precheckExpansionParamsAllEmpty(d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := configNodeExpansion(client, d); err != nil {
+		return diag.Errorf("error configuring SecMaster node expansion in create: %s", err)
+	}
+
+	d.SetId(nodeId)
+
+	return resourceNodeExpansionRead(ctx, d, meta)
+}
+
+func isNodeExpansionEmpty(nodeExpansion interface{}) bool {
+	if nodeExpansion == nil {
+		return true
+	}
+
+	fields := []string{"custom_label", "data_center", "description", "maintainer", "network_plane"}
+	for _, field := range fields {
+		if utils.PathSearch(field, nodeExpansion, "").(string) != "" {
+			return false
+		}
+	}
+
+	return true
+}
+
+func GetNodeExpansionByNodeId(client *golangsdk.ServiceClient, workspaceId, nodeId string) (interface{}, error) {
+	listPath := client.Endpoint + "v1/{project_id}/workspaces/{workspace_id}/nodes"
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{workspace_id}", workspaceId)
+	listPath = fmt.Sprintf("%s?node_id=%s", listPath, nodeId)
+	listOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", listPath, &listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeExpansion := utils.PathSearch("records|[0].node_expansion", respBody, nil)
+	if isNodeExpansionEmpty(nodeExpansion) {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return nodeExpansion, nil
+}
+
+func resourceNodeExpansionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		nodeId      = d.Get("node_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	nodeExpansion, err := GetNodeExpansionByNodeId(client, workspaceId, nodeId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving SecMaster node expansion")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("custom_label", utils.PathSearch("custom_label", nodeExpansion, nil)),
+		d.Set("data_center", utils.PathSearch("data_center", nodeExpansion, nil)),
+		d.Set("description", utils.PathSearch("description", nodeExpansion, nil)),
+		d.Set("maintainer", utils.PathSearch("maintainer", nodeExpansion, nil)),
+		d.Set("network_plane", utils.PathSearch("network_plane", nodeExpansion, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceNodeExpansionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	if err := precheckExpansionParamsAllEmpty(d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := configNodeExpansion(client, d); err != nil {
+		return diag.Errorf("error configuring SecMaster node expansion in update: %s", err)
+	}
+
+	return resourceNodeExpansionRead(ctx, d, meta)
+}
+
+func resourceNodeExpansionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		nodeId      = d.Get("node_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/nodes/{node_id}"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{workspace_id}", workspaceId)
+	deletePath = strings.ReplaceAll(deletePath, "{node_id}", nodeId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"custom_label":  "",
+			"data_center":   "",
+			"description":   "",
+			"maintainer":    "",
+			"network_plane": "",
+		},
+	}
+
+	_, err = client.Request("PUT", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting SecMaster node expansion: %s", err)
+	}
+
+	return nil
+}
+
+func resourceNodeExpansionImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<id>', but got '%s'",
+			importedId)
+	}
+
+	d.SetId(parts[1])
+	mErr := multierror.Append(nil,
+		d.Set("workspace_id", parts[0]),
+		d.Set("node_id", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

new resource to manage node expansion

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
./scripts/coverage.sh -o secmaster -f TestAccResourceNodeExpansion_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/secmaster" -v -coverprofile="./huaweicloud/services/acceptance/secmaster/secmaster_coverage.cov" -coverpkg="./huaweicloud/services/secmaster" -run TestAccResourceNodeExpansion_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceNodeExpansion_basic
=== PAUSE TestAccResourceNodeExpansion_basic
=== CONT  TestAccResourceNodeExpansion_basic
--- PASS: TestAccResourceNodeExpansion_basic (27.22s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/secmaster
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 27.334s coverage: 4.7% of statements in ./huaweicloud/services/secmaster
```
<img width="1409" height="79" alt="image" src="https://github.com/user-attachments/assets/c23fe135-cec4-4570-a224-56dff0a7e981" />


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
