### PR TITLE
feat(geminidb): add resource geminidb closing sessions of all nodes on an instance

### DIFF
--- a/docs/resources/geminidb_sessions_close.md
+++ b/docs/resources/geminidb_sessions_close.md
@@ -1,0 +1,40 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_sessions_close"
+description: |-
+  Manages a resource to close all sessions of all nodes on a GeminiDB Redis instance within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_sessions_close
+
+Manages a resource to close all sessions of all nodes on a GeminiDB Redis instance within HuaweiCloud.
+
+-> 1. This resource is a one-time action resource. Deleting this resource will not clear the corresponding request record,
+  but will only remove the resource information from the tf state file.
+  <br/>2. This resource only supports GeminiDB Redis instance.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_geminidb_sessions_close" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to close sessions. If omitted, the provider-level region
+  will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the GeminiDB Redis instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which equals to the instance ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3861,6 +3861,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ga_health_check":   ga.ResourceHealthCheck(),
 
 			"huaweicloud_geminidb_account":                     geminidb.ResourceGeminidbAccount(),
+			"huaweicloud_geminidb_sessions_close":              geminidb.ResourceGeminiDBSessionsClose(),
 			"huaweicloud_geminidb_backup":                      geminidb.ResourceGeminiDBBackup(),
 			"huaweicloud_geminidb_backup_stop":                 geminidb.ResourceGeminiDBBackupStop(),
 			"huaweicloud_geminidb_command_disable":             geminidb.ResourceCommandDisable(),

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_sessions_close_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_sessions_close_test.go
@@ -1,0 +1,39 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGeminiDBSessionsClose_basic(t *testing.T) {
+	resourceName := "huaweicloud_geminidb_sessions_close.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccCheckGeminidbInstanceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDBSessionsClose_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "instance_id", acceptance.HW_GEMINIDB_INSATNCE_ID),
+				),
+			},
+		},
+	})
+}
+
+func testAccGeminiDBSessionsClose_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_geminidb_sessions_close" "test" {
+  instance_id = "%s"
+}
+`, acceptance.HW_GEMINIDB_INSATNCE_ID)
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_sessions_close.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_sessions_close.go
@@ -1,0 +1,100 @@
+package geminidb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var geminiDbSessionsCloseParams = []string{
+	"instance_id",
+}
+
+// @API GeminiDB DELETE /v3/{project_id}/instances/{instance_id}/sessions
+func ResourceGeminiDBSessionsClose() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGeminiDBSessionsCloseCreate,
+		UpdateContext: resourceGeminiDBSessionsCloseUpdate,
+		ReadContext:   resourceGeminiDBSessionsCloseRead,
+		DeleteContext: resourceGeminiDBSessionsCloseDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(geminiDbSessionsCloseParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceGeminiDBSessionsCloseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+
+	httpUrl := "v3/{project_id}/instances/{instance_id}/sessions"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = client.Request("DELETE", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error closing sessions for instance %s: %s", instanceID, err)
+	}
+
+	d.SetId(instanceID)
+
+	return resourceGeminiDBSessionsCloseRead(ctx, d, meta)
+}
+
+func resourceGeminiDBSessionsCloseRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGeminiDBSessionsCloseUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGeminiDBSessionsCloseDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting Geminidb closing sessions for instance resource is not supported. The Geminidb closing sessions for instance " +
+		"resource is only removed from the state, the Geminidb nodes on an Instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
…n an Instance

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource geminidb closing sessions of all nodes on an instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add resource geminidb closing sessions of all nodes on an instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDBCloseSessions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDBCloseSessions_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBCloseSessions_basic
=== PAUSE TestAccGeminiDBCloseSessions_basic
=== CONT  TestAccGeminiDBCloseSessions_basic
--- PASS: TestAccGeminiDBCloseSessions_basic (15.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  15.794s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
