### PR TITLE
feat(GeminiDB): add data source to get the list of instances by tags

### DIFF
--- a/docs/data-sources/geminidb_instances_by_tags.md
+++ b/docs/data-sources/geminidb_instances_by_tags.md
@@ -1,0 +1,86 @@
+---
+subcategory: "GeminiDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_geminidb_instances_by_tags"
+description: |-
+  Use this data source to get the list of GeminiDB instances.
+---
+
+# huaweicloud_geminidb_instances_by_tags
+
+Use this data source to get the list of GeminiDB instances.
+
+## Example Usage
+
+```hcl
+variable "action" {}
+
+data "huaweicloud_geminidb_instances_by_tags" "test" {
+  action = var.action
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `action` - (Required, String) Specifies the resource type.
+  The valid values are **filter** and **count**.
+  If `action` set to **filter**, indicates query the instances based on tags filtering conditions.
+  If `action` set to **count**, indicates only query the total number of intances.
+
+* `matches` - (Optional, List) Specifies the fields to be queried.
+  The [matches](#query_matches) structure is documented below.
+
+* `tags` - (Optional, List) Specifies the list of the tags to be queried.
+  The [tags](#query_tags) structure is documented below.
+
+<a name="query_matches"></a>
+The `matches` block supports:
+
+* `key` - (Required, String) Specifies the key to be matched.
+  The valid values are as follows:
+  + **instance_name**: Indicates matching queries based on instance name.
+  + **instance_id**: Indicates matching queries based on instance ID.
+
+* `value` - (Required, String) Specifies the value of the matching field.
+
+<a name="query_tags"></a>
+The `tags` block supports:
+
+* `key` - (Required, String) Specifies the key of the tag.
+
+* `values` - (Required, List) Specifies the list of values of the tag.
+  The `values` can be empty.
+  If the values are an empty list, it indicates that any value is queried. The relationship between values is OR.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances` - The list of instances.
+  The [instances](#instances_struct) structure is documented below.
+
+* `total_count` - The total number of the instances.
+
+<a name="instances_struct"></a>
+The `instances` block supports:
+
+* `instance_id` - The instance ID.
+
+* `instance_name` - The instance name.
+
+* `tags` - Indicates the tag list associated with the resource.
+  The [tags](#tags_struct) structure is documented below.
+
+<a name="tags_struct"></a>
+The `tags` block supports:
+
+* `key` - The key of the tag.
+
+* `value` - The value of the tag.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1532,6 +1532,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_geminidb_high_risk_commands":            geminidb.DataSourceHighRiskCommands(),
 			"huaweicloud_geminidb_hot_keys":                      geminidb.DataSourceHotKeys(),
 			"huaweicloud_geminidb_instances":                     geminidb.DataSourceInstances(),
+			"huaweicloud_geminidb_instances_by_tags":             geminidb.DataSourceInstancesByTags(),
 			"huaweicloud_geminidb_instance_parameters_histories": geminidb.DataSourceGeminiDBInstanceParametersHistories(),
 			"huaweicloud_geminidb_instance_sessions":             geminidb.DataSourceInstanceSessions(),
 			"huaweicloud_geminidb_memory_mappings":               geminidb.DataSourceMemoryMappings(),

--- a/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_instances_by_tags_test.go
+++ b/huaweicloud/services/acceptance/geminidb/data_source_huaweicloud_geminidb_instances_by_tags_test.go
@@ -1,0 +1,133 @@
+package geminidb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataSourceInstancesByTags_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_geminidb_instances_by_tags.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		name       = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceInstancesByTags_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.instance_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.instance_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.tags.#"),
+
+					resource.TestCheckOutput("results_is_not_empty", "true"),
+					resource.TestCheckOutput("matches_filter_is_useful", "true"),
+					resource.TestCheckOutput("tags_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceInstancesByTags_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_gaussdb_nosql_flavors" "test" {
+  vcpus             = 2
+  engine            = "redis"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}
+
+resource "huaweicloud_geminidb_instance" "test" {
+  name              = "%[2]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  password          = "test_1234"
+  mode              = "Cluster"
+
+  datastore {
+    type           = "redis"
+    version        = "5.0"
+    storage_engine = "rocksDB"
+  }
+
+  flavor {
+    num       = "3"
+    size      = "16"
+    storage   = "ULTRAHIGH"
+    spec_code = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testDataSourceInstancesByTags_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_geminidb_instances_by_tags" "test" {
+  action = "filter"
+
+  depends_on = [huaweicloud_geminidb_instance.test]
+}
+
+data "huaweicloud_geminidb_instances_by_tags" "filter_by_count" {
+  action = "count"
+
+  depends_on = [huaweicloud_geminidb_instance.test]
+}
+
+data "huaweicloud_geminidb_instances_by_tags" "filter_by_matches" {
+  action = "filter"
+
+  matches {
+    key   = "instance_id"
+    value = huaweicloud_geminidb_instance.test.id
+  }
+}
+
+data "huaweicloud_geminidb_instances_by_tags" "filter_by_tags" {
+  action = "filter"
+
+  tags {
+    key    = data.huaweicloud_geminidb_instances_by_tags.test.instances.0.tags.0.key
+    values = [data.huaweicloud_geminidb_instances_by_tags.test.instances.0.tags.0.value]
+  }
+}
+
+
+output "results_is_not_empty" {
+  value = data.huaweicloud_geminidb_instances_by_tags.filter_by_count.total_count > 0
+}
+
+output "matches_filter_is_useful" {
+  value = length(data.huaweicloud_geminidb_instances_by_tags.filter_by_matches.instances) > 0
+}
+
+output "tags_filter_is_useful" {
+  value = length(data.huaweicloud_geminidb_instances_by_tags.filter_by_tags.instances) > 0
+}
+`, testDataSourceInstancesByTags_base(name))
+}

--- a/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_instances_by_tags.go
+++ b/huaweicloud/services/geminidb/data_source_huaweicloud_geminidb_instances_by_tags.go
@@ -1,0 +1,258 @@
+package geminidb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GeminiDB POST /v3/{project_id}/instances/resource-instances/action
+func DataSourceInstancesByTags() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstancesByTagsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"matches": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"total_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildInstancesTagsBodyParams(d *schema.ResourceData, action string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"action":  action,
+		"matches": buildFilterMatchesBodyParams(d.Get("matches").([]interface{})),
+		"tags":    buildFilterTagsBodyParams(d.Get("tags").([]interface{})),
+	}
+
+	return bodyParams
+}
+
+func buildFilterMatchesBodyParams(matches []interface{}) []map[string]interface{} {
+	if len(matches) == 0 {
+		return nil
+	}
+
+	res := make([]map[string]interface{}, len(matches))
+	for i, matchRaw := range matches {
+		if match, ok := matchRaw.(map[string]interface{}); ok {
+			res[i] = map[string]interface{}{
+				"key":   utils.PathSearch("key", match, nil),
+				"value": utils.PathSearch("value", match, nil),
+			}
+		}
+	}
+	return res
+}
+
+func buildFilterTagsBodyParams(tags []interface{}) []map[string]interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	res := make([]map[string]interface{}, len(tags))
+	for i, tagRaw := range tags {
+		if tag, ok := tagRaw.(map[string]interface{}); ok {
+			res[i] = map[string]interface{}{
+				"key":    utils.PathSearch("key", tag, nil),
+				"values": utils.PathSearch("values", tag, nil),
+			}
+		}
+	}
+
+	return res
+}
+
+func dataSourceInstancesByTagsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v3/{project_id}/instances/resource-instances/action"
+		tagsAction = d.Get("action").(string)
+		limit      = 100
+		offset     = 0
+		result     = make([]interface{}, 0)
+		totalCount float64
+	)
+
+	client, err := cfg.NewServiceClient("geminidb", region)
+	if err != nil {
+		return diag.Errorf("error creating GeminiDB client: %s", err)
+	}
+
+	reqBodyParams := buildInstancesTagsBodyParams(d, tagsAction)
+	if tagsAction == "filter" {
+		reqBodyParams["limit"] = limit
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		KeepResponseBody: true,
+	}
+
+	for {
+		if tagsAction == "filter" {
+			reqBodyParams["offset"] = offset
+		}
+
+		listOpt.JSONBody = utils.RemoveNil(reqBodyParams)
+		resp, err := client.Request("POST", listPath, &listOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving GeminiDB instances: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		totalCount = utils.PathSearch("total_count", respBody, float64(0)).(float64)
+		if tagsAction == "count" {
+			break
+		}
+
+		instances := utils.PathSearch("instances", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, instances...)
+
+		if len(instances) < limit {
+			break
+		}
+
+		offset += len(instances)
+	}
+
+	randomUUID, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(randomUUID.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("instances", flattenInstancesByTags(result)),
+		d.Set("total_count", totalCount),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInstancesByTags(instances []interface{}) []interface{} {
+	if len(instances) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(instances))
+	for i, v := range instances {
+		rst[i] = map[string]interface{}{
+			"instance_id":   utils.PathSearch("instance_id", v, nil),
+			"instance_name": utils.PathSearch("instance_name", v, nil),
+			"tags":          flattenTagsResp(utils.PathSearch("tags", v, make([]interface{}, 0)).([]interface{})),
+		}
+	}
+	return rst
+}
+
+func flattenTagsResp(tags []interface{}) []interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(tags))
+	for i, tag := range tags {
+		rst[i] = map[string]interface{}{
+			"key":   utils.PathSearch("key", tag, nil),
+			"value": utils.PathSearch("value", tag, nil),
+		}
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add data source to get the list of instances by tags.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new data source to get the list of instances by tags.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/geminidb" TESTARGS="-run TestAccDataSourceInstancesByTags_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/geminidb -v -run TestAccDataSourceInstancesByTags_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceInstancesByTags_basic
=== PAUSE TestAccDataSourceInstancesByTags_basic
=== CONT  TestAccDataSourceInstancesByTags_basic
--- PASS: TestAccDataSourceInstancesByTags_basic (1501.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/geminidb  1501.704s
```
<img width="1014" height="19" alt="image" src="https://github.com/user-attachments/assets/e2828ff0-2178-4a94-bd4d-abb2e7c8d06d" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
