### PR TITLE
feat(servicestage): environment resource supports resource name param

### DIFF
--- a/docs/resources/servicestage_environment.md
+++ b/docs/resources/servicestage_environment.md
@@ -2,12 +2,15 @@
 subcategory: "ServiceStage"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_servicestage_environment"
-description: ""
+description: |-
+  Manages an environment resource within HuaweiCloud ServiceStage.
 ---
 
 # huaweicloud_servicestage_environment
 
 Manages an environment resource within HuaweiCloud ServiceStage.
+
+-> It's a recommended to use the resource `huaweicloud_servicestagev3_environment`.
 
 ## Example Usage
 
@@ -76,6 +79,8 @@ The `basic_resources` and `optional_resources` block supports:
 
 * `id` - (Required, String) Specifies the resource ID. For most resources, this parameter needs to fill in their **id**,
   but for CCI namespace, this parameter needs to fill in **name**.
+
+* `name` - (Optional, String) Specifies the resource name.
 
 -> All resources must under the same VPC as the environment.
 

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_environment_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_environment_test.go
@@ -23,15 +23,15 @@ func getEnvResourceFunc(conf *config.Config, state *terraform.ResourceState) (in
 
 func TestAccEnvironment_basic(t *testing.T) {
 	var (
-		env          environments.Environment
-		randName     = acceptance.RandomAccResourceNameWithDash()
-		resourceName = "huaweicloud_servicestage_environment.test"
-	)
+		env environments.Environment
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&env,
-		getEnvResourceFunc,
+		resourceName = "huaweicloud_servicestage_environment.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &env, getEnvResourceFunc)
+
+		name       = acceptance.RandomAccResourceNameWithDash()
+		updateName = acceptance.RandomAccResourceNameWithDash()
+
+		baseConfig = testAccEnvironment_base(name)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -40,10 +40,10 @@ func TestAccEnvironment_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEnvironment_basic(randName),
+				Config: testAccEnvironment_basic_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform test"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "basic_resources.#", "4"),
@@ -52,10 +52,10 @@ func TestAccEnvironment_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEnvironment_update(randName),
+				Config: testAccEnvironment_basic_step2(baseConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated by terraform test"),
 					resource.TestCheckResourceAttr(resourceName, "basic_resources.#", "8"),
 					resource.TestCheckResourceAttr(resourceName, "optional_resources.#", "8"),
@@ -63,7 +63,7 @@ func TestAccEnvironment_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEnvironment_basic(randName),
+				Config: testAccEnvironment_basic_step3(baseConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "basic_resources.#", "4"),
@@ -75,75 +75,19 @@ func TestAccEnvironment_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"basic_resources",
+					"optional_resources",
+					"basic_resources_origin",
+					"optional_resources_origin",
+				},
 			},
 		},
 	})
 }
 
