### PR TITLE
feat(rocketmq): add a new one-time resource to restore instance from recycle bin

### DIFF
--- a/docs/resources/dms_rocketmq_recycle_instance_restore.md
+++ b/docs/resources/dms_rocketmq_recycle_instance_restore.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rocketmq_recycle_instance_restore"
+description: |-
+  Use this resource to restore RocketMQ instance from recycle bin within HuaweiCloud.
+---
+
+# huaweicloud_dms_rocketmq_recycle_instance_restore
+
+Use this resource to restore RocketMQ instance from recycle bin within HuaweiCloud.
+
+-> This resource is only a one-time action resource for restoring recycle bin instance. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_rocketmq_recycle_instance_restore" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the instance is located to be restored.  
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, NonUpdatable) Specifies the instance ID to be restored from recycle bin.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -3697,6 +3697,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_message_send":                     rocketmq.ResourceRocketMQMessageSend(),
 			"huaweicloud_dms_rocketmq_migration_task":                   rocketmq.ResourceDmsRocketmqMigrationTask(),
 			"huaweicloud_dms_rocketmq_node_batch_restart":               rocketmq.ResourceNodeBatchRestart(),
+			"huaweicloud_dms_rocketmq_recycle_instance_restore":         rocketmq.ResourceRecycleInstanceRestore(),
 			"huaweicloud_dms_rocketmq_topic":                            rocketmq.ResourceDmsRocketMQTopic(),
 			"huaweicloud_dms_rocketmq_user":                             rocketmq.ResourceDmsRocketMQUser(),
 			"huaweicloud_dms_rocketmq_volume_auto_expand_configuration": rocketmq.ResourceVolumeAutoExpandConfiguration(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -916,6 +916,7 @@ var (
 	// The list of dead letter message IDs. Using commas (,) to separate multiple IDs.
 	// At least one ID is required.
 	HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs = os.Getenv("HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs")
+	HW_DMS_ROCKETMQ_RECYCLE_BIN_INSTANCE_ID = os.Getenv("HW_DMS_ROCKETMQ_RECYCLE_BIN_INSTANCE_ID")
 
 	HW_SFS_TURBO_SHARE_ID                = os.Getenv("HW_SFS_TURBO_SHARE_ID")
 	HW_SFS_TURBO_BACKUP_ID               = os.Getenv("HW_SFS_TURBO_BACKUP_ID")
@@ -5096,6 +5097,13 @@ func TestAccPreCheckDMSRocketMQDeadLetterMessageIDs(t *testing.T, min int) {
 	if HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs == "" || len(strings.Split(HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs, ",")) < min {
 		t.Skipf("At least %d dead letter message IDs must be supported during the HW_DMS_ROCKETMQ_DEAD_LETTER_MESSAGE_IDs, "+
 			"separated by commas (,).", min)
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDMSRocketMQRecycleBinInstanceId(t *testing.T) {
+	if HW_DMS_ROCKETMQ_RECYCLE_BIN_INSTANCE_ID == "" {
+		t.Skip("HW_DMS_ROCKETMQ_RECYCLE_BIN_INSTANCE_ID must be set for restoring RocketMQ recycle bin instance acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -5051,13 +5051,6 @@ func TestAccPreCheckDMSKafkaConsumerGroupName(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckDMSRabbitMQInstanceId(t *testing.T) {
-	if HW_DMS_RABBITMQ_INSTANCE_ID == "" {
-		t.Skip("HW_DMS_RABBITMQ_INSTANCE_ID must be set for RabbitMQ acceptance tests")
-	}
-}
-
-// lintignore:AT003
 func TestAccPreCheckDMSKafkaRecycleBinInstanceId(t *testing.T) {
 	if HW_DMS_KAFKA_RECYCLE_BIN_INSTANCE_ID == "" {
 		t.Skip("HW_DMS_KAFKA_RECYCLE_BIN_INSTANCE_ID must be set for Kafka recycle bin instance acceptance tests")
@@ -5065,7 +5058,14 @@ func TestAccPreCheckDMSKafkaRecycleBinInstanceId(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckDMSRocketMQRecycleBinInstanceId(t *testing.T) {
+func TestAccPreCheckDMSRabbitMQInstanceId(t *testing.T) {
+	if HW_DMS_RABBITMQ_INSTANCE_ID == "" {
+		t.Skip("HW_DMS_RABBITMQ_INSTANCE_ID must be set for RabbitMQ acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDMSRabbitMQRecycleBinInstanceId(t *testing.T) {
 	if HW_DMS_RABBITMQ_RECYCLE_BIN_INSTANCE_ID == "" {
 		t.Skip("HW_DMS_RABBITMQ_RECYCLE_BIN_INSTANCE_ID must be set for restoring RabbitMQ recycle bin instance acceptance tests")
 	}

--- a/huaweicloud/services/acceptance/rabbitmq/data_source_huaweicloud_dms_rabbitmq_recycle_instances_test.go
+++ b/huaweicloud/services/acceptance/rabbitmq/data_source_huaweicloud_dms_rabbitmq_recycle_instances_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceRecycleInstances_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckDMSRocketMQRecycleBinInstanceId(t)
+			acceptance.TestAccPreCheckDMSRabbitMQRecycleBinInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/rabbitmq/resource_huaweicloud_dms_rabbitmq_recycle_instance_restore_test.go
+++ b/huaweicloud/services/acceptance/rabbitmq/resource_huaweicloud_dms_rabbitmq_recycle_instance_restore_test.go
@@ -15,7 +15,7 @@ func TestAccRecycleInstanceRestore_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckDMSRocketMQRecycleBinInstanceId(t)
+			acceptance.TestAccPreCheckDMSRabbitMQRecycleBinInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,

--- a/huaweicloud/services/acceptance/rocketmq/resource_huaweicloud_dms_rocketmq_recycle_instance_restore_test.go
+++ b/huaweicloud/services/acceptance/rocketmq/resource_huaweicloud_dms_rocketmq_recycle_instance_restore_test.go
@@ -1,0 +1,49 @@
+package rocketmq
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccRecycleInstanceRestore_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDMSRocketMQRecycleBinInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRecycleInstanceRestore_instanceNotFound(),
+				ExpectError: regexp.MustCompile("This DMS instance does not exist"),
+			},
+			{
+				Config: testAccRecycleInstanceRestore_basic(),
+			},
+		},
+	})
+}
+
+func testAccRecycleInstanceRestore_instanceNotFound() string {
+	randomUUID, _ := uuid.NewRandom()
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_rocketmq_recycle_instance_restore" "test" {
+  instance_id = "%s"
+}
+`, randomUUID.String())
+}
+
+func testAccRecycleInstanceRestore_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_rocketmq_recycle_instance_restore" "test" {
+  instance_id = "%s"
+}
+`, acceptance.HW_DMS_ROCKETMQ_RECYCLE_BIN_INSTANCE_ID)
+}

--- a/huaweicloud/services/rocketmq/resource_huaweicloud_dms_rocketmq_recycle_instance_restore.go
+++ b/huaweicloud/services/rocketmq/resource_huaweicloud_dms_rocketmq_recycle_instance_restore.go
@@ -1,0 +1,145 @@
+package rocketmq
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var recycleInstanceRestoreNonUpdatableParams = []string{
+	"instance_id",
+}
+
+// @API RocketMQ POST /v2/{project_id}/recycle
+// @API RocketMQ GET /v2/{project_id}/instances/{instance_id}/tasks/{task_id}
+func ResourceRecycleInstanceRestore() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRecycleInstanceRestoreCreate,
+		ReadContext:   resourceRecycleInstanceRestoreRead,
+		UpdateContext: resourceRecycleInstanceRestoreUpdate,
+		DeleteContext: resourceRecycleInstanceRestoreDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(recycleInstanceRestoreNonUpdatableParams),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the instance is located to be restored.`,
+			},
+
+			// Required parameters.
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The instance ID to be restored from recycle bin.`,
+			},
+
+			// Internal parameters.
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description: utils.SchemaDesc(
+					`Whether to allow parameters that do not support changes to have their change-triggered behavior set to 'ForceNew'.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func restoreRecycleInstance(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/recycle"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody: map[string]interface{}{
+			"instances": []interface{}{instanceId},
+		},
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(createResp)
+}
+
+func resourceRecycleInstanceRestoreCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		instanceId, _ = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dms", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	respBody, err := restoreRecycleInstance(client, instanceId)
+	if err != nil {
+		return diag.Errorf("error restoring instance (%s) from recycle bin: %s", instanceId, err)
+	}
+
+	jobId, _ := utils.PathSearch(fmt.Sprintf("results[?instance_id=='%s']|[0].job_id", instanceId), respBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID for restoring instance (%s) from API response", instanceId)
+	}
+
+	err = waitForInstanceTaskStatusCompleted(ctx, client, instanceId, jobId, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the instance (%s) to be restored from recycle bin: %s", instanceId, err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate resource ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	return nil
+}
+
+func resourceRecycleInstanceRestoreRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRecycleInstanceRestoreUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRecycleInstanceRestoreDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for restoring recycle bin instance. Deleting this resource 
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new one-time action resource (`huaweicloud_dms_rocketmq_recycle_instance_restore`) to restore instance from recycle bin.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new resource RocketMQ.
2. modify the error method name for RabbitMQ.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/coverage.sh -o rocketmq -f TestAccRecycleInstanceRestore_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rocketmq" -v -coverprofile="./huaweicloud/services/acceptance/rocketmq/rocketmq_coverage.cov" -coverpkg="./huaweicloud/services/rocketmq" -run TestAccRecycleInstanceRestore_basic -timeout 360m -parallel 10
=== RUN   TestAccRecycleInstanceRestore_basic
=== PAUSE TestAccRecycleInstanceRestore_basic
=== CONT  TestAccRecycleInstanceRestore_basic
--- PASS: TestAccRecycleInstanceRestore_basic (133.04s)
PASS
coverage: 6.0% of statements in ./huaweicloud/services/rocketmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rocketmq  133.158s        coverage: 6.0% of statements in ./huaweicloud/services/rocketmq
```
<img width="1070" height="42" alt="image" src="https://github.com/user-attachments/assets/10b3f254-a83c-4ad8-952c-791c9b26ffe4" />

```
./scripts/coverage.sh -o rabbitmq -f TestAccDataSourceRecycleInstances_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rabbitmq" -v -coverprofile="./huaweicloud/services/acceptance/rabbitmq/rabbitmq_coverage.cov" -coverpkg="./huaweicloud/services/rabbitmq" -run TestAccDataSourceRecycleInstances_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceRecycleInstances_basic
=== PAUSE TestAccDataSourceRecycleInstances_basic
=== CONT  TestAccDataSourceRecycleInstances_basic
--- PASS: TestAccDataSourceRecycleInstances_basic (17.33s)
PASS
coverage: 3.3% of statements in ./huaweicloud/services/rabbitmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rabbitmq  17.589s coverage: 3.3% of statements in ./huaweicloud/services/rabbitmq
```
```
./scripts/coverage.sh -o rabbitmq -f TestAccRecycleInstanceRestore_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/rabbitmq" -v -coverprofile="./huaweicloud/services/acceptance/rabbitmq/rabbitmq_coverage.cov" -coverpkg="./huaweicloud/services/rabbitmq" -run TestAccRecycleInstanceRestore_basic -timeout 360m -parallel 10
=== RUN   TestAccRecycleInstanceRestore_basic
=== PAUSE TestAccRecycleInstanceRestore_basic
=== CONT  TestAccRecycleInstanceRestore_basic
--- PASS: TestAccRecycleInstanceRestore_basic (132.32s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/rabbitmq
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rabbitmq  132.475s        coverage: 4.7% of statements in ./huaweicloud/services/rabbitmq
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
