### PR TITLE
feat(GeminiDB): add resource to manage GeminiDB high risk command

### DIFF
--- a/docs/resources/geminidb_high_risk_command.md
+++ b/docs/resources/geminidb_high_risk_command.md
@@ -1,0 +1,63 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_high_risk_command"
+description: |-
+  Manages a GeminiDB high risk command resource within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_high_risk_command
+
+Manages a GeminiDB high risk command resource within HuaweiCloud.
+
+-> This resource only supports proxy-based general-purpose GeminiDB Redis instances.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "name" {}
+
+resource "huaweicloud_geminidb_high_risk_command" "test" {
+  instance_id = var.instance_id
+  origin_name = "keys"
+  name        = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the ID of the GeminiDB instance.
+
+* `origin_name` - (Required, String, NonUpdatable) Specifies the original high risk command.
+  The valid values are as follows:
+  + **keys**
+  + **flushdb**
+  + **flushall**
+  + **hgetall**
+  + **hkeys**
+  + **hvals**
+  + **smembers**
+
+* `name` - (Required, String) Specifies the renamed name of the command.
+  If this parameter is left blank, the command is disabled.
+  The value can contain a maximum of `30` characters, including digits, letters, and underscores (_).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, the format is `instance_id/origin_name`.
+
+## Import
+
+The resource can be imported using the `instance_id` and `origin_name`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_geminidb_high_risk_command.test <instance_id>/<origin_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3872,6 +3872,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_dr_switchover_configuration": geminidb.ResourceGeminiDBDRSwitchoverConfiguration(),
 			"huaweicloud_geminidb_eip_bind":                    geminidb.ResourceEipBind(),
 			"huaweicloud_geminidb_enlarge_fail_node_delete":    geminidb.ResourceEnlargeFailNodeDelete(),
+			"huaweicloud_geminidb_high_risk_command":           geminidb.ResourceHighRiskCommand(),
 			"huaweicloud_geminidb_instance":                    geminidb.ResourceGeminiDbInstance(),
 			"huaweicloud_geminidb_instance_restart":            geminidb.ResourceInstanceRestart(),
 			"huaweicloud_geminidb_memory_mapping":              geminidb.ResourceMemoryMapping(),

--- a/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_high_risk_command_test.go
+++ b/huaweicloud/services/acceptance/geminidb/resource_huaweicloud_geminidb_high_risk_command_test.go
@@ -1,0 +1,148 @@
+package geminidb
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/geminidb"
+)
+
+func getResourceHighRiskCommandFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("geminidb", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	resourceId := strings.Split(state.Primary.ID, "/")
+
+	return geminidb.GetHighRiskCommandInfo(client, resourceId[0], resourceId[1])
+}
+
+func TestAccResourceHighRiskCommand_basic(t *testing.T) {
+	var (
+		rName  = "huaweicloud_geminidb_high_risk_command.test"
+		name   = acceptance.RandomAccResourceName()
+		object interface{}
+		rc     = acceptance.InitResourceCheck(
+			rName,
+			&object,
+			getResourceHighRiskCommandFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHighRiskCommand_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_geminidb_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "origin_name", "keys"),
+					resource.TestCheckResourceAttr(rName, "name", "test"),
+				),
+			},
+			{
+				Config: testAccHighRiskCommand_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "origin_name", "keys"),
+					resource.TestCheckResourceAttr(rName, "name", "test_update"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccHighRiskCommandImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccHighRiskCommand_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data"huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "Test_357159"
+  mode              = "Cluster"
+
+  datastore {
+    type           = "redis"
+    version        = "5.0"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "2"
+    size      = "4"
+    storage   = "ULTRAHIGH"
+    spec_code = "geminidb.redis.medium.2"
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccHighRiskCommand_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_geminidb_high_risk_command" "test" {
+  instance_id = huaweicloud_geminidb_instance.test.id
+  origin_name = "keys"
+  name        = "test"
+}
+`, testAccHighRiskCommand_base(name))
+}
+
+func testAccHighRiskCommand_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_geminidb_high_risk_command" "test" {
+  instance_id = huaweicloud_geminidb_instance.test.id
+  origin_name = "keys"
+  name        = "test_update"
+}
+`, testAccHighRiskCommand_base(name))
+}
+
+func testAccHighRiskCommandImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var originName, instanceId string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		instanceId = rs.Primary.Attributes["instance_id"]
+		originName = rs.Primary.Attributes["origin_name"]
+
+		if originName == "" || instanceId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<origin_name>', but got '%s/%s'",
+				instanceId, originName)
+		}
+
+		return fmt.Sprintf("%s/%s", instanceId, originName), nil
+	}
+}

