### PR TITLE
feat(GaussDB): add gaussdb sql execution plan status data source

### DIFF
--- a/docs/data-sources/gaussdb_sql_execution_plan_status.md
+++ b/docs/data-sources/gaussdb_sql_execution_plan_status.md
@@ -1,0 +1,63 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_sql_execution_plan_status"
+description: |-
+  Use this data source to query the binding status of a SQL execution plan of a GaussDB instance within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_sql_execution_plan_status
+
+Use this data source to query the binding status of a SQL execution plan of a GaussDB instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+variable "sql_id" {}
+
+data "huaweicloud_gaussdb_sql_execution_plan_status" "test" {
+  instance_id = var.instance_id
+  node_id     = var.node_id
+  sql_id      = var.sql_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the SQL execution plan status.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the GaussDB instance.
+
+* `node_id` - (Required, String) Specifies the node ID of the GaussDB instance.
+
+* `sql_id` - (Required, String) Specifies the SQL ID to query the execution plan status.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `sql_plan_bind_state_list` - The list of SQL execution plan bind states.
+  The [sql_plan_bind_state_list](#sql_plan_bind_state_list_struct) structure is documented below.
+
+<a name="sql_plan_bind_state_list_struct"></a>
+The `sql_plan_bind_state_list` block supports:
+
+* `outline` - The outline of the current execution plan.
+
+* `cost` - The cost of the SQL execution plan.
+
+* `status` - The binding status of the execution plan.
+  The valid values are as follows:
+  + **bind**: The execution plan is bound.
+  + **drop**: The execution plan is unbound.
+
+* `sql_hash` - The hash value of the SQL text.
+
+* `plan_id` - The ID of the SQL execution plan.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1600,6 +1600,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_dr_operation_records":            gaussdb.DataSourceGaussDbDrOperationRecords(),
 			"huaweicloud_gaussdb_instance_dr_status":              gaussdb.DataSourceGaussDbInstanceDrStatus(),
 			"huaweicloud_gaussdb_sql_patch":                       gaussdb.DataSourceGaussDbSqlPatch(),
+			"huaweicloud_gaussdb_sql_execution_plan_status":       gaussdb.DataSourceSqlExecutionPlanStatus(),
 
 			"huaweicloud_hss_agent_install_script":                       hss.DataSourceAgentInstallScript(),
 			"huaweicloud_hss_agent_versions":                             hss.DataSourceAgentVersions(),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_sql_execution_plan_status_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_sql_execution_plan_status_test.go
@@ -1,0 +1,62 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSqlExecutionPlanStatus_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_gaussdb_sql_execution_plan_status.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSqlExecutionPlanStatus_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "sql_plan_bind_state_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "sql_plan_bind_state_list.0.outline"),
+					resource.TestCheckResourceAttrSet(dataSource, "sql_plan_bind_state_list.0.cost"),
+					resource.TestCheckResourceAttrSet(dataSource, "sql_plan_bind_state_list.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "sql_plan_bind_state_list.0.sql_hash"),
+					resource.TestCheckResourceAttrSet(dataSource, "sql_plan_bind_state_list.0.plan_id"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceSqlExecutionPlanStatus_basic() string {
+	startTime := time.Now().UTC().Add(-8 * time.Hour).UnixMilli()
+	endTime := time.Now().UTC().Add(8 * time.Hour).UnixMilli()
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_instance_nodes" "test" {
+  instance_id = "%[1]s"
+}
+
+data "huaweicloud_gaussdb_slow_sql_list" "test" {
+  instance_id = "%[1]s"
+  start_time  = "%[2]d"
+  end_time    = "%[3]d"
+  threshold   = 1
+  node_ids    = data.huaweicloud_gaussdb_instance_nodes.test.nodes[*].id
+}
+
+data "huaweicloud_gaussdb_sql_execution_plan_status" "test" {
+  instance_id = "%[1]s"
+  node_id     = data.huaweicloud_gaussdb_slow_sql_list.test.slow_sql_infos[0].node_id
+  sql_id      = data.huaweicloud_gaussdb_slow_sql_list.test.slow_sql_infos[0].sql_id
+}
+`, acceptance.HW_GAUSSDB_INSTANCE_ID, startTime, endTime)
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_sql_execution_plan_status.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_sql_execution_plan_status.go
@@ -1,0 +1,161 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB POST /v3/{project_id}/instances/{instance_id}/sql/{node_id}/plans/query
+func DataSourceSqlExecutionPlanStatus() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSqlExecutionPlanStatusRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"sql_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"sql_plan_bind_state_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     sqlExecutionPlanStatusSqlPlanBindStateListSchema(),
+			},
+		},
+	}
+}
+
+func sqlExecutionPlanStatusSqlPlanBindStateListSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"outline": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cost": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sql_hash": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"plan_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceSqlExecutionPlanStatusRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("opengauss", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	httpUrl := "v3/{project_id}/instances/{instance_id}/sql/{node_id}/plans/query"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", d.Get("instance_id").(string))
+	listPath = strings.ReplaceAll(listPath, "{node_id}", d.Get("node_id").(string))
+
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	offset := 0
+	res := make([]interface{}, 0)
+	for {
+		listOpt.JSONBody = utils.RemoveNil(buildGetSqlExecutionPlanStatusBodyParams(d, offset))
+		listResp, err := client.Request("POST", listPath, &listOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving GaussDB SQL execution plan status: %s", err)
+		}
+		listRespBody, err := utils.FlattenResponse(listResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		sqlPlanBindStateList := flattenGetSqlExecutionPlanStatusSqlPlanBindStateListBody(listRespBody)
+		if len(sqlPlanBindStateList) == 0 {
+			break
+		}
+		res = append(res, sqlPlanBindStateList...)
+		offset += 100
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId.String())
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("sql_plan_bind_state_list", res),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetSqlExecutionPlanStatusBodyParams(d *schema.ResourceData, offset int) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"sql_id":    d.Get("sql_id"),
+		"page_size": 100,
+		"offset":    offset,
+	}
+	return bodyParams
+}
+
+func flattenGetSqlExecutionPlanStatusSqlPlanBindStateListBody(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("sql_plan_bind_state_list", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	if len(curArray) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"outline":  utils.PathSearch("outline", v, nil),
+			"cost":     utils.PathSearch("cost", v, nil),
+			"status":   utils.PathSearch("status", v, nil),
+			"sql_hash": utils.PathSearch("sql_hash", v, nil),
+			"plan_id":  utils.PathSearch("plan_id", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb sql execution plan status data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb sql execution plan status data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccDataSourceSqlExecutionPlanStatus_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccDataSourceSqlExecutionPlanStatus_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSqlExecutionPlanStatus_basic
=== PAUSE TestAccDataSourceSqlExecutionPlanStatus_basic
=== CONT  TestAccDataSourceSqlExecutionPlanStatus_basic
--- PASS: TestAccDataSourceSqlExecutionPlanStatus_basic (83.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   83.610s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
