### PR TITLE
feat(TaurusDB): data source to query EIP associated with a TaurusDB instance

### DIFF
--- a/docs/data-sources/taurusdb_instance_associated_eip.md
+++ b/docs/data-sources/taurusdb_instance_associated_eip.md
@@ -1,0 +1,91 @@
+---
+subcategory: "TaurusDB"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_taurusdb_instance_associated_eip"
+description: |-
+  Use this data source to query the EIP information associated with a TaurusDB instance within HuaweiCloud.
+---
+
+# huaweicloud_taurusdb_instance_associated_eip
+
+Use this data source to query the EIP information associated with a TaurusDB instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_taurusdb_instance_associated_eip" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the TaurusDB instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `can_enable_public_access` - Whether public access can be enabled.
+
+* `eip_id` - The EIP ID.
+
+* `type` - The network type of the EIP.
+  Valid values are as follows:
+  + **5_bgp**: dynamic BGP.
+  + **5_sbgp**: static BGP.
+  + **5_youxuanbgp**: premium BGP.
+
+* `port_id` - The port ID.
+
+* `public_ip_address` - The EIP address.
+
+* `private_ip_address` - The private IP address bound to the EIP.
+
+* `status` - The EIP status.
+  Valid values are as follows:
+  + **FREEZED**: The EIP is frozen.
+  + **BIND_ERROR**: The EIP failed to be bound.
+  + **BINDING**: The EIP is being bound.
+  + **PENDING_DELETE**: The EIP is being released.
+  + **PENDING_CREATE**: The EIP is being created.
+  + **NOTIFYING**: The EIP is being created.
+  + **NOTIFY_DELETE**: The EIP is being released.
+  + **PENDING_UPDATE**: The EIP is being updated.
+  + **DOWN**: The EIP has not been bound.
+  + **ACTIVE**: The EIP has been bound.
+  + **ELB**: The EIP has been bound to a load balancer.
+  + **VPN**: The EIP has been bound to a VPN.
+  + **ERROR**: The EIP is failed.
+
+* `create_time` - The time when the EIP was assigned.
+
+* `bandwidth_id` - The bandwidth ID.
+
+* `bandwidth_name` - The bandwidth name.
+
+* `bandwidth_size` - The bandwidth size in Mbit/s.
+
+* `bandwidth_share_type` - The bandwidth type. Valid values are **PER** (dedicated bandwidth)
+  and **WHOLE** (shared bandwidth).
+
+* `profile` - The additional parameters, including the order ID and product ID.
+  If profile is not empty, the EIP is billed on a yearly/monthly basis.
+
+  The [profile](#profile_struct) structure is documented below.
+
+<a name="profile_struct"></a>
+The `profile` block supports:
+
+* `order_id` - The order ID.
+
+* `product_id` - The product ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2573,6 +2573,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_taurusdb_htap_starrocks_users":                     taurusdb.DataSourceTaurusDBHtapStarrocksUsers(),
 			"huaweicloud_taurusdb_htap_storage_types":                       taurusdb.DataSourceTaurusDBHtapStorageTypes(),
 			"huaweicloud_taurusdb_instance":                                 taurusdb.DataSourceTaurusDBInstance(),
+			"huaweicloud_taurusdb_instance_associated_eip":                  taurusdb.DataSourceTaurusDBInstanceAssociatedEip(),
 			"huaweicloud_taurusdb_instances":                                taurusdb.DataSourceTaurusDBInstances(),
 			"huaweicloud_taurusdb_backups":                                  taurusdb.DataSourceTaurusDBBackups(),
 			"huaweicloud_taurusdb_instance_backups":                         taurusdb.DataSourceTaurusDBInstanceBackups(),

--- a/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_instance_associated_eip_test.go
+++ b/huaweicloud/services/acceptance/taurusdb/data_source_huaweicloud_taurusdb_instance_associated_eip_test.go
@@ -1,0 +1,54 @@
+package taurusdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceTaurusDBInstanceAssociatedEip_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	dataSource := "data.huaweicloud_taurusdb_instance_associated_eip.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceTaurusDBInstanceAssociatedEip_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "can_enable_public_access"),
+					resource.TestCheckResourceAttrSet(dataSource, "eip_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "type"),
+					resource.TestCheckResourceAttrSet(dataSource, "port_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "public_ip_address"),
+					resource.TestCheckResourceAttrSet(dataSource, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(dataSource, "status"),
+					resource.TestCheckResourceAttrSet(dataSource, "create_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "bandwidth_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "bandwidth_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "bandwidth_size"),
+					resource.TestCheckResourceAttrSet(dataSource, "bandwidth_share_type"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceTaurusDBInstanceAssociatedEip_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_taurusdb_instance_associated_eip" "test" {
+  instance_id = huaweicloud_taurusdb_instance.test.id
+
+  depends_on = [huaweicloud_taurusdb_eip_associate.test]
+}
+`, testTaurusDBEipAssociate_basic(rName))
+}

--- a/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_instance_associated_eip.go
+++ b/huaweicloud/services/taurusdb/data_source_huaweicloud_taurusdb_instance_associated_eip.go
@@ -1,0 +1,182 @@
+package taurusdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API TaurusDB GET /v3/{project_id}/instances/{instance_id}/eip
+func DataSourceTaurusDBInstanceAssociatedEip() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTaurusDBInstanceAssociatedEipRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"can_enable_public_access": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"eip_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"port_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bandwidth_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bandwidth_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bandwidth_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"bandwidth_share_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"profile": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     instanceEipProfileSchema(),
+			},
+		},
+	}
+}
+
+func instanceEipProfileSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"order_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTaurusDBInstanceAssociatedEipRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+		httpUrl    = "v3/{project_id}/instances/{instance_id}/eip"
+	)
+	client, err := cfg.NewServiceClient("gaussdb", region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error querying TaurusDB instance (%s) EIP: %s", instanceId, err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id.String())
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("can_enable_public_access", utils.PathSearch("can_enable_public_access", getRespBody, nil)),
+		d.Set("eip_id", utils.PathSearch("id", getRespBody, nil)),
+		d.Set("type", utils.PathSearch("type", getRespBody, nil)),
+		d.Set("port_id", utils.PathSearch("port_id", getRespBody, nil)),
+		d.Set("public_ip_address", utils.PathSearch("public_ip_address", getRespBody, nil)),
+		d.Set("private_ip_address", utils.PathSearch("private_ip_address", getRespBody, nil)),
+		d.Set("status", utils.PathSearch("status", getRespBody, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", getRespBody, nil)),
+		d.Set("bandwidth_id", utils.PathSearch("bandwidth_id", getRespBody, nil)),
+		d.Set("bandwidth_name", utils.PathSearch("bandwidth_name", getRespBody, nil)),
+		d.Set("bandwidth_size", utils.PathSearch("bandwidth_size", getRespBody, float64(0)).(float64)),
+		d.Set("bandwidth_share_type", utils.PathSearch("bandwidth_share_type", getRespBody, nil)),
+		d.Set("profile", flattenInstanceEipProfile(getRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInstanceEipProfile(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("profile", resp, nil)
+	if curJson == nil {
+		return nil
+	}
+
+	orderId := utils.PathSearch("order_id", curJson, nil)
+	productId := utils.PathSearch("product_id", curJson, nil)
+
+	// If both fields are nil, return nil to avoid empty object
+	if orderId == nil && productId == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"order_id":   orderId,
+			"product_id": productId,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
data source to query EIP associated with a TaurusDB instance
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
data source to query EIP associated with a TaurusDB instance
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/taurusdb' TESTARGS='-run=TestAccDataSourceTaurusDBInstanceAssociatedEip'
=== RUN   TestAccDataSourceTaurusDBInstanceAssociatedEip_basic
=== PAUSE TestAccDataSourceTaurusDBInstanceAssociatedEip_basic
=== CONT  TestAccDataSourceTaurusDBInstanceAssociatedEip_basic
--- PASS: TestAccDataSourceTaurusDBInstanceAssociatedEip_basic (1465.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/taurusdb 1465.065s
```

<img width="1103" height="199" alt="image" src="https://github.com/user-attachments/assets/6287af3c-ec2a-4edc-b50f-a7bb0fcc1129" />

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