--- a/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_high_risk_command.go
+++ b/huaweicloud/services/geminidb/resource_huaweicloud_geminidb_high_risk_command.go
@@ -1,0 +1,229 @@
+package geminidb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var highRiskCommandNonUpdatableParams = []string{
+	"instance_id",
+	"origin_name",
+}
+
+// @API GeminiDB PUT /v3/{project_id}/instances/{instance_id}/high-risk-commands
+// @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/high-risk-commands
+func ResourceHighRiskCommand() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHighRiskCommandCreate,
+		ReadContext:   resourceHighRiskCommandRead,
+		UpdateContext: resourceHighRiskCommandUpdate,
+		DeleteContext: resourceHighRiskCommandDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHighRiskCommandImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(highRiskCommandNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"origin_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func buildHighRiskCommandBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"commands": []map[string]interface{}{
+			{
+				"origin_name": d.Get("origin_name"),
+				"name":        d.Get("name"),
+			},
+		},
+	}
+
+	return bodyParams
+}
+
+func modifyHighRiskCommand(client *golangsdk.ServiceClient, d *schema.ResourceData, instanceId string) error {
+	httpUrl := "v3/{project_id}/instances/{instance_id}/high-risk-commands"
+	reqPath := client.Endpoint + httpUrl
+	reqPath = strings.ReplaceAll(reqPath, "{project_id}", client.ProjectID)
+	reqPath = strings.ReplaceAll(reqPath, "{instance_id}", instanceId)
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+		JSONBody:         buildHighRiskCommandBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", reqPath, &createOpt)
+
+	return err
+}
+
+func resourceHighRiskCommandCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		originName = d.Get("origin_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	err = modifyHighRiskCommand(client, d, instanceId)
+	if err != nil {
+		return diag.Errorf("error modifying GeminiDB high risk command: %s", err)
+	}
+
+	resourceId := fmt.Sprintf("%s/%s", instanceId, originName)
+
+	d.SetId(resourceId)
+
+	return resourceHighRiskCommandRead(ctx, d, meta)
+}
+
+func resourceHighRiskCommandRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	resourceId := strings.Split(d.Id(), "/")
+	commandInfo, err := GetHighRiskCommandInfo(client, resourceId[0], resourceId[1])
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving GeminiDB high risk commands")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instance_id", resourceId[0]),
+		d.Set("origin_name", utils.PathSearch("origin_name", commandInfo, nil)),
+		d.Set("name", utils.PathSearch("name", commandInfo, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func GetHighRiskCommandInfo(client *golangsdk.ServiceClient, instanceId, originName string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/instances/{instance_id}/high-risk-commands"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listOpts := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", listPath, &listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	commandInfo := utils.PathSearch(fmt.Sprintf("commands|[?origin_name=='%s']|[0]", originName), respBody, nil)
+	if commandInfo == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return commandInfo, nil
+}
+
+func resourceHighRiskCommandUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	resourceId := strings.Split(d.Id(), "/")
+	err = modifyHighRiskCommand(client, d, resourceId[0])
+	if err != nil {
+		return diag.Errorf("error updating GeminiDB high risk command: %s", err)
+	}
+
+	return resourceHighRiskCommandRead(ctx, d, meta)
+}
+
+func resourceHighRiskCommandDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GeminiDB high risk command modify resource is not supported. The resource is only removed from the " +
+		"state, the resource remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func resourceHighRiskCommandImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<instance_id>/<origin_name>', but got '%s'", importedId)
+	}
+
+	d.SetId(importedId)
+
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+		d.Set("origin_name", parts[1]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add resource to manage GeminiDB high risk command.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new resource to manage GeminiDB high risk command.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccResourceHighRiskCommand_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccResourceHighRiskCommand_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceHighRiskCommand_basic
=== PAUSE TestAccResourceHighRiskCommand_basic
=== CONT  TestAccResourceHighRiskCommand_basic
--- PASS: TestAccResourceHighRiskCommand_basic (1505.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1505.986s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
<img width="754" height="196" alt="111111" src="https://github.com/user-attachments/assets/0e7fa307-dc85-49dc-ab82-fdb69d045cba" />

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
