### PR TITLE
ci(golangci): migrate golangci and using v2 to ignore node20 warning report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,21 +35,6 @@ jobs:
     - name: Vet
       run: make vet
 
-  golangci:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ">=1.18"
-      - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          only-new-issues: true
-
   # This workflow contains a job called "tfproviderlint"
   # Ignore rules:
   # + R019: d.HasChanges() has many arguments, consider d.HasChangesExcept()

--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -1,0 +1,31 @@
+name: golangci-lint
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'examples/**'
+      - '*.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,169 +1,155 @@
-# Options for analysis running.
+version: "2"
 run:
-  # See the dedicated "run" documentation section.
-  timeout: 5m
-  # Which dirs to skip: issues from them won't be reported.
-  # Can use regexp here: `generated.*`, regexp is applied on full path.
-  # Default value is empty list,
-  # but default dirs are skipped independently of this option's value (see skip-dirs-use-default).
-  # "/" will be replaced by current OS file path separator to properly work on Windows.
-  skip-dirs:
-    - huaweicloud/services/deprecated
-    - huaweicloud/services/acceptance/deprecated
-
+  timeout: 10m
 linters:
-  # Disable all linters.
-  # Default: false
-  disable-all: true
-  # Enable specific linter
-  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  default: none
   enable:
     - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - typecheck
-    - unused
-    - gci
     - gocritic
     - gocyclo
     - gosec
-    - nestif
+    - govet
+    - ineffassign
     - misspell
-    - unconvert
+    - nestif
     - revive
-
-linters-settings:
-  staticcheck:
-    # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
-    # Default: ["*"]
-    checks: ["all"]
-  gocritic:
-    disabled-checks:
-      - unnamedResult
-  gosimple:
-    # Sxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
-    # Default: ["*"]
-    checks: ["all"]
-  stylecheck:
-    # STxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
-    # Default: ["*"]
-    checks: ["all", "-ST1000", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
-  gocyclo:
-    # Minimal code complexity to report.
-    # Default: 30 (but we recommend 10-20)
-    min-complexity: 20
-  nestif:
-    # Minimal complexity of if statements to report.
-    # Default: 5
-    min-complexity: 15
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    # Default is to use a neutral variety of English.
-    locale: US
-    ignore-words:
-      - classis
-      - cancelled
-      - criterias
-      - analyses
-      - versoin
-      - cancelling
-      - catalogue
-      - catalogues
-      - subscirption
-      - ageing
-      - defence
-  gci:
-    # Section configuration to compare against.
-    # Section names are case-insensitive and may contain parameters in ().
-    # The default order of sections is `standard > default > custom > blank > dot`,
-    # If `custom-order` is `true`, it follows the order of `sections` option.
-    # Default: ["standard", "default"]
-    sections:
-      - standard
-      - default
-      # Custom section: groups all imports with the specified Prefix.
-      - prefix(github.com/chnsz/golangsdk)
-      - prefix(github.com/huaweicloud/huaweicloud-sdk-go-v3)
-      - prefix(github.com/huaweicloud/terraform-provider-huaweicloud)
-      - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
-      - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
-    # Skip generated files.
-    # Default: true
-    skip-generated: false
-    # Enable custom order of sections.
-    # If `true`, make the section order the same as the order of `sections`.
-    # Default: false
-    custom-order: true
-  gosec:
-    # To select a subset of rules to run.
-    # Available rules: https://github.com/securego/gosec#available-rules
-    # Default: [] - means include all rules
-    severity: medium
-    confidence: medium
-  revive:
-    enable-all-rules: true
-    severity: warning
+    - staticcheck
+    - unconvert
+    - unused
+  settings:
+    gocritic:
+      disabled-checks:
+        - unnamedResult
+    gocyclo:
+      min-complexity: 20
+    gosec:
+      severity: medium
+      confidence: medium
+    misspell:
+      locale: US
+      ignore-rules:
+        - classis
+        - cancelled
+        - criterias
+        - analyses
+        - versoin
+        - cancelling
+        - catalogue
+        - catalogues
+        - subscirption
+        - ageing
+        - defence
+    nestif:
+      min-complexity: 15
+    revive:
+      severity: warning
+      enable-all-rules: true
+      rules:
+        - name: var-naming
+          arguments:
+            - - API
+              - ID
+              - IDS
+              - IP
+              - VM
+              - JSON
+              - HTTP
+              - URL
+              - XML
+              - YAML
+              - CSS
+              - ACL
+              - CPU
+              - SQL
+            - []
+          disabled: false
+        - name: argument-limit
+          arguments:
+            - 6
+          disabled: false
+        - name: function-result-limit
+          arguments:
+            - 4
+          disabled: false
+        - name: line-length-limit
+          arguments:
+            - 150
+          disabled: false
+        - name: add-constant
+          disabled: true
+        - name: banned-characters
+          disabled: true
+        - name: cyclomatic
+          disabled: true
+        - name: cognitive-complexity
+          disabled: true
+        - name: max-public-structs
+          disabled: true
+        - name: file-header
+          disabled: true
+        - name: function-length
+          disabled: true
+        - name: unhandled-error
+          disabled: true
+        - name: bare-return
+          disabled: true
+        - name: flag-parameter
+          disabled: true
+        - name: use-any
+          disabled: true
+        - name: unchecked-type-assertion
+          disabled: true
+    staticcheck:
+      checks:
+        - all
+        - -ST1000
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: var-naming
-        disabled: false
-        arguments:
-          - ["API", "ID", "IDS", "IP", "VM", "JSON", "HTTP", "URL", "XML", "YAML", "CSS", "ACL", "CPU", "SQL"] # AllowList
-          - [] # DenyList
-      - name: argument-limit
-        disabled: false
-        arguments: [6]
-      - name: function-result-limit
-        disabled: false
-        arguments: [4]
-      - name: line-length-limit
-        disabled: false
-        arguments: [150]
-      - name: add-constant
-        disabled: true
-      - name: banned-characters
-        disabled: true
-      - name: cyclomatic
-        disabled: true
-      - name: cognitive-complexity
-        disabled: true
-      - name: max-public-structs
-        disabled: true
-      - name: file-header
-        disabled: true
-      - name: function-length
-        disabled: true
-      - name: unhandled-error
-        disabled: true
-      - name: bare-return
-        disabled: true
-      - name: flag-parameter
-        disabled: true
-      - name: use-any
-        disabled: true
-      - name: unchecked-type-assertion
-        disabled: true
-
-issues:
-  # List of regexps of issue texts to exclude.
-  #
-  # But independently of this option we use default exclude patterns,
-  # it can be disabled by `exclude-use-default: false`.
-  # To list all excluded by default patterns execute `golangci-lint run --help`
-  #
-  # Default: []
-  exclude:
-    - "Error return value of `d.Set` is not checked"
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      text: "var-naming: don't use underscores in Go names"
-      linters:
-        - revive
-    - path: _test\.go
-      text: "confusing-naming:"
-      linters:
-        - revive
+      - linters:
+          - revive
+        path: _test\.go
+        text: 'var-naming: don''t use underscores in Go names'
+      - linters:
+          - revive
+        path: _test\.go
+        text: 'confusing-naming:'
+      - path: (.+)\.go$
+        text: Error return value of `d.Set` is not checked
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - huaweicloud/services/deprecated
+      - huaweicloud/services/acceptance/deprecated
+formatters:
+  enable:
+    - gci
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/chnsz/golangsdk)
+        - prefix(github.com/huaweicloud/huaweicloud-sdk-go-v3)
+        - prefix(github.com/huaweicloud/terraform-provider-huaweicloud)
+        - blank
+        - dot
+      custom-order: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - huaweicloud/services/deprecated
+      - huaweicloud/services/acceptance/deprecated


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There is a new warning report about golangci check, and suggest we upgrade the reference version.

