### PR TITLE
feat(dli): add some attributes to the schema of dli_spark_job

### DIFF
--- a/docs/resources/dli_spark_job.md
+++ b/docs/resources/dli_spark_job.md
@@ -141,7 +141,7 @@ The `packages` block supports:
 * `type` - (Required, String, ForceNew) Specifies the resource type of the package.
   Changing this parameter will submit a new spark job.
 
-* `package_name` - (Required, String, ForceNew) Specifies the resource name of the package.
+* `package_name` - (Required, String, ForceNew) Specifies the resource name of the package.  
   Changing this parameter will submit a new spark job.
 
 ## Attribute Reference
@@ -150,6 +150,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the spark job.
 
-* `created_at` - Time of the DLI spark job submit.
+* `app_ids` - The back-end application IDs of the batch processing job.
+
+* `kind` - The type of the batch processing job. Only Spark parameters are supported.
 
 * `owner` - The owner of the spark job.
+
+* `created_at` - Time of the DLI spark job submit, in RFC3339 format.
+
+* `updated_at` - Time of the DLI spark job update, in RFC3339 format.

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_spark_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_spark_job_test.go
@@ -85,7 +85,7 @@ resource "huaweicloud_dli_spark_job" "test" {
   name       = "%s"
   app_name   = "${huaweicloud_dli_package.test.group_name}/${huaweicloud_dli_package.test.object_name}"
   
- depends_on = [
+  depends_on = [
     huaweicloud_obs_bucket.test,
     huaweicloud_obs_bucket_object.test,
   ]

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_spark_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_spark_job.go
@@ -181,6 +181,19 @@ func ResourceDliSparkJobV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"app_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"kind": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"owner": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -282,10 +295,17 @@ func resourceDliSparkJobRead(_ context.Context, d *schema.ResourceData, meta int
 		return common.CheckDeletedDiag(d, err, "DLI spark job")
 	}
 
+	// Convert millisecond timestamps to RFC3339 format
+	createdAt := utils.FormatTimeStampRFC3339(int64(resp.CreateTime)/1000, false, "2006-01-02 15:04:05")
+	updatedAt := utils.FormatTimeStampRFC3339(int64(resp.UpdateTime)/1000, false, "2006-01-02 15:04:05")
+
 	mErr := multierror.Append(nil,
 		d.Set("queue_name", resp.Queue),
 		d.Set("name", resp.Name),
-		d.Set("created_at", time.Unix(int64(resp.CreateTime)/1000, 0).Format("2006-01-02 15:04:05")),
+		d.Set("created_at", createdAt),
+		d.Set("updated_at", updatedAt),
+		d.Set("app_ids", resp.AppId),
+		d.Set("kind", resp.Kind),
 		d.Set("owner", resp.Owner),
 	)
 	return diag.FromErr(mErr.ErrorOrNil())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add missing fields to resource `dli_spark_job`.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
1. change the implement of resource.
2. change the document of resource.
```

## PR Checklist

* [x] Tests added/passed.

```
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dli" -v -coverprofile="./huaweicloud/services/acceptance/dli/dli_coverage.cov" -coverpkg="./huaweicloud/services/dli" -run TestAccDliSparkJobV2_basic -timeout 360m -parallel 10
go: downloading go1.24.13 (linux/amd64)
=== RUN   TestAccDliSparkJobV2_basic
=== PAUSE TestAccDliSparkJobV2_basic
=== CONT  TestAccDliSparkJobV2_basic
--- PASS: TestAccDliSparkJobV2_basic (47.45s)
PASS
coverage: 4.7% of statements in ./huaweicloud/services/dli
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       47.577s coverage: 4.7% of statements in ./huaweicloud/services/dli
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.