### PR TITLE
fix(codecheck): ensure locks are properly released after use

### DIFF
--- a/huaweicloud/helper/mutexkv/mutexkv_test.go
+++ b/huaweicloud/helper/mutexkv/mutexkv_test.go
@@ -50,11 +50,13 @@ func TestMutexKVDifferentKeys(t *testing.T) {
 	mkv := NewMutexKV()
 
 	mkv.Lock("foo")
+	defer mkv.Unlock("foo")
 
 	doneCh := make(chan struct{})
 
 	go func() {
 		mkv.Lock("bar")
+		defer mkv.Unlock("bar")
 		close(doneCh)
 	}()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix CodeCheck static analysis warnings to ensure locks are properly released after use, preventing potential resource leaks or deadlocks.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
This change only adds missing lock release logic (e.g., adding defer Unlock). There are no functional changes; this is purely a code quality fix.

<img width="1366" height="692" alt="image" src="https://github.com/user-attachments/assets/f4aeef67-ddd8-4c95-9b02-d2f1734cb600" />


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestMutexKVDifferentKeys'
...
=== RUN   TestMutexKVDifferentKeys
--- PASS: TestMutexKVDifferentKeys(0.00s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv	0.032s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
