### PR TITLE
fix: fix bug caused by adding or removing elements during collection iteration

### DIFF
--- a/huaweicloud/services/apig/resource_huaweicloud_apig_api.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_api.go
@@ -1596,6 +1596,7 @@ func orderRequestParamsByRequestParamsOrder(reqParams []interface{}, requestPara
 			sortedReqParams = append(sortedReqParams, requestParamsCopy[index])
 			// Remove the processed request parameter from the original request parameters array.
 			requestParamsCopy = append(requestParamsCopy[:index], requestParamsCopy[index+1:]...)
+			break
 		}
 	}
 	// Add any remaining unsorted request parameters to the end of the sorted list.
@@ -1753,6 +1754,7 @@ func orderFuncGraphPolicyByFuncGraphPolicyOrder(policies []interface{}, funcGrap
 			sortedPolicies = append(sortedPolicies, funcGraphPolicyCopy[index])
 			// Remove the processed func graph policy from the original func graph policies array.
 			funcGraphPolicyCopy = append(funcGraphPolicyCopy[:index], funcGraphPolicyCopy[index+1:]...)
+			break
 		}
 	}
 	// Add any remaining unsorted func graph policies to the end of the sorted list.
@@ -1808,6 +1810,7 @@ func orderWebPolicyByWebPolicyOrder(policies []interface{}, webPolicyOrigin []in
 			}
 			sortedPolicies = append(sortedPolicies, webPolicyCopy[index])
 			webPolicyCopy = append(webPolicyCopy[:index], webPolicyCopy[index+1:]...)
+			break
 		}
 	}
 	sortedPolicies = append(sortedPolicies, webPolicyCopy...)
@@ -1875,6 +1878,7 @@ func orderMockPolicyByMockPolicyOrder(policies []interface{}, mockPolicyOrigin [
 			sortedPolicies = append(sortedPolicies, mockPolicyCopy[index])
 			// Remove the processed mock policy from the original mock policies array.
 			mockPolicyCopy = append(mockPolicyCopy[:index], mockPolicyCopy[index+1:]...)
+			break
 		}
 	}
 	// Add any remaining unsorted mock policies to the end of the sorted list.

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_vault.go
@@ -440,10 +440,11 @@ func orderVaultServerResourcesByResourcesOrigin(resources, resourcesOrigin []int
 				break
 			}
 		}
-		if keepRemoteState {
-			// Add any remaining unsorted resources to the end of the sorted list.
-			sortedResources = append(sortedResources, resourcesCopy)
-		}
+	}
+
+	if keepRemoteState {
+		// Add any remaining unsorted resources to the end of the sorted list.
+		sortedResources = append(sortedResources, resourcesCopy...)
 	}
 
 	return sortedResources

--- a/huaweicloud/services/cfw/data_source_huaweicloud_cfw_logs.go
+++ b/huaweicloud/services/cfw/data_source_huaweicloud_cfw_logs.go
@@ -422,7 +422,7 @@ func flattenLogsRecords(recordsResp []interface{}) []interface{} {
 	}
 
 	result := make([]interface{}, 0, len(recordsResp))
-	for _, raw := range result {
+	for _, raw := range recordsResp {
 		dstRegionID := utils.PathSearch("dst_region_id", raw, nil)
 		var dstRegionIDStr interface{}
 		if dstRegionID != nil {

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -1458,6 +1458,7 @@ func orderMountsByMountsOrderOrigin(mounts, mountsOrderOrigin []interface{}) []i
 			sortedMounts = append(sortedMounts, mountsCopy[index])
 			// Remove the processed mount configuration from the remote mounts array.
 			mountsCopy = append(mountsCopy[:index], mountsCopy[index+1:]...)
+			break
 		}
 	}
 

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_acl.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_acl.go
@@ -222,6 +222,7 @@ func orderV3AclIpCidersByIpCidersOrderOrigin(ipCiders, ipCidersOrigin []interfac
 			sortedIpCiders = append(sortedIpCiders, ipCidersCopy[index])
 			// Remove the processed ip cidr from the original ip ciders array.
 			ipCidersCopy = append(ipCidersCopy[:index], ipCidersCopy[index+1:]...)
+			break
 		}
 	}
 	// Add any remaining unsorted ip ciders to the end of the sorted list.
@@ -263,6 +264,7 @@ func orderV3AclIpRangesByIpRangesOrderOrigin(ipRanges, ipRangesOrigin []interfac
 			sortedIpRanges = append(sortedIpRanges, ipRangesCopy[index])
 			// Remove the processed ip cidr from the original ip ciders array.
 			ipRangesCopy = append(ipRangesCopy[:index], ipRangesCopy[index+1:]...)
+			break
 		}
 	}
 	// Add any remaining unsorted ip ranges to the end of the sorted list.

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_group_membership.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_group_membership.go
@@ -201,6 +201,7 @@ func orderV3AssociatedUsersByUsersOrigin(associatedUsers, usersOrigin []interfac
 			sortedAssociatedUsers = append(sortedAssociatedUsers, associatedUsersCopy[index])
 			// Remove the processed user from the original array.
 			associatedUsersCopy = append(associatedUsersCopy[:index], associatedUsersCopy[index+1:]...)
+			break
 		}
 	}
 	// Add any remaining unsorted users to the end of the sorted list.

--- a/huaweicloud/services/lakeformation/resource_huaweicloud_lakeformation_instance.go
+++ b/huaweicloud/services/lakeformation/resource_huaweicloud_lakeformation_instance.go
@@ -382,6 +382,7 @@ func orderSpecsBySpecsOrderOrigin(specs, specsOrigin []interface{}) []interface{
 			// Retain additional specification configurations from the remote service and these will not be sorted.
 			specsCopy = append(specsCopy[:copyIndex], specsCopy[copyIndex+1:]...)
 			specsOrigin = append(specsOrigin[:originIndex], specsOrigin[originIndex+1:]...)
+			break
 		}
 	}
 	sortedSpecs = append(sortedSpecs, specsCopy...)

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_assist_auth_configuration_object_management.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_assist_auth_configuration_object_management.go
@@ -221,6 +221,7 @@ func orderAssistAuthConfigurationAppliedObjects(appliedObjects, originObjects []
 			sortedObjects = append(sortedObjects, objectsCopy[index])
 			// Remove the processed applied object from the original array.
 			objectsCopy = append(objectsCopy[:index], objectsCopy[index+1:]...)
+			break
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix bug caused by adding or removing elements during collection iteration. Added missing `break` statements immediately after slice deletion within inner `range` loops in `orderSpecsBySpecsOrderOrigin` and `orderAssistAuthConfigurationAppliedObjects`. This ensures the inner loop terminates immediately after a match is found and deleted, preventing index shifting issues, element skipping, and potential out-of-bounds panics.

**Special notes for your reviewer**:
This change only adds `break` statements to inner loops that perform slice deletion during iteration. 
Outer read-only traversals (e.g., `range originObjects`) remain unchanged as they do not modify the collection and are safe to use with `range`.
No business logic changes are introduced; this is purely an iteration safety fix.
Please pay special attention to verifying that the newly added `break` statements are placed correctly after the slice modification and append operations.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  bugfix: Fixed element skipping and potential out-of-bounds panic caused by missing `break` statements after slice deletion during range iteration when sorting specs and assist auth configuration objects.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
