### PR TITLE
feat(GeminiDB): add new data source to get the list of high risk commands

### DIFF
--- a/docs/data-sources/geminidb_high_risk_commands.md
+++ b/docs/data-sources/geminidb_high_risk_commands.md
@@ -1,0 +1,48 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_high_risk_commands"
+description: |-
+  Use this data source to get the list of high risk commmands.
+---
+
+# huaweicloud_geminidb_high_risk_commands
+
+Use this data source to get the list of high risk commmands.
+
+-> This data source only supports proxy-based general-purpose GeminiDB Redis instances.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_geminidb_high_risk_commands" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the instance ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `commands` - The list of high risk commands.
+  The [commands](#commands_struct) structure is documented below.
+
+<a name="commands_struct"></a>
+The `commands` block supports:
+
+* `origin_name` - The original high risk command name.
+
+* `name` - The renamed name of the command.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1527,6 +1527,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_database_versions":             geminidb.DataSourceDatabaseVersions(),
 			"huaweicloud_geminidb_dedicated_resources":           geminidb.DataSourceDedicatedResources(),
 			"huaweicloud_geminidb_flavors":                       geminidb.DataSourceGeminiDBFlavors(),
+			"huaweicloud_geminidb_high_risk_commands":            geminidb.DataSourceHighRiskCommands(),
 			"huaweicloud_geminidb_hot_keys":                      geminidb.DataSourceHotKeys(),
 			"huaweicloud_geminidb_instance_parameters_histories": geminidb.DataSourceGeminiDBInstanceParametersHistories(),
 			"huaweicloud_geminidb_instance_sessions":             geminidb.DataSourceInstanceSessions(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_high_risk_commands_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_high_risk_commands_test.go
@@ -1,0 +1,78 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataSourceHighRiskCommands_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_geminidb_high_risk_commands.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceHighRiskCommands_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "commands.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "commands.0.origin_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "commands.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceHighRiskCommands_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data"huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "Test_357159"
+  mode              = "Cluster"
+
+  datastore {
+    type           = "redis"
+    version        = "5.0"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "2"
+    size      = "4"
+    storage   = "ULTRAHIGH"
+    spec_code = "geminidb.redis.medium.2"
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccDataSourceHighRiskCommands_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_geminidb_high_risk_commands" "test" {
+  instance_id = huaweicloud_geminidb_instance.test.id
+}
+`, testAccDatasourceHighRiskCommands_base(name))
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_high_risk_commands.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_high_risk_commands.go
@@ -1,0 +1,116 @@
+package geminidb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/high-risk-commands
+func DataSourceHighRiskCommands() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceHighRiskCommandsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"commands": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"origin_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceHighRiskCommandsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/high-risk-commands"
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the GeminiDB high risk commands: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("commands", flattenHighRiskCommands(
+			utils.PathSearch("commands", getRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenHighRiskCommands(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"origin_name": utils.PathSearch("origin_name", v, nil),
+			"name":        utils.PathSearch("name", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get the list of high risk commands.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to get the list of high risk commands.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ ./scripts/coverage.sh -o geminidb -f TestAccDataSourceHighRiskCommands_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/geminidb" -v -coverprofile="./huaweicloud/services/acceptance/geminidb/geminidb_coverage.cov" -coverpkg="./huaweicloud/services/geminidb" -run TestAccDataSourceHighRiskCommands_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceHighRiskCommands_basic
=== PAUSE TestAccDataSourceHighRiskCommands_basic
=== CONT  TestAccDataSourceHighRiskCommands_basic
--- PASS: TestAccDataSourceHighRiskCommands_basic (1476.28s)
PASS
coverage: 8.2% of statements in ./huaweicloud/services/geminidb
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1476.432s  
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/5a1a50f6-c135-4eef-8e02-607273010795" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
