### PR TITLE
feat(TaurusDB): add resource to manage user for a htap instance

### DIFF
--- a/docs/resources/taurusdb_htap_starrocks_user.md
+++ b/docs/resources/taurusdb_htap_starrocks_user.md
@@ -1,0 +1,98 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_htap_starrocks_user"
+description: |-
+  Manages a TaurusDB HTAP StarRocks database user resource within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_htap_starrocks_user
+
+Manages a TaurusDB HTAP StarRocks database user resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "htap_instance_id" {}
+variable "user_password" {}
+
+resource "huaweicloud_taurusdb_htap_starrocks_user" "test" {
+  instance_id = var.htap_instance_id
+  user_name   = "user_test"
+  password    = var.user_password
+  dml         = 2
+  ddl         = 0
+  databases   = ["*"]
+
+  lifecycle {
+    ignore_changes = [
+      password
+    ]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the StarRocks database user.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, NoneUpdatable) Specifies the StarRocks instance ID.
+
+* `user_name` - (Required, String, NoneUpdatable) Specifies the database account name.
+  The name must be `2` to `32` characters long, start with a lowercase letter, end with a lowercase letter or digit,
+  and can contain lowercase letters, digits, and underscores.
+
+* `password` - (Required, String) Specifies the password of the database account.
+  The password must be `8` to `32` characters long, cannot be the same as the username or the reversed username,
+  and must contain at least three of the following character types: uppercase letters, lowercase letters,
+  digits, and special characters (~!@#%^*-_=+?).
+
+* `databases` - (Required, List) Specifies the list of authorized databases names.
+
+* `dml` - (Optional, Int) Specifies the DML permission type.
+  The valid values are as follows:
+  + **0**: read and write permissions
+  + **1**: read-only permission
+  + **2**: read-only and setting permissions
+  + **3**: read-write and setting permissions
+  Defaults to **2**.
+
+* `ddl` - (Optional, Int) Specifies the DDL permission type.
+  The valid values are as follows:
+  + **0**: no DDL permission
+  + **1**: DDL permission
+  Defaults to **0**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in format `<instance_id>/<user_name>`.
+
+## Import
+
+The StarRocks database user can be imported using the `instance_id` and `user_name` separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_taurusdb_htap_starrocks_user.test <instance_id>/<user_name>
+```
+
+Note that the imported state may not be identical to your resource definition, the attribute `password` missing from
+the API response due to security reason. It is generally recommended running `terraform plan` after importing
+a resource. You can then decide if changes should be applied to the resource, or the resource definition should be
+updated to align with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_taurusdb_htap_starrocks_user" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      password
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -4647,6 +4647,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_htap_starrocks_replication":        taurusdb.ResourceTaurusDBHtapStarrocksReplication(),
 			"huaweicloud_taurusdb_htap_starrocks_replication_pause":  taurusdb.ResourceTaurusDBHtapStarrocksReplicationPause(),
 			"huaweicloud_taurusdb_htap_starrocks_replication_resume": taurusdb.ResourceTaurusDBHtapStarrocksReplicationResume(),
+			"huaweicloud_taurusdb_htap_starrocks_user":               taurusdb.ResourceTaurusDBHtapStarrocksUser(),
 			"huaweicloud_taurusdb_primary_standby_switch":            taurusdb.ResourceTaurusDBPrimaryStandbySwitch(),
 
 			"huaweicloud_tms_resource_tags": tms.ResourceResourceTags(),

--- a/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_user_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_user_test.go
@@ -1,0 +1,113 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/taurusdb"
+)
+
+func getHtapStarrocksUserResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	instanceID := state.Primary.Attributes["instance_id"]
+	userName := state.Primary.Attributes["user_name"]
+
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating TaurusDB client: %s", err)
+	}
+
+	users, err := taurusdb.QueryHtapStarrocksUsers(client, instanceID, userName)
+	if err != nil {
+		return nil, err
+	}
+	// If the length of users is 0, the resource does not exist.
+	if len(users) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return users[0], nil
+}
+
+func TestAccTaurusDBHtapStarrocksUser_basic(t *testing.T) {
+	var obj interface{}
+	rName := "huaweicloud_taurusdb_htap_starrocks_user.test"
+	userName := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getHtapStarrocksUserResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckTaurusDBHtapInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaurusDBHtapStarrocksUser_basic(userName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "user_name", userName),
+					resource.TestCheckResourceAttr(rName, "dml", "3"),
+					resource.TestCheckResourceAttr(rName, "ddl", "1"),
+					resource.TestCheckResourceAttr(rName, "databases.#", "2"),
+				),
+			},
+			{
+				Config: testAccTaurusDBHtapStarrocksUser_update(userName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "user_name", userName),
+					resource.TestCheckResourceAttr(rName, "dml", "0"),
+					resource.TestCheckResourceAttr(rName, "ddl", "0"),
+					resource.TestCheckResourceAttr(rName, "databases.#", "1"),
+					resource.TestCheckResourceAttr(rName, "databases.0", "*"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func testAccTaurusDBHtapStarrocksUser_basic(userName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_taurusdb_htap_starrocks_user" "test" {
+  instance_id = "%[1]s"
+  user_name   = "%[2]s"
+  password    = "Test@12345678"
+  databases   = ["sys", "information_schema"]
+  dml         = 3
+  ddl         = 1
+}
+`, acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID, userName)
+}
+
+func testAccTaurusDBHtapStarrocksUser_update(userName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_taurusdb_htap_starrocks_user" "test" {
+  instance_id = "%[1]s"
+  user_name   = "%[2]s"
+  password    = "Test@87654321"
+  dml         = 0
+  ddl         = 0
+  databases   = ["*"]
+}
+`, acceptance.HW_TAURUSDB_HTAP_INSTANCE_ID, userName)
+}

--- a/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_user.go
+++ b/huaweicloud/services/taurusdb/resource_huaweicloud_taurusdb_htap_starrocks_user.go
@@ -1,0 +1,367 @@
+package taurusdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var htapStarRocksUserNoneUpdatableParams = []string{
+	"instance_id", "user_name",
+}
+
+// @API TaurusDB POST /v3/{project_id}/instances/{instance_id}/starrocks/users
+// @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/starrocks/users
+// @API TaurusDB PUT /v3/{project_id}/instances/{instance_id}/starrocks/users/permission
+// @API TaurusDB PUT /v3/{project_id}/instances/{instance_id}/starrocks/users/password
+// @API TaurusDB DELETE /v3/{project_id}/instances/{instance_id}/starrocks/users
+func ResourceTaurusDBHtapStarrocksUser() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTaurusDBHtapStarrocksUserCreate,
+		UpdateContext: resourceTaurusDBHtapStarrocksUserUpdate,
+		ReadContext:   resourceTaurusDBHtapStarrocksUserRead,
+		DeleteContext: resourceTaurusDBHtapStarrocksUserDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHtapStarrocksUserImportState,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(htapStarRocksUserNoneUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"databases": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"dml": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"ddl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceTaurusDBHtapStarrocksUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating TaurusDB client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	userName := d.Get("user_name").(string)
+
+	createHttpUrl := "v3/{project_id}/instances/{instance_id}/starrocks/users"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceID)
+
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildCreateStarrocksUserBodyParams(d),
+	}
+
+	resp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("error creating TaurusDB HTAP StarRocks user: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	result := utils.PathSearch("result", respBody, "").(string)
+	if result != "SUCCESS" {
+		return diag.Errorf("error creating TaurusDB HTAP StarRocks user: result is %s", result)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", instanceID, userName))
+
+	return resourceTaurusDBHtapStarrocksUserRead(ctx, d, meta)
+}
+
+func buildCreateStarrocksUserBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"user_name": d.Get("user_name"),
+		"password":  d.Get("password"),
+		"databases": utils.ExpandToStringList(d.Get("databases").(*schema.Set).List()),
+	}
+	// set param ddl only when it's set by user
+	rawConfig := d.GetRawConfig()
+	if dmlVal := rawConfig.GetAttr("dml"); !dmlVal.IsNull() {
+		bodyParams["dml"] = d.Get("dml").(int)
+	}
+	// set param ddl only when it's set by user
+	if ddlVal := rawConfig.GetAttr("ddl"); !ddlVal.IsNull() {
+		bodyParams["ddl"] = d.Get("ddl").(int)
+	}
+	return bodyParams
+}
+
+func resourceTaurusDBHtapStarrocksUserRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceID = d.Get("instance_id").(string)
+		userName   = d.Get("user_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating TaurusDB client: %s", err)
+	}
+
+	// Query the user by user_name filter
+	users, err := QueryHtapStarrocksUsers(client, instanceID, userName)
+	if err != nil {
+		err = common.ConvertExpected400ErrInto404Err(err, "error_code", "DBS.200076")
+		err = common.ConvertExpected403ErrInto404Err(err, "error_name", "DBS.200044")
+		return common.CheckDeletedDiag(d, err, "error retrieving TaurusDB HTAP StarRocks user")
+	}
+
+	// No user found, return 404
+	if len(users) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving TaurusDB HTAP StarRocks user")
+	}
+
+	user := users[0]
+	databasesRaw := utils.PathSearch("databases", user, make([]interface{}, 0)).([]interface{})
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", region),
+		d.Set("instance_id", instanceID),
+		d.Set("user_name", userName),
+		d.Set("databases", utils.ExpandToStringList(databasesRaw)),
+		d.Set("dml", int(utils.PathSearch("dml", user, float64(0)).(float64))),
+		d.Set("ddl", int(utils.PathSearch("ddl", user, float64(0)).(float64))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceTaurusDBHtapStarrocksUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceID = d.Get("instance_id").(string)
+		userName   = d.Get("user_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating TaurusDB client: %s", err)
+	}
+
+	if d.HasChange("password") {
+		if err := updateStarrocksUserPassword(ctx, d, client, instanceID, userName); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChanges("databases", "dml", "ddl") {
+		if err := updateStarrocksUserPermission(ctx, d, client, instanceID, userName); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceTaurusDBHtapStarrocksUserRead(ctx, d, meta)
+}
+
+func updateStarrocksUserPassword(_ context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
+	instanceID, userName string) error {
+	updateHttpUrl := "v3/{project_id}/instances/{instance_id}/starrocks/users/password"
+	updatePath := client.Endpoint + updateHttpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceID)
+
+	updateOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	updateOpts.JSONBody = map[string]interface{}{
+		"user_name": userName,
+		"password":  d.Get("password"),
+	}
+
+	resp, err := client.Request("PUT", updatePath, &updateOpts)
+	if err != nil {
+		return fmt.Errorf("error updating TaurusDB HTAP StarRocks user password: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	result := utils.PathSearch("result", respBody, "").(string)
+	if result != "SUCCESS" {
+		return fmt.Errorf("error updating TaurusDB HTAP StarRocks user password: result is %s", result)
+	}
+
+	return nil
+}
+
+func updateStarrocksUserPermission(_ context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
+	instanceID, userName string) error {
+	updateHttpUrl := "v3/{project_id}/instances/{instance_id}/starrocks/users/permission"
+	updatePath := client.Endpoint + updateHttpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{instance_id}", instanceID)
+
+	updateOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: buildUpdateStarrocksUserBodyParams(d, userName),
+	}
+
+	resp, err := client.Request("PUT", updatePath, &updateOpts)
+	if err != nil {
+		return fmt.Errorf("error updating TaurusDB HTAP StarRocks user permission: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	result := utils.PathSearch("result", respBody, "").(string)
+	if result != "SUCCESS" {
+		return fmt.Errorf("error updating TaurusDB HTAP StarRocks user permission: result is %s", result)
+	}
+
+	return nil
+}
+
+func buildUpdateStarrocksUserBodyParams(d *schema.ResourceData, userName string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"user_name": userName,
+	}
+	if d.HasChange("databases") {
+		bodyParams["databases"] = utils.ExpandToStringList(d.Get("databases").(*schema.Set).List())
+	}
+	if d.HasChange("dml") {
+		// set param ddl only when it's set by user
+		rawConfig := d.GetRawConfig()
+		if dmlVal := rawConfig.GetAttr("dml"); !dmlVal.IsNull() {
+			bodyParams["dml"] = d.Get("dml").(int)
+		}
+	}
+	if d.HasChange("ddl") {
+		// set param ddl only when it's set by user
+		rawConfig := d.GetRawConfig()
+		if ddlVal := rawConfig.GetAttr("ddl"); !ddlVal.IsNull() {
+			bodyParams["ddl"] = d.Get("ddl").(int)
+		}
+	}
+	return bodyParams
+}
+
+func resourceTaurusDBHtapStarrocksUserDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceID = d.Get("instance_id").(string)
+		userName   = d.Get("user_name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating TaurusDB client: %s", err)
+	}
+
+	deleteHttpUrl := "v3/{project_id}/instances/{instance_id}/starrocks/users"
+	deletePath := client.Endpoint + deleteHttpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", instanceID)
+	deletePath = fmt.Sprintf("%s?user_name=%s", deletePath, userName)
+
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	resp, err := client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting TaurusDB HTAP StarRocks user")
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	result := utils.PathSearch("result", respBody, "").(string)
+	if result != "SUCCESS" {
+		return diag.Errorf("error deleting TaurusDB HTAP StarRocks user: result is %s", result)
+	}
+
+	return nil
+}
+
+func resourceHtapStarrocksUserImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importId := d.Id()
+	parts := strings.Split(importId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, must be <instance_id>/<user_name>, but got `%s`", importId)
+	}
+
+	mErr := multierror.Append(
+		d.Set("instance_id", parts[0]),
+		d.Set("user_name", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource to manage user for a htap instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add resource to manage user for a htap instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccTaurusDBHtapStarrocksUser'
=== RUN   TestAccTaurusDBHtapStarrocksUser_basic
=== PAUSE TestAccTaurusDBHtapStarrocksUser_basic
=== CONT  TestAccTaurusDBHtapStarrocksUser_basic
--- PASS: TestAccTaurusDBHtapStarrocksUser_basic (36.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 36.581s
```

<img width="1105" height="247" alt="Image" src="https://github.com/user-attachments/assets/9ebe88a3-80e0-4053-a4f8-a968640f56a9" />


* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> <img width="1000" height="262" alt="Image" src="https://github.com/user-attachments/assets/177ea611-0bb1-4caf-89f1-86d841b7b1f8" /> <<<<<<

    ab. Related resources (parent resources) not found
    \>>>>>>  <img width="1315" height="347" alt="Image" src="https://github.com/user-attachments/assets/129d64f5-8ed8-4827-ac75-1be274cec30b" /> <<<<<<

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>><img width="1058" height="281" alt="goland64_aEneCuIX9d" src="https://github.com/user-attachments/assets/83c38242-1ecd-4108-bab8-4f4c1863592c" /><<<<<<

    bb. Related resources (parent resources) not found
    \>>>>>> <img width="1379" height="379" alt="goland64_q7yoeY4exh" src="https://github.com/user-attachments/assets/29375eeb-d11e-421f-b972-74264d9d758d" /> <<<<<<
