### PR TITLE
feat(SecMaster): support collector_connection resource

### DIFF
--- a/docs/resources/secmaster_collector_connection.md
+++ b/docs/resources/secmaster_collector_connection.md
@@ -1,0 +1,88 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_collector_connection"
+description: |-
+  Manages a collector connection resource within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_collector_connection
+
+Manages a collector connection resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "connection_name" {}
+variable "template_id" {}
+
+resource "huaweicloud_secmaster_collector_connection" "test" {
+  workspace_id = var.workspace_id
+  title        = "test_connection"
+  name         = var.connection_name
+  template_id  = var.template_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the workspace ID.
+
+* `title` - (Required, String) Specifies the title of the collector connection.
+
+* `name` - (Required, String) Specifies the name of the collector connection.
+
+* `template_id` - (Required, String) Specifies the template UUID of the collector connection.
+
+* `description` - (Optional, String) Specifies the description of the collector connection.
+
+* `fields` - (Optional, List) Specifies the list of field configurations.
+
+  The [fields](#fields_struct) structure is documented below.
+
+<a name="fields_struct"></a>
+The `fields` block supports:
+
+* `title` - (Required, String) Specifies the field title. It is an input-only field that the API does not return.
+
+* `other` - (Required, String) Specifies other supplementary information. It is an input-only field that the API
+  does not return.
+
+* `name` - (Optional, String) Specifies the field name.
+
+* `type` - (Optional, String) Specifies the field type.
+
+* `value` - (Optional, String) Specifies the field value.
+
+* `template_field_id` - (Optional, String) Specifies the template field UUID.
+
+* `field_id` - (Optional, String) Specifies the unique UUID of the field. Only valid when updating an existing resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, which is the connection UUID returned by the API.
+
+* `fields_attribute` - The list of field configurations returned by the API.
+
+* `module_id` - The module UUID of the collector connection.
+
+## Import
+
+The collector connection can be imported using the `workspace_id` and `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_secmaster_collector_connection.test <workspace_id>/<id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to the `fields` not being
+imported from the API. It is generally recommended running `terraform plan` after importing this resource.
+You can then decide if changes should be applied to the resource, or the definition should be updated to align with the
+resource.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4464,6 +4464,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_collect_config":              secmaster.ResourceCollectConfig(),
 			"huaweicloud_secmaster_collector_channel_group":     secmaster.ResourceCollectorChannelGroup(),
 			"huaweicloud_secmaster_collector_channel_operation": secmaster.ResourceCollectorChannelOperation(),
+			"huaweicloud_secmaster_collector_connection":        secmaster.ResourceCollectorConnection(),
 			"huaweicloud_secmaster_collector_parser":            secmaster.ResourceCollectorParser(),
 			"huaweicloud_secmaster_component_template":          secmaster.ResourceComponentTemplate(),
 			"huaweicloud_secmaster_configuration_dictionary":    secmaster.ResourceConfigurationDictionary(),

--- a/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_collector_connection_test.go
+++ b/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_collector_connection_test.go
@@ -1,0 +1,64 @@
+package secmaster
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/secmaster"
+)
+
+func getResourceCollectorConnectionFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("secmaster", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	return secmaster.GetCollectorConnectionById(client, state.Primary.Attributes["workspace_id"], state.Primary.ID)
+}
+
+// Due to the complexity of fields configuration and API behavior, only expected failure
+// scenarios can be tested at present.
+func TestAccResourceCollectorConnection_basic(t *testing.T) {
+	var (
+		rName  = "huaweicloud_secmaster_collector_connection.test"
+		object interface{}
+		rc     = acceptance.InitResourceCheck(
+			rName,
+			&object,
+			getResourceCollectorConnectionFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+			acceptance.TestAccPreCheckSecMasterTemplateId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceCollectorConnection_basic(),
+				ExpectError: regexp.MustCompile(`参数不合法`),
+			},
+		},
+	})
+}
+
+func testAccResourceCollectorConnection_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_secmaster_collector_connection" "test" {
+  workspace_id = "%[1]s"
+  title        = "test_connection"
+  name         = "test_connection"
+  template_id  = "%[2]s"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_TEMPLATE_ID)
+}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_collector_connection.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_collector_connection.go
@@ -1,0 +1,402 @@
+package secmaster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var collectorConnectionNonUpdatableParams = []string{
+	"workspace_id",
+}
+
+// @API SecMaster POST /v1/{project_id}/workspaces/{workspace_id}/collector/connections
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/collector/connections/{connection_id}
+// @API SecMaster PUT /v1/{project_id}/workspaces/{workspace_id}/collector/connections/{connection_id}
+// @API SecMaster DELETE /v1/{project_id}/workspaces/{workspace_id}/collector/connections/{connection_id}
+func ResourceCollectorConnection() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCollectorConnectionCreate,
+		ReadContext:   resourceCollectorConnectionRead,
+		UpdateContext: resourceCollectorConnectionUpdate,
+		DeleteContext: resourceCollectorConnectionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCollectorConnectionImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(collectorConnectionNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"title": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"template_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"fields": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"title": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"other": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"template_field_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"field_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"fields_attribute": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"title": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"other": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"template_field_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"field_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+			// module_id is not required to be provided by the user, but it is required by the Update API
+			// and automatically obtained from the Read response.
+			"module_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCollectorConnectionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"title":       d.Get("title"),
+		"name":        d.Get("name"),
+		"template_id": d.Get("template_id"),
+		"module_id":   utils.ValueIgnoreEmpty(d.Get("module_id")),
+		"description": utils.ValueIgnoreEmpty(d.Get("description")),
+		"fields":      buildCollectorConnectionFieldsBodyParams(d.Get("fields").([]interface{})),
+	}
+}
+
+func buildCollectorConnectionFieldsBodyParams(fields []interface{}) []map[string]interface{} {
+	if len(fields) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, 0, len(fields))
+	for _, v := range fields {
+		rawMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"title":             utils.ValueIgnoreEmpty(rawMap["title"]),
+			"other":             utils.ValueIgnoreEmpty(rawMap["other"]),
+			"name":              utils.ValueIgnoreEmpty(rawMap["name"]),
+			"type":              utils.ValueIgnoreEmpty(rawMap["type"]),
+			"value":             utils.ValueIgnoreEmpty(rawMap["value"]),
+			"template_field_id": utils.ValueIgnoreEmpty(rawMap["template_field_id"]),
+			"field_id":          utils.ValueIgnoreEmpty(rawMap["field_id"]),
+		})
+	}
+
+	return rst
+}
+
+func resourceCollectorConnectionCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		region        = cfg.GetRegion(d)
+		createHttpUrl = "v1/{project_id}/workspaces/{workspace_id}/collector/connections"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{workspace_id}", d.Get("workspace_id").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCollectorConnectionBodyParams(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating collector connection: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	connectionId := utils.PathSearch("connection_id", respBody, "").(string)
+	if connectionId == "" {
+		return diag.Errorf("unable to find connection ID from the API response")
+	}
+
+	d.SetId(connectionId)
+
+	return resourceCollectorConnectionRead(context.Background(), d, meta)
+}
+
+func GetCollectorConnectionById(client *golangsdk.ServiceClient, workspaceId, connectionId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/workspaces/{workspace_id}/collector/connections/{connection_id}"
+	readPath := client.Endpoint + httpUrl
+	readPath = strings.ReplaceAll(readPath, "{project_id}", client.ProjectID)
+	readPath = strings.ReplaceAll(readPath, "{workspace_id}", workspaceId)
+	readPath = strings.ReplaceAll(readPath, "{connection_id}", connectionId)
+
+	readOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", readPath, &readOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func resourceCollectorConnectionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/collector/connections/{connection_id}"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	readPath := client.Endpoint + httpUrl
+	readPath = strings.ReplaceAll(readPath, "{project_id}", client.ProjectID)
+	readPath = strings.ReplaceAll(readPath, "{workspace_id}", workspaceId)
+	readPath = strings.ReplaceAll(readPath, "{connection_id}", d.Id())
+
+	readOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", readPath, &readOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving collector connection")
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("workspace_id", workspaceId),
+		d.Set("title", utils.PathSearch("title", respBody, nil)),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("template_id", utils.PathSearch("template_id", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("module_id", utils.PathSearch("module_id", respBody, nil)),
+		d.Set("fields_attribute", flattenFieldsAttribute(utils.PathSearch("fields", respBody, nil))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceCollectorConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/collector/connections/{connection_id}"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{workspace_id}", workspaceId)
+	updatePath = strings.ReplaceAll(updatePath, "{connection_id}", d.Id())
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCollectorConnectionBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating collector connection: %s", err)
+	}
+
+	return resourceCollectorConnectionRead(ctx, d, meta)
+}
+
+func flattenFieldsAttribute(fieldsResp interface{}) []interface{} {
+	if fieldsResp == nil {
+		return nil
+	}
+
+	fields, ok := fieldsResp.([]interface{})
+	if !ok || len(fields) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(fields))
+	for _, v := range fields {
+		rst = append(rst, map[string]interface{}{
+			"name":              utils.PathSearch("name", v, nil),
+			"title":             utils.PathSearch("title", v, nil),
+			"type":              utils.PathSearch("type", v, nil),
+			"value":             utils.PathSearch("value", v, nil),
+			"other":             utils.PathSearch("other", v, nil),
+			"template_field_id": utils.PathSearch("template_field_id", v, nil),
+			"field_id":          utils.PathSearch("field_id", v, nil),
+		})
+	}
+
+	return rst
+}
+
+func resourceCollectorConnectionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		workspaceId = d.Get("workspace_id").(string)
+		httpUrl     = "v1/{project_id}/workspaces/{workspace_id}/collector/connections/{connection_id}"
+	)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{workspace_id}", workspaceId)
+	deletePath = strings.ReplaceAll(deletePath, "{connection_id}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting collector connection (%s)", d.Id()))
+	}
+
+	return nil
+}
+
+func resourceCollectorConnectionImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.SplitN(importedId, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<id>', but got '%s'", importedId)
+	}
+
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, d.Set("workspace_id", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support collector_connection resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support collector_connection resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
cd ~/go/src/github.com/terraform-deer-wy && TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run=TestAccResourceCollectorConnection_basic -coverpkg=github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/secmaster -coverprofile=coverage.out && go tool cover -func=coverage.out | grep "resource_huaweicloud_secmast
er_connection.go"
=== RUN   TestAccResourceCollectorConnection_basic
=== PAUSE TestAccResourceCollectorConnection_basic
=== CONT  TestAccResourceCollectorConnection_basic
--- PASS: TestAccResourceCollectorConnection_basic (48.28s)
PASS
coverage: 5.0% of statements in github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/secmaster
```
<img width="502" height="15" alt="Snipaste_2026-06-22_10-44-50" src="https://github.com/user-attachments/assets/404d7d72-6ece-42b4-950c-eaffca2dfda8" />

<img width="910" height="716" alt="Snipaste_2026-06-22_15-07-28" src="https://github.com/user-attachments/assets/0c67ac02-51ff-4356-9182-60b596469c5f" />
<img width="1187" height="268" alt="Snipaste_2026-06-22_15-17-35" src="https://github.com/user-attachments/assets/2e1c2c68-666f-4c05-976f-ed6833adf6de" />
<img width="1014" height="398" alt="Snipaste_2026-06-22_15-19-03" src="https://github.com/user-attachments/assets/728cf8d7-6dab-4401-86d3-42bca15abc8e" />
<img width="793" height="740" alt="Snipaste_2026-06-22_15-19-54" src="https://github.com/user-attachments/assets/013c3ea7-1eec-4dca-a2c6-ac95ed1fe615" />
<img width="1644" height="184" alt="Snipaste_2026-06-22_15-22-42" src="https://github.com/user-attachments/assets/4a1c573d-b62a-4a81-bec3-ea57605d474d" />

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    
<img width="1017" height="322" alt="Snipaste_2026-06-22_11-04-05" src="https://github.com/user-attachments/assets/d6a3f590-bbdb-4641-91eb-111505aff6f1" />


    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
