### PR TITLE
feat(dataarts): add new data source to query data source permissions

### DIFF
--- a/docs/data-sources/dataarts_security_datasource_permissions.md
+++ b/docs/data-sources/dataarts_security_datasource_permissions.md
@@ -1,0 +1,48 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_datasource_permissions"
+description: |-
+  Use this data source to get the list of DataArts Security datasource configurable permissions within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_datasource_permissions
+
+Use this data source to get the list of DataArts Security datasource configurable permissions within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_security_datasource_permissions" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the datasource permissions are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the datasource permissions belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `datasource_permissions` - The list of datasource configurable permissions.  
+  The [datasource_permissions](#dataarts_security_datasource_permissions_attr) structure is documented below.
+
+<a name="dataarts_security_datasource_permissions_attr"></a>
+The `datasource_permissions` block supports:
+
+* `datasource_type` - The datasource type.
+
+* `permission_types` - The list of datasource operation permission types.
+
+* `permission_actions` - The list of supported datasource permission actions.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1138,6 +1138,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_factory_resources": dataarts.DataSourceFactoryResources(),
 			"huaweicloud_dataarts_factory_scripts":   dataarts.DataSourceFactoryScripts(),
 			// DataArts Security
+			"huaweicloud_dataarts_security_datasource_permissions":       dataarts.DataSourceSecurityDatasourcePermissions(),
 			"huaweicloud_dataarts_security_data_categories":              dataarts.DataSourceSecurityDataCategories(),
 			"huaweicloud_dataarts_security_data_recognition_rules":       dataarts.DataSourceSecurityDataRecognitionRules(),
 			"huaweicloud_dataarts_security_data_recognition_rule_groups": dataarts.DataSourceSecurityDataRecognitionRuleGroups(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_datasource_permissions_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_security_datasource_permissions_test.go
@@ -1,0 +1,50 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSecurityDatasourcePermissions_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dataarts_security_datasource_permissions.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSecurityDatasourcePermissions_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(all, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttrSet(all, "region"),
+					resource.TestMatchResourceAttr(all, "datasource_permissions.#", regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestCheckResourceAttrSet(all, "datasource_permissions.0.datasource_type"),
+					resource.TestMatchResourceAttr(all, "datasource_permissions.0.permission_types.#",
+						regexp.MustCompile(`[1-9]([0-9]*)?`)),
+					resource.TestMatchResourceAttr(all, "datasource_permissions.0.permission_actions.#",
+						regexp.MustCompile(`[1-9]([0-9]*)?`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSecurityDatasourcePermissions_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_security_datasource_permissions" "test" {
+  workspace_id = "%s"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_datasource_permissions.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_security_datasource_permissions.go
@@ -1,0 +1,143 @@
+package dataarts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/security/permission-sets/datasource/configurations
+func DataSourceSecurityDatasourcePermissions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSecurityDatasourcePermissionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the datasource permissions are located.`,
+			},
+
+			// Required parameters.
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the datasource permissions belong.`,
+			},
+
+			// Attributes.
+			"datasource_permissions": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of datasource configurable permissions.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"datasource_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The datasource type.`,
+						},
+						"permission_types": {
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Computed:    true,
+							Description: `The list of datasource operation permission types.`,
+						},
+						"permission_actions": {
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Computed:    true,
+							Description: `The list of supported datasource permission actions.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listSecurityDatasourceConfigurations(client *golangsdk.ServiceClient, workspaceId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/security/permission-sets/datasource/configurations"
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildSecurityMoreHeaders(workspaceId),
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("configurations", respBody, make([]interface{}, 0)).([]interface{}), nil
+}
+
+func flattenSecurityDatasourcePermissions(configurations []interface{}) []map[string]interface{} {
+	if len(configurations) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(configurations))
+	for _, configuration := range configurations {
+		result = append(result, map[string]interface{}{
+			"datasource_type": utils.PathSearch("datasource_type", configuration, nil),
+			"permission_types": utils.PathSearch("permission_types", configuration,
+				make([]interface{}, 0)),
+			"permission_actions": utils.PathSearch("permission_actions", configuration,
+				make([]interface{}, 0)),
+		})
+	}
+
+	return result
+}
+
+func dataSourceSecurityDatasourcePermissionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	configurations, err := listSecurityDatasourceConfigurations(client, workspaceId)
+	if err != nil {
+		return diag.Errorf("error querying DataArts Security datasource permissions: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("datasource_permissions", flattenSecurityDatasourcePermissions(configurations)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports new data source that used to query data source permissions for DataArts Studio security.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The coverage of the basic's acceptance test:
<img width="1121" height="83" alt="image" src="https://github.com/user-attachments/assets/279e5eab-c4d7-4ed9-abd6-01b0c100f41b" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query data source permissions
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o dataarts -f TestAccDataSecurityDatasourcePermissions_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataSecurityDatasourcePermissions_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSecurityDatasourcePermissions_basic
=== PAUSE TestAccDataSecurityDatasourcePermissions_basic
=== CONT  TestAccDataSecurityDatasourcePermissions_basic
--- PASS: TestAccDataSecurityDatasourcePermissions_basic (13.29s)
PASS
coverage: 3.7% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  13.403s coverage: 3.7% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
