### PR TITLE
feat(kafka): add a new data source to query recycle instance list

### DIFF
--- a/docs/data-sources/dms_kafka_recycle_instances.md
+++ b/docs/data-sources/dms_kafka_recycle_instances.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_recycle_instances"
+description: |-
+  Use this data source to query Kafka recycle bin instance list within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_recycle_instances
+
+Use this data source to query Kafka recycle bin instance list within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dms_kafka_recycle_instances" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the recycle bin instances are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `retention_days` - The retention days of the recycle bin.
+
+* `default_use_recycle` - Whether the recycle bin is enabled.
+
+* `instances` - The list of recycle bin instances.  
+  The [instances](#dms_kafka_recycle_instances_attr) structure is documented below.
+
+<a name="dms_kafka_recycle_instances_attr"></a>
+The `instances` block supports:
+
+* `id` - The ID of the instance.
+
+* `name` - The name of the instance.
+
+* `status` - The status of the instance.
+
+* `engine` - The engine of the instance.
+
+* `in_recycle_time` - The time when the instance was placed in the recycle bin, in RFC3339 format.
+
+* `save_time` - The time when the instance was saved, in days.
+
+* `auto_delete_time` - The time when the instance was automatically deleted, in RFC3339 format.
+
+* `cost_per_hour` - The cost per hour of the instance.
+
+* `error_message` - The error message.
+
+* `product_id` - The ID of the flavor of the instance.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1287,6 +1287,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_maintainwindows":                  kafka.DataSourceMaintainWindows(),
 			"huaweicloud_dms_kafka_message_diagnosis_tasks":          kafka.DataSourceDmsKafkaMessageDiagnosisTasks(),
 			"huaweicloud_dms_kafka_messages":                         kafka.DataSourceDmsKafkaMessages(),
+			"huaweicloud_dms_kafka_recycle_instances":                kafka.DataSourceRecycleInstances(),
 			"huaweicloud_dms_kafka_smart_connect_tasks":              kafka.DataSourceDmsKafkaSmartConnectTasks(),
 			"huaweicloud_dms_kafkav2_smart_connect_tasks":            kafka.DataSourceDmsKafkav2SmartConnectTasks(),
 			"huaweicloud_dms_kafka_tags":                             kafka.DataSourceTags(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -898,9 +898,10 @@ var (
 	HW_RFS_MODULE_URI             = os.Getenv("HW_RFS_MODULE_URI")
 	HW_RFS_ENABLE_FLAG            = os.Getenv("HW_RFS_ENABLE_FLAG")
 
-	HW_DMS_KAFKA_INSTANCE_ID         = os.Getenv("HW_DMS_KAFKA_INSTANCE_ID")
-	HW_DMS_KAFKA_TOPIC_NAME          = os.Getenv("HW_DMS_KAFKA_TOPIC_NAME")
-	HW_DMS_KAFKA_CONSUMER_GROUP_NAME = os.Getenv("HW_DMS_KAFKA_CONSUMER_GROUP_NAME")
+	HW_DMS_KAFKA_INSTANCE_ID             = os.Getenv("HW_DMS_KAFKA_INSTANCE_ID")
+	HW_DMS_KAFKA_TOPIC_NAME              = os.Getenv("HW_DMS_KAFKA_TOPIC_NAME")
+	HW_DMS_KAFKA_CONSUMER_GROUP_NAME     = os.Getenv("HW_DMS_KAFKA_CONSUMER_GROUP_NAME")
+	HW_DMS_KAFKA_RECYCLE_BIN_INSTANCE_ID = os.Getenv("HW_DMS_KAFKA_RECYCLE_BIN_INSTANCE_ID")
 
 	HW_DMS_RABBITMQ_INSTANCE_ID             = os.Getenv("HW_DMS_RABBITMQ_INSTANCE_ID")
 	HW_DMS_RABBITMQ_RECYCLE_BIN_INSTANCE_ID = os.Getenv("HW_DMS_RABBITMQ_RECYCLE_BIN_INSTANCE_ID")
@@ -5034,6 +5035,13 @@ func TestAccPreCheckDMSKafkaConsumerGroupName(t *testing.T) {
 func TestAccPreCheckDMSRabbitMQInstanceId(t *testing.T) {
 	if HW_DMS_RABBITMQ_INSTANCE_ID == "" {
 		t.Skip("HW_DMS_RABBITMQ_INSTANCE_ID must be set for RabbitMQ acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDMSKafkaRecycleBinInstanceId(t *testing.T) {
+	if HW_DMS_KAFKA_RECYCLE_BIN_INSTANCE_ID == "" {
+		t.Skip("HW_DMS_KAFKA_RECYCLE_BIN_INSTANCE_ID must be set for Kafka recycle bin instance acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_recycle_instances_test.go
+++ b/huaweicloud/services/acceptance/kafka/data_source_huaweicloud_dms_kafka_recycle_instances_test.go
@@ -1,0 +1,58 @@
+package kafka
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataRecycleInstances_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dms_kafka_recycle_instances.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaRecycleBinInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataRecycleInstances_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(all, "retention_days"),
+					resource.TestCheckResourceAttr(all, "default_use_recycle", "true"),
+					resource.TestMatchResourceAttr(all, "instances.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(all, "instances.0.id"),
+					resource.TestCheckResourceAttrSet(all, "instances.0.name"),
+					resource.TestCheckResourceAttrSet(all, "instances.0.status"),
+					resource.TestCheckResourceAttrSet(all, "instances.0.engine"),
+					resource.TestMatchResourceAttr(all, "instances.0.in_recycle_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(all, "instances.0.save_time"),
+					resource.TestMatchResourceAttr(all, "instances.0.auto_delete_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(all, "instances.0.product_id"),
+					resource.TestCheckOutput("instance_id_validation", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataRecycleInstances_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dms_kafka_recycle_instances" "test" {}
+
+output "instance_id_validation" {
+  value = contains(data.huaweicloud_dms_kafka_recycle_instances.test.instances[*].id, "%[1]s")
+}
+`, acceptance.HW_DMS_KAFKA_RECYCLE_BIN_INSTANCE_ID)
+}

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_recycle_instances.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_recycle_instances.go
@@ -1,0 +1,179 @@
+package kafka
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Kafka GET /v2/{project_id}/recycle
+func DataSourceRecycleInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRecycleInstancesRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the recycle bin instances are located.`,
+			},
+
+			// Attributes.
+			"retention_days": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The retention days of the recycle bin.`,
+			},
+			"default_use_recycle": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether the recycle bin is enabled.`,
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the instance.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the instance.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the instance.`,
+						},
+						"engine": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The engine of the instance.`,
+						},
+						"in_recycle_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the instance was placed in the recycle bin, in RFC3339 format.`,
+						},
+						"save_time": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The time when the instance was saved, in days.`,
+						},
+						"auto_delete_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the instance was automatically deleted, in RFC3339 format.`,
+						},
+						"cost_per_hour": {
+							Type:        schema.TypeFloat,
+							Computed:    true,
+							Description: `The cost per hour of the instance.`,
+						},
+						"error_message": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The error message.`,
+						},
+						"product_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the flavor of the instance.`,
+						},
+					},
+				},
+				Description: `The list of recycle instances.`,
+			},
+		},
+	}
+}
+
+func listRecycleInstances(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v2/{project_id}/recycle"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func dataSourceRecycleInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dms", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	respBody, err := listRecycleInstances(client)
+	if err != nil {
+		return diag.Errorf("error retrieving recycle bin instance list: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate data source ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("retention_days", utils.PathSearch("retention_days", respBody, nil)),
+		d.Set("default_use_recycle", utils.PathSearch("default_use_recycle", respBody, nil)),
+		d.Set("instances", flattenRecycleInstances(utils.PathSearch("recycle_instances", respBody,
+			make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenRecycleInstances(recycleInstances []interface{}) []map[string]interface{} {
+	if len(recycleInstances) == 0 {
+		return nil
+	}
+
+	results := make([]map[string]interface{}, 0, len(recycleInstances))
+	for _, item := range recycleInstances {
+		results = append(results, map[string]interface{}{
+			"id":     utils.PathSearch("instance_id", item, nil),
+			"name":   utils.PathSearch("name", item, nil),
+			"status": utils.PathSearch("status", item, nil),
+			"engine": utils.PathSearch("engine", item, nil),
+			"in_recycle_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("in_recycle_time",
+				item, float64(0)).(float64))/1000, false),
+			"save_time": utils.PathSearch("save_time", item, nil),
+			"auto_delete_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("auto_delete_time",
+				item, float64(0)).(float64))/1000, false),
+			"cost_per_hour": utils.PathSearch("cost_per_hour", item, nil),
+			"error_message": utils.PathSearch("error_message", item, nil),
+			"product_id":    utils.PathSearch("product_id", item, nil),
+		})
+	}
+	return results
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new data source(`huaweicloud_dms_kafka_recycle_instances`) to query recycle instance list

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new data source.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccDataRecycleInstances_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccDataRecycleInstances_basic -timeout 360m -parallel 10
=== RUN   TestAccDataRecycleInstances_basic
=== PAUSE TestAccDataRecycleInstances_basic
=== CONT  TestAccDataRecycleInstances_basic
--- PASS: TestAccDataRecycleInstances_basic (23.37s)
PASS
coverage: 2.2% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     23.554s coverage: 2.2% of statements in ./huaweicloud/services/kafka
```
<img width="1124" height="49" alt="image" src="https://github.com/user-attachments/assets/0866cccf-54b9-47ec-91ee-280f216eb7c7" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
