### PR TITLE
feat(geminidb): add new data source to get the list of slow logs

### DIFF
--- a/docs/data-sources/geminidb_slow_logs.md
+++ b/docs/data-sources/geminidb_slow_logs.md
@@ -1,0 +1,78 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_slow_logs"
+description: |-
+  Use this data source to query the list of slow logs for GeminiDB Cassandra instances within HuaweiCloud.
+---
+
+# huaweicloud_geminidb_slow_logs
+
+Use this data source to query the list of slow logs for GeminiDB Cassandra instances within HuaweiCloud.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_geminidb_slow_logs" "test" {
+  instance_id = var.instance_id
+  start_date  = "2018-08-06T10:41:14+0800"
+  end_date    = "2018-08-07T10:41:14+0800"
+}
+```
+
+### Filter by Node ID
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+
+data "huaweicloud_gemini_db_slow_logs" "test" {
+  instance_id = var.instance_id
+  node_id     = var.node_id
+  start_date  = "2018-08-06T10:41:14+0800"
+  end_date    = "2018-08-07T10:41:14+0800"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to query the slow logs.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the GeminiDB Cassandra instance ID.
+
+* `start_date` - (Required, String) Specifies the start time, format is **yyyy-mm-ddThh:mm:ssZ**.
+
+* `end_date` - (Required, String) Specifies the end time, format is **yyyy-mm-ddThh:mm:ssZ**.
+
+* `node_id` - (Optional, String) Specifies the node ID. If empty, it means querying all nodes under the instance.
+
+* `type` - (Optional, String) Specifies the statement type. If empty, it means querying all statement types.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `slow_log_list` - The list of slow logs.
+  The [slow_log_list](#slow_logs_struct) structure is documented below.
+
+<a name="slow_logs_struct"></a>
+The `slow_log_list` block supports:
+
+* `time` - The execution time.
+
+* `database` - The database name.
+
+* `query_sample` - The execution syntax.
+
+* `type` - The statement type.
+
+* `start_time` - The occurrence time, UTC time.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1541,6 +1541,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_recycling_instances":           geminidb.DataSourceGeminiDBRecyclingInstances(),
 			"huaweicloud_geminidb_restorable_time_window":        geminidb.DataSourceGeminiDBRestorableTimeWindow(),
 			"huaweicloud_geminidb_scheduled_tasks":               geminidb.DataSourceGeminiDBScheduledTasks(),
+			"huaweicloud_geminidb_slow_logs":                     geminidb.DataSourceGeminiDBSlowLogs(),
 			"huaweicloud_geminidb_ssl_cert_download_links":       geminidb.DataSourceSslCertDownloadLinks(),
 			"huaweicloud_geminidb_table_restored_databases":      geminidb.DataSourceGeminiDBTableRestoredDatabases(),
 			"huaweicloud_geminidb_table_restored_tables":         geminidb.DataSourceGeminiDBTableRestoredTables(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_slow_logs_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_slow_logs_test.go
@@ -1,0 +1,62 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGeminiDBSlowLogs_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_geminidb_slow_logs.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDBSlowLogs_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "slow_log_list.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "slow_log_list.0.time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "slow_log_list.0.database"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "slow_log_list.0.query_sample"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "slow_log_list.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "slow_log_list.0.start_time"),
+
+					resource.TestCheckOutput("node_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGeminiDBSlowLogs_basic() string {
+	beginTime := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	beginTimeString := beginTime.Format("2006-01-02T15:04:05+0000")
+	endTime := time.Now().UTC()
+	endTimeString := endTime.Format("2006-01-02T15:04:05+0000")
+	return fmt.Sprintf(`
+data "huaweicloud_geminidb_slow_logs" "test" {
+  instance_id = "%[1]s"
+  start_date  = "%[2]s"
+  end_date    = "%[3]s"
+}
+
+data "huaweicloud_geminidb_slow_logs" "node_id_filter" {
+  instance_id = "%[1]s"
+  start_date  = "%[2]s"
+  end_date    = "%[3]s"
+  node_id     = "%[4]s"
+}
+
+output "node_id_filter_useful" {
+  value = length(data.huaweicloud_geminidb_slow_logs.node_id_filter.slow_log_list) > 0
+}
+`, acceptance.HW_GEMINIDB_INSATNCE_ID, beginTimeString, endTimeString, acceptance.HW_GEMINIDB_NODE_ID)
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_slow_logs.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_slow_logs.go
@@ -1,0 +1,176 @@
+package geminidb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GeminiDB GET /v3/{project_id}/instances/{instance_id}/slowlog
+func DataSourceGeminiDBSlowLogs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGeminiDBSlowLogsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"start_date": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"end_date": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"slow_log_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"database": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"query_sample": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"start_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGeminiDBSlowLogsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+
+	httpUrl := "v3/{project_id}/instances/{instance_id}/slowlog"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceID)
+
+	// Build query parameters
+	queryParams := buildSlowLogsQueryParams(d)
+	getPath += queryParams
+
+	resp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		getPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return diag.Errorf("error retrieving scheduled jobs: %s", err)
+	}
+
+	respJson, err := json.Marshal(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var respBody interface{}
+	err = json.Unmarshal(respJson, &respBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	slowLogList := utils.PathSearch("slow_log_list", respBody, []interface{}{}).([]interface{})
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("slow_log_list", flattenSlowLogList(slowLogList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildSlowLogsQueryParams(d *schema.ResourceData) string {
+	queryParams := ""
+
+	queryParams = fmt.Sprintf("%s&start_date=%v", queryParams, d.Get("start_date"))
+	queryParams = fmt.Sprintf("%s&end_date=%v", queryParams, d.Get("end_date"))
+	if v, ok := d.GetOk("node_id"); ok {
+		queryParams = fmt.Sprintf("%s&node_id=%v", queryParams, v)
+	}
+	if v, ok := d.GetOk("type"); ok {
+		queryParams = fmt.Sprintf("%s&type=%v", queryParams, v)
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return queryParams
+}
+
+func flattenSlowLogList(slowLogList []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(slowLogList))
+
+	for _, log := range slowLogList {
+		logMap := log.(map[string]interface{})
+
+		result = append(result, map[string]interface{}{
+			"time":         utils.PathSearch("time", logMap, ""),
+			"database":     utils.PathSearch("database", logMap, ""),
+			"query_sample": utils.PathSearch("query_sample", logMap, ""),
+			"type":         utils.PathSearch("type", logMap, ""),
+			"start_time":   utils.PathSearch("start_time", logMap, ""),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new data source to get the list of slow logs
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new data source to get the list of slow logs
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccGeminiDBSlowLogs_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccGeminiDBSlowLogs_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBSlowLogs_basic
=== PAUSE TestAccGeminiDBSlowLogs_basic
=== CONT  TestAccGeminiDBSlowLogs_basic
--- PASS: TestAccGeminiDBSlowLogs_basic (22.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  23.039s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