```
Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

Now, the golangci-lint CI check was split out of the main `CI` workflow, upgraded from **golangci-lint v1** to **v2**, and moved to **golangci-lint-action@v9** (Node 24) to resolve GitHub Actions Node 20 deprecation warnings.

**What Stayed the Same**

- Runs on the same PR events (same path filters).
- **`only-new-issues: true`**: still reports only new issues introduced by the PR (via GitHub API diff).
- Still skips `huaweicloud/services/deprecated` and `huaweicloud/services/acceptance/deprecated`.
- Same core linter set in intent: errcheck, govet, staticcheck family, unused, gocritic, gocyclo, gosec, misspell, nestif, revive, unconvert, gci.
- Still runs in parallel with other CI jobs (build, vet, tfproviderlint, etc.) — only the workflow file is separate.

**Behavior: What Changed (Not Fully Equivalent)**

- 1. Linter engine (v1 → v2)
  - **Before**: floating `latest` v1.x — results could shift between CI runs.
  - **After**: pinned v2.12.2 — reproducible, but a major-version jump with different rule behavior.
  - **Impact**: Some issues may appear or disappear vs historical runs (e.g. new `staticcheck` ST* rules such as `ST1003` for identifier naming).

- 2. staticcheck consolidation
  - **Before**: `gosimple`, `stylecheck`, and `staticcheck` ran as separate linters with separate check lists.
  - **After**: Single `staticcheck` linter with merged checks.
  - **Impact**: Not 1:1 with v1; stricter or different in edge cases.

- 3. gci execution model
  - **Before**: gci ran as a linter; `skip-generated: false` explicitly linted generated files.
  - **After**: gci runs as a formatter under `formatters`; generated-file handling uses `exclusions.generated: lax`.
  - **Impact**: gci behavior on generated code may differ slightly.

- 4. Broader default exclusions (v2 migration)
  - **After** adds exclusion **presets** that v1 did not explicitly configure.
  - **Impact**: May **suppress more** issues than the historical pipeline (fewer false positives, but less strict overall).

- 5. Go toolchain
  - **Before**: `>=1.18` (minimum floor).
  - **After**: `stable` (current latest stable Go).
  - **Impact**: Analysis may differ if the Go version affects type-checking or stdlib behavior.

- 6. GitHub UI & branch protection
  - Check name changed from `CI / golangci` to `golangci-lint / golangci-lint`.
  - **Impact**: Branch protection rules referencing the old check name must be updated.

- 7. Node.js runtime (intentional fix)
  - **Before**: action@v3 on Node 16 → deprecation warnings on modern runners.
  - **After**: action@v9 on Node 24 → warnings resolved.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. migrate golangci and using v2 to ignore node20 warning report
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
