### PR TITLE
fix(codecheck): ensure valid map element access by key

### DIFF
--- a/huaweicloud/config/force_new.go
+++ b/huaweicloud/config/force_new.go
@@ -43,15 +43,17 @@ func FlexibleForceNew(keys []string, resourceSchemas ...map[string]*schema.Schem
 					if cmp.Equal(oldValue, newValue) {
 						continue
 					}
-					if resourceSchema != nil && resourceSchema[k] != nil && resourceSchema[k].DiffSuppressFunc != nil &&
-						resourceSchema[k].DiffSuppressFunc(k, oldValue.(string), newValue.(string), nil) {
-						if resourceSchema[k].Sensitive {
+
+					schemaAttr, schemaOk := resourceSchema[k]
+					if schemaOk && schemaAttr != nil && schemaAttr.DiffSuppressFunc != nil &&
+						schemaAttr.DiffSuppressFunc(k, oldValue.(string), newValue.(string), nil) {
+						if schemaAttr.Sensitive {
 							log.Printf("[DEBUG] ignoring change of %s due to DiffSuppressFunc, %v", k, "(sensitive value)")
 						} else {
 							log.Printf("[DEBUG] ignoring change of %s due to DiffSuppressFunc, %v -> %v", k, oldValue, newValue)
 						}
 					} else {
-						if resourceSchema != nil && resourceSchema[k] != nil && resourceSchema[k].Sensitive {
+						if schemaOk && schemaAttr != nil && schemaAttr.Sensitive {
 							err = multierror.Append(err, fmt.Errorf("%s can't be updated, %v", k, "(sensitive value)"))
 						} else {
 							err = multierror.Append(err, fmt.Errorf("%s can't be updated, %v -> %v", k, oldValue, newValue))

--- a/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_user_client_quotas.go
+++ b/huaweicloud/services/kafka/data_source_huaweicloud_dms_kafka_user_client_quotas.go
@@ -3,7 +3,6 @@ package kafka
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -132,23 +131,13 @@ func dataSourceDmsKafkaUserClientQuotasRead(_ context.Context, d *schema.Resourc
 				continue
 			}
 
-			listRespJson, err := json.Marshal(quota)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-
-			var listRespBody map[string]interface{}
-			err = json.Unmarshal(listRespJson, &listRespBody)
-			if err != nil {
-				return diag.FromErr(err)
-			}
 			results = append(results, map[string]interface{}{
 				"user":               utils.PathSearch("user", quota, nil),
-				"user_default":       listRespBody["user-default"],
+				"user_default":       utils.PathSearch("user-default", quota, nil),
 				"client":             utils.PathSearch("client", quota, nil),
-				"client_default":     listRespBody["client-default"],
-				"producer_byte_rate": int64(listRespBody["producer-byte-rate"].(float64)),
-				"consumer_byte_rate": int64(listRespBody["consumer-byte-rate"].(float64)),
+				"client_default":     utils.PathSearch("client-default", quota, nil),
+				"producer_byte_rate": int64(utils.PathSearch("producer-byte-rate", quota, float64(0)).(float64)),
+				"consumer_byte_rate": int64(utils.PathSearch("consumer-byte-rate", quota, float64(0)).(float64)),
 			})
 		}
 

--- a/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_data_connection.go
+++ b/huaweicloud/services/mrs/resource_huaweicloud_mapreduce_data_connection.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -235,25 +234,14 @@ func resourceDataConnectionRead(_ context.Context, d *schema.ResourceData, meta 
 }
 
 func flattenGetDataConnectionResponseBodySourceInfo(resp interface{}, password string) []interface{} {
-	var rst []interface{}
-	curString := utils.PathSearch("source_info", resp, "").(string)
-
-	var curJson map[string]interface{}
-	err := json.Unmarshal([]byte(curString), &curJson)
-	if err != nil {
-		log.Printf("[ERROR] error parsing source_info to json= %#v", resp)
-		return rst
-	}
-
-	rst = []interface{}{
+	return []interface{}{
 		map[string]interface{}{
-			"db_instance_id": curJson["rds_instance_id"],
-			"db_name":        curJson["db_name"],
-			"user_name":      curJson["user_name"],
+			"db_instance_id": utils.PathSearch("source_info.rds_instance_id", resp, "").(string),
+			"db_name":        utils.PathSearch("source_info.db_name", resp, "").(string),
+			"user_name":      utils.PathSearch("source_info.user_name", resp, "").(string),
 			"password":       password,
 		},
 	}
-	return rst
 }
 
 func resourceDataConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixes the potential panic issue in the FlexibleForceNew custom diff function. This PR ensures safe access to map elements and prevents type assertion panics when handling resource schema validation.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
No breaking changes. This is a bug fix for the internal validation logic.

Attached unit test screenshot for FlexibleForceNew

Branch Packaging
<img width="1465" height="314" alt="image" src="https://github.com/user-attachments/assets/0058f4b7-5c26-432b-856d-19c1597971a2" />

Branch Verification: forceNew equals false
<img width="1022" height="970" alt="image" src="https://github.com/user-attachments/assets/7ba7c697-a711-41a4-81b7-f9dcee5143a1" />

Branch Verification: forceNew equals true
<img width="1199" height="954" alt="image" src="https://github.com/user-attachments/assets/43bd296f-0fdb-42ec-9216-b397556c5acd" />

Trunk Packaging
<img width="1526" height="336" alt="image" src="https://github.com/user-attachments/assets/0b9f0c19-3ae2-4ea8-a352-c37b5731c079" />

Trunk Verification: forceNew equals false
<img width="1118" height="980" alt="image" src="https://github.com/user-attachments/assets/4176b841-d5a0-41b3-91b9-e0f62e300387" />

Trunk Verification: forceNew equals true
<img width="1179" height="994" alt="image" src="https://github.com/user-attachments/assets/68736d2b-1327-4514-9108-d4033602f0a6" />

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE (or a brief note like "Fix potential panic in resource validation")
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestFlexibleForceNew'
...
=== RUN   TestFlexibleForceNew
--- PASS: TestFlexibleForceNew (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config        0.105s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
