### PR TITLE
fix(golangci): repair some of warning reports

### DIFF
--- a/huaweicloud/config/auth.go
+++ b/huaweicloud/config/auth.go
@@ -138,7 +138,7 @@ func genClient(c *Config, ao golangsdk.AuthOptionsProvider) (*golangsdk.Provider
 			Rt:         transport,
 			MaxRetries: c.MaxRetries,
 		},
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
 			if client.AKSKAuthOptions.AccessKey != "" {
 				if c.SigningAlgorithm == "" || c.SigningAlgorithm == signer.HmacSHA256 {
 					return auth.Sign(req, client.AKSKAuthOptions.AccessKey, client.AKSKAuthOptions.SecretKey)

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -279,7 +279,7 @@ func (c *Config) SetServiceEndpoint(service, endpoint string) {
 	}
 }
 
-func retryBackoffFunc(ctx context.Context, respErr *golangsdk.ErrUnexpectedResponseCode, e error, retries uint) error {
+func retryBackoffFunc(ctx context.Context, _ *golangsdk.ErrUnexpectedResponseCode, e error, retries uint) error {
 	minutes := int(math.Pow(2, float64(retries)))
 	if minutes > 30 { // won't wait more than 30 minutes
 		minutes = 30

--- a/huaweicloud/config/hc_config.go
+++ b/huaweicloud/config/hc_config.go
@@ -79,7 +79,7 @@ func buildAuthCredentials(c *Config, region string, isDerived bool) (*basic.Cred
 	return &credentials, nil
 }
 
-func buildGlobalAuthCredentials(c *Config, region string) (*global.Credentials, error) {
+func buildGlobalAuthCredentials(c *Config) (*global.Credentials, error) {
 	if c.AccessKey == "" || c.SecretKey == "" {
 		return nil, fmt.Errorf("access_key or secret_key is missing in the provider")
 	}
@@ -333,7 +333,7 @@ func implNewHcClient(c *Config, region, product string, isGlobal, isDerived bool
 		WithHttpConfig(buildHTTPConfig(c))
 
 	if isGlobal {
-		credentials, err := buildGlobalAuthCredentials(c, region)
+		credentials, err := buildGlobalAuthCredentials(c)
 		if err != nil {
 			return nil, err
 		}

--- a/huaweicloud/data_source_huaweicloud_availability_zones_test.go
+++ b/huaweicloud/data_source_huaweicloud_availability_zones_test.go
@@ -15,7 +15,7 @@ func TestAccAvailabilityZones_basic(t *testing.T) {
 			{
 				Config: testAccAvailabilityZonesConfig_all,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.huaweicloud_availability_zones.all", "names.#", regexp.MustCompile("[1-9]\\d*")),
+					resource.TestMatchResourceAttr("data.huaweicloud_availability_zones.all", "names.#", regexp.MustCompile(`[1-9]\d*`)),
 				),
 			},
 		},

--- a/huaweicloud/helper/internal/vault/pgpkeys/keybase_test.go
+++ b/huaweicloud/helper/internal/vault/pgpkeys/keybase_test.go
@@ -28,6 +28,7 @@ func TestFetchKeybasePubkeys(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error parsing key for user %s: %v", user, err)
 		}
+		//nolint:gocritic
 		fingerprints = append(fingerprints, hex.EncodeToString(entity.PrimaryKey.Fingerprint[:]))
 	}
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_endpoint_whitelist_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_endpoint_whitelist_test.go
@@ -46,7 +46,6 @@ func TestAccEndpointWhiteList_basic(t *testing.T) {
 	var (
 		permissions []endpoints.EndpointPermission
 
-		name  = acceptance.RandomAccResourceName()
 		rName = "huaweicloud_apig_endpoint_whitelist.test"
 
 		rc = acceptance.InitResourceCheck(
@@ -65,7 +64,7 @@ func TestAccEndpointWhiteList_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointWhiteList_basic(name),
+				Config: testAccEndpointWhiteList_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
@@ -73,7 +72,7 @@ func TestAccEndpointWhiteList_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEndpointWhiteList_update(name),
+				Config: testAccEndpointWhiteList_update(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "instance_id", acceptance.HW_APIG_DEDICATED_INSTANCE_ID),
@@ -89,7 +88,7 @@ func TestAccEndpointWhiteList_basic(t *testing.T) {
 	})
 }
 
-func testAccEndpointWhiteList_basic(rName string) string {
+func testAccEndpointWhiteList_basic() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_apig_endpoint_whitelist" "test" {
   instance_id = "%[1]s"
@@ -101,7 +100,7 @@ resource "huaweicloud_apig_endpoint_whitelist" "test" {
 `, acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
 }
 
-func testAccEndpointWhiteList_update(rName string) string {
+func testAccEndpointWhiteList_update() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_apig_endpoint_whitelist" "test" {
   instance_id = "%[1]s"

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_feature_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_feature_test.go
@@ -25,7 +25,6 @@ func TestAccInstanceFeature_basic(t *testing.T) {
 	var (
 		feature interface{}
 		rName   = "huaweicloud_apig_instance_feature.test"
-		name    = acceptance.RandomAccResourceName()
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -44,7 +43,7 @@ func TestAccInstanceFeature_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceFeature_basic_step1(name),
+				Config: testAccInstanceFeature_basic_step1(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", "ratelimit"),
@@ -53,7 +52,7 @@ func TestAccInstanceFeature_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceFeature_basic_step2(name),
+				Config: testAccInstanceFeature_basic_step2(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", "ratelimit"),
@@ -86,7 +85,7 @@ func testAccInstanceFeatureResourceImportStateFunc(rName string) resource.Import
 	}
 }
 
-func testAccInstanceFeature_basic_step1(name string) string {
+func testAccInstanceFeature_basic_step1() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_apig_instance_feature" "test" {
   instance_id = "%[1]s"
@@ -100,7 +99,7 @@ resource "huaweicloud_apig_instance_feature" "test" {
 `, acceptance.HW_APIG_DEDICATED_INSTANCE_ID)
 }
 
-func testAccInstanceFeature_basic_step2(name string) string {
+func testAccInstanceFeature_basic_step2() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_apig_instance_feature" "test" {
   instance_id = "%[1]s"

--- a/huaweicloud/services/acceptance/ces/data_source_huaweicloud_ces_event_details_test.go
+++ b/huaweicloud/services/acceptance/ces/data_source_huaweicloud_ces_event_details_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestAccDataSourceCesEventDetails_basic(t *testing.T) {
 	dataSource := "data.huaweicloud_ces_event_details.test"
-	rName := acceptance.RandomAccResourceName()
 	dc := acceptance.InitDataSourceCheck(dataSource)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -26,7 +25,7 @@ func TestAccDataSourceCesEventDetails_basic(t *testing.T) {
 				Config: testEventReport_basic(),
 			},
 			{
-				Config: testDataSourceCesEventDetails_basic(rName),
+				Config: testDataSourceCesEventDetails_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSource, "event_info.0.event_id"),
@@ -47,7 +46,7 @@ func TestAccDataSourceCesEventDetails_basic(t *testing.T) {
 	})
 }
 
-func testDataSourceCesEventDetails_basic(name string) string {
+func testDataSourceCesEventDetails_basic() string {
 	return fmt.Sprintf(`
 %[1]s
 	

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go
@@ -132,7 +132,7 @@ func testAccCheckCTSTrackerDestroy(s *terraform.State) error {
 	return nil
 }
 
-func getCTSTrackerResourceObj(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getCTSTrackerResourceObj(conf *config.Config, _ *terraform.ResourceState) (interface{}, error) {
 	client, err := conf.NewServiceClient("cts", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating CTS client: %s", err)

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
@@ -446,7 +446,7 @@ func TestAccDDSV3Instance_withAutoEnlargePolicy(t *testing.T) {
 }
 
 func testAccCheckDDSV3InstanceFlavor(instance *instances.InstanceResponse, groupType, key string, v interface{}) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		if key == "num" {
 			if groupType == "shard" {
 				groupIDs := make([]string, 0)

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_pool_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_pool_test.go
@@ -264,7 +264,7 @@ func TestAccElbV3Pool_basic_with_type_ip(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccElbV3PoolConfig_update_with_type_ip(rName, rNameUpdate),
+				Config: testAccElbV3PoolConfig_update_with_type_ip(rNameUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
@@ -616,7 +616,7 @@ resource "huaweicloud_elb_pool" "test" {
 `, rName)
 }
 
-func testAccElbV3PoolConfig_update_with_type_ip(rName, rNameUpdate string) string {
+func testAccElbV3PoolConfig_update_with_type_ip(rNameUpdate string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_elb_pool" "test" {
   name      = "%s"

--- a/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_network_acl_test.go
+++ b/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_network_acl_test.go
@@ -103,7 +103,7 @@ func TestAccNetworkACLResource_no_subnets(t *testing.T) {
 }
 
 func testAccCheckNetworkACLNetBlockExists(r *firewalls.Firewall) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		if len(r.Subnets) == 0 {
 			return fmt.Errorf("the Subnet of IEC network ACL is not set")
 		}

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_loadbalancer_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_loadbalancer_test.go
@@ -266,7 +266,7 @@ func TestAccLBV2LoadBalancer_changeToPrePaid(t *testing.T) {
 
 func testAccCheckLBV2LoadBalancerHasSecGroup(
 	lb *loadbalancers.LoadBalancer, sg *groups.SecurityGroup) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
 		networkingClient, err := cfg.NetworkingV2Client(acceptance.HW_REGION_NAME)
 		if err != nil {

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_subnet_test.go
@@ -97,7 +97,7 @@ func TestAccVpcSubnetV1_ipv6(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_enable", "true"),
 					resource.TestMatchResourceAttr(resourceName, "ipv6_cidr",
-						regexp.MustCompile("([[:xdigit:]]*):([[:xdigit:]]*:){1,6}[[:xdigit:]]*/\\d{1,3}")),
+						regexp.MustCompile(`([[:xdigit:]]*):([[:xdigit:]]*:){1,6}[[:xdigit:]]*/\d{1,3}`)),
 					resource.TestMatchResourceAttr(resourceName, "ipv6_gateway",
 						regexp.MustCompile("([[:xdigit:]]*):([[:xdigit:]]*:){1,6}([[:xdigit:]]){1,4}")),
 					resource.TestCheckResourceAttrSet(resourceName, "ipv4_subnet_id"),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_server_test.go
@@ -90,7 +90,7 @@ func TestAccResourceAppServer_basic(t *testing.T) {
 	})
 }
 
-func testResourceAppServer_base(name string) string {
+func testResourceAppServer_base() string {
 	return fmt.Sprintf(`
 variable "ou_name" {
   type    = string
@@ -129,7 +129,7 @@ resource "huaweicloud_workspace_app_server" "test" {
     size = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].system_disk_size, null)
   }
 }
-`, testResourceAppServer_base(name), name, acceptance.HW_WORKSPACE_OU_NAME)
+`, testResourceAppServer_base(), name, acceptance.HW_WORKSPACE_OU_NAME)
 }
 
 func testResourceAppServer_basic_step2(name string) string {
@@ -152,7 +152,7 @@ resource "huaweicloud_workspace_app_server" "test" {
     size = try(data.huaweicloud_workspace_app_server_groups.test.server_groups[0].system_disk_size, null)
   }
 }
-`, testResourceAppServer_base(name), name, acceptance.HW_WORKSPACE_OU_NAME)
+`, testResourceAppServer_base(), name, acceptance.HW_WORKSPACE_OU_NAME)
 }
 
 // Before running this test, please enable a service that connects to LocalAD and the corresponding OU is created.
@@ -256,7 +256,7 @@ resource "huaweicloud_workspace_app_server" "test" {
   period        = 1
   auto_renew    = true
 }
-`, testResourceAppServer_base(name), name, acceptance.HW_WORKSPACE_OU_NAME)
+`, testResourceAppServer_base(), name, acceptance.HW_WORKSPACE_OU_NAME)
 }
 
 func testResourceAppServer_prepaid_step2(name string) string {
@@ -285,5 +285,5 @@ resource "huaweicloud_workspace_app_server" "test" {
   period        = 1
   auto_renew    = false
 }
-`, testResourceAppServer_base(name), name, acceptance.HW_WORKSPACE_OU_NAME)
+`, testResourceAppServer_base(), name, acceptance.HW_WORKSPACE_OU_NAME)
 }

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_partition.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_partition.go
@@ -190,7 +190,7 @@ func resourcePartitionUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return resourceNodeRead(ctx, d, meta)
 }
 
-func resourcePartitionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePartitionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	errorMsg := "Deleting partition resource is not supported. The partition resource is only removed from the state."
 	return diag.Diagnostics{
 		diag.Diagnostic{

--- a/huaweicloud/services/cci/resource_huaweicloud_cciv2_persistent_volume_claim.go
+++ b/huaweicloud/services/cci/resource_huaweicloud_cciv2_persistent_volume_claim.go
@@ -334,7 +334,7 @@ func resourceV2PersistentVolumeClaimUpdate(_ context.Context, _ *schema.Resource
 	return nil
 }
 
-func resourceV2PersistentVolumeClaimDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceV2PersistentVolumeClaimDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	client, err := cfg.NewServiceClient("cci", region)

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_script.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_script.go
@@ -116,7 +116,7 @@ func ResourceScript() *schema.Resource {
 						"value": {
 							Type:     schema.TypeString,
 							Required: true,
-							DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+							DiffSuppressFunc: func(_, oldValue, _ string, _ *schema.ResourceData) bool {
 								return oldValue == defaultSensitiveValue
 							},
 						},

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_script_execute.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_script_execute.go
@@ -78,7 +78,7 @@ func ResourceScriptExecute() *schema.Resource {
 						"value": {
 							Type:     schema.TypeString,
 							Required: true,
-							DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+							DiffSuppressFunc: func(_, oldValue, _ string, _ *schema.ResourceData) bool {
 								return oldValue == defaultSensitiveValue
 							},
 						},

--- a/huaweicloud/services/cph/resource_huaweicloud_cph_server.go
+++ b/huaweicloud/services/cph/resource_huaweicloud_cph_server.go
@@ -59,7 +59,7 @@ func ResourceCphServer() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+				DiffSuppressFunc: func(_, oldValue, newValue string, _ *schema.ResourceData) bool {
 					return newValue+"-1" == oldValue
 				},
 				Description: `Server name.`,

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_address_group.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_address_group.go
@@ -167,14 +167,14 @@ func resourceIpAddressGroupCreate(ctx context.Context, d *schema.ResourceData, m
 
 	//  call addIps to support more than 20 ip addresses
 	if val, ok := d.GetOk("ip_addresses"); ok {
-		err = addIps(ctx, d, meta, client, val.(*schema.Set).List())
+		err = addIps(ctx, d, client, val.(*schema.Set).List())
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	if val, ok := d.GetOk("listeners"); ok {
-		err = associateListener(ctx, d, meta, client, val.(*schema.Set).List())
+		err = associateListener(ctx, d, client, val.(*schema.Set).List())
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -311,14 +311,14 @@ func resourceIpAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 		removeIpsRaw := oldIpsRaw.(*schema.Set).Difference(newIpsRaw.(*schema.Set))
 
 		if removeIpsRaw.Len() > 0 {
-			err = removeIps(ctx, d, meta, client, removeIpsRaw.List())
+			err = removeIps(ctx, d, client, removeIpsRaw.List())
 			if err != nil {
 				return diag.FromErr(err)
 			}
 		}
 
 		if addIpsRaw.Len() > 0 {
-			err = addIps(ctx, d, meta, client, addIpsRaw.List())
+			err = addIps(ctx, d, client, addIpsRaw.List())
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -338,7 +338,7 @@ func resourceIpAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 
 		if associateListenerRaw.Len() > 0 {
-			err = associateListener(ctx, d, meta, client, associateListenerRaw.List())
+			err = associateListener(ctx, d, client, associateListenerRaw.List())
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -348,8 +348,7 @@ func resourceIpAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 	return resourceIpAddressGroupRead(ctx, d, meta)
 }
 
-func addIps(ctx context.Context, d *schema.ResourceData, meta interface{}, client *golangsdk.ServiceClient,
-	rawParams interface{}) error {
+func addIps(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient, rawParams interface{}) error {
 	addIpsHttpUrl := "v1/ip-groups/{ip_group_id}/add-ips"
 	addIpsPath := client.Endpoint + addIpsHttpUrl
 	addIpsPath = strings.ReplaceAll(addIpsPath, "{ip_group_id}", d.Id())
@@ -396,8 +395,7 @@ func addIps(ctx context.Context, d *schema.ResourceData, meta interface{}, clien
 	return nil
 }
 
-func removeIps(ctx context.Context, d *schema.ResourceData, meta interface{}, client *golangsdk.ServiceClient,
-	rawParams interface{}) error {
+func removeIps(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient, rawParams interface{}) error {
 	removeIpsHttpUrl := "v1/ip-groups/{ip_group_id}/remove-ips"
 	removeIpsPath := client.Endpoint + removeIpsHttpUrl
 	removeIpsPath = strings.ReplaceAll(removeIpsPath, "{ip_group_id}", d.Id())
@@ -439,8 +437,7 @@ func removeIps(ctx context.Context, d *schema.ResourceData, meta interface{}, cl
 	return nil
 }
 
-func associateListener(ctx context.Context, d *schema.ResourceData, meta interface{}, client *golangsdk.ServiceClient,
-	rawParams interface{}) error {
+func associateListener(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient, rawParams interface{}) error {
 	associateListenerHttpUrl := "v1/ip-groups/{ip_group_id}/associate-listener"
 	associateListenerPath := client.Endpoint + associateListenerHttpUrl
 	associateListenerPath = strings.ReplaceAll(associateListenerPath, "{ip_group_id}", d.Id())

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_consumer_group.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_consumer_group.go
@@ -250,7 +250,7 @@ func resourceDmsKafkaConsumerGroupRead(_ context.Context, d *schema.ResourceData
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceDmsKafkaConsumerGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDmsKafkaConsumerGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg               = meta.(*config.Config)
 		httpUrl           = "v2/kafka/{project_id}/instances/{instance_id}/groups/{group}"

--- a/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_user.go
+++ b/huaweicloud/services/kafka/resource_huaweicloud_dms_kafka_user.go
@@ -114,7 +114,7 @@ func buildCreateDmsKafkaUserBodyParams(d *schema.ResourceData) map[string]interf
 	return bodyParams
 }
 
-func resourceDmsKafkaUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDmsKafkaUserRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_member.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_member.go
@@ -280,7 +280,7 @@ func resourceMemberV2Delete(ctx context.Context, d *schema.ResourceData, meta in
 	return nil
 }
 
-func resourceMemberV2Import(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceMemberV2Import(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
 		err := fmtp.Errorf("invalid format specified for member. Format must be <pool_id>/<member_id>")

--- a/huaweicloud/services/meeting/config.go
+++ b/huaweicloud/services/meeting/config.go
@@ -109,7 +109,7 @@ func isExpireTimeValid(expireTime int) bool {
 	return expireTime >= 12 && expireTime <= 24
 }
 
-func getMeetingEndpoint(endpoints map[string]string, obj string) string {
+func getMeetingEndpoint(endpoints map[string]string) string {
 	if endpoint, ok := endpoints["meeting"]; ok {
 		return endpoint
 	}
@@ -118,12 +118,12 @@ func getMeetingEndpoint(endpoints map[string]string, obj string) string {
 
 // NewMeetingV1Client is a method to general a client with ver.1 meeting endpoint.
 func NewMeetingV1Client(conf *config.Config) *golangsdk.ServiceClient {
-	return common.NewCustomClient(false, getMeetingEndpoint(conf.Endpoints, "meeting"), "v1")
+	return common.NewCustomClient(false, getMeetingEndpoint(conf.Endpoints), "v1")
 }
 
 // NewMeetingV2Client is a method to general a client with ver.2 meeting endpoint.
 func NewMeetingV2Client(conf *config.Config) *golangsdk.ServiceClient {
-	return common.NewCustomClient(false, getMeetingEndpoint(conf.Endpoints, "meeting"), "v2")
+	return common.NewCustomClient(false, getMeetingEndpoint(conf.Endpoints), "v2")
 }
 
 func isValidToken(client *golangsdk.ServiceClient, token string) bool {

--- a/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_instance.go
+++ b/huaweicloud/services/rabbitmq/resource_huaweicloud_dms_rabbitmq_instance.go
@@ -790,7 +790,7 @@ func resourceDmsRabbitmqInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if d.HasChanges("product_id", "flavor_id", "broker_num", "storage_space") {
-		err = resizeRabbitMQInstance(ctx, d, meta, engineRabbitMQ)
+		err = resizeRabbitMQInstance(ctx, d, meta)
 		if err != nil {
 			mErr = multierror.Append(mErr, err)
 		}
@@ -827,7 +827,7 @@ func resourceDmsRabbitmqInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 	return resourceDmsRabbitmqInstanceRead(ctx, d, meta)
 }
 
-func resizeRabbitMQInstance(ctx context.Context, d *schema.ResourceData, meta interface{}, engineType string) error {
+func resizeRabbitMQInstance(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	cfg := meta.(*config.Config)
 	client, err := cfg.DmsV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -903,15 +903,16 @@ func resizeRabbitMQInstance(ctx context.Context, d *schema.ResourceData, meta in
 
 func doRabbitMQInstanceResize(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
 	opts instances.ResizeInstanceOpts) error {
+	instnaceId := d.Id()
 	retryFunc := func() (interface{}, bool, error) {
-		_, err := instances.Resize(client, d.Id(), opts)
+		_, err := instances.Resize(client, instnaceId, opts)
 		retry, err := handleMultiOperationsError(err)
 		return nil, retry, err
 	}
 	_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
 		Ctx:          ctx,
 		RetryFunc:    retryFunc,
-		WaitFunc:     rabbitmqInstanceStateRefreshFunc(client, d.Id()),
+		WaitFunc:     rabbitmqInstanceStateRefreshFunc(client, instnaceId),
 		WaitTarget:   []string{"RUNNING"},
 		Timeout:      d.Timeout(schema.TimeoutUpdate),
 		DelayTimeout: 1 * time.Second,
@@ -924,20 +925,20 @@ func doRabbitMQInstanceResize(ctx context.Context, d *schema.ResourceData, clien
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"PENDING"},
 		Target:       []string{"RUNNING"},
-		Refresh:      rabbitMQResizeStateRefresh(client, d, opts.OperType),
+		Refresh:      rabbitMQResizeStateRefresh(client, instnaceId),
 		Timeout:      d.Timeout(schema.TimeoutUpdate),
 		Delay:        60 * time.Second,
 		PollInterval: 10 * time.Second,
 	}
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("error waiting for instance (%s) to resize: %v", d.Id(), err)
+		return fmt.Errorf("error waiting for instance (%s) to resize: %v", instnaceId, err)
 	}
 	return nil
 }
 
-func rabbitMQResizeStateRefresh(client *golangsdk.ServiceClient, d *schema.ResourceData, operType *string) resource.StateRefreshFunc {
+func rabbitMQResizeStateRefresh(client *golangsdk.ServiceClient, instnaceId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		v, err := instances.Get(client, d.Id()).Extract()
+		v, err := instances.Get(client, instnaceId).Extract()
 		if err != nil {
 			return nil, "failed", err
 		}

--- a/huaweicloud/services/sms/resource_huaweicloud_sms_server_template.go
+++ b/huaweicloud/services/sms/resource_huaweicloud_sms_server_template.go
@@ -354,7 +354,7 @@ func resourceServerTemplateUpdate(ctx context.Context, d *schema.ResourceData, m
 	return resourceServerTemplateRead(ctx, d, meta)
 }
 
-func resourceServerTemplateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServerTemplateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*config.Config)
 	smsClient, err := config.SmsV3Client(config.GetRegion(d))
 	if err != nil {

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -22,6 +22,8 @@ import (
 	"github.com/chnsz/golangsdk"
 )
 
+var structJSONKeyRegexp = regexp.MustCompile(`"[a-z0-9A-Z_]+":`)
+
 // ConvertStructToMap converts an instance of struct to a map object, and
 // changes each key of fileds to the value of 'nameMap' if the key in it
 // or to its corresponding lowercase.
@@ -31,11 +33,7 @@ func ConvertStructToMap(obj interface{}, nameMap map[string]string) (map[string]
 		return nil, fmt.Errorf("Error converting struct to map, marshal failed:%v", err)
 	}
 
-	m, err := regexp.Compile(`"[a-z0-9A-Z_]+":`)
-	if err != nil {
-		return nil, fmt.Errorf("Error converting struct to map, compile regular express failed")
-	}
-	nb := m.ReplaceAllFunc(
+	nb := structJSONKeyRegexp.ReplaceAllFunc(
 		b,
 		func(src []byte) []byte {
 			k := string(src[1 : len(src)-2])


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

During the golangci result of full check, we found lots of warning in this repository, for the following rules, we fix they with some commits.

| Rule | What it checks | How this PR fixes it |
|------|----------------|----------------------|
| **gocritic** | Code style / suspicious patterns | `//nolint:gocritic` where the warning is a false positive |
| **staticcheck S1007** | Unnecessary backslash escapes in strings | Use raw string literals for regex patterns |
| **regexpMust** | `regexp.Compile` inside functions | Hoist to package-level `regexp.MustCompile` variable |
| **unused** | Unused function parameters | Remove the unsed function parameters and callers, or replace with `_` |

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. skip some of warning reports for go critic check
2. fix regexpMust and S1007 issues in regex usage
3. remove the unused function arguments
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o apig -f TestAccEndpointWhiteList_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccEndpointWhiteList_basic -timeout 360m -parallel 10
=== RUN   TestAccEndpointWhiteList_basic
=== PAUSE TestAccEndpointWhiteList_basic
=== CONT  TestAccEndpointWhiteList_basic
--- PASS: TestAccEndpointWhiteList_basic (29.34s)
PASS
coverage: 2.3% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      29.490s coverage: 2.3% of statements in ./huaweicloud/services/apig
```
```
./scripts/coverage.sh -o apig -f TestAccInstanceFeature_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/apig" -v -coverprofile="./huaweicloud/services/acceptance/apig/apig_coverage.cov" -coverpkg="./huaweicloud/services/apig" -run TestAccInstanceFeature_basic -timeout 360m -parallel 10
=== RUN   TestAccInstanceFeature_basic
=== PAUSE TestAccInstanceFeature_basic
=== CONT  TestAccInstanceFeature_basic
--- PASS: TestAccInstanceFeature_basic (42.15s)
PASS
coverage: 2.5% of statements in ./huaweicloud/services/apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      42.308s coverage: 2.5% of statements in ./huaweicloud/services/apig
```
```
./scripts/coverage.sh -o ga -f TestAccIpAddressGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ga" -v -coverprofile="./huaweicloud/services/acceptance/ga/ga_coverage.cov" -coverpkg="./huaweicloud/services/ga" -run TestAccIpAddressGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccIpAddressGroup_basic
=== PAUSE TestAccIpAddressGroup_basic
=== CONT  TestAccIpAddressGroup_basic
--- PASS: TestAccIpAddressGroup_basic (88.99s)
PASS
coverage: 10.5% of statements in ./huaweicloud/services/ga
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        89.171s coverage: 10.5% of statements in ./huaweicloud/services/ga
```
```
./scripts/coverage.sh -o dds -f TestAccDDSV3Instance_withAutoEnlargePolicy
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dds" -v -coverprofile="./huaweicloud/services/acceptance/dds/dds_coverage.cov" -coverpkg="./huaweicloud/services/dds" -run TestAccDDSV3Instance_withAutoEnlargePolicy -timeout 360m -parallel 10
=== RUN   TestAccDDSV3Instance_withAutoEnlargePolicy
=== PAUSE TestAccDDSV3Instance_withAutoEnlargePolicy
=== CONT  TestAccDDSV3Instance_withAutoEnlargePolicy
--- PASS: TestAccDDSV3Instance_withAutoEnlargePolicy (940.96s)
PASS
coverage: 9.2% of statements in ./huaweicloud/services/dds
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       941.098s        coverage: 9.2% of statements in ./huaweicloud/services/dds
```
```
./scripts/coverage.sh -o vpc -f TestAccVpcSubnetV1_ipv6
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/vpc" -v -coverprofile="./huaweicloud/services/acceptance/vpc/vpc_coverage.cov" -coverpkg="./huaweicloud/services/vpc" -run TestAccVpcSubnetV1_ipv6 -timeout 360m -parallel 10
=== RUN   TestAccVpcSubnetV1_ipv6
=== PAUSE TestAccVpcSubnetV1_ipv6
=== CONT  TestAccVpcSubnetV1_ipv6
--- PASS: TestAccVpcSubnetV1_ipv6 (72.17s)
PASS
coverage: 6.9% of statements in ./huaweicloud/services/vpc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       72.336s coverage: 6.9% of statements in ./huaweicloud/services/vpc
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
