### PR TITLE
feat(dataarts): add new datasource for query the list of alarm records

### DIFF
--- a/docs/data-sources/dataarts_factory_alarm_records.md
+++ b/docs/data-sources/dataarts_factory_alarm_records.md
@@ -1,0 +1,87 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_factory_alarm_records"
+description: |-
+  Use this data source to query the alarm notification records within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_factory_alarm_records
+
+Use this data source to query the alarm notification records within HuaweiCloud.
+
+## Example Usage
+
+### Query all alarm records without any filter
+
+```hcl
+data "huaweicloud_dataarts_factory_alarm_records" "test" {}
+```
+
+### Query alarm records by workspace and time range
+
+```hcl
+variable "workspace_id" {}
+variable "start_time" {}
+variable "end_time" {}
+
+data "huaweicloud_dataarts_factory_alarm_records" "test" {
+  workspace  = var.workspace_id
+  start_time = var.start_time
+  end_time   = var.end_time
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the alarm records are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace` - (Optional, String) Specifies the workspace ID.
+
+* `start_time` - (Optional, String) Specifies the start time of the alarm records, in RFC3339 format.  
+  If omitted, it defaults to one hour before the current time.
+
+* `end_time` - (Optional, String) Specifies the end time of the alarm records, in RFC3339 format.  
+  If omitted, it defaults to the current time. Only records within the last week can be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `records` - The list of alarm records.  
+  The [records](#dataarts_factory_records_object) structure is documented below.
+
+<a name="dataarts_factory_records_object"></a>
+The `records` block supports:
+
+* `alarm_time` - The alarm notification time, in RFC3339 format.
+
+* `job_name` - The name of the job.
+
+* `schedule_type` - The job instance scheduling mode.
+  + **0**: Normal scheduling
+  + **2**: Manual scheduling
+  + **5**: Data supplement
+  + **6**: Sub-job scheduling
+  + **7**: One-time scheduling
+
+* `send_msg` - The send message.
+
+* `plan_time` - The plan time, in RFC3339 format.
+
+* `remind_type` - The alarm notification type.
+  + **0**: Run successfully
+  + **1**: Run abnormally/failed
+  + **12**: Not completed
+  + **13**: Run cancelled
+
+* `send_status` - The send status.
+  + **0**: Send successfully
+  + **1**: Send failed
+
+* `job_id` - The ID of the job.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1134,9 +1134,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_quality_rule_templates":    dataarts.DataSourceQualityRuleTemplates(),
 			"huaweicloud_dataarts_quality_tasks":             dataarts.DataSourceQualityTasks(),
 			// DataArts Factory
-			"huaweicloud_dataarts_factory_jobs":      dataarts.DataSourceFactoryJobs(),
-			"huaweicloud_dataarts_factory_resources": dataarts.DataSourceFactoryResources(),
-			"huaweicloud_dataarts_factory_scripts":   dataarts.DataSourceFactoryScripts(),
+			"huaweicloud_dataarts_factory_alarm_records": dataarts.DataSourceFactoryAlarmRecords(),
+			"huaweicloud_dataarts_factory_jobs":          dataarts.DataSourceFactoryJobs(),
+			"huaweicloud_dataarts_factory_resources":     dataarts.DataSourceFactoryResources(),
+			"huaweicloud_dataarts_factory_scripts":       dataarts.DataSourceFactoryScripts(),
 			// DataArts Security
 			"huaweicloud_dataarts_security_data_categories":              dataarts.DataSourceSecurityDataCategories(),
 			"huaweicloud_dataarts_security_data_recognition_rules":       dataarts.DataSourceSecurityDataRecognitionRules(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_factory_alarm_records_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_factory_alarm_records_test.go
@@ -1,0 +1,111 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// This test requires alarm records to be created manually before running.
+// Please ensure that alarm records exist in the specified time range.
+func TestAccDataFactoryAlarmRecords_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_dataarts_factory_alarm_records.test"
+		now            = time.Now()
+		startTime      = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).Format(time.RFC3339)
+		endTime        = time.Date(now.Year(), now.Month(), now.Day(), 24, 0, 0, 0, now.Location()).Format(time.RFC3339)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataFactoryAlarmRecords_basic_step1(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "records.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "region"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.alarm_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.job_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.schedule_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.send_msg"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.plan_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.remind_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.send_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "records.0.job_id"),
+				),
+			},
+			{
+				Config: testAccDataFactoryAlarmRecords_basic_step2(startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "records.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					checkAlarmTimeInRange(dataSourceName, startTime, endTime),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataFactoryAlarmRecords_basic_step1() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_factory_alarm_records" "test" {
+  workspace = "%[1]s"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func testAccDataFactoryAlarmRecords_basic_step2(startTime, endTime string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_factory_alarm_records" "test" {
+  workspace  = "%[1]s"
+  start_time = "%[2]s"
+  end_time   = "%[3]s"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, startTime, endTime)
+}
+
+func checkAlarmTimeInRange(dataSourceName, startTime, endTime string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("can not find the data source: %s", dataSourceName)
+		}
+
+		start, err := time.Parse(time.RFC3339, startTime)
+		if err != nil {
+			return fmt.Errorf("error parsing start_time %s: %s", startTime, err)
+		}
+
+		end, err := time.Parse(time.RFC3339, endTime)
+		if err != nil {
+			return fmt.Errorf("error parsing end_time %s: %s", endTime, err)
+		}
+
+		records := rs.Primary.Attributes["records.#"]
+		if records == "0" {
+			return nil
+		}
+
+		// Check the first record's alarm_time
+		alarmTimeStr := rs.Primary.Attributes["records.0.alarm_time"]
+		alarmTime, err := time.Parse(time.RFC3339, alarmTimeStr)
+		if err != nil {
+			return fmt.Errorf("error parsing alarm_time %s: %s", alarmTimeStr, err)
+		}
+
+		if alarmTime.Before(start) || alarmTime.After(end) {
+			return fmt.Errorf("alarm_time %s is not in the range [%s, %s]", alarmTimeStr, startTime, endTime)
+		}
+
+		return nil
+	}
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_factory_alarm_records.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_factory_alarm_records.go
@@ -1,0 +1,218 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v2/{project_id}/factory/alarm-info
+func DataSourceFactoryAlarmRecords() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceFactoryAlarmRecordsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the alarm records are located.`,
+			},
+
+			// Optional parameters.
+			"workspace": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The workspace ID.`,
+			},
+			"start_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The start time of the alarm records, in RFC3339 format.`,
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The end time of the alarm records, in RFC3339 format.`,
+			},
+
+			// Attributes.
+			"records": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of alarm records.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alarm_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The alarm notification time, in RFC3339 format.`,
+						},
+						"job_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the job.`,
+						},
+						"schedule_type": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The job instance scheduling mode.`,
+						},
+						"send_msg": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The send message.`,
+						},
+						"plan_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The plan time, in RFC3339 format.`,
+						},
+						"remind_type": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The alarm notification type.`,
+						},
+						"send_status": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The send status.`,
+						},
+						"job_id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The ID of the job.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildAlarmRecordsQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if startTime, ok := d.GetOk("start_time"); ok {
+		// Convert RFC3339 time string to 13-bit timestamp (milliseconds)
+		timestamp := utils.ConvertTimeStrToNanoTimestamp(startTime.(string))
+		res = fmt.Sprintf("%s&start_time=%d", res, timestamp)
+	}
+	if endTime, ok := d.GetOk("end_time"); ok {
+		// Convert RFC3339 time string to 13-bit timestamp (milliseconds)
+		timestamp := utils.ConvertTimeStrToNanoTimestamp(endTime.(string))
+		res = fmt.Sprintf("%s&end_time=%d", res, timestamp)
+	}
+
+	if res != "" {
+		res = "&" + res[1:]
+	}
+	return res
+}
+
+func listAlarmRecords(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/factory/alarm-info?limit={limit}"
+		limit   = 100
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPathWithLimit := client.Endpoint + httpUrl
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{project_id}", client.ProjectID)
+	listPathWithLimit = strings.ReplaceAll(listPathWithLimit, "{limit}", strconv.Itoa(limit))
+	listPathWithLimit += buildAlarmRecordsQueryParams(d)
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildArchitectureMoreHeaders(d.Get("workspace").(string)),
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPathWithLimit, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &listOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		records := utils.PathSearch("alarm_info", respBody, make([]interface{}, 0)).([]interface{})
+		if len(records) < 1 {
+			break
+		}
+		result = append(result, records...)
+
+		if len(records) < limit {
+			break
+		}
+		offset += len(records)
+	}
+
+	return result, nil
+}
+
+func flattenAlarmRecords(records []interface{}) []interface{} {
+	if len(records) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(records))
+	for _, record := range records {
+		result = append(result, map[string]interface{}{
+			"alarm_time":    utils.FormatTimeStampRFC3339(int64(utils.PathSearch("alarm_time", record, float64(0)).(float64))/1000, false),
+			"job_name":      utils.PathSearch("job_name", record, nil),
+			"schedule_type": utils.PathSearch("schedule_type", record, nil),
+			"send_msg":      utils.PathSearch("send_msg", record, nil),
+			"plan_time":     utils.FormatTimeStampRFC3339(int64(utils.PathSearch("plan_time", record, float64(0)).(float64))/1000, false),
+			"remind_type":   utils.PathSearch("remind_type", record, nil),
+			"send_status":   utils.PathSearch("send_status", record, nil),
+			"job_id":        utils.PathSearch("job_id", record, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceFactoryAlarmRecordsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	records, err := listAlarmRecords(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("records", flattenAlarmRecords(records)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new datasource for query the list of alarm records.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.go`
```

## PR Checklist

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataFactoryAlarmRecords_basic -timeout 360m -parallel 10
=== RUN   TestAccDataFactoryAlarmRecords_basic
=== PAUSE TestAccDataFactoryAlarmRecords_basic
=== CONT  TestAccDataFactoryAlarmRecords_basic
--- PASS: TestAccDataFactoryAlarmRecords_basic (28.33s)
PASS
coverage: 3.9% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  28.486s coverage: 3.9% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.