### PR TITLE
feat(GeminiDB): add data source to query API that support parameter templates

### DIFF
--- a/docs/data-sources/geminidb_configuration_datastores.md
+++ b/docs/data-sources/geminidb_configuration_datastores.md
@@ -1,0 +1,62 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_configuration_datastores"
+description: |-
+  Use this data source to query API that support parameter templates.
+---
+
+# huaweicloud_geminidb_configuration_datastores
+
+Use this data source to query API that support parameter templates.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_geminidb_configuration_datastores" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `datastores` - The database API information.
+  The [datastores](#datastores_struct) structure is documented below.
+
+<a name="datastores_struct"></a>
+The `datastores` block supports:
+
+* `datastore_name` - The database API.
+  + **cassandra**: GeminiDB Cassandra instance.
+  + **mongodb**: GeminiDB Mongo instance.
+  + **influxdb**: GeminiDB Influx instance.
+  + **redis**: GeminiDB Redis instance.
+  + **dynamodb**: GeminiDB DynamoDB-Compatible instance.
+  + **hbase**: GeminiDB HBase instance.
+
+* `version` - The database API version.
+  + **3.11**: GeminiDB Cassandra instance 3.11.
+  + **4.0**: GeminiDB Mongo instance 4.0.
+  + **1.8**: GeminiDB Influx instance 1.8.
+  + **5.0**: GeminiDB Redis instance 5.0.
+
+* `mode` - The instance type.
+  + **Cluster**: GeminiDB Cassandra cluster instance with classic storage, GeminiDB Influx cluster instance
+  with classic storage, and proxy cluster GeminiDB Redis instance with classic storage.
+  + **CloudNativeCluster**: GeminiDB Cassandra cluster instance with cloud native storage, GeminiDB Influx
+  cluster (performance-enhanced) instance with cloud native storage, and GeminiDB Redis cluster instance with
+  cloud native storage.
+  + **ReplicaSet**: GeminiDB Mongo instance 4.0 in a replica set.
+  + **EnhancedCluster**: GeminiDB Influx cluster (performance-enhanced) instance with classic storage.
+  + **InfluxdbSingle**: single-node GeminiDB Influx instance.
+  + **RedisCluster**: Redis Cluster GeminiDB Redis instance which classic storage.
+  + **Replication**: primary/standby GeminiDB Redis instance with classic storage.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1524,6 +1524,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_available_flavors":             geminidb.DataSourceAvailableFlavors(),
 			"huaweicloud_geminidb_backups":                       geminidb.DataSourceGeminiDBBackups(),
 			"huaweicloud_geminidb_big_keys":                      geminidb.DataSourceBigKeys(),
+			"huaweicloud_geminidb_configuration_datastores":      geminidb.DataSourceConfigurationDatastores(),
 			"huaweicloud_geminidb_database_versions":             geminidb.DataSourceDatabaseVersions(),
 			"huaweicloud_geminidb_dedicated_resources":           geminidb.DataSourceDedicatedResources(),
 			"huaweicloud_geminidb_flavors":                       geminidb.DataSourceGeminiDBFlavors(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_configuration_datastores_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_configuration_datastores_test.go
@@ -1,0 +1,37 @@
+package geminidb
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceConfigurationDatastores_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_geminidb_configuration_datastores.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceConfigurationDatastores_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "datastores.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "datastores.0.datastore_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "datastores.0.version"),
+					resource.TestCheckResourceAttrSet(dataSource, "datastores.0.mode"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceConfigurationDatastores_basic = `data "huaweicloud_geminidb_configuration_datastores" "test" {}`

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_configuration_datastores.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_configuration_datastores.go
@@ -1,0 +1,115 @@
+package geminidb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GeminiDB GET /v3/{project_id}/configurations/datastores
+func DataSourceConfigurationDatastores() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceConfigurationDatastoresRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"datastores": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"datastore_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceConfigurationDatastoresRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/configurations/datastores"
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving the GeminiDB API that support parameter templates: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("datastores", flattenConfigurationDatastores(
+			utils.PathSearch("datastores", getRespBody, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenConfigurationDatastores(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		result = append(result, map[string]interface{}{
+			"datastore_name": utils.PathSearch("datastore_name", v, nil),
+			"version":        utils.PathSearch("version", v, nil),
+			"mode":           utils.PathSearch("mode", v, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to query API that support parameter templates.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new datasource to query API that support parameter templates.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccDataSourceConfigurationDatastores_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccDataSourceConfigurationDatastores_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceConfigurationDatastores_basic
=== PAUSE TestAccDataSourceConfigurationDatastores_basic
=== CONT  TestAccDataSourceConfigurationDatastores_basic
--- PASS: TestAccDataSourceConfigurationDatastores_basic (21.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  21.484s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/c0f5a3a9-abef-47c7-a699-ada397567b06" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
