### PR TITLE
fix(modelarts/v2_service): fix the mapping of the 'type' field in 'log_configs'

### DIFF
--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_service.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelartsv2_service.go
@@ -745,10 +745,10 @@ func buildV2ServiceLogConfigs(logConfigs []interface{}) []map[string]interface{}
 	for _, logConfig := range logConfigs {
 		result = append(result, map[string]interface{}{
 			// Required parameters.
-			"weight": utils.PathSearch("weight", logConfig, nil),
+			"type": utils.PathSearch("type", logConfig, nil),
 			// Optional parameters.
-			"log_group_id":  utils.PathSearch("log_group_id", logConfig, nil),
-			"log_stream_id": utils.PathSearch("log_stream_id", logConfig, nil),
+			"log_group_id":  utils.ValueIgnoreEmpty(utils.PathSearch("log_group_id", logConfig, nil)),
+			"log_stream_id": utils.ValueIgnoreEmpty(utils.PathSearch("log_stream_id", logConfig, nil)),
 		})
 	}
 
@@ -1019,7 +1019,7 @@ func flattenServiceLogConfigs(logConfigs []interface{}) []map[string]interface{}
 
 	for _, logConfig := range logConfigs {
 		result = append(result, map[string]interface{}{
-			"weight":        utils.PathSearch("weight", logConfig, nil),
+			"type":          utils.PathSearch("type", logConfig, nil),
 			"log_group_id":  utils.PathSearch("log_group_id", logConfig, nil),
 			"log_stream_id": utils.PathSearch("log_stream_id", logConfig, nil),
 		})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

In `log_configs` structure, change the incorrect field name `weight `to `type` (the field name defined in the schema is `type`).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