-func TestAccEnvironment_withEpsId(t *testing.T) {
-	var (
-		env          environments.Environment
-		randName     = acceptance.RandomAccResourceNameWithDash()
-		resourceName = "huaweicloud_servicestage_environment.test"
-	)
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&env,
-		getEnvResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccEnvironment_withEpsId(randName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", randName),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func testAccEnvironment_base(rName string) string {
+func testAccEnvironment_base(name string) string {
 	return fmt.Sprintf(`
-variable "subnet_config" {
-  type = list(object({
-    cidr       = string
-    gateway_ip = string
-  }))
-
-  default = [
-    {cidr = "192.168.192.0/18", gateway_ip = "192.168.192.1"},
-    {cidr = "192.168.128.0/18", gateway_ip = "192.168.128.1"},
-  ]
-}
-
-variable "rds_config" {
-  type = list(object({
-    fixed_ip = string
-    port     = string
-  }))
-
-  default = [
-    {fixed_ip = "192.168.0.58", port = "8636"},
-    {fixed_ip = "192.168.0.160", port = "8637"},
-  ]
-}
-
 variable "dcs_config" {
   type = list(object({
     port = number
@@ -153,6 +97,11 @@ variable "dcs_config" {
     {port = 6388},
     {port = 6389},
   ]
+}
+
+variable "enterprise_project_id" {
+  type    = string
+  default = "%[1]s"
 }
 
 data "huaweicloud_availability_zones" "test" {}
@@ -170,48 +119,36 @@ data "huaweicloud_images_image" "test" {
 }
 
 resource "huaweicloud_kps_keypair" "test" {
-  name = "%[1]s"
+  name = "%[2]s"
 }
 
 resource "huaweicloud_vpc" "test" {
-  name = "%[1]s"
-  cidr = "192.168.0.0/16"
+  name                  = "%[2]s"
+  cidr                  = "192.168.0.0/16"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
 
 resource "huaweicloud_vpc_subnet" "test" {
-  name        = "%[1]s"
-  cidr        = "192.168.0.0/24"
-  gateway_ip  = "192.168.0.1"
+  name        = "%[2]s"
+  cidr        = cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0)
+  gateway_ip  = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 8, 0), 1)
   vpc_id      = huaweicloud_vpc.test.id
   ipv6_enable = true
 }
 
 resource "huaweicloud_networking_secgroup" "test" {
-  name = "%[1]s"
+  name                 = "%[2]s"
+  delete_default_rules = true
 }
 
-%s
+%[3]s
 
-%s`, rName, testAccEnvironment_baseRes(rName), testAccEnvironment_optioanlRes(rName))
+%[4]s
+`, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name, testAccEnvironment_baseRes(name), testAccEnvironment_optioanlRes(name))
 }
 
-func testAccEnvironment_baseRes(rName string) string {
+func testAccEnvironment_baseRes(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_vpc_eip" "cce_bind" {
-  count = 2
-
-  publicip {
-    type = "5_bgp"
-  }
-
-  bandwidth {
-    share_type  = "PER"
-    size        = 5
-    name        = "%[1]s_${count.index}"
-    charge_mode = "traffic"
-  }
-}
-
 resource "huaweicloud_cce_cluster" "test" {
   count = 2
 
@@ -223,7 +160,7 @@ resource "huaweicloud_cce_cluster" "test" {
   container_network_type = "vpc-router"
   cluster_version        = "v1.19"
   cluster_type           = "VirtualMachine"
-  eip                    = huaweicloud_vpc_eip.cce_bind[count.index].address
+  enterprise_project_id  = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   kube_proxy_mode = "iptables"
 
@@ -265,9 +202,10 @@ resource "huaweicloud_cce_node" "test" {
 resource "huaweicloud_cci_namespace" "test" {
   count = 2
 
-  name                = "%[1]s-${count.index}"
-  type                = "gpu-accelerated"
-  auto_expend_enabled = true
+  name                  = "%[1]s-${count.index}"
+  type                  = "gpu-accelerated"
+  auto_expend_enabled   = true
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 }
 
 resource "huaweicloud_vpc_subnet" "cci_bind" {
@@ -275,8 +213,8 @@ resource "huaweicloud_vpc_subnet" "cci_bind" {
 
   name       = "%[1]s-${count.index}"
   vpc_id     = huaweicloud_vpc.test.id
-  cidr       = var.subnet_config[count.index].cidr
-  gateway_ip = var.subnet_config[count.index].gateway_ip
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 8, count.index + 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 8, count.index + 1), 1)
 }
 
 resource "huaweicloud_cci_network" "test" {
@@ -292,12 +230,13 @@ resource "huaweicloud_cci_network" "test" {
 resource "huaweicloud_compute_instance" "test" {
   count = 2
 
-  name               = "%[1]s-${count.index}"
-  image_id           = data.huaweicloud_images_image.test.id
-  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
-  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
-  key_pair           = huaweicloud_kps_keypair.test.name
-  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  name                  = "%[1]s-${count.index}"
+  image_id              = data.huaweicloud_images_image.test.id
+  flavor_id             = data.huaweicloud_compute_flavors.test.ids[0]
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  key_pair              = huaweicloud_kps_keypair.test.name
+  security_group_ids    = [huaweicloud_networking_secgroup.test.id]
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   network {
     uuid = huaweicloud_vpc_subnet.test.id
@@ -326,6 +265,7 @@ resource "huaweicloud_as_group" "test" {
   scaling_group_name       = "%[1]s"
   scaling_configuration_id = huaweicloud_as_configuration.test.id
   vpc_id                   = huaweicloud_vpc.test.id
+  enterprise_project_id    = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   max_instance_number    = 3
   min_instance_number    = 0
@@ -344,10 +284,10 @@ resource "huaweicloud_as_group" "test" {
     id = huaweicloud_networking_secgroup.test.id
   }
 }
-`, rName)
+`, name)
 }
 
-func testAccEnvironment_optioanlRes(rName string) string {
+func testAccEnvironment_optioanlRes(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_network_acl" "test" {
   name = "%[1]s"
@@ -383,15 +323,23 @@ resource "huaweicloud_networking_secgroup_rule" "in_v4_elb_member" {
 resource "huaweicloud_elb_loadbalancer" "test" {
   count = 2
 
-  name            = "%[1]s_${count.index}"
-  description     = "Created by terraform."
-  vpc_id          = huaweicloud_vpc.test.id
-  ipv4_subnet_id  = huaweicloud_vpc_subnet.test.ipv4_subnet_id
-  ipv6_network_id = huaweicloud_vpc_subnet.test.id
+  name                  = "%[1]s_${count.index}"
+  description           = "Created by terraform."
+  vpc_id                = huaweicloud_vpc.test.id
+  ipv4_subnet_id        = huaweicloud_vpc_subnet.test.ipv4_subnet_id
+  ipv6_network_id       = huaweicloud_vpc_subnet.test.id
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0]
   ]
+
+  lifecycle {
+    ignore_changes = [
+      l4_flavor_id,
+      l7_flavor_id,
+    ]
+  }
 }
 
 resource "huaweicloud_elb_listener" "test" {
@@ -444,6 +392,8 @@ resource "huaweicloud_elb_member" "test" {
 resource "huaweicloud_vpc_eip" "test" {
   count = 2
 
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
   publicip {
     type = "5_bgp"
   }
@@ -459,20 +409,18 @@ resource "huaweicloud_vpc_eip" "test" {
 resource "huaweicloud_rds_instance" "test" {
   count = 2
 
-  name              = "%[1]s_${count.index}"
-  flavor            = "rds.pg.n1.large.2"
-  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  subnet_id         =  huaweicloud_vpc_subnet.test.id
-  vpc_id            = huaweicloud_vpc.test.id
-  time_zone         = "UTC+08:00"
-  fixed_ip          = var.rds_config[count.index].fixed_ip
+  name                  = "%[1]s_${count.index}"
+  flavor                = "rds.pg.n1.large.2"
+  availability_zone     = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  subnet_id             =  huaweicloud_vpc_subnet.test.id
+  vpc_id                = huaweicloud_vpc.test.id
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   db {
-    password = "Huawei##123"
-    type     = "PostgreSQL"
-    version  = "12"
-    port     = var.rds_config[count.index].port
+    type    = "PostgreSQL"
+    version = "16"
+    port    = 8634
   }
 
   volume {
@@ -484,18 +432,19 @@ resource "huaweicloud_rds_instance" "test" {
 resource "huaweicloud_dcs_instance" "test" {
   count = 2
 
-  name               = "%[1]s_${count.index}"
-  engine_version     = "5.0"
-  password           = "Huawei##123"
-  engine             = "Redis"
-  port               = var.dcs_config[count.index].port
-  capacity           = 0.125
-  vpc_id             = huaweicloud_vpc.test.id
-  subnet_id          = huaweicloud_vpc_subnet.test.id
-  availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
-  flavor             = "redis.ha.xu1.tiny.r2.128"
-  maintain_begin     = "22:00:00"
-  maintain_end       = "02:00:00"
+  name                  = "%[1]s_${count.index}"
+  engine_version        = "5.0"
+  password              = "Huawei##123"
+  engine                = "Redis"
+  port                  = var.dcs_config[count.index].port
+  capacity              = 0.125
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  availability_zones    = [data.huaweicloud_availability_zones.test.names[0]]
+  flavor                = "redis.ha.xu1.tiny.r2.128"
+  maintain_begin        = "22:00:00"
+  maintain_end          = "02:00:00"
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   backup_policy {
     backup_type = "auto"
@@ -505,38 +454,44 @@ resource "huaweicloud_dcs_instance" "test" {
     save_days   = 1
   }
 }
-`, rName)
+`, name)
 }
 
-func testAccEnvironment_basic(rName string) string {
+func testAccEnvironment_basic_step1(baseConfig, name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_servicestage_environment" "test" {
-  name        = "%s"
-  description = "Created by terraform test"
-  vpc_id      = huaweicloud_vpc.test.id
+  name                  = "%[2]s"
+  description           = "Created by terraform test"
+  vpc_id                = huaweicloud_vpc.test.id
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   basic_resources {
     type = "cce"
     id   = huaweicloud_cce_cluster.test[0].id
+    name = huaweicloud_cce_cluster.test[0].name
   }
   basic_resources {
     type = "cci"
-    id   = huaweicloud_cci_namespace.test[0].name
+    id   = huaweicloud_cci_namespace.test[0].id
+    name = huaweicloud_cci_namespace.test[0].name
   }
   basic_resources {
     type = "ecs"
     id   = huaweicloud_compute_instance.test[0].id
+    name = huaweicloud_compute_instance.test[0].name
   }
   basic_resources {
     type = "as"
     id   = huaweicloud_as_group.test[0].id
+    name = huaweicloud_as_group.test[0].scaling_group_name
   }
 
   optional_resources {
     type = "elb"
     id   = huaweicloud_elb_loadbalancer.test[0].id
+    name = huaweicloud_elb_loadbalancer.test[0].name
   }
   optional_resources {
     type = "eip"
@@ -545,101 +500,95 @@ resource "huaweicloud_servicestage_environment" "test" {
   optional_resources {
     type = "rds"
     id   = huaweicloud_rds_instance.test[0].id
+    name = huaweicloud_rds_instance.test[0].name
   }
   optional_resources {
     type = "dcs"
     id   = huaweicloud_dcs_instance.test[0].id
+    name = huaweicloud_dcs_instance.test[0].name
   }
 }
-`, testAccEnvironment_base(rName), rName)
+`, baseConfig, name)
 }
 
-func testAccEnvironment_update(rName string) string {
+func testAccEnvironment_basic_step2(baseConfig, name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_servicestage_environment" "test" {
-  name        = "%s-update"
-  description = "Updated by terraform test"
-  vpc_id      = huaweicloud_vpc.test.id
+  name                  = "%[2]s"
+  description           = "Updated by terraform test"
+  vpc_id                = huaweicloud_vpc.test.id
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
 
   dynamic "basic_resources" {
-    for_each = huaweicloud_cce_cluster.test[*].id
+    for_each = huaweicloud_cce_cluster.test
     content {
       type = "cce"
-      id   = basic_resources.value
+      id   = basic_resources.value.id
+      name = basic_resources.value.name
     }
   }
   dynamic "basic_resources" {
-    for_each = huaweicloud_cci_namespace.test[*].name
+    for_each = huaweicloud_cci_namespace.test
     content {
       type = "cci"
-      id   = basic_resources.value
+      id   = basic_resources.value.id
+      name = basic_resources.value.name
     }
   }
   dynamic "basic_resources" {
-    for_each = huaweicloud_compute_instance.test[*].id
+    for_each = huaweicloud_compute_instance.test
     content {
       type = "ecs"
-      id   = basic_resources.value
+      id   = basic_resources.value.id
+      name = basic_resources.value.name
     }
   }
   dynamic "basic_resources" {
-    for_each = huaweicloud_as_group.test[*].id
+    for_each = huaweicloud_as_group.test
     content {
       type = "as"
-      id   = basic_resources.value
+      id   = basic_resources.value.id
+      name = basic_resources.value.scaling_group_name
     }
   }
 
   dynamic "optional_resources" {
-    for_each = huaweicloud_elb_loadbalancer.test[*].id
+    for_each = huaweicloud_elb_loadbalancer.test
     content {
       type = "elb"
-      id   = optional_resources.value
+      id   = optional_resources.value.id
+      name = optional_resources.value.name
     }
   }
   dynamic "optional_resources" {
-    for_each = huaweicloud_vpc_eip.test[*].id
+    for_each = huaweicloud_vpc_eip.test
     content {
       type = "eip"
-      id   = optional_resources.value
+      id   = optional_resources.value.id
     }
   }
   dynamic "optional_resources" {
-    for_each = huaweicloud_rds_instance.test[*].id
+    for_each = huaweicloud_rds_instance.test
     content {
       type = "rds"
-      id   = optional_resources.value
+      id   = optional_resources.value.id
+      name = optional_resources.value.name
     }
   }
   dynamic "optional_resources" {
-    for_each = huaweicloud_dcs_instance.test[*].id
+    for_each = huaweicloud_dcs_instance.test
     content {
       type = "dcs"
-      id   = optional_resources.value
+      id   = optional_resources.value.id
+      name = optional_resources.value.name
     }
   }
 }
-`, testAccEnvironment_base(rName), rName)
+`, baseConfig, name)
 }
 
-func testAccEnvironment_withEpsId(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_servicestage_environment" "test" {
-  name                  = "%s"
-  vpc_id                = huaweicloud_vpc.test.id
-  enterprise_project_id = "%s"
-
-  dynamic "basic_resources" {
-    for_each = huaweicloud_cce_cluster.test[*].id
-    content {
-      type = "cce"
-      id   = basic_resources.value
-    }
-  }
-}
-`, testAccEnvironment_base(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+func testAccEnvironment_basic_step3(baseConfig, name string) string {
+	return testAccEnvironment_basic_step1(baseConfig, name)
 }

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_environment.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestage_environment.go
@@ -7,13 +7,18 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/servicestage/v2/environments"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+var environmentObjSliceParamKeys = []string{
+	"basic_resources",
+	"optional_resources",
+}
 
 // @API ServiceStage POST /v2/{project_id}/cas/environments
 // @API ServiceStage GET /v2/{project_id}/cas/environments/{environment_id}
