### PR TITLE
feat(kafka): add new one-time action resource to restore instance from recycle bin

### DIFF
--- a/docs/resources/dms_kafka_recycle_instance_restore.md
+++ b/docs/resources/dms_kafka_recycle_instance_restore.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_kafka_recycle_instance_restore"
+description: |-
+  Use this resource to restore Kafka instance from recycle bin within HuaweiCloud.
+---
+
+# huaweicloud_dms_kafka_recycle_instance_restore
+
+Use this resource to restore Kafka instance from recycle bin within HuaweiCloud.
+
+-> This resource is only a one-time action resource for restoring recycle bin instance. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_kafka_recycle_instance_restore" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the instance is located to be restored.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the instance ID to be restored from recycle bin.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3661,6 +3661,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_message_produce":                   kafka.ResourceDmsKafkaMessageProduce(),
 			"huaweicloud_dms_kafka_partition_reassign":                kafka.ResourceDmsKafkaPartitionReassign(),
 			"huaweicloud_dms_kafka_permissions":                       kafka.ResourceDmsKafkaPermissions(),
+			"huaweicloud_dms_kafka_recycle_instance_restore":          kafka.ResourceRecycleInstanceRestore(),
 			"huaweicloud_dms_kafka_smart_connect":                     kafka.ResourceDmsKafkaSmartConnect(),
 			"huaweicloud_dms_kafka_smart_connect_task":                kafka.ResourceDmsKafkaSmartConnectTask(),
 			"huaweicloud_dms_kafkav2_smart_connect_task":              kafka.ResourceDmsKafkav2SmartConnectTask(),

--- a/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_recycle_instance_restore_test.go
+++ b/huaweicloud/services/acceptance/kafka/resource_huaweicloud_dms_kafka_recycle_instance_restore_test.go
@@ -1,0 +1,49 @@
+package kafka
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccResourceRecycleInstanceRestore_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSKafkaRecycleBinInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceRecycleInstanceRestore_instanceNotFound(),
+				ExpectError: regexp.MustCompile("This DMS instance does not exist"),
+			},
+			{
+				Config: testAccResourceRecycleInstanceRestore_basic(),
+			},
+		},
+	})
+}
+
+func testAccResourceRecycleInstanceRestore_instanceNotFound() string {
+	randomUUID, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_recycle_instance_restore" "test" {
+  instance_id = "%s"
+}
+`, randomUUID)
+}
+
+func testAccResourceRecycleInstanceRestore_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_kafka_recycle_instance_restore" "test" {
+  instance_id = "%s"
+}
+`, acceptance.HW_DMS_KAFKA_RECYCLE_BIN_INSTANCE_ID)
+}

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_recycle_instance_restore.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_recycle_instance_restore.go
@@ -1,0 +1,144 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var recycleInstanceRestoreNonUpdatableParams = []string{
+	"instance_id",
+}
+
+// @API Kafka POST /v2/{project_id}/recycle
+// @API Kafka GET /v2/{project_id}/instances/{instance_id}/tasks/{task_id}
+func ResourceRecycleInstanceRestore() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRecycleInstanceRestoreCreate,
+		ReadContext:   resourceRecycleInstanceRestoreRead,
+		UpdateContext: resourceRecycleInstanceRestoreUpdate,
+		DeleteContext: resourceRecycleInstanceRestoreDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(recycleInstanceRestoreNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the instance is located to be restored.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The instance ID to be restored from recycle bin.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func restoreRecycleInstance(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/recycle"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"instances": []interface{}{instanceId},
+		},
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(createResp)
+}
+
+func resourceRecycleInstanceRestoreCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId, _ = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dms", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	respBody, err := restoreRecycleInstance(client, instanceId)
+	if err != nil {
+		return diag.Errorf("error restoring instance (%s) from recycle bin: %s", instanceId, err)
+	}
+
+	jobId, _ := utils.PathSearch(fmt.Sprintf("results[?instance_id=='%s']|[0].job_id", instanceId), respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID of restoring instance (%s) from the API response", instanceId)
+	}
+
+	if err = waitForInstanceTaskStatusComplete(ctx, client, instanceId, jobId, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.Errorf("error waiting for the instance (%s) to be restored from recycle bin: %s", instanceId, err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate resource ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	return nil
+}
+
+func resourceRecycleInstanceRestoreRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRecycleInstanceRestoreUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRecycleInstanceRestoreDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for restoring recycle bin instance. Deleting this resource 
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new one-time action resource(`huaweicloud_dms_kafka_recycle_instance_restore`) to restore Kafka instance from recycle bin.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new one-time action resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o kafka -f TestAccResourceRecycleInstanceRestore_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/kafka" -v -coverprofile="./huaweicloud/services/acceptance/kafka/kafka_coverage.cov" -coverpkg="./huaweicloud/services/kafka" -run TestAccResourceRecycleInstanceRestore_basic -timeout 360m -parallel 10
=== RUN   TestAccResourceRecycleInstanceRestore_basic
=== PAUSE TestAccResourceRecycleInstanceRestore_basic
=== CONT  TestAccResourceRecycleInstanceRestore_basic
--- PASS: TestAccResourceRecycleInstanceRestore_basic (134.25s)
PASS
coverage: 2.8% of statements in ./huaweicloud/services/kafka
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/kafka     134.371s        coverage: 2.8% of statements in ./huaweicloud/services/kafka
```
<img width="1085" height="44" alt="image" src="https://github.com/user-attachments/assets/077c29fc-9b47-4f50-8972-83aabe69a2f6" />


* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
