### PR TITLE
feat(GaussDB): add gaussdb top twenty tables storage usage data source

### DIFF
--- a/docs/data-sources/gaussdb_top_twenty_tables_storage_usage.md
+++ b/docs/data-sources/gaussdb_top_twenty_tables_storage_usage.md
@@ -1,0 +1,99 @@
+---
+subcategory: "GaussDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_top_twenty_tables_storage_usage"
+description: |-
+  Use this data source to query the storage usage of the top 20 tables of a GaussDB instance within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_top_twenty_tables_storage_usage
+
+Use this data source to query the storage usage of the top 20 tables of a GaussDB instance within HuaweiCloud.
+
+## Example Usage
+
+### Query top 20 tables by storage usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_gaussdb_top_twenty_tables_storage_usage" "test" {
+  instance_id = var.instance_id
+}
+```
+
+### Query with job_id and node_id
+
+```hcl
+variable "instance_id" {}
+variable "job_id" {}
+variable "node_id" {}
+
+data "huaweicloud_gaussdb_top_twenty_tables_storage_usage" "test" {
+  instance_id = var.instance_id
+  job_id      = var.job_id
+  node_id     = var.node_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the top table storage usage.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the GaussDB instance.
+
+* `job_id` - (Optional, String) Specifies the workflow ID, obtained from the first call without any task parameters.
+
+* `node_id` - (Optional, String) Specifies the workflow execution node ID, obtained from the first call without any task
+   parameters.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `state` - The job status, which is returned when `job_id` in the request is not empty.
+
+* `table_volumes` - The list of top table storage usage information.
+  The [table_volumes](#table_volumes_struct) structure is documented below.
+
+<a name="table_volumes_struct"></a>
+The `table_volumes` block supports:
+
+* `id` - The ID of the table.
+
+* `table_name` - The name of the table.
+
+* `table_owner` - The owner of the table.
+
+* `database_name` - The name of the database.
+
+* `schema_name` - The name of the schema.
+
+* `is_part_type` - Whether the table has partition table properties.
+
+* `is_hash_cluster_key` - Whether it contains hash partition column information.
+
+* `tuples` - The number of tuples in the table.
+
+* `create_time` - The creation time of the table.
+
+* `update_time` - The update time of the table.
+
+* `average_size` - The average size of the table.
+
+* `max_ratio` - The maximum ratio.
+
+* `min_ratio` - The minimum ratio.
+
+* `table_size` - The size of the table (e.g., "24 kB").
+
+* `skew_size` - The skew size of the table.
+
+* `skew_ratio` - The skew ratio of the table.
+
+* `skew_stddev` - The skew standard deviation of the table.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1612,6 +1612,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_database_storage_usage":          gaussdb.DataSourceDatabaseStorageUsage(),
 			"huaweicloud_gaussdb_schemas_storage_usage":           gaussdb.DataSourceSchemasStorageUsage(),
 			"huaweicloud_gaussdb_tables_storage_usage":            gaussdb.DataSourceTablesStorageUsage(),
+			"huaweicloud_gaussdb_top_twenty_tables_storage_usage": gaussdb.DataSourceTopTwentyTablesStorageUsage(),
 
 			"huaweicloud_hss_agent_install_script":                       hss.DataSourceAgentInstallScript(),
 			"huaweicloud_hss_agent_versions":                             hss.DataSourceAgentVersions(),

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_top_twenty_tables_storage_usage_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_top_twenty_tables_storage_usage_test.go
@@ -1,0 +1,63 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTopTwentyTablesStorageUsage_basic(t *testing.T) {
+	dataSource1 := "data.huaweicloud_gaussdb_top_twenty_tables_storage_usage.test1"
+	dataSource2 := "data.huaweicloud_gaussdb_top_twenty_tables_storage_usage.test2"
+	dc1 := acceptance.InitDataSourceCheck(dataSource1)
+	dc2 := acceptance.InitDataSourceCheck(dataSource2)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceTopTwentyTablesStorageUsage_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc1.CheckResourceExists(),
+					dc2.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource1, "job_id"),
+					resource.TestCheckResourceAttrSet(dataSource1, "node_id"),
+					resource.TestCheckResourceAttrSet(dataSource2, "table_volumes.#"),
+					resource.TestCheckResourceAttrSet(dataSource2, "table_volumes.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource2, "table_volumes.0.table_name"),
+					resource.TestCheckResourceAttrSet(dataSource2, "table_volumes.0.table_owner"),
+					resource.TestCheckResourceAttrSet(dataSource2, "table_volumes.0.database_name"),
+					resource.TestCheckResourceAttrSet(dataSource2, "table_volumes.0.schema_name"),
+					resource.TestCheckResourceAttrSet(dataSource2, "table_volumes.0.is_part_type"),
+					resource.TestCheckResourceAttrSet(dataSource2, "table_volumes.0.is_hash_cluster_key"),
+					resource.TestCheckResourceAttrSet(dataSource2, "table_volumes.0.tuples"),
+					resource.TestCheckResourceAttrSet(dataSource2, "table_volumes.0.create_time"),
+					resource.TestCheckResourceAttrSet(dataSource2, "table_volumes.0.update_time"),
+					resource.TestCheckResourceAttrSet(dataSource2, "table_volumes.0.table_size"),
+					resource.TestCheckResourceAttrSet(dataSource2, "state"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceTopTwentyTablesStorageUsage_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_gaussdb_top_twenty_tables_storage_usage" "test1" {
+  instance_id = "%[1]s"
+}
+
+data "huaweicloud_gaussdb_top_twenty_tables_storage_usage" "test2" {
+  instance_id = "%[1]s"
+  job_id      = data.huaweicloud_gaussdb_top_twenty_tables_storage_usage.test1.job_id
+  node_id     = data.huaweicloud_gaussdb_top_twenty_tables_storage_usage.test1.node_id
+}
+`, acceptance.HW_GAUSSDB_INSTANCE_ID)
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_top_twenty_tables_storage_usage.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_top_twenty_tables_storage_usage.go
@@ -1,0 +1,225 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDB GET /v3.1/{project_id}/instances/{instance_id}/top-table-volume
+func DataSourceTopTwentyTablesStorageUsage() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTopTwentyTablesStorageUsageRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"table_volumes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     topTableVolumeSchema(),
+			},
+		},
+	}
+}
+
+func topTableVolumeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"table_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"table_owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"schema_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_part_type": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"is_hash_cluster_key": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"tuples": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"average_size": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"max_ratio": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"min_ratio": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"table_size": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"skew_size": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"skew_ratio": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"skew_stddev": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTopTwentyTablesStorageUsageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	client, err := cfg.NewServiceClient("opengauss", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	httpUrl := "v3.1/{project_id}/instances/{instance_id}/top-table-volume"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", d.Get("instance_id").(string))
+	getPath += buildTopTwentyTablesStorageUsageQueryParams(d)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving GaussDB top twenty tables storage usage: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId.String())
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("job_id", utils.PathSearch("job_id", getRespBody, nil)),
+		d.Set("node_id", utils.PathSearch("node_id", getRespBody, nil)),
+		d.Set("state", utils.PathSearch("state", getRespBody, nil)),
+		d.Set("table_volumes", flattenTopTableVolumeBody(getRespBody)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildTopTwentyTablesStorageUsageQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("job_id"); ok {
+		res += "&job_id=" + v.(string)
+	}
+	if v, ok := d.GetOk("node_id"); ok {
+		res += "&node_id=" + v.(string)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}
+
+func flattenTopTableVolumeBody(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("table_volumes", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	if len(curArray) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":                  utils.PathSearch("id", v, nil),
+			"table_name":          utils.PathSearch("table_name", v, nil),
+			"table_owner":         utils.PathSearch("table_owner", v, nil),
+			"database_name":       utils.PathSearch("database_name", v, nil),
+			"schema_name":         utils.PathSearch("schema_name", v, nil),
+			"is_part_type":        utils.PathSearch("is_part_type", v, nil),
+			"is_hash_cluster_key": utils.PathSearch("is_hash_cluster_key", v, nil),
+			"tuples":              utils.PathSearch("tuples", v, nil),
+			"create_time":         utils.PathSearch("create_time", v, nil),
+			"update_time":         utils.PathSearch("update_time", v, nil),
+			"average_size":        utils.PathSearch("average_size", v, nil),
+			"max_ratio":           utils.PathSearch("max_ratio", v, nil),
+			"min_ratio":           utils.PathSearch("min_ratio", v, nil),
+			"table_size":          utils.PathSearch("table_size", v, nil),
+			"skew_size":           utils.PathSearch("skew_size", v, nil),
+			"skew_ratio":          utils.PathSearch("skew_ratio", v, nil),
+			"skew_stddev":         utils.PathSearch("skew_stddev", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb top twenty tables storage usage data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb top twenty tables storage usage data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccDataSourceTopTwentyTablesStorageUsage_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccDataSourceTopTwentyTablesStorageUsage_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceTopTwentyTablesStorageUsage_basic
=== PAUSE TestAccDataSourceTopTwentyTablesStorageUsage_basic
=== CONT  TestAccDataSourceTopTwentyTablesStorageUsage_basic
--- PASS: TestAccDataSourceTopTwentyTablesStorageUsage_basic (51.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   51.289s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