@@ -64,59 +69,126 @@ func ResourceEnvironment() *schema.Resource {
 				ForceNew: true,
 			},
 			"basic_resources": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"cce", "cci", "ecs", "as",
-							}, false),
-						},
 						"id": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 					},
 				},
+				DiffSuppressFunc: utils.SuppressObjectSliceDiffs(),
 			},
 			"optional_resources": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"elb", "eip", "rds", "dcs", "cse",
-							}, false),
-						},
 						"id": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 					},
 				},
+				DiffSuppressFunc: utils.SuppressObjectSliceDiffs(),
+			},
+
+			// Internal attributes.
+			"basic_resources_origin": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: utils.SuppressDiffAll,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Description: utils.SchemaDesc(
+					`The script configuration value of this change is also the original value used for comparison with
+ the new value next time the change is made. The corresponding parameter name is 'basic_resources'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+			"optional_resources_origin": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: utils.SuppressDiffAll,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Description: utils.SchemaDesc(
+					`The script configuration value of this change is also the original value used for comparison with
+ the new value next time the change is made. The corresponding parameter name is 'optional_resources'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
 			},
 		},
 	}
 }
 
-func buildResourcesList(resources *schema.Set) []environments.Resource {
-	if resources.Len() < 1 {
+func buildResourcesList(resources []interface{}) []environments.Resource {
+	if len(resources) < 1 {
 		return nil
 	}
 
-	result := make([]environments.Resource, resources.Len())
-	for i, v := range resources.List() {
+	result := make([]environments.Resource, 0, len(resources))
+	for _, v := range resources {
 		res := v.(map[string]interface{})
-		result[i] = environments.Resource{
+		result = append(result, environments.Resource{
 			Type: res["type"].(string),
 			ID:   res["id"].(string),
-		}
+			Name: utils.PathSearch("name", res, "").(string),
+		})
 	}
 
 	return result
@@ -129,10 +201,53 @@ func buildEnvironmentCreateOpts(d *schema.ResourceData, cfg *config.Config) envi
 		Description:         &desc,
 		VpcId:               d.Get("vpc_id").(string),
 		DeployMode:          d.Get("deploy_mode").(string),
-		BaseResources:       buildResourcesList(d.Get("basic_resources").(*schema.Set)),
-		OptionalResources:   buildResourcesList(d.Get("optional_resources").(*schema.Set)),
+		BaseResources:       buildResourcesList(d.Get("basic_resources").([]interface{})),
+		OptionalResources:   buildResourcesList(d.Get("optional_resources").([]interface{})),
 		EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
 	}
+}
+
+func orderEnvironmentResourcesByOrigin(resources []map[string]interface{},
+	resourcesOrigin []interface{}) []map[string]interface{} {
+	if len(resourcesOrigin) < 1 {
+		return resources
+	}
+
+	sortedResources := make([]map[string]interface{}, 0, len(resources))
+	resourcesCopy := resources
+	for _, resourceOrigin := range resourcesOrigin {
+		idOrigin := utils.PathSearch("id", resourceOrigin, "").(string)
+		typeOrigin := utils.PathSearch("type", resourceOrigin, "").(string)
+		for index, resource := range resourcesCopy {
+			if utils.PathSearch("id", resource, "").(string) != idOrigin || utils.PathSearch("type", resource, "").(string) != typeOrigin {
+				continue
+			}
+
+			sortedResources = append(sortedResources, resourcesCopy[index])
+			resourcesCopy = append(resourcesCopy[:index], resourcesCopy[index+1:]...)
+			break
+		}
+	}
+
+	sortedResources = append(sortedResources, resourcesCopy...)
+	return sortedResources
+}
+
+func flattenEnvironmentResources(resources []environments.Resource, resourcesOrigin []interface{}) []map[string]interface{} {
+	if len(resources) < 1 {
+		return nil
+	}
+
+	parsedResources := make([]map[string]interface{}, 0, len(resources))
+	for _, v := range resources {
+		parsedResources = append(parsedResources, map[string]interface{}{
+			"type": v.Type,
+			"id":   v.ID,
+			"name": v.Name,
+		})
+	}
+
+	return orderEnvironmentResourcesByOrigin(parsedResources, resourcesOrigin)
 }
 
 func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -151,23 +266,15 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(resp.ID)
 
+	// If the request is successful, obtain the values ​​of all JSON parameters first and save them to the
+	// corresponding '_origin' attributes for subsequent determination and construction of the request body during
+	// next updates.
+	err = utils.RefreshObjectParamOriginValues(d, environmentObjSliceParamKeys)
+	if err != nil {
+		return diag.Errorf("unable to refresh the origin values: %s", err)
+	}
+
 	return resourceEnvironmentRead(ctx, d, meta)
-}
-
-func flattenEnvironmentResources(resources []environments.Resource) []map[string]interface{} {
-	if len(resources) < 1 {
-		return nil
-	}
-
-	result := make([]map[string]interface{}, len(resources))
-	for i, v := range resources {
-		result[i] = map[string]interface{}{
-			"type": v.Type,
-			"id":   v.ID,
-		}
-	}
-
-	return result
 }
 
 func resourceEnvironmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -190,8 +297,8 @@ func resourceEnvironmentRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("vpc_id", resp.VpcId),
 		d.Set("deploy_mode", resp.DeployMode),
 		d.Set("enterprise_project_id", resp.EnterpriseProjectId),
-		d.Set("basic_resources", flattenEnvironmentResources(resp.BaseResources)),
-		d.Set("optional_resources", flattenEnvironmentResources(resp.OptionalResources)),
+		d.Set("basic_resources", flattenEnvironmentResources(resp.BaseResources, d.Get("basic_resources_origin").([]interface{}))),
+		d.Set("optional_resources", flattenEnvironmentResources(resp.OptionalResources, d.Get("optional_resources_origin").([]interface{}))),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -218,13 +325,13 @@ func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if d.HasChanges("basic_resources", "optional_resources") {
-		oldSet, newSet := d.GetChange("basic_resources")
-		baseRes := buildResourcesList(newSet.(*schema.Set))
-		rmRes := buildResourcesList(oldSet.(*schema.Set))
+		oldList, newList := d.GetChange("basic_resources")
+		baseRes := buildResourcesList(newList.([]interface{}))
+		rmRes := buildResourcesList(oldList.([]interface{}))
 
-		oldSet, newSet = d.GetChange("optional_resources")
-		optRes := buildResourcesList(newSet.(*schema.Set))
-		rmRes = append(rmRes, buildResourcesList(oldSet.(*schema.Set))...)
+		oldList, newList = d.GetChange("optional_resources")
+		optRes := buildResourcesList(newList.([]interface{}))
+		rmRes = append(rmRes, buildResourcesList(oldList.([]interface{}))...)
 		updateOpt := environments.ResourceOpts{
 			AddBaseResources:     baseRes,
 			AddOptionalResources: optRes,
@@ -233,6 +340,14 @@ func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta
 		_, err := environments.UpdateResources(client, d.Id(), updateOpt)
 		if err != nil {
 			return diag.Errorf("error updating ServiceStage environment (%s): %s", d.Id(), err)
+		}
+
+		// If the request is successful, obtain the values ​​of all JSON parameters first and save them to the
+		// corresponding '_origin' attributes for subsequent determination and construction of the request body during
+		// next updates.
+		err = utils.RefreshObjectParamOriginValues(d, environmentObjSliceParamKeys)
+		if err != nil {
+			return diag.Errorf("unable to refresh the origin values: %s", err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Environment resource supports new parameter for `basic_resources` and `optional_resources`.
And supplement a recommand description to the v2 environment resource document to recommand users using `huaweicloud_servicestagev3_environment` resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. environment resource supports resource name parameter
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o servicestage -f TestAccEnvironment_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccEnvironment_basic -timeout 360m -parallel 10
=== RUN   TestAccEnvironment_basic
=== PAUSE TestAccEnvironment_basic
=== CONT  TestAccEnvironment_basic
--- PASS: TestAccEnvironment_basic (1051.48s)
PASS
coverage: 5.8% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      1051.608s       coverage: 5.8% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
