### PR TITLE
feat(rocketmq): add new data-source for query the list of dms recycle instances

### DIFF
--- a/docs/data-sources/dms_rocketmq_recycle_instances.md
+++ b/docs/data-sources/dms_rocketmq_recycle_instances.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rocketmq_recycle_instances"
+description: |-
+  Use this data source to query the list of DMS RocketMQ recycle instances within HuaweiCloud.
+---
+
+# huaweicloud_dms_rocketmq_recycle_instances
+
+Use this data source to query the list of DMS RocketMQ recycle instances within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_dms_rocketmq_recycle_instances" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the RocketMQ recycle instances are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances` - The list of the recycle instances.  
+  The [instances](#dms_rocketmq_recycle_instances_attr) structure is documented below.
+
+<a name="dms_rocketmq_recycle_instances_attr"></a>
+The `instances` block supports:
+
+* `id` - The ID of the instance.
+
+* `name` - The name of the instance.
+
+* `status` - The status of the instance.
+
+* `engine` - The message engine type.
+
+* `in_recycle_time` - The time when the instance was recycled, in RFC3339 format.
+
+* `save_time` - The number of days the instance is retained in the recycle bin.
+
+* `auto_delete_time` - The time when the instance will be automatically deleted, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1330,6 +1330,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_message_traces":              rocketmq.DataSourceDmsRocketmqMessageTraces(),
 			"huaweicloud_dms_rocketmq_messages":                    rocketmq.DataSourceDmsRocketMQMessages(),
 			"huaweicloud_dms_rocketmq_migration_tasks":             rocketmq.DataSourceDmsRocketmqMigrationTasks(),
+			"huaweicloud_dms_rocketmq_recycle_instances":           rocketmq.DataSourceRocketmqRecycleInstances(),
 			"huaweicloud_dms_rocketmq_tags":                        rocketmq.DataSourceTags(),
 			"huaweicloud_dms_rocketmq_topic_access_users":          rocketmq.DataSourceDmsRocketmqTopicAccessUsers(),
 			"huaweicloud_dms_rocketmq_topic_consumer_groups":       rocketmq.DataSourceDmsRocketmqTopicConsumerGroups(),

--- a/huaweicloud/services/acceptance/rocketmq/data_source_huaweicloud_dms_rocketmq_recycle_instances_test.go
+++ b/huaweicloud/services/acceptance/rocketmq/data_source_huaweicloud_dms_rocketmq_recycle_instances_test.go
@@ -1,0 +1,47 @@
+package rocketmq
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before running this test, please create a recycled RocketMQ instance in DMS service first.
+func TestAccDataRocketmqRecycleInstances_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_dms_rocketmq_recycle_instances.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataRocketmqRecycleInstances_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "instances.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.engine"),
+					resource.TestMatchResourceAttr(dataSourceName, "instances.0.in_recycle_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.save_time"),
+					resource.TestMatchResourceAttr(dataSourceName, "instances.0.auto_delete_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataRocketmqRecycleInstances_basic = `
+data "huaweicloud_dms_rocketmq_recycle_instances" "test" {}
+`

--- a/huaweicloud/services/rocketmq/data_source_huaweicloud_dms_rocketmq_recycle_instances.go
+++ b/huaweicloud/services/rocketmq/data_source_huaweicloud_dms_rocketmq_recycle_instances.go
@@ -1,0 +1,148 @@
+package rocketmq
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RocketMQ GET /v2/{project_id}/recycle
+func DataSourceRocketmqRecycleInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRocketmqRecycleInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the RocketMQ recycle instances are located.`,
+			},
+
+			// Attributes.
+			"instances": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        recycleInstanceSchema(),
+				Description: `The list of the recycle instances.`,
+			},
+		},
+	}
+}
+
+func recycleInstanceSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the instance.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the instance.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the instance.`,
+			},
+			"engine": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The message engine type.`,
+			},
+			"in_recycle_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the instance was recycled, in RFC3339 format.`,
+			},
+			"save_time": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of days the instance is retained in the recycle bin.`,
+			},
+			"auto_delete_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time when the instance will be automatically deleted, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func flattenRecycleInstances(recycleInstances []interface{}) []map[string]interface{} {
+	if len(recycleInstances) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(recycleInstances))
+	for _, instance := range recycleInstances {
+		result = append(result, map[string]interface{}{
+			"id":               utils.PathSearch("instance_id", instance, nil),
+			"name":             utils.PathSearch("name", instance, nil),
+			"status":           utils.PathSearch("status", instance, nil),
+			"engine":           utils.PathSearch("engine", instance, nil),
+			"in_recycle_time":  utils.FormatTimeStampRFC3339(int64(utils.PathSearch("in_recycle_time", instance, float64(0)).(float64))/1000, false),
+			"save_time":        utils.PathSearch("save_time", instance, nil),
+			"auto_delete_time": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("auto_delete_time", instance, float64(0)).(float64))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceRocketmqRecycleInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/recycle"
+	)
+
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving recycle instances: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instances", flattenRecycleInstances(utils.PathSearch("recycle_instances", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data-source for query the list of dms recycle instances.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. implement the provider logic
2. add acceptance tests for the provider
3. add documentation for the provider
4. add resource mapping in `provider.go`
```

## PR Checklist

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rocketmq" -v -coverprofile="./huaweicloud/services/acceptance/rocketmq/rocketmq_coverage.cov" -coverpkg="./huaweicloud/services/rocketmq" -run TestAccDataDmsRocketmqRecycleInstances_basic -timeout 360m -parallel 10
=== RUN   TestAccDataDmsRocketmqRecycleInstances_basic
=== PAUSE TestAccDataDmsRocketmqRecycleInstances_basic
=== CONT  TestAccDataDmsRocketmqRecycleInstances_basic
--- PASS: TestAccDataDmsRocketmqRecycleInstances_basic (19.15s)
PASS
coverage: 4.9% of statements in ./huaweicloud/services/rocketmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rocketmq  19.263s coverage: 4.9% of statements in ./huaweicloud/services/rocketmq
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.