### PR TITLE
feat(GeminiDB): add new data source to get the list of instance hot keys

### DIFF
--- a/docs/data-sources/geminidb_hot_keys.md
+++ b/docs/data-sources/geminidb_hot_keys.md
@@ -1,0 +1,61 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_hot_keys"
+description: |-
+  Use this data source to get the list of GeminiDB Redis instance hot keys.
+---
+
+# huaweicloud_geminidb_hot_keys
+
+Use this data source to get the list of GeminiDB Redis instance hot keys.
+
+-> This data source only supports GeminiDB Redis instances.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_geminidb_hot_keys" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `keys` - The list of GeminiDB Redis instance hot keys.
+  The [keys](#keys_struct) structure is documented below.
+
+<a name="keys_struct"></a>
+The `keys` block supports:
+
+* `name` - The name of the hot key.
+
+* `type` - The type of the hot key.
+  + **string**
+  + **hash**
+  + **list**
+  + **zset**
+  + **set**
+  + **exhash**
+  + **stream**
+
+* `command` - The command of the hot key.
+
+* `qps` - The QPS of the hot key.
+
+* `db_id` - The DB ID to which the hot key belongs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1519,6 +1519,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_database_versions":             geminidb.DataSourceDatabaseVersions(),
 			"huaweicloud_geminidb_dedicated_resources":           geminidb.DataSourceDedicatedResources(),
 			"huaweicloud_geminidb_flavors":                       geminidb.DataSourceGeminiDBFlavors(),
+			"huaweicloud_geminidb_hot_keys":                      geminidb.DataSourceHotKeys(),
 			"huaweicloud_geminidb_instance_parameters_histories": geminidb.DataSourceGeminiDBInstanceParametersHistories(),
 			"huaweicloud_geminidb_instance_sessions":             geminidb.DataSourceInstanceSessions(),
 			"huaweicloud_geminidb_memory_mappings":               geminidb.DataSourceMemoryMappings(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_hot_keys_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_hot_keys_test.go
@@ -1,0 +1,44 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceHotKeys_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_geminidb_hot_keys.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			// Because there is no available data for testing, the test case is only
+			// used to verify that the API can be invoked.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccCheckGeminidbInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceHotKeys_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "keys.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceHotKeys_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_geminidb_hot_keys" "test" {
+  instance_id = "%[1]s"
+}
+`, acceptance.HW_GEMINIDB_INSATNCE_ID)
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_hot_keys.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_hot_keys.go
@@ -1,0 +1,159 @@
+package geminidb
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/hot-keys
+func DataSourceHotKeys() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceHotKeysRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"keys": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"command": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"qps": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"db_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func listHotKeys(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/hot-keys?limit={limit}"
+		instanceId = d.Get("instance_id").(string)
+		limit      = 50
+		offset     = 0
+		result     = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{limit}", strconv.Itoa(limit))
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		currentPath := fmt.Sprintf("%s&offset=%v", listPath, offset)
+		listResp, err := client.Request("GET", currentPath, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody := utils.PathSearch("rules", resp, make([]interface{}, 0)).([]interface{})
+		result = append(result, respBody...)
+		if len(respBody) < limit {
+			break
+		}
+
+		offset += len(respBody)
+	}
+
+	return result, nil
+}
+
+func dataSourceHotKeysRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	resp, err := listHotKeys(client, d)
+	if err != nil {
+		return diag.Errorf("error retrieving GeminiDB Redis instance hot keys: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(generateUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("keys", flattenHotKeys(resp)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenHotKeys(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"name":    utils.PathSearch("name", v, nil),
+			"type":    utils.PathSearch("type", v, nil),
+			"command": utils.PathSearch("command", v, nil),
+			"qps":     utils.PathSearch("qps", v, nil),
+			"db_id":   utils.PathSearch("db_id", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get the list of instance hot keys.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to get the list of the instance hot keys.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccDataSourceHotKeys_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccDataSourceHotKeys_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceHotKeys_basic
=== PAUSE TestAccDataSourceHotKeys_basic
=== CONT  TestAccDataSourceHotKeys_basic
--- PASS: TestAccDataSourceHotKeys_basic (28.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  28.285s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/9c3a5c99-2b35-417e-a1ed-d517d7a577f5" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
